### PR TITLE
feat: improve tooling based on real-world LLM usage review

### DIFF
--- a/reports/2026-03-31-002-llm-usage-review-ewm-investigation.md
+++ b/reports/2026-03-31-002-llm-usage-review-ewm-investigation.md
@@ -1,0 +1,450 @@
+# LLM Usage Review: EWM/RAP Investigation — Feedback Analysis & Implementation Plan
+
+> **Source:** Post-session self-review by an LLM after investigating EWM RAP actions via ARC-1 v0.2.0
+> **Date:** 2026-03-31 (revised with peer review corrections)
+> **Scope:** 7 tools available, 4 used across ~28 calls over 12+ turns
+
+---
+
+## Executive Summary
+
+An LLM used ARC-1 to investigate a custom EWM packing scenario (RAP actions, BDEFs, service definitions). The analysis succeeded but was inefficient — 12+ turns where 5 would have sufficed. The feedback is highly credible and identifies real gaps, primarily in **tool discoverability** and **SQL dialect documentation** rather than in missing functionality. All features the LLM wished it had used already exist.
+
+**Key insight:** The tools are capable, but LLMs don't discover capabilities organically during a session. The fix is better tool descriptions and guardrails, not new features.
+
+> **Note:** This document was reviewed against the actual codebase and corrected for several technical inaccuracies in the initial analysis — see items marked *[Corrected]* below.
+
+---
+
+## Feedback Item Analysis
+
+### 1. Never Used `SAPContext` — Biggest Token Waste
+
+**Feedback:** After reading a 237KB class (`Z1EWM_CL_ODATA_PACK_RAP`), the LLM manually followed dependencies with ~5 separate `SAPRead` calls instead of one `SAPContext` call.
+
+**Evaluation: Valid — this is the #1 priority issue.**
+
+**Current state of `SAPContext` description:**
+
+```
+"Get compressed dependency context for an ABAP object. Returns only the public API
+contracts (method signatures, interface definitions, type declarations) of all objects
+that the target depends on — NOT the full source code. This is the most token-efficient
+way to understand dependencies."
+```
+
+The description is already good and mentions the `source` parameter to skip a round-trip. But the problem is **when** the LLM thinks to use it. After reading a large class, the natural next step is to read individual dependencies — not to invoke a separate "context" tool.
+
+**Root cause:** The tool description tells the LLM *what* SAPContext does but doesn't create a strong enough trigger for *when* to use it. The final paragraph says "Use SAPContext BEFORE writing code" which scopes it too narrowly — this LLM was reading/analyzing, not writing.
+
+**Proposed changes:**
+
+1. **Expand the "when to use" guidance** in the SAPContext tool description:
+
+   Add at the start of the description:
+   ```
+   IMPORTANT: After reading a large class/program with SAPRead, use SAPContext as
+   your NEXT call to understand its dependencies. Do NOT manually follow dependencies
+   with multiple SAPRead calls — SAPContext does this in one call with 7-30x fewer tokens.
+   ```
+
+   Change the final guidance from:
+   ```
+   Use SAPContext BEFORE writing code that modifies or extends existing objects.
+   ```
+   To:
+   ```
+   Use SAPContext whenever you need to understand an object's dependencies — whether
+   for analysis, debugging, or before writing code. If you've just read a class with
+   SAPRead and need to understand what it calls/uses, SAPContext is always the next step.
+   ```
+
+2. **Add a hint in `SAPRead` responses for large objects.** When the response exceeds a threshold, append a hint:
+
+   ```
+   Hint: This object is large. Use SAPContext(type='CLAS', name='...') to get compressed
+   dependency contracts instead of reading each dependency individually.
+   ```
+
+   **Implementation:** In `ts-src/handlers/intent.ts`, after the SAPRead CLAS handler returns, check response length and append hint.
+
+   **Threshold choice:** 50KB would fire on many medium-sized classes. A line count of ~2000 lines or ~100KB is a better threshold — targets genuinely large objects where manual dep-chasing is costly.
+
+   *[Corrected]* **`source` parameter trade-off:** The hint should recommend `SAPContext(type, name)` without `source` for very large objects (>5000 lines / 200KB). Passing a 237KB/7258-line class back as a `source` parameter wastes tokens. For objects that large, it's cheaper to let SAPContext re-fetch internally. The `source` skip-round-trip optimization is most valuable for smaller classes (~500-2000 lines).
+
+**Note:** `SAPContext` is always available — it's registered unconditionally in `tools.ts`, not gated behind `config.readOnly`. The `source` parameter is correctly implemented in `handleSAPContext` (`if (args.source) { source = String(args.source); }` before fetching). This is purely a discoverability problem.
+
+**Files to modify:**
+- `ts-src/handlers/tools.ts` — SAPContext description (lines ~120-145)
+- `ts-src/handlers/tools.ts` — SAPRead description (add cross-reference to SAPContext)
+- `ts-src/handlers/intent.ts` — SAPRead handler, add size-based hint (~line 280)
+
+**Effort:** Low
+**Impact:** High — would have saved ~5 tool calls and significant tokens in this session
+
+---
+
+### 2. Tried `source_code` Search Without Probing Features First
+
+**Feedback:** LLM tried `SAPSearch(searchType='source_code')` and got a "not available (requires SAP_BASIS >= 7.51)" error. Should have started with `SAPManage(action='probe')`.
+
+**Evaluation: Valid, but with two important technical corrections.**
+
+The error is informative — the LLM learned from it immediately. The real question is whether we should make probing easier and more complete.
+
+*[Corrected]* **Two separate read-only mechanisms exist:**
+
+The initial analysis conflated two different systems:
+
+- **`config.readOnly`** (CLI flag / `SAP_READ_ONLY`) → controls tool **registration** in `tools.ts`. When true, `SAPManage` is simply not registered as a tool (`if (!config.readOnly) tools.push(SAPManage)` at line 286).
+- **`TOOL_SCOPES['SAPManage'] = 'write'`** → controls per-user **authInfo scope enforcement** in `handleToolCall`, only active when `authInfo` is present (XSUAA/OIDC deployments).
+
+For local stdio deployments (Claude Desktop, Cursor), `authInfo` is never present, so `TOOL_SCOPES` is irrelevant. The real problem is that `SAPManage` is not registered when `config.readOnly = true`. The fix is simpler than initially proposed: move `SAPManage` outside the `if (!config.readOnly)` block in `tools.ts` and change its scope in `TOOL_SCOPES` to `'read'`.
+
+*[Corrected]* **`probeFeatures` does NOT probe source_code search availability:**
+
+The `PROBES` array in `features.ts` checks 6 endpoints:
+```
+hana, abapGit, rap, amdp, ui5, transport
+```
+
+There is **no probe for the textSearch endpoint** (`/sap/bc/adt/repository/informationsystem/textSearch`). Even if the LLM runs `SAPManage(probe)`, it will never learn that source_code search is unavailable. The probe recommendation in the original feedback is therefore incomplete — it wouldn't have actually prevented the wasted call.
+
+**Proposed changes (revised):**
+
+1. **De-gate `SAPManage` from read-only mode.** Move it outside `if (!config.readOnly)` in `tools.ts`. Change `TOOL_SCOPES['SAPManage']` from `'write'` to `'read'`. Probe and features are purely read operations (HEAD requests).
+
+2. **Add `sourceSearch` to `PROBES` in `features.ts`:**
+
+   ```typescript
+   { id: 'sourceSearch', endpoint: '/sap/bc/adt/repository/informationsystem/textSearch?searchString=_&maxResults=1', description: 'Source code full-text search (requires SAP_BASIS ≥ 7.51)' }
+   ```
+
+   Then reference `cachedFeatures?.sourceSearch?.available` in the `source_code` search path of `handleSAPSearch` to fail fast with a clear message.
+
+3. **Add auto-probe on first tool call.** When any tool is invoked for the first time in a session, automatically run `probeFeatures()` in the background and cache the results.
+
+   **Implementation note:** `probeFeatures` signature is `probeFeatures(client: AdtHttpClient, config: FeatureConfig)`. The `FeatureConfig` is derived from `ServerConfig` by mapping individual feature flags (`_config.featureHana`, `_config.featureRap`, etc.) — exactly as `handleSAPManage` currently does (lines ~735-749). Auto-probe is not a one-liner; it needs the same `FeatureConfig` construction.
+
+4. **Improve the source_code search error message** to suggest alternatives:
+
+   Current: `"Source code search is not available (requires SAP_BASIS ≥ 7.51)"`
+
+   Proposed: `"Source code search is not available (requires SAP_BASIS ≥ 7.51). Alternative: use SAPQuery on metadata tables like SEOCOMPO (class methods) or REPOSRC (source text) to find references."`
+
+**Files to modify:**
+- `ts-src/handlers/tools.ts` — move SAPManage outside readOnly guard
+- `ts-src/handlers/intent.ts` — TOOL_SCOPES change, auto-probe logic, FeatureConfig construction
+- `ts-src/adt/features.ts` — add `sourceSearch` probe to `PROBES` array
+- `ts-src/adt/types.ts` — add `sourceSearch` to `ResolvedFeatures` type (if needed)
+
+**Effort:** Medium (three coupled changes: de-gate + add probe + auto-probe)
+**Impact:** Medium — prevents wasted calls and makes probe actually useful for source_code search
+
+---
+
+### 3. Wrong ABAP SQL Syntax in `SAPQuery`
+
+**Feedback:** LLM used `FETCH FIRST 20 ROWS ONLY` (ANSI SQL) instead of the `maxRows` parameter. The `/sap/bc/adt/datapreview/freestyle` endpoint uses ABAP Open SQL, not ANSI SQL.
+
+**Evaluation: Valid and actionable — this is the #2 priority issue.**
+
+**Current `SAPQuery` description:**
+```
+"Execute ABAP SQL queries against SAP tables. Returns structured data with column
+names and rows. Powerful for reverse-engineering: query metadata tables..."
+```
+
+The description mentions "ABAP SQL" but doesn't explain how it differs from standard SQL. The `maxRows` parameter description is minimal: `"Maximum rows (default 100)"`.
+
+**Proposed changes:**
+
+1. **Add SQL dialect guidance to the `SAPQuery` description:**
+
+   ```
+   IMPORTANT — SQL dialect: This executes ABAP Open SQL, NOT standard/ANSI SQL.
+   Key differences:
+   - Row limiting: Do NOT use FETCH FIRST, LIMIT, or ROWNUM. Use the maxRows parameter instead.
+   - Aggregates: COUNT(*), SUM(), AVG() work. Use SELECT SINGLE for single-row results.
+   - String literals: Use single quotes ('value'), not double quotes.
+   - Table aliases: Supported with AS keyword.
+   - JOINs: INNER JOIN and LEFT OUTER JOIN supported. No RIGHT JOIN or FULL JOIN.
+   - LIKE: Works as expected with % and _ wildcards.
+   - UP TO n ROWS: Supported at end of SELECT, but prefer maxRows parameter.
+   ```
+
+2. **Detect and correct common SQL mistakes at runtime.** In the `SAPQuery` handler, detect patterns like `FETCH FIRST`, `LIMIT \d+`, `ROWNUM` and either:
+   - Auto-strip them and add a note: "Removed FETCH FIRST clause — use maxRows parameter instead"
+   - Or reject with a clear error before hitting SAP
+
+   **Implementation:** In `ts-src/handlers/intent.ts` around line 394, add a SQL pre-processor:
+
+   ```typescript
+   // Strip ANSI row-limit clauses and warn
+   const ansiLimitPattern = /\b(FETCH\s+FIRST\s+\d+\s+ROWS\s+ONLY|LIMIT\s+\d+)\s*$/i;
+   if (ansiLimitPattern.test(sql)) {
+     sql = sql.replace(ansiLimitPattern, '').trim();
+     warnings.push('Removed ANSI row-limit clause. Use the maxRows parameter instead.');
+   }
+   ```
+
+3. **Improve the `maxRows` parameter description:**
+
+   Current: `"Maximum rows (default 100)"`
+
+   Proposed: `"Maximum rows to return (default 100). This is the ONLY way to limit rows — do not use FETCH FIRST, LIMIT, or ROWNUM in your SQL."`
+
+**Files to modify:**
+- `ts-src/handlers/tools.ts` — SAPQuery description and maxRows description
+- `ts-src/handlers/intent.ts` — SQL pre-processor/validator (~line 394)
+
+**Effort:** Low
+**Impact:** High — SQL dialect confusion will affect every LLM user
+
+---
+
+### 4. Over-Broad `SAPSearch` Patterns
+
+**Feedback:** LLM searched `Z1EWM*` (80 results, mostly irrelevant) and `Z1EWM*BDEF*` (0 results, because BDEF is an object type not a name part). Better alternatives: `SAPRead(type='DEVC')` for package contents, `SAPQuery` on TADIR for type-filtered searches.
+
+**Evaluation: Valid. The tool description could better guide search strategy.**
+
+**Current `SAPSearch` description:** Describes wildcards and search modes but doesn't mention `DEVC` or `SAPQuery` on TADIR as alternatives for package-scoped exploration.
+
+**Proposed changes:**
+
+1. **Add search strategy guidance to `SAPSearch` description:**
+
+   ```
+   Tips for efficient searching:
+   - To list ALL objects in a package: use SAPRead(type='DEVC', name='PACKAGE_NAME') instead
+   - To find objects of a specific type in a package: use SAPQuery on TADIR:
+     SAPQuery(sql="SELECT obj_name FROM tadir WHERE devclass = 'PKG' AND object = 'CLAS'")
+   - Object type (CLAS, PROG, BDEF, etc.) is NOT part of the object name — don't include
+     it in search patterns. Use objectType filter for source_code search instead.
+   ```
+
+2. **Add `objectType` filter to object search mode.** Currently `objectType` is only documented for `source_code` search. The ADT quickSearch endpoint supports type filtering via `objectType` parameter.
+
+   *[Corrected]* **ADT format mapping required.** The quickSearch endpoint uses compound type format — `CLAS/OC` (classes), `BDEF/BDO` (behavior definitions), `PROG/P` (programs), `SRVD/SRV` (service definitions), etc. The `searchObject` return values already contain this format in `objectType` fields. If we expose `objectType` as a user-facing parameter accepting simple types like `CLAS`, the server needs a mapping layer:
+
+   ```typescript
+   const ADT_OBJECT_TYPE_MAP: Record<string, string> = {
+     CLAS: 'CLAS/OC', INTF: 'INTF/OI', PROG: 'PROG/P',
+     BDEF: 'BDEF/BDO', SRVD: 'SRVD/SRV', DDLS: 'DDLS/DF',
+     TABL: 'TABL/DT', FUGR: 'FUGR/F', FUNC: 'FUNC/FF', ...
+   };
+   ```
+
+   This mapping is the actual complexity of the feature, not the plumbing.
+
+3. **Add `packageName` filter to object search mode.** The `searchSource` (text search) already supports `packageName`, but `searchObject` (quickSearch) does not pass it through. Searching `Z1EWM*` scoped to `ZTGW_EWM_ODATA_BL` would have been far more useful than the 80-result dump. One parameter addition in `client.ts` covers this.
+
+   Current `searchObject` URL:
+   ```
+   /sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=${query}&maxResults=${maxResults}
+   ```
+
+   With both filters:
+   ```
+   ...&query=${query}&maxResults=${maxResults}&objectType=${adtType}&packageName=${pkg}
+   ```
+
+**Files to modify:**
+- `ts-src/handlers/tools.ts` — SAPSearch description (add tips), schema (allow objectType + packageName for object search)
+- `ts-src/adt/client.ts` — `searchObject` method (add objectType + packageName params, ADT type mapping)
+- `ts-src/handlers/intent.ts` — pass new params to search
+
+**Effort:** Low (description) / Medium (objectType filter due to ADT format mapping + packageName)
+**Impact:** Medium — reduces wasted broad searches. objectType + packageName together make object search significantly more precise.
+
+---
+
+### 5. Never Used `SAPNavigate` for Where-Used
+
+**Feedback:** When needing to find who calls `Z1EWM_CL_ODATA_PACK_RAP`, the LLM guessed instead of using `SAPNavigate(action='references')`.
+
+**Evaluation: Valid but lower priority — the feature exists and is documented.**
+
+The `SAPNavigate` description already says: "Navigate code: find definitions, references, and code completion. Use for 'go to definition', 'where is this used?'" and supports `type+name` as an alternative to `uri`.
+
+**Root cause:** The LLM simply didn't think to use it. This is partly a discoverability issue — when you're deep in analysis, you don't re-scan all available tools.
+
+**Proposed changes:**
+
+1. **Cross-reference `SAPNavigate` in `SAPRead` results.** When returning a class source, add a subtle hint:
+
+   ```
+   Tip: Use SAPNavigate(action='references', type='CLAS', name='...') to find all callers.
+   ```
+
+   This is lighter than the SAPContext hint — only add it when the class has public methods that might be called externally.
+
+2. **Add "where-used" as a keyword in the SAPNavigate description** since LLMs often think in SAP terminology:
+
+   Current: `"find definitions, references, and code completion"`
+   Proposed: `"find definitions, references (where-used list), and code completion"`
+
+**Files to modify:**
+- `ts-src/handlers/tools.ts` — SAPNavigate description
+
+**Effort:** Very low
+**Impact:** Low-medium — nice to have but not a major friction point
+
+---
+
+### 6. Sequential Searches When Parallel Is Fine
+
+**Feedback:** The LLM made independent `SAPRead` calls sequentially across multiple turns instead of batching them.
+
+**Evaluation: Valid but NOT an ARC-1 issue — this is an MCP client / LLM behavior issue.**
+
+ARC-1 is a server. Whether the client batches tool calls is determined by:
+1. The LLM's tendency to batch (Claude does this well, others vary)
+2. The MCP client's ability to send parallel tool calls
+3. Whether the LLM perceives the calls as independent
+
+**There is nothing ARC-1 can do server-side to force parallel calls.** However, tool descriptions could hint at parallelism:
+
+**Proposed change (minor):**
+
+Add a general note to the server's tool listing preamble (if one exists) or to the most-used tools:
+
+```
+Tip: SAPRead, SAPSearch, SAPQuery, and SAPNavigate calls are stateless and independent.
+Batch multiple calls in one turn when you need several objects.
+```
+
+**Implementation:** This could be added as a server-level `instructions` field in the MCP protocol, or as a note in each tool description. The MCP SDK supports a server-level `instructions` string.
+
+**Files to modify:**
+- `ts-src/server/server.ts` — add MCP server instructions field
+
+**Effort:** Very low
+**Impact:** Low — depends on client/LLM behavior
+
+---
+
+## Priority Matrix (Revised)
+
+| # | Issue | Priority | Effort | Impact |
+|---|-------|----------|--------|--------|
+| 3 | SQL dialect documentation + pre-processor | **P1** | Low | High |
+| 1 | SAPContext discoverability (description + hints) | **P1** | Low | High |
+| 2 | SAPManage de-gating + sourceSearch probe + auto-probe | **P2** | Medium | Medium |
+| 4 | Search strategy guidance (description only) | **P2** | Very low | Medium |
+| 4b | objectType + packageName filter for object search | **P3** | Medium | Medium |
+| 5 | SAPNavigate where-used discoverability | **P3** | Very low | Low-Med |
+| 6 | Parallel call hints | **P3** | Very low | Low |
+
+---
+
+## Recommended Implementation Plan (Revised)
+
+### Phase 1: SQL Pre-processor + Description Improvements (P1 — immediate)
+
+**Implementation order within Phase 1:**
+
+1. **SQL pre-processor first** (item 3) — single function in `intent.ts`, zero risk, pure win. Strip `FETCH FIRST`, `LIMIT n`, `ROWNUM` before `runQuery` call.
+
+2. **Tool descriptions** in `ts-src/handlers/tools.ts`:
+   - **SAPQuery:** Add ABAP SQL dialect section, improve `maxRows` description
+   - **SAPContext:** Strengthen "when to use" trigger, remove write-only framing
+   - **SAPRead:** Add cross-reference to SAPContext for large objects
+   - **SAPSearch:** Add search strategy tips, DEVC alternative, type-is-not-name warning
+   - **SAPNavigate:** Add "where-used" keyword
+
+3. **Large-response hint** in `intent.ts` — append SAPContext suggestion after SAPRead returns large objects. Threshold: ~2000 lines or ~100KB (not 50KB — that fires on medium classes). The hint should NOT suggest passing `source` for objects >5000 lines — let SAPContext re-fetch.
+
+**Files:** `ts-src/handlers/tools.ts`, `ts-src/handlers/intent.ts`
+**Estimated scope:** ~50 lines description + ~20 lines pre-processor + ~10 lines hint logic.
+
+### Phase 2: Feature Probing Overhaul (P2)
+
+These three changes are tightly coupled — do them together:
+
+1. **De-gate `SAPManage`** — move outside `if (!config.readOnly)` in `tools.ts`, change scope to `'read'`
+2. **Add `sourceSearch` probe** — add textSearch endpoint to `PROBES` in `features.ts`, add to `ResolvedFeatures` type
+3. **Auto-probe on first call** — in `handleToolCall`, if `cachedFeatures` is null, construct `FeatureConfig` from `ServerConfig` (same mapping as `handleSAPManage` lines ~735-749) and call `probeFeatures()`. Not a one-liner.
+
+**Files:** `ts-src/handlers/tools.ts`, `ts-src/handlers/intent.ts`, `ts-src/adt/features.ts`, `ts-src/adt/types.ts`
+**Estimated scope:** ~40-50 lines across 4 files.
+
+### Phase 3: Search Enhancements (P2-P3)
+
+1. **`objectType` filter for object search** — needs ADT compound format mapping (`CLAS` → `CLAS/OC`, etc.). Medium effort due to the mapping layer, not the plumbing.
+2. **`packageName` filter for object search** — low effort, just add query param to `searchObject` URL.
+
+**Files:** `ts-src/adt/client.ts`, `ts-src/handlers/tools.ts`, `ts-src/handlers/intent.ts`
+**Estimated scope:** ~30-40 lines (mapping table + parameter threading).
+
+### Phase 4: Server-Level Hints (P3)
+
+1. **MCP server instructions** — add parallel-call guidance and general workflow tips
+2. **Cross-tool hints in responses** — context-aware suggestions based on what was just returned
+
+**Estimated scope:** ~10-20 lines in server.ts.
+
+---
+
+## Validation
+
+All six issues map to existing functionality that the LLM failed to discover. The one genuinely missing piece is the `sourceSearch` probe in `features.ts` — without it, `SAPManage(probe)` wouldn't have prevented the source_code search failure even if the LLM had used it.
+
+The fixes are primarily:
+
+- **50% documentation** — better tool descriptions with stronger triggers
+- **30% guardrails** — SQL pre-processor, large-response hints, auto-probe
+- **20% features** — sourceSearch probe, objectType/packageName filter, read-only probe access
+
+This aligns with the principle that for MCP servers, **tool descriptions are the UX** — they are the primary interface through which LLMs understand capabilities.
+
+---
+
+## Comparison with Previous Feedback (Report 001)
+
+Report `2026-03-31-001` covered an ISU/BPEM investigation session. Common themes:
+
+| Theme | Report 001 | This Report |
+|-------|-----------|-------------|
+| SAPContext underused | Not mentioned | **#1 issue** |
+| SQL dialect confusion | Not mentioned | **#2 issue** |
+| Feature probing missed | Not mentioned | Mentioned |
+| Search inefficiency | Mentioned (different angle) | **#4 issue** |
+| Large response handling | Mentioned (237KB friction) | Same issue, same class size |
+| Error message quality | **#1 issue** (401 errors) | Not mentioned |
+
+The two reports are complementary — Report 001 focuses on onboarding friction (auth errors, first-use experience) while this report focuses on tool usage efficiency during an established session.
+
+---
+
+## Appendix: Ideal 5-Turn Workflow (from feedback, annotated)
+
+The LLM's proposed optimal workflow, with practical notes:
+
+```
+Turn 1 (parallel):
+  SAPManage(action='probe')
+  SAPRead(type='DEVC', name='ZTGW_EWM_ODATA_BL')
+
+Turn 2 (parallel):
+  SAPRead(type='BDEF', name='Z1EWM_X_HANDLINGUNIT_NIO')
+  SAPRead(type='SRVD', name='Z1EWM_NIO')
+  SAPRead(type='CLAS', name='Z1EWM_CL_ODATA_PACK_RAP')
+
+Turn 3:
+  SAPContext(type='CLAS', name='Z1EWM_CL_ODATA_PACK_RAP', maxDeps=15)
+  # Note: omit source= for this 237KB/7258-line class — let SAPContext re-fetch
+  # internally rather than passing 237KB back as a parameter. The source= optimization
+  # is better suited for smaller classes (~500-2000 lines).
+
+Turn 4:
+  SAPRead(type='CLAS', name='/TGW/CL_CE_HUNIT_ITEM_BO')
+
+Turn 5:
+  SAPNavigate(action='references', type='CLAS', name='Z1EWM_CL_ODATA_PACK_RAP')
+```
+
+This reduces from 28 tool calls / 12+ turns to ~9 tool calls / 5 turns — a 3x efficiency improvement. Post-implementation, this workflow should be achievable naturally without the LLM needing to know it in advance.
+
+**Note on Turn 1:** After adding the `sourceSearch` probe (Phase 2), `SAPManage(probe)` will correctly report source_code search availability. Currently it doesn't — this is a gap.

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -13,6 +13,7 @@ describe('Feature Detection', () => {
         amdp: 'on',
         ui5: 'on',
         transport: 'on',
+        sourceSearch: 'on',
       };
       const result = resolveWithoutProbing(config);
 
@@ -30,6 +31,7 @@ describe('Feature Detection', () => {
         amdp: 'off',
         ui5: 'off',
         transport: 'off',
+        sourceSearch: 'off',
       };
       const result = resolveWithoutProbing(config);
 
@@ -46,6 +48,7 @@ describe('Feature Detection', () => {
         amdp: 'auto',
         ui5: 'auto',
         transport: 'auto',
+        sourceSearch: 'auto',
       };
       const result = resolveWithoutProbing(config);
 
@@ -61,6 +64,7 @@ describe('Feature Detection', () => {
         amdp: 'on',
         ui5: 'off',
         transport: 'auto',
+        sourceSearch: 'auto',
       };
       const result = resolveWithoutProbing(config);
 
@@ -80,6 +84,7 @@ describe('Feature Detection', () => {
         amdp: 'auto',
         ui5: 'auto',
         transport: 'auto',
+        sourceSearch: 'auto',
       };
       const result = resolveWithoutProbing(config);
 

--- a/tests/unit/adt/xml-parser.test.ts
+++ b/tests/unit/adt/xml-parser.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   findDeepNodes,
+  parseClassStructure,
   parseFunctionGroup,
   parseInstalledComponents,
   parsePackageContents,
@@ -348,6 +349,53 @@ describe('XML Parser', () => {
       expect(result.user).toBe('TEST_USER');
       expect(result.collections).toHaveLength(1);
       expect(result.collections[0]).toEqual({ title: 'Core', href: '/sap/bc/adt/core' });
+    });
+  });
+
+  // ─── parseClassStructure ───────────────────────────────────────────
+
+  describe('parseClassStructure', () => {
+    it('parses method line ranges from objectstructure XML', () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+<objectStructure>
+  <objectStructureElement type="CLAS/OM" name="RUN">
+    <link href="source/main#start=5,4;end=5,6" rel="definition"/>
+    <link href="source/main#start=10,2;end=20,11" rel="implementation"/>
+  </objectStructureElement>
+  <objectStructureElement type="CLAS/OM" name="EXECUTE">
+    <link href="source/main#start=22,2;end=30,11"/>
+  </objectStructureElement>
+  <objectStructureElement type="CLAS/OA" name="GV_DATA">
+    <link href="source/main#start=3,4;end=3,20"/>
+  </objectStructureElement>
+</objectStructure>`;
+      const methods = parseClassStructure(xml);
+      expect(methods).toHaveLength(2);
+      expect(methods[0]?.name).toBe('RUN');
+      expect(methods[0]?.startLine).toBe(10);
+      expect(methods[0]?.endLine).toBe(20);
+      expect(methods[1]?.name).toBe('EXECUTE');
+      expect(methods[1]?.startLine).toBe(22);
+      expect(methods[1]?.endLine).toBe(30);
+    });
+
+    it('handles empty objectstructure', () => {
+      const xml = '<objectStructure/>';
+      const methods = parseClassStructure(xml);
+      expect(methods).toEqual([]);
+    });
+
+    it('picks widest line range for methods with multiple links', () => {
+      const xml = `<objectStructure>
+  <objectStructureElement type="CLAS/OM" name="SAVE">
+    <link href="source/main#start=50,12;end=50,15"/>
+    <link href="source/main#start=50,4;end=80,11"/>
+  </objectStructureElement>
+</objectStructure>`;
+      const methods = parseClassStructure(xml);
+      expect(methods).toHaveLength(1);
+      expect(methods[0]?.startLine).toBe(50);
+      expect(methods[0]?.endLine).toBe(80);
     });
   });
 

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -465,9 +465,13 @@ describe('Intent Handler', () => {
     });
 
     it('maps write tools to write scope', () => {
-      for (const tool of ['SAPWrite', 'SAPActivate', 'SAPManage']) {
+      for (const tool of ['SAPWrite', 'SAPActivate']) {
         expect(TOOL_SCOPES[tool]).toBe('write');
       }
+    });
+
+    it('maps SAPManage to read scope (probe/features are read-only operations)', () => {
+      expect(TOOL_SCOPES.SAPManage).toBe('read');
     });
 
     it('maps transport to admin scope', () => {
@@ -785,6 +789,112 @@ ENDCLASS.`;
       expect(result.isError).toBeUndefined();
       expect(result.content[0]?.text).toContain('BOR ZBUS_OBJ.CREATE');
       expect(result.content[0]?.text).toContain('REPORT zprog1');
+    });
+  });
+
+  // ─── CLAS method-level reading ──────────────────────────────────────
+
+  describe('SAPRead CLAS method', () => {
+    it('reads a single method from a class', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      // First call: objectstructure
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: `<objectStructure>
+          <objectStructureElement type="CLAS/OM" name="RUN">
+            <link href="source/main#start=5,4;end=5,6" rel="definition"/>
+            <link href="source/main#start=10,2;end=20,11" rel="implementation"/>
+          </objectStructureElement>
+        </objectStructure>`,
+        headers: {},
+      });
+      // Second call: full source
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: 'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\n  METHOD run.\n    WRITE: / hello.\n    WRITE: / world.\n    DATA: lv_test TYPE string.\n    lv_test = |Hello|.\n    WRITE: / lv_test.\n    IF lv_test IS NOT INITIAL.\n      WRITE: / lv_test.\n    ENDIF.\n    WRITE: / bye.\n  ENDMETHOD.',
+        headers: {},
+      });
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        method: 'RUN',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('METHOD run');
+      // Should NOT contain the first 9 lines
+      expect(result.content[0]?.text).not.toContain('line1');
+    });
+
+    it('returns error with method list when method not found', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      // First call: objectstructure (for getClassMethod)
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: `<objectStructure>
+          <objectStructureElement type="CLAS/OM" name="RUN">
+            <link href="source/main#start=10,2;end=20,11"/>
+          </objectStructureElement>
+          <objectStructureElement type="CLAS/OM" name="EXECUTE">
+            <link href="source/main#start=22,2;end=30,11"/>
+          </objectStructureElement>
+        </objectStructure>`,
+        headers: {},
+      });
+      // Second call: objectstructure (for getClassMethods, to list available methods)
+      requestSpy.mockResolvedValueOnce({
+        status: 200,
+        data: `<objectStructure>
+          <objectStructureElement type="CLAS/OM" name="RUN">
+            <link href="source/main#start=10,2;end=20,11"/>
+          </objectStructureElement>
+          <objectStructureElement type="CLAS/OM" name="EXECUTE">
+            <link href="source/main#start=22,2;end=30,11"/>
+          </objectStructureElement>
+        </objectStructure>`,
+        headers: {},
+      });
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        method: 'NONEXISTENT',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('not found');
+      expect(result.content[0]?.text).toContain('RUN');
+      expect(result.content[0]?.text).toContain('EXECUTE');
+    });
+  });
+
+  // ─── SAPSearch with objectType/packageName ─────────────────────────
+
+  describe('SAPSearch object search with filters', () => {
+    it('passes objectType to object search', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      requestSpy.mockClear();
+      await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPSearch', {
+        query: 'ZCL_*',
+        objectType: 'CLAS',
+      });
+      // Find the quickSearch call among all calls (auto-probe may add background calls)
+      const allUrls = requestSpy.mock.calls.map((c: any[]) => c[0]?.url ?? '');
+      const searchUrl = allUrls.find((u: string) => u.includes('quickSearch'));
+      expect(searchUrl).toContain('objectType=CLAS%2FOC');
+    });
+
+    it('passes packageName to object search', async () => {
+      const mockInstance = (axios.create as any)();
+      const requestSpy = mockInstance.request as ReturnType<typeof vi.fn>;
+      requestSpy.mockClear();
+      await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPSearch', {
+        query: 'Z*',
+        packageName: 'ZTEST_PKG',
+      });
+      const allUrls = requestSpy.mock.calls.map((c: any[]) => c[0]?.url ?? '');
+      const searchUrl = allUrls.find((u: string) => u.includes('quickSearch'));
+      expect(searchUrl).toContain('packageName=ZTEST_PKG');
     });
   });
 

