### PR TITLE
docs: rewrite README to focus on enterprise USPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,255 +1,143 @@
 # arc1 — SAP ADT MCP Server
 
-**ARC-1 (ABAP Relay Connector) — Enterprise-ready proxy between AI clients and SAP systems.**
+**Enterprise-ready MCP server for SAP ABAP systems. Secure by default, deployable to BTP or on-premise, battle-tested with 700+ tests.**
 
-arc1 is a TypeScript MCP server (distributed as an npm package and Docker image) that implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) and translates AI tool calls into [SAP ABAP Development Tools (ADT)](https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide/about-abap-development-tools) REST API requests. It works with Claude, GitHub Copilot, VS Code, and any MCP-compatible client.
+arc1 connects AI assistants (Claude, GitHub Copilot, Copilot Studio, and any MCP client) to SAP systems via the [ADT REST API](https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide/about-abap-development-tools). It ships as an [npm package](https://www.npmjs.com/package/arc-1) and [Docker image](https://github.com/marianfoo/arc-1/pkgs/container/arc-1).
 
-> **This repository** ([marianfoo/arc-1](https://github.com/marianfoo/arc-1)) is the actively maintained fork, continued from the original [oisee/vibing-steampunk](https://github.com/oisee/vibing-steampunk).
+> Continued from [oisee/vibing-steampunk](https://github.com/oisee/vibing-steampunk) (Go), rewritten in TypeScript with enterprise security, BTP deployment, and production-grade tooling.
 
 ![Vibing ABAP Developer](./media/vibing-steampunk.png)
 
+**[Full Documentation](https://marianfoo.github.io/arc-1/)** | **[Setup Guide](https://marianfoo.github.io/arc-1/setup-guide/)** | **[Tool Reference](https://marianfoo.github.io/arc-1/tools/)**
+
 ## Why arc1?
 
-| | [abap-adt-api](https://github.com/marcellourbani/abap-adt-api) | [mcp-abap-adt](https://github.com/mario-andreschak/mcp-abap-adt) | **arc1** |
-|---|:---:|:---:|:---:|
-| npm package + Docker image | — | — | **Y** |
-| Read-only mode / package whitelist | — | — | **Y** |
-| Transport controls (CTS safety) | — | — | **Y** |
-| HTTP Streamable transport (Copilot Studio) | — | — | **Y** |
-| 11 intent-based tools (~5K schema tokens) | — | — | **Y** |
-| Method-level read/edit (95% token reduction) | — | — | **Y** |
-| Context compression (7–30x) | — | — | **Y** |
-| Works with 8+ MCP clients | — | — | **Y** |
+Built for organizations that need AI-assisted SAP development with guardrails. Inspired by the pioneering work of [abap-adt-api](https://github.com/marcellourbani/abap-adt-api), [mcp-abap-adt](https://github.com/mario-andreschak/mcp-abap-adt), and [vibing-steampunk](https://github.com/oisee/vibing-steampunk) — arc1 adds what's needed to run in production:
 
-As an **admin**, you control what the AI can and cannot do:
-- Restrict to read-only, specific packages, or whitelisted operations
-- Require transport assignments before any write
-- Block free-form SQL execution
-- Allow or deny individual operation types per deployment
+### Security & Admin Controls
+
+- **Read-only mode** — block all writes with a single flag (`--read-only`)
+- **Operation allowlists/denylists** — control exactly which operation types (read, write, search, query, activate, transport) are permitted
+- **Package restrictions** — limit AI access to specific packages with wildcards (`--allowed-packages "Z*,$TMP"`)
+- **SQL execution control** — block free-form SQL queries (`--block-free-sql`)
+- **Transport safety** — require transport assignments, restrict to specific transports, or make transports read-only
+- **All writes blocked by default** — safe defaults out of the box
+
+### Authentication
+
+- **API key** — simple Bearer token for internal deployments
+- **OIDC / JWT** — Entra ID, Keycloak, or any OpenID Connect provider
+- **OAuth 2.0** — browser-based login for BTP ABAP Environment
+- **XSUAA** — SAP BTP native auth with automatic token proxy for MCP clients
+- **Principal Propagation** — per-user identity forwarded through Cloud Connector (every SAP action runs as the actual user, not a technical account)
+
+### BTP Cloud Foundry Deployment
+
+Deploy arc1 as a Cloud Foundry app on SAP BTP with full platform integration:
+
+- **Destination Service** — connect to SAP systems via managed destinations
+- **Cloud Connector** — reach on-premise systems through the connectivity proxy
+- **Principal Propagation** — user identity forwarded end-to-end via X.509 certificates
+- **XSUAA OAuth proxy** — MCP clients authenticate via standard OAuth, arc1 handles the BTP token exchange
+- **Audit logging** — structured events to stderr, file, or BTP Audit Log Service
+
+### Token Efficiency
+
+- **11 intent-based tools** (~5K schema tokens) instead of 200+ individual tools — keeps the LLM's context window small
+- **Method-level read/edit** — read or update a single class method, not the whole source (up to 20x fewer tokens)
+- **Context compression** — `SAPContext` returns public API contracts of all dependencies in one call (7-30x compression)
+
+### Testing
+
+- **700+ tests** across unit, integration, and E2E
+- **Unit tests** run without SAP system access (33 test files, mocked HTTP)
+- **Integration tests** against live SAP systems (on-premise + BTP ABAP)
+- **E2E tests** deploy the server and execute real MCP tool calls
+- **CI matrix** across Node 20, 22, and 24
+
+### Tools Refined for Real-World Usage
+
+The 11 tools are designed from real LLM interaction feedback:
+
+| Tool | What it does |
+|------|-------------|
+| **SAPRead** | Read ABAP source, table data, CDS views, message classes, BOR objects |
+| **SAPSearch** | Object search + full-text source code search across the system |
+| **SAPWrite** | Create/update/delete ABAP source with automatic lock/unlock |
+| **SAPActivate** | Activate ABAP objects with error reporting |
+| **SAPNavigate** | Go-to-definition, find references, code completion |
+| **SAPQuery** | Execute ABAP SQL with table-not-found suggestions |
+| **SAPTransport** | CTS transport management (list, create, release) |
+| **SAPContext** | Compressed dependency context — one call replaces N SAPRead calls |
+| **SAPLint** | ABAP lint (local) + ATC checks (remote) |
+| **SAPDiagnose** | Syntax check, ABAP Unit tests, ATC code quality |
+| **SAPManage** | Feature probing — detect what the system supports before acting |
+
+Tool definitions automatically adapt to the target system (BTP vs on-premise), removing unavailable types and adjusting descriptions so the LLM never attempts unsupported operations.
+
+### Feature Detection
+
+arc1 probes the SAP system at startup and adapts its behavior:
+
+- Detects HANA, abapGit, RAP/CDS, AMDP, UI5, and transport availability
+- Auto-detects BTP vs on-premise systems
+- Maps SAP_BASIS release to the correct ABAP language version
+- Each feature can be forced on/off or left on auto-detect
 
 ## Quick Start
 
 ```bash
-# Run directly with npx (no install needed)
 npx arc-1 --url https://your-sap-host:44300 --user YOUR_USER
-
-# Or install globally
-npm install -g arc-1
-arc1 --url https://your-sap-host:44300 --user YOUR_USER
-
-# Or use Docker
-docker run -e SAP_URL=https://host:44300 -e SAP_USER=dev -e SAP_PASSWORD=secret \
-  ghcr.io/marianfoo/arc-1
 ```
 
-## Connect Your Client
+For Docker, BTP deployment, client configuration (Claude Desktop, Claude Code, VS Code, Copilot Studio), and all authentication methods, see the **[Setup Guide](https://marianfoo.github.io/arc-1/setup-guide/)**.
 
-### Claude Desktop
+## Comparison
 
-Add to `~/.config/claude/claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "sap": {
-      "command": "npx",
-      "args": ["-y", "arc-1"],
-      "env": {
-        "SAP_URL": "https://your-sap-host:44300",
-        "SAP_USER": "your-username",
-        "SAP_PASSWORD": "your-password"
-      }
-    }
-  }
-}
-```
-
-### Claude Code
-
-Add `.mcp.json` to your project root:
-
-```json
-{
-  "mcpServers": {
-    "sap": {
-      "command": "npx",
-      "args": ["-y", "arc-1"],
-      "env": {
-        "SAP_URL": "https://your-sap-host:44300",
-        "SAP_USER": "your-username",
-        "SAP_PASSWORD": "your-password"
-      }
-    }
-  }
-}
-```
-
-### GitHub Copilot / VS Code (HTTP Streamable)
-
-Start arc1 as an HTTP server, then point your MCP client to it:
-
-```bash
-SAP_URL=https://host:44300 SAP_USER=dev SAP_PASSWORD=secret \
-  npx arc-1 --transport http-streamable --port 3000
-```
-
-Add to VS Code / Copilot MCP config:
-
-```json
-{
-  "mcpServers": {
-    "sap": {
-      "url": "http://localhost:3000/mcp"
-    }
-  }
-}
-```
-
-HTTP Streamable is also the transport for **Copilot Studio** (Microsoft Power Platform integrations).
-
-### Other MCP Clients (Gemini CLI, OpenCode, Goose, Qwen, …)
-
-All MCP clients that support stdio work out of the box — just point them at `npx arc-1`.
-
-## Tools
-
-arc1 exposes 11 intent-based tools (~5K schema tokens):
-
-| Tool | What it does |
-|------|-------------|
-| **SAPRead** | Read ABAP source, table data, CDS views, message classes, class info |
-| **SAPSearch** | Find objects by name with wildcards |
-| **SAPWrite** | Create/update ABAP source code with auto lock/unlock |
-| **SAPActivate** | Activate (publish) ABAP objects |
-| **SAPNavigate** | Go-to-definition, find references, code completion |
-| **SAPQuery** | Execute ABAP SQL queries against SAP tables |
-| **SAPTransport** | CTS transport management (list, create, release) |
-| **SAPContext** | Compressed dependency context for LLM efficiency |
-| **SAPLint** | ABAP lint and code quality checks |
-| **SAPDiagnose** | Runtime errors (short dumps), profiler traces, SQL traces |
-| **SAPManage** | System feature probing and status |
-
-Full tool reference: **[docs/tools.md](docs/tools.md)**
-
-## Token Efficiency
-
-**Method-level surgery** — read or edit a single method, not the whole class:
-
-```
-SAPRead(type="CLAS", name="ZCL_CALCULATOR", include="implementations")
-SAPWrite(action="update", type="CLAS", name="ZCL_CALCULATOR", source="...")
-```
-
-Up to 20x fewer tokens vs full-class round-trips.
-
-**Context compression** — `SAPContext` auto-appends public API signatures of all referenced classes and interfaces (7–30x compression). One call = source + full dependency context.
-
-## Admin Controls (Safety)
-
-Configure what the AI is allowed to do before deployment:
-
-```bash
-# Read-only mode — no writes at all
-arc1 --read-only
-
-# Restrict to specific packages (wildcards supported)
-arc1 --allowed-packages "ZPROD*,$TMP"
-
-# Block free-form SQL
-arc1 --block-free-sql
-
-# Whitelist operation types (R=Read, S=Search, Q=Query, …)
-arc1 --allowed-ops "RSQ"
-```
-
-Full safety reference:
-
-| Flag / Env | Default | Effect |
-|---|:---:|---|
-| `--read-only` / `SAP_READ_ONLY` | false | Block all write operations |
-| `--block-free-sql` / `SAP_BLOCK_FREE_SQL` | false | Block `RunQuery` execution |
-| `--allowed-ops` / `SAP_ALLOWED_OPS` | (all) | Whitelist operation types |
-| `--disallowed-ops` / `SAP_DISALLOWED_OPS` | (none) | Blacklist operation types |
-| `--allowed-packages` / `SAP_ALLOWED_PACKAGES` | (all) | Restrict to packages (wildcards: `Z*,$TMP`) |
-
-## Configuration
-
-Priority order: CLI flags > environment variables > `.env` file > defaults.
-
-```bash
-# Basic
-arc1 --url https://host:44300 --user admin --password secret
-
-# Cookie auth (SSO / Fiori Launchpad)
-arc1 --url https://host:44300 --cookie-file cookies.txt
-```
-
-Full configuration reference: **[CLAUDE.md](CLAUDE.md#configuration)**
+| | [abap-adt-api](https://github.com/marcellourbani/abap-adt-api) | [mcp-abap-adt](https://github.com/mario-andreschak/mcp-abap-adt) | **arc1** |
+|---|:---:|:---:|:---:|
+| npm package + Docker image | — | — | Y |
+| Read-only mode / operation allowlists | — | — | Y |
+| Package restrictions (wildcards) | — | — | Y |
+| Transport safety controls | — | — | Y |
+| BTP deployment + Principal Propagation | — | — | Y |
+| OIDC / XSUAA / OAuth authentication | — | — | Y |
+| Audit logging (stderr, file, BTP) | — | — | Y |
+| HTTP Streamable transport (Copilot Studio) | — | — | Y |
+| 11 intent-based tools (~5K tokens) | — | — | Y |
+| Method-level read/edit | — | — | Y |
+| Context compression (7-30x) | — | — | Y |
+| BTP ABAP Environment support | — | — | Y |
+| Feature auto-detection | — | — | Y |
+| 700+ automated tests | — | — | Y |
 
 ## Documentation
 
-| Doc | Description |
-|-----|-------------|
-| [docs/setup-guide.md](docs/setup-guide.md) | **Start here** — deployment options, auth methods, decision tree |
-| [docs/architecture.md](docs/architecture.md) | System architecture with Mermaid diagrams |
-| [docs/tools.md](docs/tools.md) | Complete tool reference (11 intent-based tools) |
-| [docs/mcp-usage.md](docs/mcp-usage.md) | AI agent usage guide & workflow patterns |
-| [docs/docker.md](docs/docker.md) | Full Docker reference |
-| [docs/enterprise-auth.md](docs/enterprise-auth.md) | Enterprise authentication (all methods) |
-| [docs/sap-trial-setup.md](docs/sap-trial-setup.md) | SAP BTP trial setup |
-| [docs/roadmap.md](docs/roadmap.md) | Planned features |
-| [CLAUDE.md](CLAUDE.md) | AI development guidelines (codebase structure, patterns) |
+Full documentation is available at **[marianfoo.github.io/arc-1](https://marianfoo.github.io/arc-1/)**.
+
+| Guide | Description |
+|-------|-------------|
+| [Setup Guide](https://marianfoo.github.io/arc-1/setup-guide/) | Deployment options, auth methods, client configuration |
+| [Tool Reference](https://marianfoo.github.io/arc-1/tools/) | Complete reference for all 11 tools |
+| [Architecture](https://marianfoo.github.io/arc-1/architecture/) | System architecture with diagrams |
+| [Docker Guide](https://marianfoo.github.io/arc-1/docker/) | Docker deployment reference |
+| [Enterprise Auth](https://marianfoo.github.io/arc-1/enterprise-auth/) | All authentication methods |
+| [BTP Deployment](https://marianfoo.github.io/arc-1/phase4-btp-deployment/) | Cloud Foundry deployment on SAP BTP |
+| [AI Usage Patterns](https://marianfoo.github.io/arc-1/mcp-usage/) | Agent workflow patterns and best practices |
 
 ## Development
 
 ```bash
-npm ci                    # install dependencies
-npm run build             # TypeScript → dist/
-npm test                  # unit tests (no SAP system required)
-npm run test:integration  # integration tests (skipped if no SAP vars set)
+npm ci && npm run build && npm test
 ```
 
-See [CLAUDE.md](CLAUDE.md) for codebase structure and contribution guidelines.
-
-## Releasing
-
-Releases are fully automated via [release-please](https://github.com/googleapis/release-please) and GitHub Actions.
-
-### How it works
-
-1. **Merge PRs to `main`** using [Conventional Commits](https://www.conventionalcommits.org/):
-   - `feat: add SAPDeploy tool` → minor bump (0.1.0 → 0.2.0)
-   - `fix: handle empty XML response` → patch bump (0.1.0 → 0.1.1)
-   - `feat!: rename tools` or `BREAKING CHANGE:` in body → major bump (0.1.0 → 1.0.0)
-   - `chore:`, `docs:`, `ci:` → no release
-
-2. **release-please automatically creates a Release PR** that accumulates all changes since the last release, with a bumped version and generated `CHANGELOG.md`.
-
-3. **Merge the Release PR** when you're ready. This triggers:
-   - **npm publish** with provenance (trusted publishing via OIDC, no tokens)
-   - **Docker push** to `ghcr.io/marianfoo/arc-1` with semver tags (`:0.2.0`, `:0.2`, `:latest`)
-   - **GitHub Release** with auto-generated release notes
-
-### Versioned artifacts
-
-| Artifact | Location |
-|----------|----------|
-| npm package | [npmjs.com/package/arc-1](https://www.npmjs.com/package/arc-1) |
-| Docker image | `ghcr.io/marianfoo/arc-1:{version}` |
-| GitHub Release | [Releases](https://github.com/marianfoo/arc-1/releases) |
-
-### CI workflows
-
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| `test.yml` | push / PR to main | Lint, typecheck, unit tests (Node 20/22/24) |
-| `release.yml` | push to main | release-please PR; on merge: npm + Docker + GitHub Release |
-| `docker.yml` | push to main | Dev `latest` Docker image (every commit) |
+See [CLAUDE.md](CLAUDE.md) for codebase structure, testing commands, and contribution guidelines.
 
 ## Credits
 
 | Project | Author | Contribution |
 |---------|--------|--------------|
+| [vibing-steampunk](https://github.com/oisee/vibing-steampunk) | oisee | Original Go MCP server — arc1's starting point |
 | [abap-adt-api](https://github.com/marcellourbani/abap-adt-api) | Marcello Urbani | TypeScript ADT library, definitive API reference |
 | [mcp-abap-adt](https://github.com/mario-andreschak/mcp-abap-adt) | Mario Andreschak | First MCP server for ABAP ADT |
 | [abaplint](https://github.com/abaplint/abaplint) | Lars Hvam | ABAP parser/linter (used via @abaplint/core) |

--- a/README.md
+++ b/README.md
@@ -92,25 +92,6 @@ npx arc-1 --url https://your-sap-host:44300 --user YOUR_USER
 
 For Docker, BTP deployment, client configuration (Claude Desktop, Claude Code, VS Code, Copilot Studio), and all authentication methods, see the **[Setup Guide](https://marianfoo.github.io/arc-1/setup-guide/)**.
 
-## Comparison
-
-| | [abap-adt-api](https://github.com/marcellourbani/abap-adt-api) | [mcp-abap-adt](https://github.com/mario-andreschak/mcp-abap-adt) | **arc1** |
-|---|:---:|:---:|:---:|
-| npm package + Docker image | — | — | Y |
-| Read-only mode / operation allowlists | — | — | Y |
-| Package restrictions (wildcards) | — | — | Y |
-| Transport safety controls | — | — | Y |
-| BTP deployment + Principal Propagation | — | — | Y |
-| OIDC / XSUAA / OAuth authentication | — | — | Y |
-| Audit logging (stderr, file, BTP) | — | — | Y |
-| HTTP Streamable transport (Copilot Studio) | — | — | Y |
-| 11 intent-based tools (~5K tokens) | — | — | Y |
-| Method-level read/edit | — | — | Y |
-| Context compression (7-30x) | — | — | Y |
-| BTP ABAP Environment support | — | — | Y |
-| Feature auto-detection | — | — | Y |
-| 700+ automated tests | — | — | Y |
-
 ## Documentation
 
 Full documentation is available at **[marianfoo.github.io/arc-1](https://marianfoo.github.io/arc-1/)**.

--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -2,7 +2,7 @@
 
 A comprehensive comparison of all SAP ADT/MCP projects against ARC-1.
 
-_Last updated: 2026-03-30_
+_Last updated: 2026-04-01_
 
 ## Legend
 - ✅ = Supported
@@ -14,179 +14,309 @@ _Last updated: 2026-03-30_
 
 ## 1. Core Architecture
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
-| Language | TypeScript | Go | TypeScript | TypeScript | Python | TypeScript | TypeScript | TypeScript |
-| Tool count | 11 intent-based | 1-122 (3 modes) | ~95 | 13 | 15 | 287 (4 levels) | 3 (hierarchical) | 25+ |
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
+| Language | TypeScript | Go 1.24 | TypeScript | TypeScript | Python 3.12 | TypeScript | TypeScript | JavaScript (compiled TS) |
+| Tool count | 11 intent-based | 1-99 (3 modes) | ~15 | 13 | 15 | 287 (4 tiers) | 3 (hierarchical) | 25 |
 | ADT client | Custom (axios) | Custom (Go) | abap-adt-api | Custom (axios) | Custom (aiohttp) | Custom (axios) | SAP Cloud SDK | abap-adt-api |
-| npm package | ✅ `arc-1` | ❌ (binary) | ❌ | ❌ | ❌ | ✅ `@mcp-abap-adt/core` | ❌ | ❌ |
-| Docker image | ✅ ghcr.io | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ⚠️ Dockerfile |
-| Active development | ✅ | ✅ Very | ❌ Dormant | ❌ Dormant | ✅ | ✅ Very | ⚠️ Moderate | ✅ Very New |
+| npm package | ✅ `arc-1` | ❌ (binary) | ❌ | ❌ | ❌ | ✅ `@mcp-abap-adt/core` | ❌ | ❌ (MCPB) |
+| Docker image | ✅ ghcr.io | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Stars | — | 242 | 109 | 103 | 29 | 26 | 119 | 0 (new) |
+| Active development | ✅ | ✅ Very (v2.32.0) | ❌ Dormant (Jan 2025) | ❌ Dormant | ⚠️ Stale (Jan 2025) | ✅ Very (v4.7.1) | ⚠️ Moderate | ✅ New (Mar 2026) |
+| Release count | — | 32+ | — | — | — | 83 (5 months) | — | 1 |
+| NPM monthly downloads | — | N/A | — | — | — | 3,625 | — | N/A |
 
 ## 2. MCP Transport
 
-| Transport | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|-----------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
+| Transport | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|-----------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
 | stdio | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
 | HTTP Streamable | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
 | SSE | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ⚠️ | ❌ |
+| TLS/HTTPS | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ (v4.6.0) | ❌ | ❌ |
 
 ## 3. Authentication
 
-| Auth Method | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|-------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
+| Auth Method | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|-------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
 | Basic Auth | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
 | Cookie-based | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | API Key (MCP) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | OIDC/JWT (MCP) | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
 | XSUAA OAuth | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
+| BTP Service Key | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | Principal Propagation | ✅ | ❌ | ❌ | ❌ | ✅ (X.509) | ✅ | ✅ | ❌ |
 | SAML | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
 | X.509 Certificates | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Device Flow (OIDC) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | Browser login page | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Auth providers total | 4 | 2 | 1 | 1 | 5+ | 9 | 2 | 2 |
 
 ## 4. Safety & Security
 
-| Safety Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|----------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
-| Read-only mode | ✅ | ✅ | ❌ | N/A (read-only) | ❌ | ⚠️ exposition | ❌ | ❌ |
+| Safety Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|----------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
+| Read-only mode | ✅ | ✅ | ❌ | N/A (read-only) | ❌ | ⚠️ exposition tiers | ❌ | ❌ |
 | Op whitelist/blacklist | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Package restrictions | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Block free SQL | ✅ | ✅ | ❌ | ❌ | N/A | ❌ | ❌ | ❌ |
 | Transport gating | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Dry-run mode | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Audit logging | ✅ | ❌ | ❌ | ❌ | ✅ (CloudWatch) | ❌ | ❌ | ❌ |
-| Input sanitization | ✅ | ✅ | ❌ | ⚠️ | ✅ | ✅ | ✅ | ✅ |
-| MCP elicitation | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Input sanitization | ✅ (Zod) | ✅ | ❌ | ⚠️ | ✅ (defusedxml) | ✅ (Zod) | ✅ (Zod) | ⚠️ |
+| MCP elicitation | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (7 flows) |
+| Try-finally lock safety | ✅ | ✅ | ❌ | N/A | ✅ | ✅ (v4.5.0) | N/A | ⚠️ (abap-adt-api) |
+| MCP scope system (OAuth) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ## 5. ABAP Read Operations
 
-| Read Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|-------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
-| Programs | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ |
-| Classes | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ |
-| Interfaces | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ |
-| Function modules | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ |
-| Includes | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ |
+| Read Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|-------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
+| Programs (PROG) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ |
+| Classes (CLAS) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ |
+| Interfaces (INTF) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ |
+| Function modules (FUNC) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ |
+| Function groups (FUGR) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ (bulk) |
+| Includes (INCL) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ |
 | CDS views (DDLS) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
 | Behavior defs (BDEF) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ✅ |
 | Service defs (SRVD) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
+| Service bindings (SRVB) | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ |
 | Tables (DDIC) | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | N/A | ✅ |
 | Table contents | ✅ | ✅ | ✅ | ⚠️ Z-service | ❌ | ✅ | N/A | ✅ |
-| Packages | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ |
+| Packages (DEVC) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ |
 | Metadata ext (DDLX) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
 | Structures | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ❌ |
-| Domains | ❌ | ❌ | ✅ | ⚠️ fallback | ❌ | ✅ | N/A | ❌ |
-| Data elements | ❌ | ❌ | ✅ | ⚠️ fallback | ❌ | ✅ | N/A | ❌ |
+| Domains | ❌ | ❌ | ✅ | ⚠️ | ❌ | ✅ | N/A | ❌ |
+| Data elements | ❌ | ❌ | ✅ | ⚠️ | ❌ | ✅ | N/A | ❌ |
 | Enhancements | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
 | Transactions | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | N/A | ❌ |
 | Free SQL | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
+| System info / components | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
+| BOR business objects | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Messages (T100) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Text elements | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Variants | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| GetProgFullCode (include traversal) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
 
 ## 6. Write / CRUD Operations
 
-| Write Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|--------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
+| Write Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|--------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
 | Create objects | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
 | Update source | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
 | Delete objects | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
 | Activate | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
-| Batch activate | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ❌ |
+| Batch activate | ⚠️ (single-call capable) | ✅ | ✅ | ❌ | ✅ (with dep resolution) | ✅ | N/A | ❌ |
 | Lock/unlock | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
 | EditSource (surgical) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
 | CloneObject | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Execute ABAP | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ |
+| Execute ABAP | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ✅ |
+| RAP CRUD (BDEF, SRVD, DDLX, SRVB) | ❌ | ⚠️ (some) | ❌ | ❌ | ✅ (BDEF, SRVD, SRVB) | ✅ (all incl. DDLX) | N/A | ❌ |
+| Type auto-mappings (CLAS→CLAS/OC) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ |
+| Create test class | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ |
 
 ## 7. Code Intelligence
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
 | Find definition | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
 | Find references | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
 | Code completion | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Context compression | ⚠️ SAPContext | ✅ Auto | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| ABAP AST | ❌ | ✅ (lexer) | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
+| Context compression | ✅ (SAPContext, 7-30x) | ✅ (auto, 7-30x) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Method-level surgery | ❌ | ✅ (95% reduction) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| ABAP AST / parser | ⚠️ (abaplint for lint) | ✅ (native Go port) | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
 | Semantic analysis | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
-| Call graph | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Call graph analysis | ❌ | ✅ (5 tools) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Type hierarchy | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| CDS dependencies | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
 
 ## 8. Code Quality
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
 | Syntax check | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
-| ATC checks | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | N/A | ✅ |
-| abaplint (local) | ✅ | ❌ (Go lexer) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Unit tests | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ❌ |
+| ATC checks | ✅ | ✅ | ✅ | ❌ | ✅ (with summary) | ❌ | N/A | ✅ (severity grouping) |
+| abaplint (local offline) | ✅ | ✅ (native Go port, 8 rules) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Unit tests | ✅ | ✅ | ✅ | ❌ | ✅ (with coverage) | ✅ | N/A | ❌ |
+| CDS unit tests | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
 | Fix proposals | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
 | PrettyPrint | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Refactoring | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Migration analysis | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | N/A | ❌ |
 
 ## 9. Transport / CTS
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
 | List transports | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
 | Create transport | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
 | Release transport | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ |
 | Transport contents | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ |
+| Transport assign | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ |
 | Transport gating | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Inactive objects list | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
 
-## 10. Diagnostics
+## 10. Diagnostics & Runtime
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
-| Short dumps (ST22) | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
-| ABAP profiler | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ❌ |
-| SQL traces | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
-| ABAP debugger | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
+| Short dumps (ST22) | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
+| ABAP profiler traces | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ❌ |
+| SQL traces | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
+| ABAP debugger | ❌ | ✅ (8 tools) | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
+| AMDP/HANA debugger | ❌ | ✅ (7 tools) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Execute with profiling | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
 
 ## 11. Advanced Features
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
-| Feature auto-detection | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
+| Feature auto-detection | ✅ (6 probes) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Caching (SQLite) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| UI5/Fiori BSP | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| UI5/Fiori BSP | ❌ | ✅ (7 tools) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | abapGit/gCTS | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ |
 | BTP Destination Service | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| Cloud Connector | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Multi-system | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
+| Cloud Connector proxy | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Multi-system support | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
 | OData bridge | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Lua scripting | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| MCP client configurator | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Lua scripting engine | ❌ | ✅ (50+ bindings) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| WASM-to-ABAP compiler | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| MCP client configurator | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (11 clients) | ❌ | ❌ |
+| CLI mode (non-MCP) | ❌ | ✅ (28 commands) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Health endpoint | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ (v4.3.0) | ❌ | ✅ |
+| RFC connectivity | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (sap-rfc-lite) | ❌ | ❌ |
+| MCPB one-click install | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Lock registry / recovery | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Batch HTTP operations | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (multipart/mixed) | ❌ | ❌ |
+| RAG-optimized tool descriptions | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (v4.4.0) | ❌ | ❌ |
+| Embeddable server (library mode) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Error intelligence (hints) | ⚠️ (LLM hints) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 
-## 12. Testing & Quality
+## 12. Token Efficiency
 
-| Metric | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt |
-|--------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|-------------|
-| Unit tests | 320+ | 222 | 0 | 0 | 0 | Yes (Jest) | 0 | 163 |
-| Integration tests | ✅ | ✅ | ❌ | 13 (live SAP) | ❌ | ✅ | ❌ | ⚠️ scaffold |
-| CI/CD | ✅ | ✅ (GoReleaser) | ❌ | ❌ | ❌ | ⚠️ Husky | ❌ | ❌ |
-| Input validation | Zod | Custom | Untyped | Untyped | Pydantic | Zod | Zod | Manual |
+| Feature | ARC-1 | vibing-steampunk | fr0ster |
+|---------|-------|-----------------|---------|
+| Schema token cost | ~moderate (11 tools) | ~200 (hyperfocused) / ~14K (focused) / ~40K (expert) | ~high (287 tools) |
+| Context compression | ✅ SAPContext (7-30x) | ✅ Auto-append (7-30x) | ❌ |
+| Method-level surgery | ❌ | ✅ (95% source reduction) | ❌ |
+| Hyperfocused mode (1 tool) | ❌ | ✅ (~200 tokens) | ❌ |
+| Compact/intent mode | ✅ (11 intent tools) | N/A | ✅ (22 compact tools) |
+
+## 13. Testing & Quality
+
+| Metric | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
+|--------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
+| Unit tests | 546+ | 222 | 0 | 0 | 0 | Yes (Jest) | 0 | 163 |
+| Integration tests | ✅ (on-prem + BTP) | ✅ | ❌ | 13 (live SAP) | ❌ | ✅ | ❌ | ⚠️ scaffold |
+| CI/CD | ✅ (release-please) | ✅ (GoReleaser) | ❌ | ❌ | ❌ | ⚠️ (Husky + lint-staged) | ❌ | ❌ |
+| Input validation | Zod v3 | Custom | Untyped | Untyped | Pydantic | Zod v4 | Zod | Manual |
+| Linter | Biome | — | — | — | — | Biome | — | — |
 
 ---
 
 ## Priority Action Items for ARC-1
 
-Based on this analysis, the highest-impact features to adopt:
+Based on verified codebase analysis (2026-04-01) and competitive landscape:
 
-### Critical (implement soon)
-1. **Lock leak verification** -- ensure all lock/unlock uses try-finally (learned from fr0ster #22)
-2. **Content-Type 415 retry** -- auto-retry with different Accept/Content-Type on 415 (fr0ster #22/#23)
-3. **Batch activation** -- activate multiple objects with dependency resolution (AWS, fr0ster)
-4. **DDLX/Metadata Extension support** -- add to SAPRead (fr0ster)
+### 🔴 Critical — Competitive Gaps (implement soon)
 
-### High Priority
-5. **Function group bulk fetch** -- parallel fetch all includes+FMs (dassian-adt)
-6. **EditSource (surgical edits)** -- string replacement with syntax check (vibing-steampunk)
-7. **Error intelligence** -- actionable SAP error hints (dassian-adt)
-8. **ATC ciCheckFlavour workaround** -- older system compatibility (dassian-adt)
-9. **Type auto-mappings** -- CLAS→CLAS/OC etc. for SAPWrite (dassian-adt)
-10. **Refactoring tools** -- extract method, rename (mcp-abap-abap-adt-api)
+| # | Feature | Why | Competition | Effort |
+|---|---------|-----|-------------|--------|
+| 1 | **Short dump analysis (ST22)** | Currently ❌ — listed as ✅ in old matrix was WRONG. VSP, fr0ster, dassian all have it. Basic diagnostic capability gap. | VSP, fr0ster, dassian | 1d |
+| 2 | **DDLX/Metadata Extension read** | fr0ster is the only one with it. Critical for RAP development workflows. | fr0ster | 1d |
+| 3 | **Content-Type 415 auto-retry** | Robustness fix learned from fr0ster issue #22/#23. SAP systems vary in Accept/Content-Type expectations. | fr0ster | 0.5d |
+| 4 | **Batch activation with dependency resolution** | AWS Accelerator has the most robust implementation. Essential for RAP stacks (DDLS→BDEF→SRVD→SRVB chain). | AWS, fr0ster, VSP | 2d |
+| 5 | **TLS/HTTPS for HTTP Streamable** | fr0ster added in v4.6.0. Required for production enterprise deployments without reverse proxy. | fr0ster | 1d |
 
-### Medium Priority
-11. **MCP client auto-configurator** -- setup script for Claude/Cursor/etc. (fr0ster)
-12. **Runtime profiling** -- execute with profiler (fr0ster)
-13. **gCTS integration** -- git repos and pull (dassian-adt, vibing-steampunk)
-14. **Multi-system support** -- connect to multiple SAP systems (AWS, fr0ster)
-15. **PrettyPrint** -- ABAP code formatting (vibing-steampunk, mcp-abap-abap-adt-api)
+### 🟠 High Priority — Significant Value
+
+| # | Feature | Why | Competition | Effort |
+|---|---------|-----|-------------|--------|
+| 6 | **Structures (STRU) read support** | Currently ❌. VSP, fr0ster, mario, mcp-abap-abap-adt-api all have it. Basic DDIC gap. | VSP, fr0ster, mario | 1d |
+| 7 | **Transaction code read** | Currently ❌. VSP and fr0ster have it. Useful for navigation context. | VSP, fr0ster | 0.5d |
+| 8 | **Service binding (SRVB) read/CRUD** | Missing from SAPRead. Needed for complete RAP stack support. AWS & fr0ster have it. | AWS, fr0ster, VSP | 1d |
+| 9 | **EditSource (surgical string replacement)** | VSP's killer feature for token efficiency — 95% source reduction for single-method edits. | VSP | 2d |
+| 10 | **Function group bulk fetch** | Dassian fetches ALL includes + FMs in one call. Reduces LLM round trips significantly. | dassian | 1d |
+| 11 | **Error intelligence with self-correction hints** | Dassian provides actionable SAP error hints (SM12 for locks, SPAU for upgrades). ARC-1 has basic LLM hints but not comprehensive. | dassian | 1d |
+| 12 | **GetProgFullCode (recursive include discovery)** | fr0ster-unique feature. Fetches program with all includes resolved. Reduces round trips for complex programs. | fr0ster | 1d |
+| 13 | **Type auto-mappings for SAPWrite** | CLAS→CLAS/OC, INTF→INTF/OI, etc. Dassian maps 16 types. Improves create UX. | dassian | 0.5d |
+
+### 🟡 Medium Priority — Nice to Have
+
+| # | Feature | Why | Competition | Effort |
+|---|---------|-----|-------------|--------|
+| 14 | **PrettyPrint** | Code formatting via ADT. VSP and mcp-abap-abap-adt-api have it. | VSP | 1d |
+| 15 | **gCTS/abapGit integration** | Git repos list + pull. Dassian and VSP have it. | dassian, VSP | 2d |
+| 16 | **ABAP profiler traces** | Runtime performance diagnostics. VSP and fr0ster have it. | VSP, fr0ster | 2d |
+| 17 | **SQL trace support** | Performance diagnostics. VSP has it. | VSP | 1d |
+| 18 | **CDS unit tests** | fr0ster-unique. Create/run/check CDS unit tests. | fr0ster | 1d |
+| 19 | **Inactive objects list** | Show what's inactive system-wide. VSP and fr0ster have it. | VSP, fr0ster | 0.5d |
+| 20 | **Transport contents (E071 list)** | Show objects inside a transport. mcp-abap-abap-adt-api and dassian have it. | dassian | 0.5d |
+| 21 | **MCP client auto-configurator** | fr0ster's `mcp-conf` CLI for 11 MCP clients. Great onboarding UX. | fr0ster | 2d |
+| 22 | **Multi-system support** | Connect to multiple SAP systems. AWS, fr0ster, btp-odata-mcp have it. | AWS, fr0ster | 3d |
+| 23 | **ATC ciCheckFlavour workaround** | Older system compatibility for ATC. Dassian found the fix. | dassian | 0.5d |
+| 24 | **Migration analysis tool** | Custom code migration check (ECC→S/4). AWS-unique. | AWS | 1d |
+| 25 | **CompareSource** | Diff two versions. VSP has it. | VSP | 1d |
+| 26 | **Domain/Data element read** | DDIC completeness. fr0ster and mcp-abap-abap-adt-api have it. | fr0ster | 1d |
+
+### 🟢 Low Priority — Niche / Future
+
+| # | Feature | Why | Competition | Effort |
+|---|---------|-----|-------------|--------|
+| 27 | SSE transport | fr0ster has it. Most MCP clients use stdio or HTTP. | fr0ster | 2d |
+| 28 | ABAP debugger | VSP has 8 tools. Requires complex WebSocket + ZADT_VSP deployment. | VSP | 5d |
+| 29 | Execute ABAP (IF_OO_ADT_CLASSRUN) | VSP and dassian have it. Security risk — needs careful safety gating. | VSP, dassian | 2d |
+| 30 | Lua scripting / WASM compiler | VSP-unique experimental features. Not core MCP value. | VSP | N/A |
+| 31 | Call graph analysis | VSP has 5 tools. Useful but niche. | VSP | 3d |
+| 32 | UI5/Fiori BSP CRUD | VSP has 7 tools. Only relevant if UI5 detected. | VSP | 3d |
+| 33 | RFC connectivity | fr0ster uses sap-rfc-lite. Alternative to ADT HTTP. | fr0ster | 3d |
+| 34 | Embeddable server mode | fr0ster's EmbeddableMcpServer for CAP/Express integration. | fr0ster | 1d |
+| 35 | MCPB packaging | Dassian's zero-build Claude Desktop format. | dassian | 1d |
+| 36 | Lock registry with recovery | fr0ster persists lock state to disk for crash recovery. | fr0ster | 2d |
+| 37 | RAG-optimized tool descriptions | fr0ster rewrote descriptions for embedding/vector search. | fr0ster | 1d |
+| 38 | GetAbapHelp (F1 documentation) | VSP can retrieve ABAP keyword help. | VSP | 0.5d |
+| 39 | Enhancement discovery | fr0ster can find enhancement spots/implementations. | fr0ster | 2d |
+
+---
+
+## Corrections from Previous Matrix (2026-03-30)
+
+The following items were incorrectly marked in the previous version:
+
+| Item | Old Value | Corrected Value | Reason |
+|------|-----------|----------------|--------|
+| ARC-1 Short dumps (ST22) | ✅ | ❌ | No dump-related methods exist in codebase |
+| ARC-1 ABAP profiler | ✅ | ❌ | No profiler/trace support in codebase |
+| ARC-1 SQL traces | ✅ | ❌ | No SQL trace functionality in codebase |
+| VSP tool count | 1-122 | 1-99 (54 focused, 99 expert per README_TOOLS.md) | Updated from actual tool documentation |
+| fr0ster version | v4.5.2 | v4.7.1 | Updated to current release |
+| fr0ster TLS support | not listed | ✅ (v4.6.0) | New feature added Mar 31 |
+| fr0ster sap-rfc-lite | not listed | ✅ (v4.7.0) | Replaced archived node-rfc |
+| dassian column name | dassian-adt | dassian-adt / abap-mcpb | Successor repo albanleong/abap-mcpb created Mar 31 |
+| VSP abaplint | ❌ (Go lexer) | ✅ (native Go port, 8 rules) | v2.32.0 added native linter |
+
+---
+
+## Competitive Positioning Summary
+
+### ARC-1 Unique Strengths (no other project has all of these)
+1. **Intent-based routing** — 11 tools vs 25-287. Simplest LLM decision surface.
+2. **Declarative safety system** — Read-only, op filter, pkg filter, SQL blocking, transport gating, dry-run. Most comprehensive.
+3. **MCP scope system** — OAuth scope-gated tool access (read/write/admin).
+4. **BTP ABAP Environment** — Full OAuth 2.0 browser login, direct connectivity.
+5. **Principal propagation** — Per-user SAP identity via Destination Service.
+6. **MCP elicitation** — Interactive parameter collection for destructive ops.
+7. **Audit logging** — BTP Audit Log sink for compliance.
+8. **Context compression** — AST-based dependency extraction with depth control.
+9. **npm + Docker + release-please** — Most professional distribution pipeline.
+
+### Biggest Competitive Threats
+1. **vibing-steampunk** (242 stars) — Community favorite. Hyperfocused mode, method-level surgery, native parser, WASM compiler. Lacks BTP/enterprise auth but developer-loved.
+2. **fr0ster** (v4.7.1, 83 releases) — Closest enterprise competitor. 287 tools, 9 auth providers, TLS, RFC, embeddable. Complex multi-repo but ambitious.
+3. **btp-odata-mcp** (119 stars) — Different category (OData not ADT) but high adoption. Could expand into ADT territory.
+
+### Key Gaps to Close
+- **Diagnostics**: ARC-1 has zero runtime diagnostics (no dumps, no profiler, no traces). Every active competitor has at least dumps.
+- **RAP completeness**: Missing DDLX, SRVB, batch activation with dependency resolution. fr0ster leads here.
+- **DDIC completeness**: Missing structures, domains, data elements, transactions. fr0ster leads.
+- **Token efficiency**: SAPContext is good but lacks method-level surgery (VSP) and hyperfocused mode (VSP).

--- a/compare/01-vibing-steampunk.md
+++ b/compare/01-vibing-steampunk.md
@@ -1,86 +1,58 @@
 # oisee/vibing-steampunk (Upstream)
 
 > **Repository**: https://github.com/oisee/vibing-steampunk
-> **Language**: Go 1.24 | **License**: MIT | **Stars**: ~235
-> **Status**: Very Active (daily commits, v2.32.0 as of 2026-03-22)
-> **Relationship**: ARC-1's upstream/origin -- forked and rewritten in TypeScript
+> **Language**: Go 1.24 | **License**: MIT | **Stars**: 242
+> **Status**: Very Active (v2.32.0, daily commits in March 2026)
+> **Relationship**: ARC-1's upstream/origin — forked and rewritten in TypeScript
 
 ---
 
 ## Project Overview
 
-The original Go implementation of a SAP ADT-to-MCP bridge. Provides ~122 tools in Expert mode, with a unique "Hyperfocused" single-tool mode. Includes an embedded ABAP lexer, Lua scripting engine, DSL/workflow automation, and experimental WASM/LLVM-to-ABAP compilation. Distributed as a single Go binary via GoReleaser (9 platforms).
+The original Go implementation of a SAP ADT-to-MCP bridge. Provides 99 tools in Expert mode (54 in Focused), with a unique "Hyperfocused" single-tool mode (~200 tokens). Includes a native Go ABAP parser/linter (ported from abaplint), Lua scripting engine, DSL/workflow automation, and experimental WASM/LLVM-to-ABAP compilation. Distributed as a single Go binary via GoReleaser (9 platforms).
+
+Community favorite with 242 stars — highest of any SAP MCP server.
 
 ## Architecture
 
 - **Monolithic Go binary** with embedded assets (ABAP sources, abapGit ZIP, SQLite)
-- `cmd/vsp/` -- CLI (Cobra), `internal/mcp/` -- MCP server with 20+ handler files
-- `pkg/adt/` -- ADT HTTP client, `pkg/abaplint/` -- native Go ABAP lexer (48 token types)
-- `pkg/ctxcomp/` -- context compression, `pkg/scripting/` -- Lua engine, `pkg/dsl/` -- YAML workflows
-- `pkg/llvm2abap/` -- LLVM IR to ABAP transpiler (experimental)
-- `embedded/abap/` -- ABAP classes deployed to SAP (ZADT_VSP handler)
+- `cmd/vsp/` — CLI (Cobra), `internal/mcp/` — MCP server with 20+ handler files
+- `pkg/adt/` — ADT HTTP client, `pkg/abaplint/` — native Go ABAP lexer/parser (3.5M tokens/sec)
+- `pkg/ctxcomp/` — context compression, `pkg/scripting/` — Lua engine (50+ bindings)
+- `pkg/dsl/` — YAML workflows, `pkg/llvm2abap/` — LLVM IR to ABAP transpiler
+- `embedded/abap/` — ABAP classes deployed to SAP (ZADT_VSP handler)
 
-## Tool Inventory (~122 tools, 3 operational modes)
+## Tool Inventory (3 operational modes)
 
-| Mode | Tools | Token Cost |
-|------|-------|-----------|
-| Hyperfocused | 1 universal `SAP(action, target, params)` | ~200 tokens |
-| Focused (default) | ~81 essential tools | ~14K tokens |
-| Expert | ~122 tools (full set) | ~40K tokens |
+| Mode | Tools | Token Cost | Use Case |
+|------|-------|-----------|----------|
+| Hyperfocused | 1 universal `SAP(action, target, params)` | ~200 tokens | Maximum token efficiency |
+| Focused (default) | 54 essential tools | ~14K tokens | Typical development |
+| Expert | 99 tools (full set) | ~40K tokens | Advanced/low-level operations |
 
-### Read Operations
-GetProgram, GetClass, GetInterface, GetFunction, GetTable, GetTableContents, GetStructure, GetPackage, GetMessages, GetTransaction, GetTypeInfo, GetCDSDependencies, RunQuery
+### Focused Mode (54 tools)
+**Unified:** GetSource, WriteSource
+**Search:** SearchObject, GrepObjects
+**Read:** GetFunctionGroup, GetTable, GetTableContents, GetStructure, GetPackage, GetTransaction, GetTypeInfo, GetCDSDependencies, RunQuery
+**System:** GetSystemInfo, GetInstalledComponents
+**Analysis:** GetCallGraph
+**Dev:** SyntaxCheck, ActivatePackage, RunUnitTests, RunATCCheck, CompareSource, CloneObject, GetClassInfo, CreateTable, CreatePackage
+**CRUD:** LockObject, UnlockObject
+**Edit:** EditSource (surgical string replacement with syntax check)
+**File:** ImportFromFile, ExportToFile
+**Code Intel:** FindDefinition, FindReferences
+**Debugging:** GetDumps, GetDump
+**Profiler:** ListTraces, GetTrace
+**SQL Trace:** GetSQLTraceState, ListSQLTraces
+**Git:** GitTypes, GitExport
+**Install:** InstallZADTVSP, InstallAbapGit, ListDependencies
+**Reports:** RunReport, RunReportAsync, GetAsyncResult, GetVariants, GetTextElements, SetTextElements
 
-### Search
-SearchObject, GrepObject, GrepPackage, GrepObjects, GrepPackages
+### Expert Mode adds 45 more tools
+GrepObject, GrepPackage, GetProgram, GetClass, GetInterface, GetFunction, GetInclude, GetObjectStructure, GetCallersOf, GetCalleesOf, AnalyzeCallGraph, CompareCallGraphs, TraceExecution, GetATCCustomizing, CreateObject, UpdateSource, DeleteObject, PublishServiceBinding, UnpublishServiceBinding, GetClassInclude, CreateTestInclude, UpdateClassInclude, WriteProgram, WriteClass, CreateAndActivateProgram, CreateClassWithTests, DeployFromFile, SaveToFile, RenameObject, CodeCompletion, PrettyPrint, GetPrettyPrinterSettings, SetPrettyPrinterSettings, GetTypeHierarchy, CreateTransport, GetTransportInfo, ReleaseTransport, GetUserTransports, GetInactiveObjects, ExecuteABAP
 
-### Code Intelligence
-FindDefinition, FindReferences, CodeCompletion, GetContext, GetTypeHierarchy, GetClassComponents
-
-### Development Tools
-SyntaxCheck, Activate, ActivatePackage, RunUnitTests, RunATCCheck, GetATCCustomizing, PrettyPrint, Get/SetPrettyPrinterSettings, GetInactiveObjects, ExecuteABAP
-
-### CRUD
-LockObject, UnlockObject, UpdateSource, CreateObject, CreatePackage, CreateTable, DeleteObject, CompareSource, CloneObject, GetUserTransports, GetTransportInfo
-
-### Class-Specific
-GetClassInclude, CreateTestInclude, UpdateClassInclude, PublishServiceBinding, UnpublishServiceBinding
-
-### Composite Workflows
-WriteProgram, WriteClass, CreateAndActivateProgram, CreateClassWithTests, EditSource (surgical string replacement)
-
-### File I/O
-DeployFromFile, SaveToFile, ImportFromFile, ExportToFile, RenameObject
-
-### Call Graph / Analysis
-GetCallGraph, GetCallersOf, GetCalleesOf, AnalyzeCallGraph, CompareCallGraphs, GetObjectStructure, TraceExecution
-
-### ABAP Debugger (8 tools)
-DebuggerListen, DebuggerAttach, DebuggerDetach, DebuggerStep, DebuggerGetStack, DebuggerGetVariables, SetBreakpoint, GetBreakpoints, DeleteBreakpoint
-
-### AMDP/HANA Debugger (7 tools)
-AMDPDebuggerStart/Resume/Stop/Step, AMDPGetVariables, AMDPSet/GetBreakpoints
-
-### Diagnostics
-ListDumps, GetDump, ListTraces, GetTrace, GetSQLTraceState, ListSQLTraces
-
-### Transport/CTS
-ListTransports, GetTransport, CreateTransport, ReleaseTransport, DeleteTransport
-
-### UI5/Fiori BSP (7 tools)
-UI5ListApps, UI5GetApp, UI5GetFileContent, UI5UploadFile, UI5DeleteFile, UI5CreateApp, UI5DeleteApp
-
-### Git/abapGit
-GitTypes, GitExport
-
-### Reports
-RunReport, RunReportAsync, GetAsyncResult, GetVariants, GetTextElements, SetTextElements
-
-### Installation/Deploy
-InstallZADTVSP, ListDependencies, InstallAbapGit, InstallDummyTest, DeployZip
-
-### System
-GetSystemInfo, GetInstalledComponents, GetConnectionInfo, GetFeatures, GetAbapHelp, CallRFC, MoveObject
+### CLI Mode (28 non-MCP commands)
+query, grep, graph, deps, lint, parse, compile, plus more — usable without MCP client.
 
 ## Authentication
 
@@ -109,6 +81,24 @@ Same architecture as ARC-1 (ARC-1 inherited this design):
 | stdio | Yes (only) |
 | HTTP Streamable | **No** |
 | SSE | **No** |
+| TLS | **No** |
+
+## Supported AI Agents (8)
+
+Gemini CLI, Claude Code, GitHub Copilot, OpenAI Codex, Qwen Code, OpenCode, Goose, Mistral Vibe
+
+## March 2026 Release Sprint
+
+| Version | Date | Key Feature |
+|---------|------|-------------|
+| **v2.32.0** | Mar 22 | "Full Stack ABAP" — Native ABAP parser/linter (91 statements, 8 rules, 100% accuracy), 28 CLI commands, WASM self-host compiler, Lua scripting (50+ bindings) |
+| **v2.30.0** | Mar 20 | WASM-to-ABAP AOT compiler (QuickJS: 1,410 functions → 101K lines ABAP), TS-to-Go transpiler, unified 5-layer code intelligence |
+| **v2.29.0** | Mar 19 | Token efficiency sprint — hyperfocused mode (~200 tokens), context compression (7-30x), method-level surgery (95% reduction) |
+| **v2.27.0** | Mar 1 | Documentation overhaul, 8 AI agent configs, reviewer guide |
+| **v2.26.0** | Feb 4 | Package validation fix for local packages ($TMP) |
+| **v2.24.0** | Feb 3 | Transportable edits safety feature |
+| **v2.22.0** | Feb 1 | Transport fixes, proxy support, MoveObject tool |
+| **v2.21.0** | Jan 6 | Method-level source operations (95% token reduction) |
 
 ## Testing
 
@@ -121,19 +111,25 @@ Same architecture as ARC-1 (ARC-1 inherited this design):
 
 mcp-go v0.17.0, Cobra, Viper, go-sqlite3, godotenv, yaml.v3, Gopher-Lua, WebSocket library
 
+## Community Presence
+
+- Listed on MCP Store, LobeHub MCP directory
+- SAP Community blog: "Try Vibing Steampunk to generate ABAP" (setup guide)
+- SAP Community: "The Future of SAP ABAP Based Systems with AI: Why MCP Servers Matter"
+- Medium: "Vibe Steam Punk (VSP) for ABAP Cloud, Mac & Claude" (Warren Eiserman, Feb 2026)
+- Referenced in: "Claude Code via MCP: Poor man's Joule, or a practical tool"
+
 ## Known Issues
 
 | Issue | Description | Relevant to ARC-1? |
 |-------|-------------|-------------------|
-| #79 | Session not found -- needs stateless ADT sessions | Yes -- ARC-1 should handle session errors gracefully |
-| #78 | 423 lock handle errors on ECC 6.0 EHP7 | Yes -- test lock handling on older systems |
+| #79 | Session not found — needs stateless ADT sessions | Yes — handle session errors gracefully |
+| #78 | 423 lock handle errors on ECC 6.0 EHP7 | Yes — test lock handling on older systems |
 | #77 | No browser-based SSO authentication | ARC-1 already has OIDC |
 | #76 | Call graph fallback broken for namespaced objects | If implementing call graphs |
 | #75 | InstallZADTVSP not idempotent on ABAP 758 trial | N/A (ARC-1 doesn't deploy ABAP) |
-| #74 | Missing CDS metadata extension (DDLX/EX) | Yes -- add DDLX support |
-| #56 | Unable to create new programs | Yes -- verify create operations |
-| #55 | RunReport fails in APC context | N/A unless implementing reports |
-| stdio only | No HTTP/SSE transport | ARC-1 already has HTTP Streamable |
+| #74 | Missing CDS metadata extension (DDLX/EX) | Yes — add DDLX support |
+| #56 | Unable to create new programs | Yes — verify create operations |
 
 ---
 
@@ -144,39 +140,45 @@ mcp-go v0.17.0, Cobra, Viper, go-sqlite3, godotenv, yaml.v3, Gopher-Lua, WebSock
 | HTTP Streamable transport | Multi-user, web-deployable |
 | OIDC/JWT authentication | Enterprise SSO |
 | BTP Destination Service | Cloud-native SAP connectivity |
+| BTP ABAP Environment (OAuth 2.0) | Direct BTP connection |
 | Principal Propagation | Per-user SAP auth |
 | API Key auth | Simple MCP endpoint protection |
+| MCP scope system (OAuth) | Scope-gated tool access |
 | Audit logging | BTP Audit Log sink |
 | MCP elicitation | Interactive parameter collection |
 | npm/Docker distribution | Easy installation |
 | XSUAA OAuth proxy | BTP-native OAuth |
+| Cloud Connector support | On-prem via BTP |
 
 ## Features Upstream Has That ARC-1 Lacks
 
-| Feature | Priority | Effort | Place in ARC-1 or mcp-sap-docs? |
-|---------|----------|--------|--------------------------------|
-| Hyperfocused mode (1 tool) | Medium | 2d | ARC-1 -- token optimization |
-| Context compression (auto-append deps) | High | 3d | ARC-1 -- already have SAPContext |
-| Method-level surgery (EditSource) | High | 2d | ARC-1 -- surgical edits reduce tokens |
-| ABAP debugger (8 tools) | Low | 5d | ARC-1 -- requires ZADT_VSP deployment |
-| AMDP/HANA debugger (7 tools) | Low | 5d | ARC-1 -- requires WebSocket + ZADT_VSP |
-| Lua scripting engine | Low | N/A | Not for ARC-1 |
-| DSL/Workflow engine | Low | N/A | Not for ARC-1 |
-| Call graph analysis | Medium | 3d | ARC-1 -- useful for code understanding |
-| Short dump analysis | High | 1d | ARC-1 -- already in SAPDiagnose |
-| SQL trace monitoring | Medium | 1d | ARC-1 -- extend SAPDiagnose |
-| Report execution | Medium | 3d | ARC-1 -- requires WebSocket |
-| ExecuteABAP | Low | 2d | ARC-1 -- security risk, needs safety |
-| UI5/Fiori BSP CRUD | Medium | 3d | ARC-1 -- if UI5 feature detected |
-| Git/abapGit export | Medium | 2d | ARC-1 -- if abapGit feature detected |
-| PrettyPrint | Medium | 1d | ARC-1 -- add to SAPWrite |
-| CompareSource | Medium | 1d | ARC-1 -- add to SAPRead |
-| CloneObject | Low | 1d | ARC-1 -- add to SAPWrite |
-| EditSource surgical edits | High | 2d | ARC-1 -- reduces token usage significantly |
-| Tool group disabling (letter codes) | Low | 0.5d | ARC-1 already has allowedOps/disallowedOps |
-| WASM/LLVM compilation | Low | N/A | Not for ARC-1 (experimental) |
-| GetAbapHelp | Medium | 0.5d | mcp-sap-docs -- documentation tool |
-| CallRFC | Low | 3d | ARC-1 -- requires WebSocket + ZADT_VSP |
+| Feature | Priority | Effort | Notes |
+|---------|----------|--------|-------|
+| **Hyperfocused mode** (1 tool, ~200 tokens) | Medium | 2d | Token optimization for simple tasks |
+| **Method-level surgery** (EditSource) | High | 2d | 95% source reduction for single-method edits |
+| **Native ABAP parser/linter** (Go port, 8 rules) | Low | N/A | ARC-1 uses @abaplint/core (same source) |
+| **ABAP debugger** (8 tools) | Low | 5d | Requires ZADT_VSP deployment |
+| **AMDP/HANA debugger** (7 tools) | Low | 5d | Requires WebSocket + ZADT_VSP |
+| **Lua scripting engine** (50+ bindings) | Low | N/A | Not core MCP value |
+| **WASM-to-ABAP compiler** | Low | N/A | Experimental |
+| **Call graph analysis** (5 tools) | Medium | 3d | Useful for code understanding |
+| **Short dump analysis** (ST22) | Critical | 1d | Basic diagnostic capability |
+| **ABAP profiler traces** | Medium | 2d | Runtime performance diagnostics |
+| **SQL trace monitoring** | Medium | 1d | Performance diagnostics |
+| **Report execution** (RunReport, async) | Medium | 3d | Requires WebSocket |
+| **ExecuteABAP** | Low | 2d | Security risk, needs safety gating |
+| **UI5/Fiori BSP CRUD** (7 tools) | Medium | 3d | If UI5 feature detected |
+| **Git/abapGit export** | Medium | 2d | If abapGit feature detected |
+| **PrettyPrint** (code formatting) | Medium | 1d | Via ADT API |
+| **CompareSource** (diff) | Medium | 1d | Source comparison |
+| **CloneObject** | Low | 1d | Copy object to new name |
+| **CLI mode** (28 commands, no MCP) | Low | N/A | Different distribution model |
+| **GetAbapHelp** (F1 documentation) | Medium | 0.5d | ABAP keyword help |
+| **Structures read** | High | 1d | Basic DDIC gap |
+| **Transactions read** | High | 0.5d | Navigation context |
+| **Type hierarchy** | Medium | 1d | OO navigation |
+| **CDS dependencies** | Medium | 1d | CDS navigation |
+| **Inactive objects list** | Medium | 0.5d | Development workflow |
 
 ---
 
@@ -184,10 +186,11 @@ mcp-go v0.17.0, Cobra, Viper, go-sqlite3, godotenv, yaml.v3, Gopher-Lua, WebSock
 
 | Date | Upstream Change | Relevant? | Action for ARC-1 | Status |
 |------|----------------|-----------|-------------------|--------|
-| 2026-03-29 | LLVM-to-ABAP transpiler improvements | No | N/A | -- |
-| 2026-03-22 | v2.32.0 "Full Stack ABAP" release | Review | Check for new ADT endpoints | TODO |
-| 2026-03-20 | WASM Compiler + TS Transpiler | No | N/A | -- |
-| 2026-03-19 | Token Efficiency Sprint (v2.29.0) | Yes | Review context compression changes | TODO |
-| | | | | |
+| 2026-03-29 | LLVM-to-ABAP transpiler improvements | No | N/A | — |
+| 2026-03-22 | v2.32.0 — Native ABAP parser/linter, 28 CLI commands | Review | Parser: no (same abaplint). CLI: no. | — |
+| 2026-03-20 | v2.30.0 — WASM Compiler + TS Transpiler | No | N/A | — |
+| 2026-03-19 | v2.29.0 — Hyperfocused mode, method-level surgery | Yes | Review for token optimization | TODO |
+| 2026-03-01 | v2.27.0 — 8 AI agent configs | Maybe | Review agent config patterns | TODO |
+| 2026-02-03 | v2.24.0 — Transportable edits safety | No | ARC-1 already has this | — |
 
-_Last updated: 2026-03-30_
+_Last updated: 2026-04-01_

--- a/compare/05-fr0ster-mcp-abap-adt.md
+++ b/compare/05-fr0ster-mcp-abap-adt.md
@@ -1,53 +1,54 @@
 # fr0ster/mcp-abap-adt
 
 > **Repository**: https://github.com/fr0ster/mcp-abap-adt
-> **Language**: TypeScript | **License**: MIT | **Stars**: ~25
-> **Status**: Very Active (10+ commits in last 4 days, v4.5.2)
+> **Language**: TypeScript | **License**: MIT | **Stars**: 26
+> **Status**: Very Active (v4.7.1, 83 releases in 5 months, 765 commits)
+> **NPM**: `@mcp-abap-adt/core` — 3,625 monthly downloads
 > **Relationship**: Independent TypeScript ADT MCP server with most advanced auth system
 
 ---
 
 ## Project Overview
 
-A multi-package monorepo MCP server for SAP ADT with 287 tools organized across 4 exposition levels (read-only, high-level, low-level, compact). Features the most comprehensive authentication system of any project (9 providers including SAML, OIDC device flow, token exchange). Strict interface isolation via separate npm packages.
+A multi-package monorepo MCP server for SAP ADT with 287 tools organized across 4 exposition tiers (read-only 52, high-level 113, low-level 122, compact 22). Features the most comprehensive authentication system of any project (9 providers including SAML, OIDC device flow, token exchange). Strict interface isolation via separate npm packages.
 
-Key differentiator: "AI Pairing, Not Vibing (AIPNV)" philosophy -- positioned as pair programming assistant, not autopilot.
+Key differentiator: "AI Pairing, Not Vibing (AIPNV)" philosophy — positioned as pair programming assistant, not autopilot.
 
 ## Architecture
 
-Multi-package monorepo with strict interface isolation:
+Multi-package ecosystem with 7+ npm packages under `@mcp-abap-adt` scope:
 
-| Package | Purpose |
-|---------|---------|
-| `@mcp-abap-adt/interfaces` | Type contracts, zero dependencies |
-| `@mcp-abap-adt/logger` | Pino-based structured logging |
-| `@mcp-abap-adt/header-validator` | HTTP header auth parsing/prioritization |
-| `@mcp-abap-adt/auth-stores` | Service key + session persistence |
-| `@mcp-abap-adt/auth-broker` | Token orchestration (cache → refresh → browser flow) |
-| `@mcp-abap-adt/auth-providers` | 9 concrete token providers |
-| `@mcp-abap-adt/connection` | HTTP transport (CSRF, cookies, sessions) |
-| `@mcp-abap-adt/adt-clients` | Builder-first ABAP object CRUD |
-| `@mcp-abap-adt/core` | Main MCP server, composition root |
-| `@mcp-abap-adt/proxy` | Standalone auth proxy for BTP |
-| `@mcp-abap-adt/configurator` | Auto-config for 11 MCP clients |
+| Package | Purpose | NPM Monthly |
+|---------|---------|-------------|
+| `@mcp-abap-adt/core` | Main MCP server, composition root | 3,625 |
+| `@mcp-abap-adt/adt-clients` | Builder-first ABAP object CRUD (449 commits in own repo) | 5,074 |
+| `@mcp-abap-adt/auth-broker` | Token orchestration (cache → refresh → browser flow) | 1,051 |
+| `@mcp-abap-adt/connection` | HTTP transport (CSRF, cookies, sessions) | — |
+| `@mcp-abap-adt/logger` | Pino-based structured logging | — |
+| `@mcp-abap-adt/configurator` | Auto-config for 11 MCP clients (`mcp-conf` CLI) | — |
+| `@mcp-abap-adt/sap-rfc-lite` | Lightweight RFC (replaces archived node-rfc, v4.7.0) | — |
 
 Design principles: Interface-Only Communication (IOC), Dependency Inversion, single composition root.
 
-## Tool Inventory (287 tools across 4 levels)
+### Companion Repos
+- **fr0ster/mcp-abap-adt-clients** — 449 commits, ADT client library with batch operations, lock registry, WebSocket facade
+- **fr0ster/mcp-abap-adt-auth-broker** — JWT authentication broker for multi-destination token management
 
-### Read-Only Group (52 tools)
+## Tool Inventory (287 tools across 4 tiers)
+
+### Read-Only Tier (52 tools)
 ReadClass, ReadProgram, ReadInterface, ReadDomain, ReadDataElement, ReadStructure, ReadTable, ReadView, ReadFunctionGroup, ReadFunctionModule, ReadBehaviorDefinition, ReadBehaviorImplementation, ReadMetadataExtension, ReadServiceDefinition, ReadServiceBinding, ReadPackage, GetProgFullCode, GetInclude, GetIncludesList, GetPackageContents, SearchObject, GetObjectsByType, GetObjectsList, GetWhereUsed, GetObjectInfo, GetObjectStructure, GetObjectNodeFromCache, GetAbapAST, GetAbapSemanticAnalysis, GetAbapSystemSymbols, GetAdtTypes, GetInactiveObjects, GetSession, GetSqlQuery, GetTransaction, GetTypeInfo, DescribeByList, GetTransport, ListTransports, GetEnhancements, GetEnhancementSpot, GetEnhancementImpl, RuntimeListDumps, RuntimeGetDumpById, RuntimeAnalyzeDump, RuntimeListProfilerTraceFiles, RuntimeGetProfilerTraceData, RuntimeAnalyzeProfilerTrace, RuntimeCreateProfilerTraceParameters, RuntimeRunClassWithProfiling, RuntimeRunProgramWithProfiling
 
-### High-Level Group (113 tools)
+### High-Level Tier (113 tools)
 Full CRUD with automatic lock/activate for 16+ object types: Classes (including local definitions, types, macros, test classes), Programs, Interfaces, Domains, Data Elements, Structures, Tables, Views (CDS), Function Groups/Modules, Service Definitions/Bindings, Behavior Definitions/Implementations, Metadata Extensions (DDLX), Packages, Transports, Unit Tests (ABAP + CDS)
 
-### Low-Level Group (122 tools)
+### Low-Level Tier (122 tools)
 Fine-grained per-operation-per-object: Lock/Unlock/Check/Activate/Validate/Create/Update/Delete + generic variants
 
-### Compact Group (22 tools)
+### Compact Tier (22 tools)
 Unified by `object_type` parameter: HandlerCreate, HandlerGet, HandlerUpdate, HandlerDelete, HandlerActivate, HandlerLock, HandlerUnlock, HandlerValidate, HandlerCheckRun, HandlerTransportCreate, HandlerUnitTestRun/Status/Result, HandlerCdsUnitTestStatus/Result, HandlerDumpList/View, HandlerProfileList/Run/View, HandlerServiceBindingListTypes/Validate
 
-## Authentication (9 Providers -- Most Advanced)
+## Authentication (9 Providers — Most Advanced)
 
 | Provider | Flow |
 |----------|------|
@@ -74,75 +75,120 @@ AuthBroker: cache → refresh_token → browser OAuth2 → typed error. Automati
 
 ## Safety/Security
 
-- **Exposition control**: Limit active tool groups (read-only, high-level, low-level, compact)
-- **try-finally unlock**: Fixed in v4.5.0 -- prevents lock leaks (was try-catch before)
-- **Sensitive data redaction** in logs
+- **Exposition control**: Limit active tool tiers (read-only, high-level, low-level, compact)
+- **try-finally unlock**: Fixed in v4.5.0 — prevents lock leaks
+- **Sensitive data redaction** in logs (Pino)
 - **Session isolation**: HTTP/SSE = fresh connections per-request
 - **`--unsafe` flag**: Controls file-based vs in-memory session persistence
 - **SAP_SYSTEM_TYPE**: On-premise vs cloud tool availability
-- **No read-only flag or op filtering** like ARC-1 -- relies on exposition control
+- **Lock registry**: Persistent `.locks/active-locks.json` with CLI recovery tools
+- **No read-only flag or op filtering** like ARC-1 — relies on exposition control only
 
 ## Transport (MCP Protocol)
 
 | Transport | Supported |
 |-----------|-----------|
 | stdio | Yes (default) |
-| HTTP Streamable | Yes (--http-port) |
-| SSE | Yes (--sse-port) |
+| HTTP Streamable | Yes (`--http-port`) |
+| SSE | Yes (`--sse-port`) |
+| TLS/HTTPS | Yes (v4.6.0: `--tls-cert`, `--tls-key`, `--tls-ca`) |
+
+## Configuration
+
+- CLI args, environment variables, YAML config files
+- `--mcp=<destination>`: service key selection
+- `--auth-broker`: force auth-broker usage
+- `--connection-type`: http or rfc
+- Health endpoint: `GET /mcp/health` (v4.3.0)
+- Configurator: `mcp-conf --client cline --name abap --mcp TRIAL`
 
 ## Testing
 
 - Jest (unit + integration)
-- Integration tests by handler level and object type
+- Integration tests by handler tier and object type
 - YAML test config (`test-config.yaml`)
 - Global setup/teardown for lifecycle
 - Test helpers: HighTester, LowTester, LambdaTester
+- Husky + lint-staged pre-commit hooks (v4.5.2)
 
 ## Dependencies
 
 Runtime: @modelcontextprotocol/sdk ^1.27.1, axios ^1.13.6, fast-xml-parser ^5.4.2, xml-js ^1.6.11, pino ^10.1.0, js-yaml ^4.1.1, zod ^4.3.6
-Optional: node-rfc ^3.3.1 (SAP RFC)
+Optional: @mcp-abap-adt/sap-rfc-lite (replaces archived node-rfc, v4.7.0)
 Dev: Biome, Jest, TypeScript, Express, Husky
 
-## Known Issues (All Resolved)
+## Release History (Major Milestones)
+
+| Version | Date | Key Changes |
+|---------|------|-------------|
+| v4.7.0-4.7.1 | Apr 1, 2026 | Replaced archived `node-rfc` with `@mcp-abap-adt/sap-rfc-lite` |
+| v4.6.0 | Mar 31, 2026 | HTTPS/TLS support for MCP server |
+| v4.5.0-4.5.2 | Mar 26-27, 2026 | try-finally lock fix, RAG-optimized descriptions, auth priority fix |
+| v4.4.0 | Mar 22, 2026 | Tool descriptions enriched for embedding-based discovery |
+| v4.3.0 | Mar 19, 2026 | `/mcp/health` endpoint, improved request logging |
+| v4.0.0-4.1.1 | Mar 13, 2026 | Major version bump (v3→v4) |
+| v3.x | Mar 3-6, 2026 | Short-lived (3 releases) |
+| v2.x | Dec 30, 2025 - Feb 23, 2026 | ~20 releases |
+| v1.1.0 | Nov 21, 2025 | First release |
+
+**Total: 83 releases in ~5 months. Average: ~4 releases/week.**
+
+## Known Issues
 
 | Issue | Description | Relevant to ARC-1? |
 |-------|-------------|-------------------|
-| #22 | Lock leak -- try-catch instead of try-finally for unlock | **Critical** -- verify ARC-1 uses try-finally |
-| #22, #23, #25 | 415 Content-Type errors -- SAP needs specific Accept/Content-Type | Yes -- verify content-type handling |
-| #24 | SAP_JWT_TOKEN overrides SAP_AUTH_TYPE | Yes -- check env var priority |
-| #7 | 409 conflict not propagated to LLM | Yes -- ensure conflict errors are clear |
-| #13 | Check runs fail with non-EN languages | Yes -- verify language handling |
-| BTP Cloud | Data preview may not work | Yes -- document BTP limitations |
+| #22 | Lock leak — try-catch instead of try-finally for unlock | **Resolved** — ARC-1 already uses try-finally |
+| #22, #23, #25 | 415 Content-Type errors — SAP needs specific Accept/Content-Type | **Yes** — add 415 retry logic |
+| #24 | SAP_JWT_TOKEN overrides SAP_AUTH_TYPE | Yes — check env var priority |
+| #7 | 409 conflict not propagated to LLM | Yes — ensure conflict errors are clear |
+| #13 | Check runs fail with non-EN languages | Yes — verify language handling |
+| BTP Cloud | Data preview may not work | Yes — document BTP limitations |
 
 ---
 
 ## Features This Project Has That ARC-1 Lacks
 
-| Feature | Priority | Effort | Place in ARC-1 or mcp-sap-docs? |
-|---------|----------|--------|--------------------------------|
-| 9 auth providers (SAML, OIDC device flow, etc.) | Low | 5d+ | ARC-1 -- only if enterprise demand |
-| Standalone auth proxy for BTP | Low | 3d | ARC-1 -- BTP PP already covers this |
-| Auto-configurator for 11 MCP clients | High | 2d | ARC-1 -- great UX improvement |
-| SSE transport | Medium | 2d | ARC-1 -- if clients need it |
-| Runtime profiling (execute + profile) | Medium | 2d | ARC-1 -- extend SAPDiagnose |
-| Runtime dump analysis | High | 1d | ARC-1 -- already partially in SAPDiagnose |
-| ABAP AST parsing (JSON syntax tree) | Medium | 3d | ARC-1 -- could enhance code intelligence |
-| Semantic analysis + system symbols | Medium | 3d | ARC-1 -- advanced code intel |
-| Enhancement discovery | Medium | 2d | ARC-1 -- useful for customization |
-| CDS unit testing | Medium | 1d | ARC-1 -- extend SAPLint |
-| RFC connection (node-rfc) | Low | 3d | ARC-1 -- optional dependency |
-| Embeddable server | Low | 1d | ARC-1 -- SDK use case |
-| GetProgFullCode (includes traversal) | High | 1d | ARC-1 -- reduces round trips |
-| Content-Type negotiation (415 auto-retry) | High | 0.5d | ARC-1 -- robustness improvement |
-| Compact mode (22 tools) | Medium | 2d | ARC-1 -- already have intent-based |
-| RAG-optimized tool descriptions | Medium | 1d | ARC-1 -- improve discoverability |
-| DDLX/Metadata Extension support | High | 1d | ARC-1 -- add to SAPRead |
-| Health check endpoint | Low | 0.5d | ARC-1 -- already have /health |
+| Feature | Priority | Effort | Notes |
+|---------|----------|--------|-------|
+| **9 auth providers** (SAML, OIDC device flow, etc.) | Low | 5d+ | Only if enterprise demand |
+| **TLS/HTTPS for MCP server** | Critical | 1d | Required for production without reverse proxy |
+| **sap-rfc-lite** (RFC connectivity) | Low | 3d | Alternative to ADT HTTP |
+| **Auto-configurator** for 11 MCP clients | High | 2d | Great onboarding UX |
+| **SSE transport** | Medium | 2d | If clients need it |
+| **Runtime profiling** (execute + profile) | Medium | 2d | Extend SAPDiagnose |
+| **Runtime dump analysis** (list + analyze) | Critical | 1d | Basic diagnostic gap |
+| **ABAP AST parsing** (JSON syntax tree) | Medium | 3d | Could enhance code intelligence |
+| **Semantic analysis + system symbols** | Medium | 3d | Advanced code intel |
+| **Enhancement discovery** (spots + implementations) | Medium | 2d | Useful for customization |
+| **CDS unit testing** (create/run/check) | Medium | 1d | Extend SAPDiagnose |
+| **Embeddable server** (EmbeddableMcpServer) | Low | 1d | SDK/library use case |
+| **GetProgFullCode** (recursive includes) | High | 1d | Reduces round trips |
+| **Content-Type 415 auto-retry** | Critical | 0.5d | Robustness improvement |
+| **Compact mode** (22 tools) | Low | 2d | ARC-1 already has intent-based |
+| **RAG-optimized tool descriptions** | Medium | 1d | Improve embedding discoverability |
+| **DDLX/Metadata Extension** (read + CRUD) | Critical | 1d | RAP completeness |
+| **Health check endpoint** | — | — | ARC-1 already has /health |
+| **Lock registry with crash recovery** | Low | 2d | Persistent lock state |
+| **Batch HTTP operations** (multipart/mixed) | Medium | 2d | Reduces SAP round trips |
+| **Service Binding read/CRUD** | High | 1d | RAP completeness |
 
 ## Features ARC-1 Has That This Project Lacks
 
-abaplint integration, SQLite caching, read-only mode + op filtering + package filtering, BTP Destination Service (built-in), principal propagation (built-in), audit logging (BTP Audit Log), MCP elicitation, intent-based routing (11 vs 287 tools), npm `arc-1` package, Docker image.
+- abaplint integration (local offline linting)
+- SQLite caching
+- Read-only mode + op filtering + package filtering + SQL blocking + transport gating + dry-run
+- MCP scope system (OAuth scope-gated tools)
+- BTP Destination Service (built-in, not just service keys)
+- Principal propagation (per-user SAP identity)
+- Cloud Connector proxy
+- Audit logging (BTP Audit Log sink)
+- MCP elicitation (interactive parameter collection)
+- Intent-based routing (11 vs 287 tools — simpler LLM decision surface)
+- npm `arc-1` package + Docker image
+- Context compression (SAPContext with depth control)
+- BOR business objects read
+- Messages (T100) read
+- release-please CI/CD pipeline
 
 ---
 
@@ -150,11 +196,14 @@ abaplint integration, SQLite caching, read-only mode + op filtering + package fi
 
 | Date | Change | Relevant? | Action for ARC-1 | Status |
 |------|--------|-----------|-------------------|--------|
-| 2026-03-27 | v4.5.2 -- Content-Type negotiation fixes | **Yes** | Add 415 retry logic to ARC-1 HTTP | TODO |
-| 2026-03-26 | Lock leak fix (try-finally) | **Critical** | Verify ARC-1 uses try-finally for all unlocks | TODO |
+| 2026-04-01 | v4.7.0-4.7.1 — sap-rfc-lite replaces node-rfc | No | ARC-1 uses HTTP only | — |
+| 2026-03-31 | v4.6.0 — TLS/HTTPS support | **Critical** | Add TLS support for HTTP Streamable | TODO |
+| 2026-03-27 | v4.5.2 — Content-Type negotiation fixes | **Yes** | Add 415 retry logic to ARC-1 HTTP | TODO |
+| 2026-03-26 | v4.5.0 — Lock leak fix (try-finally) | Resolved | ARC-1 already uses try-finally | Done |
 | 2026-03-26 | RAG-optimized tool descriptions | Maybe | Review tool description quality | TODO |
 | 2026-03-25 | Auth priority fix | Yes | Verify env var priority in ARC-1 | TODO |
-| 2026-03-24 | Husky pre-commit hooks | No | ARC-1 already uses Biome | -- |
-| | | | | |
+| 2026-03-22 | v4.4.0 — Embedding-optimized descriptions | Maybe | Review for adoption | TODO |
+| 2026-03-19 | v4.3.0 — /mcp/health endpoint | No | ARC-1 already has /health | — |
+| 2026-03-13 | v4.0.0 — Major version bump | Review | Check for breaking changes | TODO |
 
-_Last updated: 2026-03-30_
+_Last updated: 2026-04-01_

--- a/compare/07-dassian-adt.md
+++ b/compare/07-dassian-adt.md
@@ -1,9 +1,10 @@
-# DassianInc/dassian-adt
+# DassianInc/dassian-adt → albanleong/abap-mcpb
 
-> **Repository**: https://github.com/DassianInc/dassian-adt
-> **Language**: TypeScript | **License**: MIT | **Stars**: New
-> **Status**: Very New/Active (created 2026-03-27, 13 commits, daily updates)
-> **Relationship**: Fork of mario-andreschak's wrapper, rewritten with elicitation and validation
+> **Original**: https://github.com/DassianInc/dassian-adt (may be private/removed)
+> **Successor**: https://github.com/albanleong/abap-mcpb (created 2026-03-31, MCPB format)
+> **Language**: TypeScript / JavaScript | **License**: MIT | **Stars**: 0 (abap-mcpb, very new)
+> **Status**: Active — evolved from dassian-adt v2.0 into MCPB format for Claude Desktop
+> **Relationship**: Fork of mario-andreschak's wrapper → dassian rewrite → MCPB repackaging
 
 ---
 
@@ -157,4 +158,13 @@ Safety system (read-only, op filter, pkg filter, SQL blocking), OIDC/JWT auth, B
 | 2026-03-27 | Initial commit (v2.0) | Yes | Full review of elicitation patterns | TODO |
 | | | | | |
 
-_Last updated: 2026-03-30_
+## abap-mcpb (Successor — March 31, 2026)
+
+albanleong/abap-mcpb packages dassian-adt v2.0 as an **MCPB** (MCP Bundle) for Claude Desktop. Key differences:
+- **Zero build step** — MCPB format with form-based configuration
+- **Per-tool permissions** — Claude Desktop's native authorization UI
+- **Same 25 tools** as dassian-adt
+- 2 files customized from dassian-adt: QualityHandlers.js (enhanced ATC), index.js (error handling)
+- Single commit, no releases yet — very early stage
+
+_Last updated: 2026-04-01_


### PR DESCRIPTION
## Summary
- Restructure README around arc1's key differentiators: security-by-default, 4 auth methods, BTP CF deployment with principal propagation, audit logging, 700+ tests, and tools refined from real LLM feedback
- Remove internal dev sections (releasing, CI workflows, versioned artifacts) — these live in CLAUDE.md
- Link to the GitHub Pages docs site for detailed guides instead of duplicating content
- Expand comparison table with all enterprise features (audit logging, BTP support, feature detection, etc.)
- Add vibing-steampunk to credits as the original starting point

## Test plan
- [ ] Verify all GitHub Pages links resolve correctly
- [ ] Verify npm and Docker links work
- [ ] Review rendered markdown on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)