### PR TITLE
feat: auto-detect BTP Audit Log binding on startup

### DIFF
--- a/ts-src/server/server.ts
+++ b/ts-src/server/server.ts
@@ -228,6 +228,18 @@ export async function createAndStartServer(config: ServerConfig): Promise<Server
     logger.info('File logging enabled', { logFile: config.logFile });
   }
 
+  // Add BTP Audit Log sink if auditlog service is bound (auto-detected from VCAP_SERVICES)
+  try {
+    const { BTPAuditLogSink, parseBTPAuditLogConfig } = await import('./sinks/btp-auditlog.js');
+    const auditLogConfig = parseBTPAuditLogConfig();
+    if (auditLogConfig) {
+      logger.addSink(new BTPAuditLogSink(auditLogConfig));
+      logger.info('BTP Audit Log sink enabled', { url: auditLogConfig.url });
+    }
+  } catch {
+    // BTP audit log sink is optional — ignore if parsing fails
+  }
+
   // Emit structured server_start audit event
   logger.emitAudit({
     timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Auto-detects `auditlog` premium service binding in VCAP_SERVICES on startup
- Registers `BTPAuditLogSink` when binding exists — no env var needed
- Graceful no-op when not on BTP or no binding present

Single 12-line change in `server.ts`.

## Test plan
- [x] 421 unit tests, 56 integration tests passing locally
- [ ] Deploy to BTP and verify audit events in Audit Log Viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)