--- a/tests/unit/handlers/tools.test.ts
+++ b/tests/unit/handlers/tools.test.ts
@@ -38,7 +38,8 @@ describe('Tool Definitions', () => {
     const names = tools.map((t) => t.name);
     expect(names).not.toContain('SAPWrite');
     expect(names).not.toContain('SAPActivate');
-    expect(names).not.toContain('SAPManage');
+    // SAPManage is now always registered (probe/features are read-only operations)
+    expect(names).toContain('SAPManage');
     // Navigate, Diagnose, and SAPContext should still be available
     expect(names).toContain('SAPNavigate');
     expect(names).toContain('SAPDiagnose');

--- a/ts-src/adt/client.ts
+++ b/ts-src/adt/client.ts
@@ -23,6 +23,7 @@ import { AdtHttpClient, type AdtHttpConfig } from './http.js';
 import { checkOperation, OperationType, type SafetyConfig } from './safety.js';
 import type { AdtSearchResult, SourceSearchResult } from './types.js';
 import {
+  parseClassStructure,
   parseFunctionGroup,
   parseInstalledComponents,
   parsePackageContents,
@@ -31,6 +32,26 @@ import {
   parseSystemInfo,
   parseTableContents,
 } from './xml-parser.js';
+
+/** Map simple object type names to ADT compound format for quickSearch filtering */
+const ADT_OBJECT_TYPE_MAP: Record<string, string> = {
+  CLAS: 'CLAS/OC',
+  INTF: 'INTF/OI',
+  PROG: 'PROG/P',
+  FUGR: 'FUGR/F',
+  FUNC: 'FUGR/FF',
+  TABL: 'TABL/DT',
+  VIEW: 'VIEW/DV',
+  DDLS: 'DDLS/DF',
+  BDEF: 'BDEF/BDO',
+  SRVD: 'SRVD/SRV',
+  INCL: 'PROG/I',
+  DTEL: 'DTEL/DE',
+  DOMA: 'DOMA/DD',
+  TTYP: 'TTYP/DA',
+  MSAG: 'MSAG/N',
+  DEVC: 'DEVC/K',
+};
 
 export class AdtClient {
   readonly http: AdtHttpClient;
@@ -113,6 +134,45 @@ export class AdtClient {
       }
     }
     return parts.join('\n\n');
+  }
+
+  /**
+   * Get a single method's source from a class.
+   *
+   * Fetches the class objectstructure to find the method's line range,
+   * then reads the full source and extracts just that method.
+   */
+  async getClassMethod(name: string, method: string): Promise<string | null> {
+    checkOperation(this.safety, OperationType.Read, 'GetClassMethod');
+    const encodedName = encodeURIComponent(name);
+
+    // Get class structure to find method line ranges
+    const structResp = await this.http.get(`/sap/bc/adt/oo/classes/${encodedName}/objectstructure`);
+    const methods = parseClassStructure(structResp.body);
+
+    // Find the requested method (case-insensitive, handle interface methods with ~)
+    const methodUpper = method.toUpperCase();
+    const found = methods.find((m) => {
+      const mName = m.name.toUpperCase();
+      return mName === methodUpper || mName.endsWith(`~${methodUpper}`);
+    });
+
+    if (!found) return null;
+
+    // Fetch full source and extract the method lines
+    const sourceResp = await this.http.get(`/sap/bc/adt/oo/classes/${encodedName}/source/main`);
+    const lines = sourceResp.body.split('\n');
+    // ADT line numbers are 1-based
+    const extracted = lines.slice(found.startLine - 1, found.endLine);
+    return extracted.join('\n');
+  }
+
+  /** Get the list of methods in a class with their line ranges */
+  async getClassMethods(name: string): Promise<Array<{ name: string; startLine: number; endLine: number }>> {
+    checkOperation(this.safety, OperationType.Read, 'GetClassMethods');
+    const encodedName = encodeURIComponent(name);
+    const resp = await this.http.get(`/sap/bc/adt/oo/classes/${encodedName}/objectstructure`);
+    return parseClassStructure(resp.body);
   }
 
   /** Get interface source code */
@@ -201,12 +261,22 @@ export class AdtClient {
 
   // ─── Search Operations ─────────────────────────────────────────────
 
-  /** Search for ABAP objects by name pattern */
-  async searchObject(query: string, maxResults = 100): Promise<AdtSearchResult[]> {
+  /** Search for ABAP objects by name pattern, optionally filtered by type and package */
+  async searchObject(
+    query: string,
+    maxResults = 100,
+    objectType?: string,
+    packageName?: string,
+  ): Promise<AdtSearchResult[]> {
     checkOperation(this.safety, OperationType.Search, 'SearchObject');
-    const resp = await this.http.get(
-      `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=${encodeURIComponent(query)}&maxResults=${maxResults}`,
-    );
+    let url = `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=${encodeURIComponent(query)}&maxResults=${maxResults}`;
+    if (objectType) {
+      // Map simple type names to ADT compound format (CLAS → CLAS/OC, etc.)
+      const adtType = ADT_OBJECT_TYPE_MAP[objectType.toUpperCase()] ?? objectType;
+      url += `&objectType=${encodeURIComponent(adtType)}`;
+    }
+    if (packageName) url += `&packageName=${encodeURIComponent(packageName)}`;
+    const resp = await this.http.get(url);
     return parseSearchResults(resp.body);
   }
 

--- a/ts-src/adt/config.ts
+++ b/ts-src/adt/config.ts
@@ -21,6 +21,7 @@ export interface FeatureConfig {
   amdp: FeatureMode;
   ui5: FeatureMode;
   transport: FeatureMode;
+  sourceSearch: FeatureMode;
 }
 
 /** Default feature config: all auto-detect */
@@ -32,6 +33,7 @@ export function defaultFeatureConfig(): FeatureConfig {
     amdp: 'auto',
     ui5: 'auto',
     transport: 'auto',
+    sourceSearch: 'auto',
   };
 }
 

--- a/ts-src/adt/features.ts
+++ b/ts-src/adt/features.ts
@@ -37,6 +37,11 @@ const PROBES: FeatureProbe[] = [
   { id: 'amdp', endpoint: '/sap/bc/adt/debugger/amdp', description: 'AMDP debugging' },
   { id: 'ui5', endpoint: '/sap/bc/adt/filestore/ui5-bsp', description: 'UI5/Fiori BSP' },
   { id: 'transport', endpoint: '/sap/bc/adt/cts/transportrequests', description: 'CTS transport management' },
+  {
+    id: 'sourceSearch',
+    endpoint: '/sap/bc/adt/repository/informationsystem/textSearch?searchString=_&maxResults=1',
+    description: 'Source code full-text search (requires SAP_BASIS ≥ 7.51)',
+  },
 ];
 
 /** Resolve a single feature based on its mode */
@@ -172,6 +177,7 @@ export function resolveWithoutProbing(config: FeatureConfig): ResolvedFeatures {
     amdp: 'AMDP debugging',
     ui5: 'UI5/Fiori BSP',
     transport: 'CTS transport management',
+    sourceSearch: 'Source code full-text search (requires SAP_BASIS ≥ 7.51)',
   };
 
   for (const [id, mode] of Object.entries(config)) {

--- a/ts-src/adt/types.ts
+++ b/ts-src/adt/types.ts
@@ -40,6 +40,7 @@ export interface ResolvedFeatures {
   amdp: FeatureStatus;
   ui5: FeatureStatus;
   transport: FeatureStatus;
+  sourceSearch: FeatureStatus;
   /** Detected SAP_BASIS release (e.g. "750", "757"). Populated during probe. */
   abapRelease?: string;
 }

--- a/ts-src/adt/xml-parser.ts
+++ b/ts-src/adt/xml-parser.ts
@@ -305,6 +305,55 @@ export function parseSourceSearchResults(xml: string): SourceSearchResult[] {
   return results;
 }
 
+/**
+ * Parse class objectstructure response to extract method line ranges.
+ *
+ * The objectstructure endpoint returns the class structure with
+ * ADT links containing fragment identifiers that encode line ranges:
+ *   source/main#start=20,2;end=58,11
+ *
+ * We extract the method name and its implementation line range.
+ */
+export function parseClassStructure(xml: string): Array<{ name: string; startLine: number; endLine: number }> {
+  const parsed = parseXml(xml);
+  const elements = findDeepNodes(parsed, 'objectStructureElement');
+  const methods: Array<{ name: string; startLine: number; endLine: number }> = [];
+
+  for (const el of elements) {
+    const type = String(el['@_type'] ?? '');
+    // Match method types: CLAS/OM (instance method), CLAS/OO (class/static method)
+    // Exclude: CLAS/OA (attributes), CLAS/OC (class), CLAS/OE (events), CLAS/OT (types)
+    if (type !== 'CLAS/OM' && type !== 'CLAS/OO') continue;
+
+    const name = String(el['@_name'] ?? '');
+    if (!name) continue;
+
+    // Find the implementation link — it has rel="source" or rel="impl" or contains the largest block
+    const links = Array.isArray(el.link) ? el.link : el.link ? [el.link] : [];
+    for (const link of links as Array<Record<string, unknown>>) {
+      const href = String(link['@_href'] ?? '');
+      // Look for implementation block (typically the second fragment, or the one with larger range)
+      const fragMatch = href.match(/source\/main#start=(\d+),\d+;end=(\d+),\d+/);
+      if (fragMatch) {
+        const startLine = Number(fragMatch[1]);
+        const endLine = Number(fragMatch[2]);
+        // Pick the widest range for this method (implementation, not definition identifier)
+        const existing = methods.find((m) => m.name === name);
+        if (!existing || endLine - startLine > existing.endLine - existing.startLine) {
+          if (existing) {
+            existing.startLine = startLine;
+            existing.endLine = endLine;
+          } else {
+            methods.push({ name, startLine, endLine });
+          }
+        }
+      }
+    }
+  }
+
+  return methods;
+}
+
 // ─── Helpers ────────────────────────────────────────────────────────
 
 /** Safely get a nested array from parsed XML */

--- a/ts-src/handlers/intent.ts
+++ b/ts-src/handlers/intent.ts
@@ -14,6 +14,7 @@ import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import type { AdtClient } from '../adt/client.js';
 import { findDefinition, findReferences, getCompletion } from '../adt/codeintel.js';
+import { defaultFeatureConfig } from '../adt/config.js';
 import { createObject, deleteObject, lockObject, safeUpdateSource, unlockObject } from '../adt/crud.js';
 import { activate, runAtcCheck, runUnitTests, syntaxCheck } from '../adt/devtools.js';
 import { AdtApiError, AdtNetworkError, AdtSafetyError } from '../adt/errors.js';
@@ -53,7 +54,7 @@ export const TOOL_SCOPES: Record<string, string> = {
   SAPDiagnose: 'read',
   SAPWrite: 'write',
   SAPActivate: 'write',
-  SAPManage: 'write',
+  SAPManage: 'read',
   SAPTransport: 'admin',
 };
 
@@ -148,6 +149,14 @@ export async function handleToolCall(
         `Insufficient scope: '${requiredScope}' required for ${toolName}. Your scopes: [${authInfo.scopes.join(', ')}]`,
       );
     }
+  }
+
+  // Auto-probe features on first tool call (background, non-blocking)
+  if (!cachedFeatures && !autoProbeTriggered) {
+    autoProbeTriggered = true;
+    triggerAutoProbe(client, _config).catch(() => {
+      // Swallow errors — auto-probe is best-effort
+    });
   }
 
   // Run within request context so HTTP-level logs get the requestId
@@ -246,8 +255,22 @@ async function handleSAPRead(client: AdtClient, args: Record<string, unknown>): 
   switch (type) {
     case 'PROG':
       return textResult(await client.getProgram(name));
-    case 'CLAS':
+    case 'CLAS': {
+      const method = args.method as string | undefined;
+      if (method) {
+        const methodSource = await client.getClassMethod(name, method);
+        if (methodSource === null) {
+          // If method not found, list available methods
+          const methods = await client.getClassMethods(name);
+          const methodNames = methods.map((m) => m.name).join(', ');
+          return errorResult(
+            `Method "${method}" not found in class ${name}. Available methods: ${methodNames || '(none)'}`,
+          );
+        }
+        return textResult(methodSource);
+      }
       return textResult(await client.getClass(name, args.include as string | undefined));
+    }
     case 'INTF':
       return textResult(await client.getInterface(name));
     case 'FUNC': {
@@ -369,10 +392,10 @@ async function handleSAPSearch(client: AdtClient, args: Record<string, unknown>)
   const query = String(args.query ?? '');
   const maxResults = Number(args.maxResults ?? 100);
   const searchType = String(args.searchType ?? 'object');
+  const objectType = args.objectType as string | undefined;
+  const packageName = args.packageName as string | undefined;
 
   if (searchType === 'source_code') {
-    const objectType = args.objectType as string | undefined;
-    const packageName = args.packageName as string | undefined;
     try {
       const results = await client.searchSource(query, maxResults, objectType, packageName);
       return textResult(JSON.stringify(results, null, 2));
@@ -380,14 +403,15 @@ async function handleSAPSearch(client: AdtClient, args: Record<string, unknown>)
       if (err instanceof AdtApiError && (err.statusCode === 404 || err.statusCode === 501)) {
         return errorResult(
           `Source code search is not available on this SAP system (requires SAP_BASIS ≥ 7.51). ` +
-            `Use SAPSearch with searchType="object" to search by object name instead, or use SAPQuery to search metadata tables.`,
+            `Use SAPSearch with searchType="object" to search by object name instead, or use SAPQuery to search metadata tables ` +
+            `(e.g., SEOCOMPO for class methods, REPOSRC for source text).`,
         );
       }
       throw err;
     }
   }
 
-  const results = await client.searchObject(query, maxResults);
+  const results = await client.searchObject(query, maxResults, objectType, packageName);
   return textResult(JSON.stringify(results, null, 2));
 }
 
@@ -718,6 +742,8 @@ async function handleSAPContext(client: AdtClient, args: Record<string, unknown>
 
 /** Cached feature status — populated on first probe */
 let cachedFeatures: ResolvedFeatures | undefined;
+/** Whether auto-probe has been triggered (to avoid duplicate probes) */
+let autoProbeTriggered = false;
 
 async function handleSAPManage(
   client: AdtClient,
@@ -737,7 +763,6 @@ async function handleSAPManage(
     }
 
     case 'probe': {
-      const { defaultFeatureConfig } = await import('../adt/config.js');
       const featureConfig = defaultFeatureConfig();
       // Override with server config feature toggles
       featureConfig.hana = config.featureHana as 'auto' | 'on' | 'off';
@@ -746,6 +771,7 @@ async function handleSAPManage(
       featureConfig.amdp = config.featureAmdp as 'auto' | 'on' | 'off';
       featureConfig.ui5 = config.featureUi5 as 'auto' | 'on' | 'off';
       featureConfig.transport = config.featureTransport as 'auto' | 'on' | 'off';
+      featureConfig.sourceSearch = 'auto'; // Always auto-detect
 
       cachedFeatures = await probeFeatures(client.http, featureConfig);
       return textResult(JSON.stringify(cachedFeatures, null, 2));
@@ -756,7 +782,22 @@ async function handleSAPManage(
   }
 }
 
+/** Auto-probe features in the background on first tool call */
+async function triggerAutoProbe(client: AdtClient, config: ServerConfig): Promise<void> {
+  const featureConfig = defaultFeatureConfig();
+  featureConfig.hana = config.featureHana as 'auto' | 'on' | 'off';
+  featureConfig.abapGit = config.featureAbapGit as 'auto' | 'on' | 'off';
+  featureConfig.rap = config.featureRap as 'auto' | 'on' | 'off';
+  featureConfig.amdp = config.featureAmdp as 'auto' | 'on' | 'off';
+  featureConfig.ui5 = config.featureUi5 as 'auto' | 'on' | 'off';
+  featureConfig.transport = config.featureTransport as 'auto' | 'on' | 'off';
+  featureConfig.sourceSearch = 'auto';
+  cachedFeatures = await probeFeatures(client.http, featureConfig);
+  logger.info('Auto-probe completed', { features: Object.keys(cachedFeatures).length });
+}
+
 /** Reset cached features (for testing) */
 export function resetCachedFeatures(): void {
   cachedFeatures = undefined;
+  autoProbeTriggered = false;
 }

--- a/ts-src/handlers/tools.ts
+++ b/ts-src/handlers/tools.ts
@@ -25,7 +25,8 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
     {
       name: 'SAPRead',
       description:
-        'Read SAP ABAP objects. Types: PROG, CLAS, INTF, FUNC, FUGR (use expand_includes=true to get all include sources), INCL, DDLS, BDEF, SRVD, TABL, VIEW, TABLE_CONTENTS, DEVC, SOBJ (BOR business objects — returns method catalog or full implementation), SYSTEM, COMPONENTS, MESSAGES, TEXT_ELEMENTS, VARIANTS. For CLAS: omit include to get the full class source (definition + implementation combined). The include param is optional — use it only to read class-local sections: definitions (local types), implementations (local helper classes), macros, testclasses (ABAP Unit). For SOBJ: returns BOR method catalog; use method param to read a specific method implementation.',
+        'Read SAP ABAP objects. Types: PROG, CLAS, INTF, FUNC, FUGR (use expand_includes=true to get all include sources), INCL, DDLS, BDEF, SRVD, TABL, VIEW, TABLE_CONTENTS, DEVC, SOBJ (BOR business objects — returns method catalog or full implementation), SYSTEM, COMPONENTS, MESSAGES, TEXT_ELEMENTS, VARIANTS. For CLAS: omit include to get the full class source (definition + implementation combined). Use the method param to read a SINGLE method from a class — much more efficient than fetching the entire source for large classes. The include param is optional — use it only to read class-local sections: definitions (local types), implementations (local helper classes), macros, testclasses (ABAP Unit). For SOBJ: returns BOR method catalog; use method param to read a specific method implementation.\n\n' +
+        'After reading a large class, use SAPContext to understand its dependencies instead of manually reading each one. Use SAPNavigate(action="references") to find where a class is used (where-used list).',
       inputSchema: {
         type: 'object',
         properties: {
@@ -68,7 +69,7 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
           method: {
             type: 'string',
             description:
-              'For SOBJ type only. BOR method name to read. If omitted, returns the full method catalog for the BOR object.',
+              'For CLAS: read a single method instead of the full class source. Returns only that method\'s implementation — much more token-efficient for large classes (e.g., a 7000-line class returns ~50 lines for one method). Supports interface methods (e.g., "IF_INTERFACE~METHOD"). If omitted, returns the full class. For SOBJ: BOR method name to read. If omitted, returns the full method catalog.',
           },
           expand_includes: {
             type: 'boolean',
@@ -85,9 +86,13 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
       name: 'SAPSearch',
       description:
         'Search for ABAP objects or search within source code. Two modes:\n' +
-        '1. Object search (default): Search by name pattern with wildcards (* for any characters). Returns object type, name, package, description, and ADT URI. Use this to find classes, programs, function modules, tables, etc.\n' +
+        '1. Object search (default): Search by name pattern with wildcards (* for any characters). Returns object type, name, package, description, and ADT URI. Supports objectType filter (e.g., CLAS, BDEF, PROG) and packageName filter.\n' +
         '2. Source code search (searchType="source_code"): Full-text search within ABAP source code across the system. Use this to find all objects containing a specific string (e.g., a method call, variable name, or class reference). Requires SAP_BASIS ≥ 7.51.\n\n' +
-        'Tips: BOR business objects appear as SOBJ type in results. The uri field from results can be used directly with SAPNavigate for references.',
+        'Tips for efficient searching:\n' +
+        '- To list ALL objects in a package: use SAPRead(type="DEVC", name="PACKAGE_NAME") instead — one call replaces multiple searches.\n' +
+        '- To find objects of a specific type: use the objectType filter (e.g., objectType="BDEF"). Object type is NOT part of the name — don\'t include it in query patterns.\n' +
+        "- For type-filtered package queries: SAPQuery(sql=\"SELECT obj_name FROM tadir WHERE devclass = 'PKG' AND object = 'CLAS'\").\n" +
+        '- BOR business objects appear as SOBJ type in results. The uri field from results can be used directly with SAPNavigate for references.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -104,9 +109,13 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
           },
           objectType: {
             type: 'string',
-            description: 'For source_code search: filter by object type (e.g., PROG, CLAS, FUNC)',
+            description:
+              'Filter by object type (e.g., CLAS, BDEF, PROG, INTF, FUNC, TABL, DDLS, SRVD). Works for both object search and source_code search.',
           },
-          packageName: { type: 'string', description: 'For source_code search: filter by package name' },
+          packageName: {
+            type: 'string',
+            description: 'Filter by package name. Works for both object search and source_code search.',
+          },
           maxResults: { type: 'number', description: 'Maximum results (default 100 for object, 50 for source_code)' },
         },
         required: ['query'],
@@ -152,7 +161,7 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
     {
       name: 'SAPNavigate',
       description:
-        'Navigate code: find definitions, references, and code completion. Use for "go to definition", "where is this used?", and auto-complete. For references: you can use type+name instead of uri (e.g., type="CLAS", name="ZCL_ORDER") for a where-used list without needing the full ADT URI.',
+        'Navigate code: find definitions, references (where-used list), and code completion. Use for "go to definition", "where is this used?", "who calls this class?", and auto-complete. For references/where-used: you can use type+name instead of uri (e.g., type="CLAS", name="ZCL_ORDER") for a where-used list without needing the full ADT URI. This is the best way to find all callers of a class, interface, or function module.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -182,13 +191,33 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
       description:
         'Execute ABAP SQL queries against SAP tables. Returns structured data with column names and rows. ' +
         'Powerful for reverse-engineering: query metadata tables like DD02L (table catalog), DD03L (field catalog), ' +
-        'SWOTLV (BOR method implementations), TADIR (object directory), TFDIR (function modules). ' +
-        'If a table is not found, similar table names will be suggested automatically.',
+        'SEOCOMPO (class/interface components), SWOTLV (BOR method implementations), TADIR (object directory), TFDIR (function modules). ' +
+        'If a table is not found, similar table names will be suggested automatically.\n\n' +
+        'IMPORTANT — SQL dialect: This executes ABAP Open SQL, NOT standard/ANSI SQL. Key differences:\n' +
+        '- Row limiting: Do NOT use FETCH FIRST, LIMIT, or ROWNUM — they will cause syntax errors. Use the maxRows parameter instead (applied server-side). UP TO n ROWS is supported but maxRows overrides it.\n' +
+        '- Only SELECT: INSERT, UPDATE, DELETE, and DDL (CREATE/DROP/ALTER) are not supported.\n' +
+        '- JOINs: INNER JOIN and LEFT OUTER JOIN supported. RIGHT OUTER JOIN supported on newer systems. No FULL OUTER JOIN.\n' +
+        '- Subqueries: Supported in WHERE and HAVING clauses, but NOT in JOIN ON conditions.\n' +
+        '- UNION: Supported from SAP_BASIS ≥ 7.50. Cannot combine with UP TO or OFFSET.\n' +
+        '- Aggregates: COUNT(*), SUM(), AVG(), MIN(), MAX() work. GROUP BY and HAVING supported.\n' +
+        '- String functions: CONCAT(), LENGTH(), SUBSTRING(), REPLACE(), LPAD(), RPAD() (from 7.40+).\n' +
+        '- CASE WHEN: Supported (from 7.40 SP08+).\n' +
+        '- LIKE: Works with % and _ wildcards. Case-sensitive.\n' +
+        '- Field access in JOINs: Use tilde notation table~field for disambiguation.\n' +
+        '- Client handling: Automatic client filtering is active by default (MANDT column filtered automatically).\n' +
+        '- String literals: Use single quotes only.',
       inputSchema: {
         type: 'object',
         properties: {
-          sql: { type: 'string', description: 'ABAP SQL SELECT statement' },
-          maxRows: { type: 'number', description: 'Maximum rows (default 100)' },
+          sql: {
+            type: 'string',
+            description: 'ABAP Open SQL SELECT statement. Do NOT use FETCH FIRST, LIMIT, or ROWNUM.',
+          },
+          maxRows: {
+            type: 'number',
+            description:
+              'Maximum rows to return (default 100). This is the ONLY reliable way to limit rows — do not use FETCH FIRST, LIMIT, or ROWNUM in your SQL (they cause syntax errors). The server applies this limit regardless of your SQL.',
+          },
         },
         required: ['sql'],
       },
@@ -232,19 +261,20 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
   tools.push({
     name: 'SAPContext',
     description:
-      'Get compressed dependency context for an ABAP object. Returns only the public API contracts ' +
-      '(method signatures, interface definitions, type declarations) of all objects that the target depends on — ' +
+      'IMPORTANT: After reading a class/program with SAPRead, use SAPContext as your NEXT call to understand its dependencies. ' +
+      'Do NOT manually follow dependencies with multiple SAPRead calls — SAPContext does this in one call with 7-30x fewer tokens.\n\n' +
+      'Returns only the public API contracts (method signatures, interface definitions, type declarations) of all objects that the target depends on — ' +
       'NOT the full source code. This is the most token-efficient way to understand dependencies. ' +
       'Instead of N separate SAPRead calls returning full source (~200 lines each), SAPContext returns ONE response ' +
-      'with compressed contracts (~15-30 lines each). Typical compression: 7-30x fewer tokens.\n\n' +
+      'with compressed contracts (~15-30 lines each).\n\n' +
       'What gets extracted per dependency:\n' +
       '- Classes: CLASS DEFINITION with PUBLIC SECTION only (methods, types, constants). PROTECTED, PRIVATE and IMPLEMENTATION stripped.\n' +
       '- Interfaces: Full interface definition (interfaces are already public contracts).\n' +
       '- Function modules: FUNCTION signature block only (IMPORTING/EXPORTING parameters).\n\n' +
       'Filtering: SAP standard objects (CL_ABAP_*, IF_ABAP_*, CX_SY_*) are excluded — the LLM already knows standard SAP APIs. ' +
       'Custom objects (Z*, Y*) are prioritized.\n\n' +
-      'Use SAPContext BEFORE writing code that modifies or extends existing objects. ' +
-      'Use SAPRead to get the full source of the target object, then SAPContext to understand its dependencies.',
+      "Use SAPContext whenever you need to understand an object's dependencies — whether for analysis, debugging, or before writing code. " +
+      "If you've just read a class with SAPRead and need to understand what it calls/uses, SAPContext is always the next step.",
     inputSchema: {
       type: 'object',
       properties: {
@@ -282,33 +312,31 @@ export function getToolDefinitions(config: ServerConfig): ToolDefinition[] {
     },
   });
 
-  // SAPManage — registered when not in read-only mode
-  if (!config.readOnly) {
-    tools.push({
-      name: 'SAPManage',
-      description:
-        'Probe and report SAP system capabilities. Use this BEFORE attempting operations that depend on optional ' +
-        'features (abapGit, RAP/CDS, AMDP, HANA, UI5/Fiori, CTS transports).\n\n' +
-        'Actions:\n' +
-        '- "features": Get cached feature status from last probe (fast, no SAP round-trip). ' +
-        'Returns which features are available, their mode (auto/on/off), and when they were last probed.\n' +
-        '- "probe": Re-probe the SAP system now (makes 6 parallel HEAD requests, ~1-2s). ' +
-        'Use this on first use or if you suspect feature availability has changed.\n\n' +
-        'Returns JSON with 6 features, each having: id, available (bool), mode, message, and probedAt timestamp. ' +
-        '"available: false" means do NOT attempt operations that depend on it.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          action: {
-            type: 'string',
-            enum: ['features', 'probe'],
-            description: 'Action: "features" for cached status, "probe" to re-check SAP system',
-          },
+  // SAPManage — always registered (probe/features are read-only operations)
+  tools.push({
+    name: 'SAPManage',
+    description:
+      'Probe and report SAP system capabilities. Use this BEFORE attempting operations that depend on optional ' +
+      'features (source code search, abapGit, RAP/CDS, AMDP, HANA, UI5/Fiori, CTS transports).\n\n' +
+      'Actions:\n' +
+      '- "features": Get cached feature status from last probe (fast, no SAP round-trip). ' +
+      'Returns which features are available, their mode (auto/on/off), and when they were last probed.\n' +
+      '- "probe": Re-probe the SAP system now (makes parallel HEAD requests, ~1-2s). ' +
+      'Use this on first use or if you suspect feature availability has changed.\n\n' +
+      'Returns JSON with features, each having: id, available (bool), mode, message, and probedAt timestamp. ' +
+      '"available: false" means do NOT attempt operations that depend on it.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['features', 'probe'],
+          description: 'Action: "features" for cached status, "probe" to re-check SAP system',
         },
-        required: ['action'],
       },
-    });
-  }
+      required: ['action'],
+    },
+  });
 
   // Transport tools — registered when transports are enabled or not in read-only mode
   if (config.enableTransports || !config.readOnly) {


### PR DESCRIPTION
## Summary

- **SAPRead CLAS method-level reading**: New `method` parameter extracts a single method from large classes using ADT `objectstructure` endpoint line ranges, avoiding full class source dumps
- **SAPSearch filters**: Added `objectType` and `packageName` parameters for object search with ADT compound type mapping (CLAS→CLAS/OC, BDEF→BDEF/BDO, etc.)
- **SAPQuery SQL guidance**: Comprehensive ABAP Open SQL dialect hints in tool description (no FETCH FIRST/LIMIT/ROWNUM, tilde notation, supported JOINs/functions) — no runtime pre-processor
- **SAPManage always registered**: Moved outside read-only gate so probe/features are accessible regardless of write mode; scope changed to 'read'
- **Auto-probe**: Features are probed automatically on first tool call (background, non-blocking)
- **sourceSearch probe**: New feature probe for `/sap/bc/adt/repository/informationsystem/textSearch`
- **Tool descriptions**: Improved cross-references, where-used discoverability in SAPNavigate, stronger SAPContext triggers

## Test plan

- [x] All 520 unit tests pass (`npm test`)
- [x] TypeScript typecheck clean (`npm run typecheck`)
- [x] Biome lint clean (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] New tests for: parseClassStructure XML parsing, CLAS method-level read, method-not-found error, objectType/packageName search filters
- [x] Verified ADT API assumptions against test system (65.109.59.210)

🤖 Generated with [Claude Code](https://claude.com/claude-code)