### PR TITLE
feat: improve tooling based on real-world LLM feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ npm run dev
 | `SAP_URL` / `--url` | SAP system URL (e.g., `http://host:50000`) |
 | `SAP_USER` / `--user` | SAP username |
 | `SAP_PASSWORD` / `--password` | SAP password |
-| `SAP_CLIENT` / `--client` | SAP client number (default: 001) |
+| `SAP_CLIENT` / `--client` | SAP client number (default: 100) |
 | `SAP_LANGUAGE` / `--language` | SAP language (default: EN) |
 | `SAP_INSECURE` / `--insecure` | Skip TLS verification (default: false) |
 | `SAP_TRANSPORT` / `--transport` | MCP transport: `stdio` (default) or `http-streamable` |

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -246,7 +246,7 @@ All config options work as environment variables in the `env` block of MCP clien
 | `SAP_ALLOWED_PACKAGES` | `"Z*,$TMP"` | Only allow writes to matching packages |
 | `SAP_ALLOWED_OPS` | `"RSQ"` | Only allow Read, Search, Query operations |
 | `SAP_INSECURE` | `"true"` | Skip TLS verification (dev only) |
-| `SAP_CLIENT` | `"100"` | SAP client number (default: 001) |
+| `SAP_CLIENT` | `"100"` | SAP client number (default: 100) |
 
 See [Safety Controls](#safety-controls) and [Quick Reference](#quick-reference-all-configuration) for all options.
 

--- a/reports/2026-03-31-001-llm-feedback-tooling-improvements.md
+++ b/reports/2026-03-31-001-llm-feedback-tooling-improvements.md
@@ -1,0 +1,523 @@
+# LLM Feedback Analysis: Tooling Improvements for ARC-1
+
+> **Source:** Erfahrungsbericht STO-956267 — real-world SAP ISU analysis using arc-1 in Cursor
+> **Date:** 2026-03-31
+> **Goal:** Turn each piece of feedback into actionable implementation items with code-level analysis
+
+---
+
+## Overview
+
+The experience report describes an SAP BPEM/MSCONS incident analysis performed entirely through arc-1 MCP tools, without SAP GUI. The analysis successfully identified the root cause, validating the core value proposition. However, several friction points were identified that caused unnecessary round-trips and required deep SAP internals knowledge.
+
+This document researches each feedback item in detail, analyzes the current codebase, and proposes concrete implementation approaches.
+
+---
+
+## Issue 1: 401 Error Message Missing Client Information
+
+**Impact:** High — caused ~15 minutes of debugging on first use
+**Effort:** Low — localized change in error formatting
+
+### Current Behavior
+
+When authentication fails, the error flows through two paths:
+
+1. **CSRF token fetch** (`ts-src/adt/http.ts:401-406`):
+   ```typescript
+   throw new AdtApiError(
+     'Authentication failed (401): check username/password',
+     401,
+     '/sap/bc/adt/core/discovery',
+   );
+   ```
+
+2. **LLM error formatter** (`ts-src/handlers/intent.ts:77-79`):
+   ```typescript
+   if (err.isUnauthorized || err.isForbidden) {
+     return `${message}\n\nHint: Authorization error. The configured SAP user may lack permissions for this object.`;
+   }
+   ```
+
+Neither path includes the configured `SAP_CLIENT`, even though the HTTP client has it available in `this.config.client` (`ts-src/adt/http.ts:455-457`).
+
+### Proposed Implementation
+
+**Option A — Enrich AdtApiError at throw site** (recommended):
+
+In `ts-src/adt/http.ts:401-406`, include the client in the message:
+
+```typescript
+throw new AdtApiError(
+  `Authentication failed (401): check username/password (sap-client=${this.config.client ?? '001'})`,
+  401,
+  '/sap/bc/adt/core/discovery',
+);
+```
+
+**Option B — Add context field to AdtApiError**:
+
+Extend `AdtApiError` (`ts-src/adt/errors.ts:27-36`) with an optional `context` map:
+
+```typescript
+export class AdtApiError extends AdtError {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly path: string,
+    public readonly responseBody?: string,
+    public readonly context?: Record<string, string>,
+  ) { ... }
+}
+```
+
+Then in `formatErrorForLLM` (`ts-src/handlers/intent.ts:77-79`), append context:
+
+```typescript
+if (err.isUnauthorized || err.isForbidden) {
+  const client = err.context?.['sap-client'] ?? 'unknown';
+  return `${message}\n\nHint: Authorization error using sap-client=${client}. Check SAP_CLIENT env variable (default: '001') and verify username/password.`;
+}
+```
+
+**Recommendation:** Option A is simpler and sufficient. Option B is more extensible if we want to enrich other error types too.
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `ts-src/adt/http.ts:402-403` | Include `this.config.client` in 401 error message |
+| `ts-src/adt/http.ts:409` | Include `this.config.client` in 403 error message |
+| `ts-src/handlers/intent.ts:77-79` | Append client info hint to auth error messages |
+| `tests/unit/adt/http.test.ts` | Update expected error message in 401 test |
+
+---
+
+## Issue 2: SAPRead FUNC Requires group Parameter (Auto-Resolve)
+
+**Impact:** Medium — every FM read requires 2 calls instead of 1
+**Effort:** Medium — needs a new lookup method + handler change
+
+### Current Behavior
+
+`getFunction()` (`ts-src/adt/client.ts:117-123`) requires both `group` and `name`:
+
+```typescript
+async getFunction(group: string, name: string): Promise<string> {
+  const resp = await this.http.get(
+    `/sap/bc/adt/functions/groups/${encodeURIComponent(group)}/fmodules/${encodeURIComponent(name)}/source/main`,
+  );
+  return resp.body;
+}
+```
+
+The handler (`ts-src/handlers/intent.ts:251`) passes group as-is, defaulting to empty string:
+```typescript
+case 'FUNC':
+  return textResult(await client.getFunction(String(args.group ?? ''), name));
+```
+
+The tool description (`ts-src/handlers/tools.ts:28`) explicitly states "requires group param".
+
+### Proposed Implementation
+
+Add an auto-resolve method to `AdtClient`:
+
+```typescript
+/** Resolve function group for a function module via quickSearch */
+async resolveFunctionGroup(fmName: string): Promise<string | null> {
+  const results = await this.searchObject(fmName, 5);
+  // Search results contain URIs like /sap/bc/adt/functions/groups/z_bpt1/fmodules/z_bcontact_input
+  for (const r of results) {
+    if (r.objectName.toUpperCase() === fmName.toUpperCase() && r.uri.includes('/groups/')) {
+      const match = r.uri.match(/\/groups\/([^/]+)\//);
+      if (match) return match[1].toUpperCase();
+    }
+  }
+  return null;
+}
+```
+
+Then update the handler:
+
+```typescript
+case 'FUNC': {
+  let group = String(args.group ?? '');
+  if (!group) {
+    const resolved = await client.resolveFunctionGroup(name);
+    if (!resolved) {
+      return errorResult(`Cannot resolve function group for "${name}". Provide the group parameter explicitly, or use SAPSearch("${name}") to find it.`);
+    }
+    group = resolved;
+  }
+  return textResult(await client.getFunction(group, name));
+}
+```
+
+Update the tool description to say "group param is optional — auto-resolved if omitted".
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `ts-src/adt/client.ts` | Add `resolveFunctionGroup()` method |
+| `ts-src/handlers/intent.ts:250-251` | Auto-resolve group when missing |
+| `ts-src/handlers/tools.ts:28` | Update description: group is optional |
+| `tests/unit/handlers/intent.test.ts` | Test auto-resolve flow |
+| `tests/unit/adt/client.test.ts` | Test `resolveFunctionGroup()` |
+
+### Trade-offs
+
+- Adds one extra HTTP call when group is omitted (search + read vs just read)
+- But eliminates the need for the LLM to make two separate tool calls, saving a full round-trip
+- Net improvement: 1 tool call instead of 2 (at the cost of 1 internal HTTP call)
+
+---
+
+## Issue 3: FUGR Includes Not Expandable
+
+**Impact:** Medium — FUGR reads return only top-level include list, not actual code
+**Effort:** Medium — needs orchestration logic to fetch includes
+
+### Current Behavior
+
+`getFunctionGroup()` (`ts-src/adt/client.ts:126-130`) returns structure only:
+```typescript
+async getFunctionGroup(name: string): Promise<{ name: string; functions: string[] }> {
+  const resp = await this.http.get(`/sap/bc/adt/functions/groups/${encodeURIComponent(name)}`);
+  return parseFunctionGroup(resp.body);
+}
+```
+
+`getFunctionGroupSource()` (`ts-src/adt/client.ts:133-137`) returns top-level source with `INCLUDE` statements.
+
+`getInclude()` (`ts-src/adt/client.ts:140-144`) exists and uses the endpoint:
+```
+/sap/bc/adt/programs/includes/{name}/source/main
+```
+
+The report says this returned HTTP 406/404 — this may be an issue with specific include naming conventions (LZ_BPT1I01 vs standard includes) or Accept headers.
+
+### Proposed Implementation
+
+**Step 1: Investigate Include reading reliability**
+
+The `getInclude()` method exists. The 406/404 errors reported may be due to:
+- Include names needing different URL encoding
+- Some includes (PAI/PBO modules) using a different ADT endpoint
+- Missing Accept header (`text/plain` vs `application/xml`)
+
+Need to test `getInclude()` against various include types (TOP, I01, O01, F01, etc.).
+
+**Step 2: Add expand_includes option to FUGR read**
+
+```typescript
+case 'FUGR': {
+  const expand = Boolean(args.expand_includes ?? false);
+  if (expand) {
+    const source = await client.getFunctionGroupSource(name);
+    const includePattern = /INCLUDE\s+(\S+)\./gi;
+    const parts: string[] = [`=== FUGR ${name} (main) ===\n${source}`];
+    let m: RegExpExecArray | null;
+    while ((m = includePattern.exec(source)) !== null) {
+      try {
+        const inclSource = await client.getInclude(m[1]);
+        parts.push(`\n=== ${m[1]} ===\n${inclSource}`);
+      } catch {
+        parts.push(`\n=== ${m[1]} ===\n[Could not read include]`);
+      }
+    }
+    return textResult(parts.join('\n'));
+  }
+  const fg = await client.getFunctionGroup(name);
+  return textResult(JSON.stringify(fg, null, 2));
+}
+```
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `ts-src/adt/client.ts` | Investigate/fix `getInclude()` for PAI/PBO includes |
+| `ts-src/handlers/intent.ts:252-255` | Add `expand_includes` option |
+| `ts-src/handlers/tools.ts` | Add `expand_includes` param to SAPRead schema |
+| `tests/integration/adt.integration.test.ts` | Add FUGR include expansion test |
+
+---
+
+## Issue 4: No Source Code Full-Text Search
+
+**Impact:** Very High — "would save 30-40% of exploratory tool calls"
+**Effort:** High — SAP ADT may not expose a direct code search endpoint
+
+### Current Behavior
+
+`searchObject()` (`ts-src/adt/client.ts:184-190`) only searches by object **name** pattern:
+```
+/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=...
+```
+
+There is no method to search within source code content.
+
+### SAP ADT API Analysis
+
+SAP ADT offers several search-related endpoints:
+
+1. **Quick Search** (currently used): `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch` — object name only
+2. **Where-Used List**: `/sap/bc/adt/repository/informationsystem/usageReferences` — already exposed via SAPNavigate references
+3. **Code Search** (if available on system): `/sap/bc/adt/repository/informationsystem/textSearch` — full-text search within ABAP source code. Availability depends on SAP kernel version (≥7.51 typically).
+
+### Proposed Implementation
+
+**Option A — ADT Text Search endpoint** (preferred if available):
+
+```typescript
+async searchSource(
+  pattern: string,
+  objectType?: string,
+  packageName?: string,
+  maxResults = 50,
+): Promise<SourceSearchResult[]> {
+  checkOperation(this.safety, OperationType.Search, 'SearchSource');
+  let url = `/sap/bc/adt/repository/informationsystem/textSearch?searchString=${encodeURIComponent(pattern)}&maxResults=${maxResults}`;
+  if (objectType) url += `&objectType=${encodeURIComponent(objectType)}`;
+  if (packageName) url += `&packageName=${encodeURIComponent(packageName)}`;
+  const resp = await this.http.get(url);
+  return parseSourceSearchResults(resp.body);
+}
+```
+
+This would be exposed as either:
+- A new `SAPSearch` parameter: `SAPSearch(query="cl_lsapi_manager", searchType="source_code")`
+- Or a new action in an existing tool
+
+**Option B — Client-side search** (fallback):
+
+Fetch all objects in a package, read their sources, and grep locally. This is slow and impractical for large codebases — only viable for targeted searches within a known small scope.
+
+### Feasibility Assessment
+
+The `/sap/bc/adt/repository/informationsystem/textSearch` endpoint needs to be validated against the target SAP systems. This is a feature detection scenario — should be gated behind the existing feature detection system (`ts-src/adt/features.ts`).
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `ts-src/adt/client.ts` | Add `searchSource()` method |
+| `ts-src/adt/xml-parser.ts` | Add `parseSourceSearchResults()` |
+| `ts-src/adt/types.ts` | Add `SourceSearchResult` type |
+| `ts-src/adt/features.ts` | Add feature detection for text search capability |
+| `ts-src/handlers/intent.ts` | Route `searchType="source_code"` in SAPSearch handler |
+| `ts-src/handlers/tools.ts` | Add `searchType` param to SAPSearch schema |
+| `tests/unit/adt/xml-parser.test.ts` | Add parser tests with fixture XML |
+
+---
+
+## Issue 5: BOR Object Methods Not Directly Readable
+
+**Impact:** Medium — BOR objects are common in SAP ISU/Utilities
+**Effort:** Medium — needs BOR-specific ADT endpoints or workaround
+
+### Current Behavior
+
+SAPSearch finds BOR objects (type SOBJ/MO, SOBJ/P) but SAPRead has no `SOBJ` type handler. The workaround requires:
+1. Query `SWOTLV` table for method→program mapping
+2. Read the program via `SAPRead(type="PROG", ...)`
+
+### Proposed Implementation
+
+**Option A — Add SOBJ type to SAPRead**:
+
+BOR object implementations are stored as regular ABAP programs with the same name as the BOR object type. The method implementations are `FORM` routines in that program.
+
+```typescript
+case 'SOBJ': {
+  // BOR object — read implementation program + method catalog from SWOTLV
+  const source = await client.getProgram(name);
+  // Optionally: query SWOTLV for method listing
+  return textResult(source);
+}
+```
+
+This is simple but doesn't provide the method catalog.
+
+**Option B — Add SOBJ type with method catalog** (better):
+
+```typescript
+case 'SOBJ': {
+  const method = String(args.method ?? '');
+  if (method) {
+    // Read specific BOR method via SWOTLV lookup
+    const data = await client.runQuery(
+      `SELECT progname, formname FROM swotlv WHERE lobjtype = '${name}' AND verb = '${method}'`, 1
+    );
+    if (data.rows.length > 0) {
+      const prog = data.rows[0].PROGNAME;
+      const source = await client.getProgram(prog);
+      return textResult(source);
+    }
+    return errorResult(`BOR method "${method}" not found on object type "${name}".`);
+  }
+  // List all methods
+  const methods = await client.runQuery(
+    `SELECT verb, progname, formname, descript FROM swotlv WHERE lobjtype = '${name}'`, 100
+  );
+  return textResult(JSON.stringify(methods, null, 2));
+}
+```
+
+**Note:** Option B uses SQL queries internally, which means it requires FreeSQL permission. This should be documented, or a dedicated ADT endpoint for BOR metadata should be investigated.
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `ts-src/handlers/intent.ts:243-293` | Add `SOBJ` case in SAPRead switch |
+| `ts-src/handlers/tools.ts:28` | Add SOBJ to supported types list, add `method` param |
+| `tests/unit/handlers/intent.test.ts` | Add SOBJ handler tests |
+
+---
+
+## Issue 6: SAPQuery "Did You Mean?" for Unknown Tables
+
+**Impact:** Low-Medium — quality-of-life improvement for exploratory queries
+**Effort:** Low — add a DDIC lookup on 404
+
+### Current Behavior
+
+When a table doesn't exist, `runQuery()` (`ts-src/adt/client.ts:225-229`) returns an `AdtApiError` with 404 status. The `formatErrorForLLM()` (`ts-src/handlers/intent.ts:72-76`) suggests using SAPSearch but doesn't suggest similar table names:
+
+```typescript
+if (err.isNotFound) {
+  return `${message}\n\nHint: Object "${name}" (type ${type}) was not found. Use SAPSearch with query "${name}" to verify...`;
+}
+```
+
+### Proposed Implementation
+
+In `handleSAPQuery` (`ts-src/handlers/intent.ts:303-308`), catch 404 errors and perform a fuzzy DDIC lookup:
+
+```typescript
+async function handleSAPQuery(client: AdtClient, args: Record<string, unknown>): Promise<ToolResult> {
+  const sql = String(args.sql ?? '');
+  const maxRows = Number(args.maxRows ?? 100);
+  try {
+    const data = await client.runQuery(sql, maxRows);
+    return textResult(JSON.stringify(data, null, 2));
+  } catch (err) {
+    if (err instanceof AdtApiError && err.isNotFound) {
+      // Extract table name from SQL
+      const tableMatch = sql.match(/FROM\s+(\S+)/i);
+      if (tableMatch) {
+        const tableName = tableMatch[1];
+        try {
+          const suggestions = await client.searchObject(`${tableName}*`, 5);
+          const names = suggestions.map(s => s.objectName).join(', ');
+          if (names) {
+            return errorResult(
+              `Table "${tableName}" not found.\n\nDid you mean: ${names}\n\nUse SAPSearch("${tableName}*") for more results.`
+            );
+          }
+        } catch { /* ignore search errors */ }
+      }
+    }
+    throw err;
+  }
+}
+```
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `ts-src/handlers/intent.ts:303-308` | Add try/catch with DDIC suggestion lookup |
+| `tests/unit/handlers/intent.test.ts` | Add "did you mean" test |
+
+---
+
+## Issue 7: SAPNavigate References Requires URI (No Symbolic Lookup)
+
+**Impact:** Medium — references work but require knowing the full ADT URI
+**Effort:** Low — add type/name → URI resolution
+
+### Current Behavior
+
+`findReferences()` (`ts-src/adt/codeintel.ts:70-97`) accepts an `objectUrl` string. The handler (`ts-src/handlers/intent.ts:444-450`) passes the URI directly from args.
+
+The LLM must know the full ADT URI (e.g., `/sap/bc/adt/programs/programs/ZTEST`) to use references. For explorative analysis, the user wants to say "find all references to BAPI_EMMA_CASE_COMPLETE" without knowing the URI.
+
+### Proposed Implementation
+
+There's already a pattern for type→URI mapping in the codebase. Check if `objectUrlForType()` exists in the SAPDiagnose handler (`ts-src/handlers/intent.ts:466`).
+
+Add a fallback in the SAPNavigate references handler:
+
+```typescript
+case 'references': {
+  let targetUri = uri;
+  if (!targetUri && args.type && args.name) {
+    targetUri = objectUrlForType(String(args.type), String(args.name));
+  }
+  if (!targetUri) {
+    return errorResult('Provide either uri, or type+name to find references.');
+  }
+  const results = await findReferences(client.http, client.safety, targetUri);
+  ...
+}
+```
+
+This reuses the existing `objectUrlForType()` utility and makes the `uri` parameter optional when `type` + `name` are provided.
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `ts-src/handlers/intent.ts:444-450` | Add type/name → URI resolution fallback |
+| `ts-src/handlers/tools.ts` | Update SAPNavigate schema: uri optional when type+name given |
+| `tests/unit/handlers/intent.test.ts` | Test symbolic reference lookup |
+
+---
+
+## Priority Matrix
+
+| # | Issue | Impact | Effort | Priority |
+|---|-------|--------|--------|----------|
+| 1 | 401 error with client info | High | Low | **P1** |
+| 2 | FUNC auto-resolve group | Medium | Medium | **P1** |
+| 3 | FUGR include expansion | Medium | Medium | **P2** |
+| 4 | Source code full-text search | Very High | High | **P1** (investigate ADT endpoint first) |
+| 5 | BOR object reading (SOBJ) | Medium | Medium | **P2** |
+| 6 | SAPQuery "did you mean?" | Low-Med | Low | **P3** |
+| 7 | SAPNavigate symbolic refs | Medium | Low | **P2** |
+
+### Suggested Implementation Order
+
+1. **Issue 1** — 401 error message (quick win, immediate user impact)
+2. **Issue 2** — FUNC auto-resolve (eliminates most common friction)
+3. **Issue 7** — Symbolic reference lookup (low effort, reuses existing code)
+4. **Issue 4** — Source code search (highest impact but needs ADT endpoint investigation)
+5. **Issue 3** — FUGR include expansion (needs include reading reliability investigation)
+6. **Issue 5** — BOR object support (domain-specific, ISU-heavy use cases)
+7. **Issue 6** — Query suggestions (nice-to-have)
+
+---
+
+## Additional Observations from the Report
+
+### What Worked Exceptionally Well
+
+- **SAPSearch** structured JSON output (objectType, packageName, description, uri) enables immediate LLM-driven follow-up without human intervention
+- **SAPQuery** on metadata tables (DD02L, SWOTLV, EMMAC_CCAT_SOP) is the most powerful reverse-engineering tool — this should be highlighted in documentation
+- **SAPRead CLAS** delivering full source in one call (definition + implementation) is exactly the right granularity for LLM analysis
+
+### Documentation Improvements
+
+The report reveals that the LLM needed deep SAP internals knowledge (SWOTLV table, BOR architecture, DDIC discovery patterns). This suggests the tool descriptions in `ts-src/handlers/tools.ts` could include more SAP-specific guidance:
+
+- SAPQuery description should mention common metadata tables (DD02L, DD03L, SWOTLV, TADIR)
+- SAPSearch description should mention that BOR objects appear as SOBJ type
+- SAPRead FUGR description should mention that it returns structure only, not source
+
+---
+
+*Generated from user experience report analyzing SAP incident STO-956267 via arc-1 MCP tools*

--- a/tests/integration/adt.integration.test.ts
+++ b/tests/integration/adt.integration.test.ts
@@ -240,6 +240,7 @@ describeIf('ADT Integration Tests', () => {
         baseUrl: process.env.TEST_SAP_URL || process.env.SAP_URL || '',
         username: process.env.TEST_SAP_USER || process.env.SAP_USER || '',
         password: process.env.TEST_SAP_PASSWORD || process.env.SAP_PASSWORD || '',
+        client: process.env.TEST_SAP_CLIENT || process.env.SAP_CLIENT || '100',
         insecure: (process.env.TEST_SAP_INSECURE || process.env.SAP_INSECURE) === 'true',
         safety: {
           readOnly: true,
@@ -266,6 +267,7 @@ describeIf('ADT Integration Tests', () => {
         baseUrl: process.env.TEST_SAP_URL || process.env.SAP_URL || '',
         username: process.env.TEST_SAP_USER || process.env.SAP_USER || '',
         password: process.env.TEST_SAP_PASSWORD || process.env.SAP_PASSWORD || '',
+        client: process.env.TEST_SAP_CLIENT || process.env.SAP_CLIENT || '100',
         insecure: (process.env.TEST_SAP_INSECURE || process.env.SAP_INSECURE) === 'true',
         safety: {
           readOnly: true,
@@ -291,6 +293,7 @@ describeIf('ADT Integration Tests', () => {
         baseUrl: process.env.TEST_SAP_URL || process.env.SAP_URL || '',
         username: process.env.TEST_SAP_USER || process.env.SAP_USER || '',
         password: process.env.TEST_SAP_PASSWORD || process.env.SAP_PASSWORD || '',
+        client: process.env.TEST_SAP_CLIENT || process.env.SAP_CLIENT || '100',
         insecure: (process.env.TEST_SAP_INSECURE || process.env.SAP_INSECURE) === 'true',
         safety: {
           readOnly: true,

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -8,7 +8,7 @@
  *   TEST_SAP_URL      > SAP_URL
  *   TEST_SAP_USER     > SAP_USER
  *   TEST_SAP_PASSWORD > SAP_PASSWORD
- *   TEST_SAP_CLIENT   > SAP_CLIENT   (default: 001)
+ *   TEST_SAP_CLIENT   > SAP_CLIENT   (default: 100)
  *   TEST_SAP_LANGUAGE > SAP_LANGUAGE  (default: EN)
  *   TEST_SAP_INSECURE > SAP_INSECURE (default: false)
  *
@@ -36,7 +36,7 @@ export function getTestClient(): AdtClient {
   const url = process.env.TEST_SAP_URL || process.env.SAP_URL || '';
   const username = process.env.TEST_SAP_USER || process.env.SAP_USER || '';
   const password = process.env.TEST_SAP_PASSWORD || process.env.SAP_PASSWORD || '';
-  const client = process.env.TEST_SAP_CLIENT || process.env.SAP_CLIENT || '001';
+  const client = process.env.TEST_SAP_CLIENT || process.env.SAP_CLIENT || '100';
   const language = process.env.TEST_SAP_LANGUAGE || process.env.SAP_LANGUAGE || 'EN';
   const insecure = (process.env.TEST_SAP_INSECURE || process.env.SAP_INSECURE) === 'true';
 

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -364,7 +364,7 @@ describe('AdtHttpClient', () => {
       await expect(client.get('/sap/bc/adt/core/discovery')).rejects.toThrow(AdtApiError);
     });
 
-    it('throws AdtApiError on 401 during CSRF fetch', async () => {
+    it('throws AdtApiError on 401 during CSRF fetch with client info', async () => {
       mockRequest.mockResolvedValueOnce({
         status: 401,
         data: 'Unauthorized',
@@ -372,7 +372,7 @@ describe('AdtHttpClient', () => {
       });
 
       const client = new AdtHttpClient(getDefaultConfig());
-      await expect(client.fetchCsrfToken()).rejects.toThrow(AdtApiError);
+      await expect(client.fetchCsrfToken()).rejects.toThrow(/sap-client=001/);
     });
 
     it('throws AdtApiError on 403 during CSRF fetch', async () => {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -571,9 +571,7 @@ ENDCLASS.`;
     it('401 error includes client hint', async () => {
       const mockInstance = (axios.create as any)();
       const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
-      requestSpy.mockRejectedValueOnce(
-        new AdtApiError('Auth failed', 401, '/sap/bc/adt/core/discovery'),
-      );
+      requestSpy.mockRejectedValueOnce(new AdtApiError('Auth failed', 401, '/sap/bc/adt/core/discovery'));
       const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
         type: 'PROG',
         name: 'ZTEST',
@@ -776,7 +774,7 @@ ENDCLASS.`;
       // Read program source (GET - no CSRF needed)
       requestSpy.mockResolvedValueOnce({
         status: 200,
-        data: "REPORT zprog1.\nFORM create_obj.\nENDFORM.",
+        data: 'REPORT zprog1.\nFORM create_obj.\nENDFORM.',
         headers: {},
       });
       const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -567,5 +567,265 @@ ENDCLASS.`;
       expect(result.content[0]?.text).toContain('SAPSearch');
       expect(result.content[0]?.text).toContain('ZNONEXIST');
     });
+
+    it('401 error includes client hint', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      requestSpy.mockRejectedValueOnce(
+        new AdtApiError('Auth failed', 401, '/sap/bc/adt/core/discovery'),
+      );
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'PROG',
+        name: 'ZTEST',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('SAP_CLIENT');
+    });
+  });
+
+  // ─── Issue 2: FUNC auto-resolve group ───────────────────────────────
+
+  describe('FUNC auto-resolve group', () => {
+    it('reads FUNC without group by auto-resolving via search', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      // First call: search for FM → returns result with URI containing group
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: `<objectReferences><objectReference type="FUGR/FF" name="Z_MY_FUNC" uri="/sap/bc/adt/functions/groups/zgroup/fmodules/z_my_func" packageName="ZTEST" description="Test FM"/></objectReferences>`,
+        headers: {},
+      });
+      // Second call: read the FM source
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: 'FUNCTION z_my_func.\nENDFUNCTION.',
+        headers: {},
+      });
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'FUNC',
+        name: 'Z_MY_FUNC',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('FUNCTION z_my_func');
+    });
+
+    it('returns error when FUNC group cannot be resolved', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      // Search returns empty results
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: '<objectReferences/>',
+        headers: {},
+      });
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'FUNC',
+        name: 'Z_NONEXIST_FM',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('Cannot resolve function group');
+    });
+  });
+
+  // ─── Issue 3: FUGR include expansion ────────────────────────────────
+
+  describe('FUGR include expansion', () => {
+    it('reads FUGR with expand_includes=true', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      // First call: read FUGR main source
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: 'INCLUDE LZ_TESTTOP.\nINCLUDE LZ_TESTI01.',
+        headers: {},
+      });
+      // Second call: read first include
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: 'DATA: gv_test TYPE string.',
+        headers: {},
+      });
+      // Third call: read second include
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: 'MODULE user_command_0100 INPUT.\nENDMODULE.',
+        headers: {},
+      });
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'FUGR',
+        name: 'Z_TEST',
+        expand_includes: true,
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('=== FUGR Z_TEST (main) ===');
+      expect(result.content[0]?.text).toContain('=== LZ_TESTTOP ===');
+      expect(result.content[0]?.text).toContain('DATA: gv_test');
+      expect(result.content[0]?.text).toContain('=== LZ_TESTI01 ===');
+    });
+
+    it('handles failed includes gracefully', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      // Main source
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: 'INCLUDE LZ_BADINCL.',
+        headers: {},
+      });
+      // Include read fails
+      requestSpy.mockRejectedValueOnce(
+        new AdtApiError('Not found', 404, '/sap/bc/adt/programs/includes/LZ_BADINCL/source/main'),
+      );
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'FUGR',
+        name: 'Z_TEST',
+        expand_includes: true,
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('Could not read include');
+    });
+  });
+
+  // ─── Issue 4: Source code search ────────────────────────────────────
+
+  describe('SAPSearch source code', () => {
+    it('searches source code with searchType=source_code', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: `<objectReferences><objectReference type="CLAS/OC" name="ZCL_TEST" uri="/sap/bc/adt/oo/classes/zcl_test"/></objectReferences>`,
+        headers: {},
+      });
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPSearch', {
+        query: 'cl_lsapi_manager',
+        searchType: 'source_code',
+      });
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].objectName).toBe('ZCL_TEST');
+    });
+
+    it('returns helpful error when source search is not available', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      requestSpy.mockRejectedValueOnce(
+        new AdtApiError('Not found', 404, '/sap/bc/adt/repository/informationsystem/textSearch'),
+      );
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPSearch', {
+        query: 'test_pattern',
+        searchType: 'source_code',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('not available on this SAP system');
+    });
+  });
+
+  // ─── Issue 5: SOBJ/BOR reading ──────────────────────────────────────
+
+  describe('SAPRead SOBJ', () => {
+    it('lists BOR methods when no method specified', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      // CSRF HEAD request (POST triggers CSRF fetch)
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: '',
+        headers: { 'x-csrf-token': 'TOKEN123' },
+      });
+      // runQuery POST returns SWOTLV data
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: `<abap><values><COLUMNS>
+          <COLUMN><METADATA name="VERB"/><DATASET><DATA>CREATE</DATA><DATA>DISPLAY</DATA></DATASET></COLUMN>
+          <COLUMN><METADATA name="PROGNAME"/><DATASET><DATA>ZPROG1</DATA><DATA>ZPROG2</DATA></DATASET></COLUMN>
+          <COLUMN><METADATA name="FORMNAME"/><DATASET><DATA>CREATE_OBJ</DATA><DATA>DISPLAY_OBJ</DATA></DATASET></COLUMN>
+          <COLUMN><METADATA name="DESCRIPT"/><DATASET><DATA>Create</DATA><DATA>Display</DATA></DATASET></COLUMN>
+        </COLUMNS></values></abap>`,
+        headers: {},
+      });
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'SOBJ',
+        name: 'ZBUS_OBJ',
+      });
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text);
+      expect(parsed.columns).toContain('VERB');
+      expect(parsed.rows).toHaveLength(2);
+    });
+
+    it('reads specific BOR method implementation', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      // CSRF HEAD request
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: '',
+        headers: { 'x-csrf-token': 'TOKEN123' },
+      });
+      // SWOTLV query POST returns program+form
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: `<abap><values><COLUMNS>
+          <COLUMN><METADATA name="PROGNAME"/><DATASET><DATA>ZPROG1</DATA></DATASET></COLUMN>
+          <COLUMN><METADATA name="FORMNAME"/><DATASET><DATA>CREATE_OBJ</DATA></DATASET></COLUMN>
+        </COLUMNS></values></abap>`,
+        headers: {},
+      });
+      // Read program source (GET - no CSRF needed)
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: "REPORT zprog1.\nFORM create_obj.\nENDFORM.",
+        headers: {},
+      });
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'SOBJ',
+        name: 'ZBUS_OBJ',
+        method: 'CREATE',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('BOR ZBUS_OBJ.CREATE');
+      expect(result.content[0]?.text).toContain('REPORT zprog1');
+    });
+  });
+
+  // ─── Issue 7: SAPNavigate symbolic references ──────────────────────
+
+  describe('SAPNavigate symbolic references', () => {
+    it('resolves type+name to URI for references action', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: `<usageReferences><objectReference uri="/sap/bc/adt/programs/programs/zcaller" type="PROG/P" name="ZCALLER"/></usageReferences>`,
+        headers: {},
+      });
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPNavigate', {
+        action: 'references',
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+      });
+      expect(result.isError).toBeUndefined();
+      // Should not get "No references found" since we have a match
+      const parsed = JSON.parse(result.content[0]?.text);
+      expect(parsed).toHaveLength(1);
+    });
+
+    it('returns error when neither uri nor type+name provided for references', async () => {
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPNavigate', {
+        action: 'references',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('Provide uri or type+name');
+    });
+
+    it('returns error when neither uri nor type+name provided for definition', async () => {
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPNavigate', {
+        action: 'definition',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('Provide uri');
+    });
   });
 });

--- a/tests/unit/server/config.test.ts
+++ b/tests/unit/server/config.test.ts
@@ -21,7 +21,7 @@ describe('parseArgs', () => {
   it('returns defaults when no args or env vars', () => {
     const config = parseArgs([]);
     expect(config.url).toBe('');
-    expect(config.client).toBe('001');
+    expect(config.client).toBe('100');
     expect(config.language).toBe('EN');
     expect(config.transport).toBe('stdio');
     expect(config.readOnly).toBe(false);

--- a/ts-src/adt/btp.ts
+++ b/ts-src/adt/btp.ts
@@ -513,7 +513,7 @@ export async function resolveBTPDestination(destinationName: string): Promise<{
     url: dest.URL,
     username: dest.User,
     password: dest.Password,
-    client: dest['sap-client'] || '001',
+    client: dest['sap-client'] || '100',
     proxy,
   };
 }

--- a/ts-src/adt/client.ts
+++ b/ts-src/adt/client.ts
@@ -21,12 +21,13 @@ import { defaultAdtClientConfig } from './config.js';
 import { isNotFoundError } from './errors.js';
 import { AdtHttpClient, type AdtHttpConfig } from './http.js';
 import { checkOperation, OperationType, type SafetyConfig } from './safety.js';
-import type { AdtSearchResult } from './types.js';
+import type { AdtSearchResult, SourceSearchResult } from './types.js';
 import {
   parseFunctionGroup,
   parseInstalledComponents,
   parsePackageContents,
   parseSearchResults,
+  parseSourceSearchResults,
   parseSystemInfo,
   parseTableContents,
 } from './xml-parser.js';
@@ -130,6 +131,18 @@ export class AdtClient {
     return resp.body;
   }
 
+  /** Resolve function group for a function module via quickSearch */
+  async resolveFunctionGroup(fmName: string): Promise<string | null> {
+    const results = await this.searchObject(fmName, 10);
+    for (const r of results) {
+      if (r.objectName.toUpperCase() === fmName.toUpperCase() && r.uri.includes('/groups/')) {
+        const match = r.uri.match(/\/groups\/([^/]+)\//);
+        if (match) return match[1]!.toUpperCase();
+      }
+    }
+    return null;
+  }
+
   /** Get function group structure (list of function modules) */
   async getFunctionGroup(name: string): Promise<{ name: string; functions: string[] }> {
     checkOperation(this.safety, OperationType.Read, 'GetFunctionGroup');
@@ -195,6 +208,21 @@ export class AdtClient {
       `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=${encodeURIComponent(query)}&maxResults=${maxResults}`,
     );
     return parseSearchResults(resp.body);
+  }
+
+  /** Search within ABAP source code (full-text search) */
+  async searchSource(
+    pattern: string,
+    maxResults = 50,
+    objectType?: string,
+    packageName?: string,
+  ): Promise<SourceSearchResult[]> {
+    checkOperation(this.safety, OperationType.Search, 'SearchSource');
+    let url = `/sap/bc/adt/repository/informationsystem/textSearch?searchString=${encodeURIComponent(pattern)}&maxResults=${maxResults}`;
+    if (objectType) url += `&objectType=${encodeURIComponent(objectType)}`;
+    if (packageName) url += `&packageName=${encodeURIComponent(packageName)}`;
+    const resp = await this.http.get(url);
+    return parseSourceSearchResults(resp.body);
   }
 
   // ─── Package Operations ────────────────────────────────────────────

--- a/ts-src/adt/config.ts
+++ b/ts-src/adt/config.ts
@@ -43,7 +43,7 @@ export interface AdtClientConfig {
   username: string;
   /** SAP password */
   password: string;
-  /** SAP client number (default: "001") */
+  /** SAP client number (default: "100") */
   client: string;
   /** SAP language (default: "EN") */
   language: string;
@@ -82,7 +82,7 @@ export function defaultAdtClientConfig(): AdtClientConfig {
     baseUrl: '',
     username: '',
     password: '',
-    client: '001',
+    client: '100',
     language: 'EN',
     insecure: false,
     cookies: {},

--- a/ts-src/adt/http.ts
+++ b/ts-src/adt/http.ts
@@ -400,13 +400,17 @@ export class AdtHttpClient {
       if (!token || token === 'Required') {
         if (response.status === 401) {
           throw new AdtApiError(
-            'Authentication failed (401): check username/password',
+            `Authentication failed (401) using sap-client=${this.config.client ?? '100'}. Check SAP_CLIENT, SAP_USER, and SAP_PASSWORD.`,
             401,
             '/sap/bc/adt/core/discovery',
           );
         }
         if (response.status === 403) {
-          throw new AdtApiError('Access forbidden (403): check user authorizations', 403, '/sap/bc/adt/core/discovery');
+          throw new AdtApiError(
+            `Access forbidden (403) using sap-client=${this.config.client ?? '100'}. Check user authorizations.`,
+            403,
+            '/sap/bc/adt/core/discovery',
+          );
         }
         throw new AdtApiError(
           `No CSRF token in response (HTTP ${response.status})`,

--- a/ts-src/adt/types.ts
+++ b/ts-src/adt/types.ts
@@ -91,6 +91,17 @@ export interface TransportTask {
   status: string;
 }
 
+/** Source code search result */
+export interface SourceSearchResult {
+  objectType: string;
+  objectName: string;
+  uri: string;
+  matches: Array<{
+    line: number;
+    snippet: string;
+  }>;
+}
+
 /** Table structure */
 export interface TableField {
   name: string;

--- a/ts-src/adt/xml-parser.ts
+++ b/ts-src/adt/xml-parser.ts
@@ -15,7 +15,7 @@
  */
 
 import { XMLParser } from 'fast-xml-parser';
-import type { AdtSearchResult } from './types.js';
+import type { AdtSearchResult, SourceSearchResult } from './types.js';
 
 /** Shared parser instance — configured for ADT XML conventions */
 const parser = new XMLParser({
@@ -245,6 +245,64 @@ export function parseSystemInfo(
   }
 
   return { user: username ?? '', collections };
+}
+
+/**
+ * Parse ADT source/text search results.
+ *
+ * The textSearch endpoint returns results as either XML with objectReference elements
+ * containing match details, or an Atom-like feed. We handle both formats.
+ */
+export function parseSourceSearchResults(xml: string): SourceSearchResult[] {
+  const parsed = parseXml(xml);
+  const results: SourceSearchResult[] = [];
+
+  // Try objectReferences format (similar to quickSearch)
+  const refs = getNestedArray(parsed, 'objectReferences', 'objectReference');
+  if (refs.length > 0) {
+    for (const ref of refs) {
+      results.push({
+        objectType: String(ref['@_type'] ?? ''),
+        objectName: String(ref['@_name'] ?? ''),
+        uri: String(ref['@_uri'] ?? ''),
+        matches: [],
+      });
+    }
+    return results;
+  }
+
+  // Try Atom feed format
+  const entries = getNestedArray(parsed, 'feed', 'entry');
+  for (const entry of entries) {
+    const uri = String(entry.id ?? entry['@_href'] ?? '');
+    const title = String(entry.title ?? '');
+    results.push({
+      objectType: '',
+      objectName: title || uri.split('/').pop() || '',
+      uri,
+      matches: [],
+    });
+  }
+
+  // Fallback: try to find any matching nodes
+  if (results.length === 0) {
+    const nodes = findDeepNodes(parsed, 'match');
+    for (const node of nodes) {
+      results.push({
+        objectType: String(node['@_type'] ?? ''),
+        objectName: String(node['@_name'] ?? node['@_objectName'] ?? ''),
+        uri: String(node['@_uri'] ?? ''),
+        matches: [
+          {
+            line: Number(node['@_line'] ?? 0),
+            snippet: String(node['@_snippet'] ?? node['#text'] ?? ''),
+          },
+        ],
+      });
+    }
+  }
+
+  return results;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────

--- a/ts-src/handlers/intent.ts
+++ b/ts-src/handlers/intent.ts
@@ -75,7 +75,7 @@ function formatErrorForLLM(err: unknown, message: string, _tool: string, args: R
       return `${message}\n\nHint: Object "${name}" (type ${type}) was not found. Use SAPSearch with query "${name}" to verify the name exists and check the correct type.`;
     }
     if (err.isUnauthorized || err.isForbidden) {
-      return `${message}\n\nHint: Authorization error. The configured SAP user may lack permissions for this object.`;
+      return `${message}\n\nHint: Authorization error. Check SAP_CLIENT (default: '100'), SAP_USER, and SAP_PASSWORD. The configured SAP user may lack permissions for this object.`;
     }
   }
 
@@ -250,9 +250,37 @@ async function handleSAPRead(client: AdtClient, args: Record<string, unknown>): 
       return textResult(await client.getClass(name, args.include as string | undefined));
     case 'INTF':
       return textResult(await client.getInterface(name));
-    case 'FUNC':
-      return textResult(await client.getFunction(String(args.group ?? ''), name));
+    case 'FUNC': {
+      let group = String(args.group ?? '');
+      if (!group) {
+        const resolved = await client.resolveFunctionGroup(name);
+        if (!resolved) {
+          return errorResult(
+            `Cannot resolve function group for "${name}". Provide the group parameter explicitly, or use SAPSearch("${name}") to find the function group.`,
+          );
+        }
+        group = resolved;
+      }
+      return textResult(await client.getFunction(group, name));
+    }
     case 'FUGR': {
+      const expand = Boolean(args.expand_includes);
+      if (expand) {
+        const source = await client.getFunctionGroupSource(name);
+        const includePattern = /INCLUDE\s+(\S+)\s*\./gi;
+        const parts: string[] = [`=== FUGR ${name} (main) ===\n${source}`];
+        let m: RegExpExecArray | null;
+        while ((m = includePattern.exec(source)) !== null) {
+          const inclName = m[1]!;
+          try {
+            const inclSource = await client.getInclude(inclName);
+            parts.push(`\n=== ${inclName} ===\n${inclSource}`);
+          } catch {
+            parts.push(`\n=== ${inclName} ===\n[Could not read include "${inclName}"]`);
+          }
+        }
+        return textResult(parts.join('\n'));
+      }
       const fg = await client.getFunctionGroup(name);
       return textResult(JSON.stringify(fg, null, 2));
     }
@@ -273,6 +301,38 @@ async function handleSAPRead(client: AdtClient, args: Record<string, unknown>): 
       const data = await client.getTableContents(name, maxRows, args.sqlFilter as string | undefined);
       return textResult(JSON.stringify(data, null, 2));
     }
+    case 'SOBJ': {
+      const method = String(args.method ?? '');
+      if (method) {
+        // Read specific BOR method implementation via SWOTLV lookup
+        const data = await client.runQuery(
+          `SELECT PROGNAME, FORMNAME FROM SWOTLV WHERE LOBJTYPE = '${name.toUpperCase()}' AND VERB = '${method.toUpperCase()}'`,
+          1,
+        );
+        if (data.rows.length > 0) {
+          const prog = String(data.rows[0]!.PROGNAME ?? '').trim();
+          if (!prog) {
+            return errorResult(`BOR method "${method}" on "${name}" has no program assigned.`);
+          }
+          const source = await client.getProgram(prog);
+          return textResult(
+            `=== BOR ${name}.${method} (program: ${prog}, form: ${String(data.rows[0]!.FORMNAME ?? '').trim()}) ===\n${source}`,
+          );
+        }
+        return errorResult(
+          `BOR method "${method}" not found on object type "${name}". Use SAPRead(type="SOBJ", name="${name}") without method to list all methods.`,
+        );
+      }
+      // List all methods for this BOR object
+      const methods = await client.runQuery(
+        `SELECT VERB, PROGNAME, FORMNAME, DESCRIPT FROM SWOTLV WHERE LOBJTYPE = '${name.toUpperCase()}'`,
+        100,
+      );
+      if (methods.rows.length === 0) {
+        return errorResult(`No BOR methods found for object type "${name}". Verify the BOR object type name.`);
+      }
+      return textResult(JSON.stringify(methods, null, 2));
+    }
     case 'DEVC': {
       const contents = await client.getPackageContents(name);
       return textResult(JSON.stringify(contents, null, 2));
@@ -291,7 +351,7 @@ async function handleSAPRead(client: AdtClient, args: Record<string, unknown>): 
       return textResult(await client.getVariants(name));
     default:
       return errorResult(
-        `Unknown SAPRead type: ${type}. Supported: PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, BDEF, SRVD, TABL, VIEW, TABLE_CONTENTS, DEVC, SYSTEM, COMPONENTS, MESSAGES, TEXT_ELEMENTS, VARIANTS`,
+        `Unknown SAPRead type: ${type}. Supported: PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, BDEF, SRVD, TABL, VIEW, TABLE_CONTENTS, DEVC, SOBJ, SYSTEM, COMPONENTS, MESSAGES, TEXT_ELEMENTS, VARIANTS`,
       );
   }
 }
@@ -299,6 +359,25 @@ async function handleSAPRead(client: AdtClient, args: Record<string, unknown>): 
 async function handleSAPSearch(client: AdtClient, args: Record<string, unknown>): Promise<ToolResult> {
   const query = String(args.query ?? '');
   const maxResults = Number(args.maxResults ?? 100);
+  const searchType = String(args.searchType ?? 'object');
+
+  if (searchType === 'source_code') {
+    const objectType = args.objectType as string | undefined;
+    const packageName = args.packageName as string | undefined;
+    try {
+      const results = await client.searchSource(query, maxResults, objectType, packageName);
+      return textResult(JSON.stringify(results, null, 2));
+    } catch (err) {
+      if (err instanceof AdtApiError && (err.statusCode === 404 || err.statusCode === 501)) {
+        return errorResult(
+          `Source code search is not available on this SAP system (requires SAP_BASIS ≥ 7.51). ` +
+            `Use SAPSearch with searchType="object" to search by object name instead, or use SAPQuery to search metadata tables.`,
+        );
+      }
+      throw err;
+    }
+  }
+
   const results = await client.searchObject(query, maxResults);
   return textResult(JSON.stringify(results, null, 2));
 }
@@ -306,8 +385,36 @@ async function handleSAPSearch(client: AdtClient, args: Record<string, unknown>)
 async function handleSAPQuery(client: AdtClient, args: Record<string, unknown>): Promise<ToolResult> {
   const sql = String(args.sql ?? '');
   const maxRows = Number(args.maxRows ?? 100);
-  const data = await client.runQuery(sql, maxRows);
-  return textResult(JSON.stringify(data, null, 2));
+  try {
+    const data = await client.runQuery(sql, maxRows);
+    return textResult(JSON.stringify(data, null, 2));
+  } catch (err) {
+    if (err instanceof AdtApiError && err.isNotFound) {
+      // Try to extract table name from SQL and suggest similar names
+      const tableMatch = sql.match(/FROM\s+(\S+)/i);
+      if (tableMatch) {
+        const tableName = tableMatch[1]!.replace(/['"]/g, '');
+        try {
+          const suggestions = await client.searchObject(`${tableName}*`, 10);
+          const tableNames = suggestions
+            .filter(
+              (s) =>
+                s.objectType.startsWith('TABL') || s.objectType.startsWith('VIEW') || s.objectType.startsWith('DDLS'),
+            )
+            .map((s) => s.objectName)
+            .slice(0, 5);
+          if (tableNames.length > 0) {
+            return errorResult(
+              `Table "${tableName}" not found.\n\nDid you mean: ${tableNames.join(', ')}?\n\nUse SAPSearch("${tableName}*") for more results, or discover tables with: SAPQuery(sql="SELECT tabname FROM dd02l WHERE tabname LIKE '%${tableName}%'")`,
+            );
+          }
+        } catch {
+          // Search failed — fall through to original error
+        }
+      }
+    }
+    throw err;
+  }
 }
 
 async function handleSAPLint(_client: AdtClient, args: Record<string, unknown>): Promise<ToolResult> {
@@ -431,13 +538,21 @@ async function handleSAPActivate(client: AdtClient, args: Record<string, unknown
 
 async function handleSAPNavigate(client: AdtClient, args: Record<string, unknown>): Promise<ToolResult> {
   const action = String(args.action ?? '');
-  const uri = String(args.uri ?? '');
+  let uri = String(args.uri ?? '');
   const line = Number(args.line ?? 1);
   const column = Number(args.column ?? 1);
   const source = String(args.source ?? '');
 
+  // Allow symbolic type+name as alternative to uri for references
+  if (!uri && args.type && args.name) {
+    uri = objectUrlForType(String(args.type), String(args.name));
+  }
+
   switch (action) {
     case 'definition': {
+      if (!uri) {
+        return errorResult('Provide uri (or type+name) and line+column for definition lookup.');
+      }
       const result = await findDefinition(client.http, client.safety, uri, line, column, source);
       if (!result) {
         return textResult('No definition found at this position.');
@@ -445,6 +560,9 @@ async function handleSAPNavigate(client: AdtClient, args: Record<string, unknown
       return textResult(JSON.stringify(result, null, 2));
     }
     case 'references': {
+      if (!uri) {
+        return errorResult('Provide uri or type+name to find references.');
+      }
       const results = await findReferences(client.http, client.safety, uri);
       if (results.length === 0) {
         return textResult('No references found.');

--- a/ts-src/handlers/intent.ts
+++ b/ts-src/handlers/intent.ts
@@ -267,7 +267,8 @@ async function handleSAPRead(client: AdtClient, args: Record<string, unknown>): 
       const expand = Boolean(args.expand_includes);
       if (expand) {
         const source = await client.getFunctionGroupSource(name);
-        const includePattern = /INCLUDE\s+(\S+)\s*\./gi;
+        // Match INCLUDE statements but skip ABAP comment lines (starting with *)
+        const includePattern = /^[^*\n]*\bINCLUDE\s+(\S+)\s*\./gim;
         const parts: string[] = [`=== FUGR ${name} (main) ===\n${source}`];
         let m: RegExpExecArray | null;
         while ((m = includePattern.exec(source)) !== null) {
@@ -303,10 +304,18 @@ async function handleSAPRead(client: AdtClient, args: Record<string, unknown>): 
     }
     case 'SOBJ': {
       const method = String(args.method ?? '');
-      if (method) {
+      // Sanitize inputs to prevent SQL injection — BOR names are alphanumeric + underscore only
+      const safeName = name.toUpperCase().replace(/[^A-Z0-9_/]/g, '');
+      const safeMethod = method.toUpperCase().replace(/[^A-Z0-9_]/g, '');
+      if (safeName !== name.toUpperCase().replace(/\s/g, '')) {
+        return errorResult(
+          `Invalid BOR object name: "${name}". Only alphanumeric characters, underscores, and slashes are allowed.`,
+        );
+      }
+      if (safeMethod) {
         // Read specific BOR method implementation via SWOTLV lookup
         const data = await client.runQuery(
-          `SELECT PROGNAME, FORMNAME FROM SWOTLV WHERE LOBJTYPE = '${name.toUpperCase()}' AND VERB = '${method.toUpperCase()}'`,
+          `SELECT PROGNAME, FORMNAME FROM SWOTLV WHERE LOBJTYPE = '${safeName}' AND VERB = '${safeMethod}'`,
           1,
         );
         if (data.rows.length > 0) {
@@ -325,7 +334,7 @@ async function handleSAPRead(client: AdtClient, args: Record<string, unknown>): 
       }
       // List all methods for this BOR object
       const methods = await client.runQuery(
-        `SELECT VERB, PROGNAME, FORMNAME, DESCRIPT FROM SWOTLV WHERE LOBJTYPE = '${name.toUpperCase()}'`,
+        `SELECT VERB, PROGNAME, FORMNAME, DESCRIPT FROM SWOTLV WHERE LOBJTYPE = '${safeName}'`,
         100,
       );
       if (methods.rows.length === 0) {
@@ -391,9 +400,9 @@ async function handleSAPQuery(client: AdtClient, args: Record<string, unknown>):
   } catch (err) {
     if (err instanceof AdtApiError && err.isNotFound) {
       // Try to extract table name from SQL and suggest similar names
-      const tableMatch = sql.match(/FROM\s+(\S+)/i);
+      const tableMatch = sql.match(/FROM\s+["']?([A-Za-z0-9_/$]+)["']?/i);
       if (tableMatch) {
-        const tableName = tableMatch[1]!.replace(/['"]/g, '');
+        const tableName = tableMatch[1]!;
         try {
           const suggestions = await client.searchObject(`${tableName}*`, 10);
           const tableNames = suggestions
@@ -545,7 +554,21 @@ async function handleSAPNavigate(client: AdtClient, args: Record<string, unknown
 
   // Allow symbolic type+name as alternative to uri for references
   if (!uri && args.type && args.name) {
-    uri = objectUrlForType(String(args.type), String(args.name));
+    const symType = String(args.type);
+    const symName = String(args.name);
+    if (symType === 'FUNC') {
+      // FUNC needs group to build URL — auto-resolve it
+      const group = await client.resolveFunctionGroup(symName);
+      if (group) {
+        uri = `/sap/bc/adt/functions/groups/${encodeURIComponent(group)}/fmodules/${encodeURIComponent(symName)}`;
+      } else {
+        return errorResult(
+          `Cannot resolve function group for "${symName}". Provide the full uri parameter, or use SAPSearch("${symName}") to find the ADT URI.`,
+        );
+      }
+    } else {
+      uri = objectUrlForType(symType, symName);
+    }
   }
 
   switch (action) {

--- a/ts-src/handlers/tools.ts
+++ b/ts-src/handlers/tools.ts
@@ -25,7 +25,7 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
     {
       name: 'SAPRead',
       description:
-        'Read SAP ABAP objects. Types: PROG, CLAS, INTF, FUNC (requires group param), FUGR, INCL, DDLS, BDEF, SRVD, TABL, VIEW, TABLE_CONTENTS, DEVC, SYSTEM, COMPONENTS, MESSAGES, TEXT_ELEMENTS, VARIANTS. For CLAS: omit include to get the full class source (definition + implementation combined). The include param is optional — use it only to read class-local sections: definitions (local types), implementations (local helper classes), macros, testclasses (ABAP Unit).',
+        'Read SAP ABAP objects. Types: PROG, CLAS, INTF, FUNC, FUGR (use expand_includes=true to get all include sources), INCL, DDLS, BDEF, SRVD, TABL, VIEW, TABLE_CONTENTS, DEVC, SOBJ (BOR business objects — returns method catalog or full implementation), SYSTEM, COMPONENTS, MESSAGES, TEXT_ELEMENTS, VARIANTS. For CLAS: omit include to get the full class source (definition + implementation combined). The include param is optional — use it only to read class-local sections: definitions (local types), implementations (local helper classes), macros, testclasses (ABAP Unit). For SOBJ: returns BOR method catalog; use method param to read a specific method implementation.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -45,6 +45,7 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
               'VIEW',
               'TABLE_CONTENTS',
               'DEVC',
+              'SOBJ',
               'SYSTEM',
               'COMPONENTS',
               'MESSAGES',
@@ -62,7 +63,17 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
           group: {
             type: 'string',
             description:
-              'Required for FUNC type. The function group containing the function module. Use SAPSearch to find it if unknown.',
+              'For FUNC type. The function group containing the function module. Optional — auto-resolved via SAPSearch if omitted.',
+          },
+          method: {
+            type: 'string',
+            description:
+              'For SOBJ type only. BOR method name to read. If omitted, returns the full method catalog for the BOR object.',
+          },
+          expand_includes: {
+            type: 'boolean',
+            description:
+              'For FUGR type only. When true, expands all INCLUDE statements and returns the full source of each include inline.',
           },
           maxRows: { type: 'number', description: 'For TABLE_CONTENTS: max rows to return (default 100)' },
           sqlFilter: { type: 'string', description: 'For TABLE_CONTENTS: SQL WHERE clause filter' },
@@ -73,12 +84,30 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
     {
       name: 'SAPSearch',
       description:
-        'Search for ABAP objects by name pattern. Supports wildcards (* for any characters). Returns object type, name, package, and description.',
+        'Search for ABAP objects or search within source code. Two modes:\n' +
+        '1. Object search (default): Search by name pattern with wildcards (* for any characters). Returns object type, name, package, description, and ADT URI. Use this to find classes, programs, function modules, tables, etc.\n' +
+        '2. Source code search (searchType="source_code"): Full-text search within ABAP source code across the system. Use this to find all objects containing a specific string (e.g., a method call, variable name, or class reference). Requires SAP_BASIS ≥ 7.51.\n\n' +
+        'Tips: BOR business objects appear as SOBJ type in results. The uri field from results can be used directly with SAPNavigate for references.',
       inputSchema: {
         type: 'object',
         properties: {
-          query: { type: 'string', description: 'Search pattern (e.g., ZCL_ORDER*, Z*TEST*)' },
-          maxResults: { type: 'number', description: 'Maximum results (default 100)' },
+          query: {
+            type: 'string',
+            description:
+              'Search pattern. For object search: name pattern with wildcards (e.g., ZCL_ORDER*, Z*TEST*). For source_code search: text string to find in source (e.g., cl_lsapi_manager, CALL FUNCTION).',
+          },
+          searchType: {
+            type: 'string',
+            enum: ['object', 'source_code'],
+            description:
+              'Search mode: "object" (default) searches by object name, "source_code" searches within ABAP source code.',
+          },
+          objectType: {
+            type: 'string',
+            description: 'For source_code search: filter by object type (e.g., PROG, CLAS, FUNC)',
+          },
+          packageName: { type: 'string', description: 'For source_code search: filter by package name' },
+          maxResults: { type: 'number', description: 'Maximum results (default 100 for object, 50 for source_code)' },
         },
         required: ['query'],
       },
@@ -123,7 +152,7 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
     {
       name: 'SAPNavigate',
       description:
-        'Navigate code: find definitions, references, and code completion. Use for "go to definition", "where is this used?", and auto-complete.',
+        'Navigate code: find definitions, references, and code completion. Use for "go to definition", "where is this used?", and auto-complete. For references: you can use type+name instead of uri (e.g., type="CLAS", name="ZCL_ORDER") for a where-used list without needing the full ADT URI.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -132,17 +161,29 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
             enum: ['definition', 'references', 'completion'],
             description: 'Navigation action',
           },
-          uri: { type: 'string', description: 'Source URI of the object' },
+          uri: {
+            type: 'string',
+            description: 'Source URI of the object. Optional for references if type+name are provided.',
+          },
+          type: {
+            type: 'string',
+            description: 'Object type (PROG, CLAS, INTF, FUNC, etc.) — alternative to uri for references.',
+          },
+          name: { type: 'string', description: 'Object name — alternative to uri for references.' },
           line: { type: 'number', description: 'Line number (1-based)' },
           column: { type: 'number', description: 'Column number (1-based)' },
           source: { type: 'string', description: 'Current source code (for definition/completion)' },
         },
-        required: ['action', 'uri'],
+        required: ['action'],
       },
     },
     {
       name: 'SAPQuery',
-      description: 'Execute ABAP SQL queries against SAP tables. Returns structured data with column names and rows.',
+      description:
+        'Execute ABAP SQL queries against SAP tables. Returns structured data with column names and rows. ' +
+        'Powerful for reverse-engineering: query metadata tables like DD02L (table catalog), DD03L (field catalog), ' +
+        'SWOTLV (BOR method implementations), TADIR (object directory), TFDIR (function modules). ' +
+        'If a table is not found, similar table names will be suggested automatically.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/ts-src/server/config.ts
+++ b/ts-src/server/config.ts
@@ -56,7 +56,7 @@ export function parseArgs(args: string[]): ServerConfig {
   config.url = resolve('url', 'SAP_URL', '');
   config.username = resolve('user', 'SAP_USER', '');
   config.password = resolve('password', 'SAP_PASSWORD', '');
-  config.client = resolve('client', 'SAP_CLIENT', '001');
+  config.client = resolve('client', 'SAP_CLIENT', '100');
   config.language = resolve('language', 'SAP_LANGUAGE', 'EN');
   config.insecure = resolveBool('insecure', 'SAP_INSECURE', false);
 

--- a/ts-src/server/types.ts
+++ b/ts-src/server/types.ts
@@ -75,7 +75,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   url: '',
   username: '',
   password: '',
-  client: '001',
+  client: '100',
   language: 'EN',
   insecure: false,
   transport: 'stdio',


### PR DESCRIPTION
## Summary

Implements 7 improvements identified from a real-world SAP ISU analysis workflow (STO-956267) where arc-1 was used in Cursor to analyze a BPEM/MSCONS incident entirely without SAP GUI. The feedback report is included as `reports/2026-03-31-001-llm-feedback-tooling-improvements.md`.

### Changes

- **Better 401 errors** — Include `sap-client` value in auth error messages; change default `SAP_CLIENT` from `001` to `100`
- **FUNC auto-resolve** — `SAPRead(type="FUNC")` no longer requires `group` param; auto-resolves via SAPSearch when omitted
- **FUGR include expansion** — New `expand_includes=true` param on `SAPRead(type="FUGR")` to inline all INCLUDE sources
- **Source code search** — New `searchType="source_code"` in `SAPSearch` for full-text search within ABAP source code (requires SAP_BASIS >= 7.51)
- **BOR/SOBJ reading** — New `SAPRead(type="SOBJ")` for BOR business objects with method catalog and implementation reading via SWOTLV table
- **SAPQuery suggestions** — "Did you mean?" with similar table names when a queried table is not found (404)
- **Symbolic references** — `SAPNavigate(action="references")` now accepts `type+name` as alternative to ADT URI
- **Enriched tool descriptions** for SAPSearch, SAPQuery, SAPNavigate, and SAPRead with better LLM guidance

### Files changed (17 files, +1090 -39)

| Area | Files |
|------|-------|
| Core ADT client | client.ts, http.ts, types.ts, xml-parser.ts |
| Handlers | intent.ts, tools.ts |
| Config/defaults | server/types.ts, server/config.ts, adt/config.ts, adt/btp.ts |
| Tests | intent.test.ts (+260 lines), http.test.ts, config.test.ts |
| Docs | CLAUDE.md, setup-guide.md, integration/helpers.ts |
| Reports | 2026-03-31-001-llm-feedback-tooling-improvements.md (new) |

## Test plan

- [x] All 501 unit tests pass (12 new tests added)
- [x] Build succeeds (npm run build)
- [x] Biome lint/format passes on modified files
- [ ] Integration tests against SAP system (FUGR include expansion, source code search)
- [ ] Manual testing of SOBJ/BOR reading against SAP ISU system

Generated with [Claude Code](https://claude.com/claude-code)