### PR TITLE
docs: align setup/auth docs with current ARC-1 behavior

### DIFF
--- a/docs/auth-test-process.md
+++ b/docs/auth-test-process.md
@@ -1,14 +1,15 @@
 # Authentication Test Process
 
-Step-by-step verification for each authentication phase. Run these tests after deploying arc1 to confirm each phase works as intended.
+Use this checklist after deployment changes to verify ARC-1 authentication end-to-end.
+
+Scope: ARC-1 `v0.3.x`.
+
+---
 
 ## Prerequisites
 
 ```bash
-# Build arc1
 npm run build
-
-# Run unit tests first (all must pass)
 npm test
 ```
 
@@ -16,292 +17,136 @@ npm test
 
 ## Phase 1: API Key Authentication
 
-### Unit Tests
-
-```bash
-# Run Phase 1 related tests
-npm test
-```
-
-### Manual Integration Test
-
-**1. Start arc1 with API key:**
+### Start ARC-1
 
 ```bash
 npx arc-1 --url http://your-sap:8000 \
   --user DEVELOPER --password secret --client 001 \
-  --transport http-streamable --port 8080 \
+  --transport http-streamable --http-addr 0.0.0.0:8080 \
   --api-key 'test-key-12345'
 ```
 
-**2. Verify health endpoint (no auth required):**
+### Verify
 
 ```bash
+# health endpoint stays public
 curl -s http://localhost:8080/health
-# Expected: {"status":"ok"}
-```
 
-**3. Verify request without API key is rejected:**
-
-```bash
+# no auth -> 401
 curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/mcp
-# Expected: 401
-```
 
-**4. Verify request with wrong API key is rejected:**
-
-```bash
+# wrong key (and no OIDC fallback) -> 403
 curl -s -o /dev/null -w "%{http_code}" \
   -H "Authorization: Bearer wrong-key" \
   http://localhost:8080/mcp
-# Expected: 401
-```
 
-**5. Verify request with correct API key succeeds:**
-
-```bash
+# valid key -> 200
 curl -s -H "Authorization: Bearer test-key-12345" \
   -H "Content-Type: application/json" \
   http://localhost:8080/mcp \
   -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
-# Expected: 200 with JSON-RPC response containing tool list
 ```
 
-**6. Verify case-insensitive Bearer prefix:**
+Checklist:
 
-```bash
-curl -s -H "Authorization: bearer test-key-12345" \
-  -H "Content-Type: application/json" \
-  http://localhost:8080/mcp \
-  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
-# Expected: 200 (same as above)
-```
-
-### Checklist
-
-- [ ] Health endpoint returns 200 without auth
-- [ ] Missing Authorization header → 401
-- [ ] Wrong API key → 401
-- [ ] Correct API key → 200 with tools
-- [ ] Case-insensitive "Bearer" prefix works
-- [ ] MCP client (VS Code/Cursor) connects with Authorization header
+- [ ] `/health` is reachable without auth
+- [ ] missing auth returns 401
+- [ ] wrong API key returns 403
+- [ ] valid API key returns 200
 
 ---
 
-## Phase 2: OAuth / JWT Authentication
+## Phase 2: OIDC JWT Validation
 
-### Unit Tests
-
-```bash
-npm test
-```
-
-### Manual Integration Test
-
-**Prerequisites:** You need an OIDC Identity Provider (EntraID, Keycloak, Cognito).
-
-**1. Start arc1 with OIDC:**
+### Start ARC-1
 
 ```bash
 npx arc-1 --url http://your-sap:8000 \
   --user DEVELOPER --password secret --client 001 \
-  --transport http-streamable --port 8080 \
-  --oidc-issuer 'https://your-idp.example.com' \
-  --oidc-audience 'your-audience'
+  --transport http-streamable --http-addr 0.0.0.0:8080 \
+  --oidc-issuer 'https://login.microsoftonline.com/<tenant-id>/v2.0' \
+  --oidc-audience '<expected-aud>'
 ```
 
-**2. Verify Protected Resource Metadata endpoint:**
+### Verify
 
 ```bash
-curl -s http://localhost:8080/.well-known/oauth-protected-resource | jq .
-# Expected: JSON with "resource", "authorization_servers", "bearer_methods_supported"
-```
-
-**3. Verify request without token is rejected:**
-
-```bash
+# no auth -> 401
 curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/mcp
-# Expected: 401
-```
 
-**4. Get a real JWT from your IdP:**
+# invalid token -> 403
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer invalid.jwt.token" \
+  http://localhost:8080/mcp
 
-```bash
-# Example for Azure CLI:
-TOKEN=$(az account get-access-token --resource your-audience --query accessToken -o tsv)
-
-# Example for Keycloak (password grant for testing):
-TOKEN=$(curl -s -X POST https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token \
-  -d "grant_type=password&client_id=arc1&username=testuser&password=testpass" | jq -r .access_token)
-```
-
-**5. Verify request with valid JWT succeeds:**
-
-```bash
+# valid token -> 200
 curl -s -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   http://localhost:8080/mcp \
   -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
-# Expected: 200 with tool list
 ```
 
-**6. Verify expired/invalid token is rejected:**
+Checklist:
 
-```bash
-curl -s -o /dev/null -w "%{http_code}" \
-  -H "Authorization: Bearer invalid.jwt.token" \
-  http://localhost:8080/mcp
-# Expected: 401
-```
-
-**7. Check logs for username extraction:**
-
-```
-# In arc1 stderr output, look for:
-# [OIDC] Authenticated user: <username>
-```
-
-### Checklist
-
-- [ ] Protected Resource Metadata endpoint returns valid JSON
-- [ ] Missing token → 401
-- [ ] Invalid/expired token → 401
-- [ ] Valid JWT → 200 with tools
-- [ ] Username extracted from JWT claims (check logs)
-- [ ] JWKS auto-discovery works (check logs for JWKS fetch)
+- [ ] missing token returns 401
+- [ ] invalid token returns 403
+- [ ] valid token returns 200
+- [ ] token `aud` matches configured `SAP_OIDC_AUDIENCE`
 
 ---
 
-## Phase 3: Principal Propagation
+## Phase 3: Principal Propagation (BTP Destination Path)
 
-### Unit Tests
+Prerequisites:
 
-```bash
-npm test
-```
+- ARC-1 on BTP CF
+- `SAP_BTP_DESTINATION` + `SAP_BTP_PP_DESTINATION` configured
+- `SAP_PP_ENABLED=true`
+- Cloud Connector + SAP cert mapping configured
 
-### Manual Integration Test
-
-**Prerequisites:**
-- Phase 2 (OIDC) configured and working
-- SAP system configured with STRUST, CERTRULE, ICM (see [Phase 3 Setup](phase3-principal-propagation-setup.md))
-
-**1. Generate test CA:**
+### Verify
 
 ```bash
-openssl genrsa -out /tmp/test-ca.key 2048
-openssl req -new -x509 -key /tmp/test-ca.key -out /tmp/test-ca.crt -days 365 \
-  -subj "/CN=arc1-test-ca/O=Test/C=DE"
+cf logs arc1-mcp-server --recent | grep -E "Principal propagation|per-user|BTP destination"
 ```
 
-**2. Import CA cert into SAP STRUST** (see Phase 3 docs)
+In SAP:
 
-**3. Configure CERTRULE** to map `CN=<username>` → SAP user
+- Check `SM20` for user-level entries
+- Check `SM30` (`VUSREXTID`) mappings if user resolution fails
 
-**4. Start arc1 with PP:**
+Checklist:
 
-```bash
-npx arc-1 --url https://your-sap:44300 \
-  --transport http-streamable --port 8080 \
-  --oidc-issuer 'https://your-idp.example.com' \
-  --oidc-audience 'your-audience' \
-  --pp-ca-key /tmp/test-ca.key \
-  --pp-ca-cert /tmp/test-ca.crt \
-  --pp-cert-ttl 5m \
-  --insecure
-```
-
-**Note:** No `--user` or `--password` needed when PP is active.
-
-**5. Authenticate and make a request:**
-
-```bash
-TOKEN=$(az account get-access-token --resource your-audience --query accessToken -o tsv)
-
-curl -s -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  http://localhost:8080/mcp \
-  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"SAPRead","arguments":{"type":"SYSTEM"}},"id":1}'
-# Expected: Response showing SAP system info
-```
-
-**6. Verify per-user identity in SAP:**
-
-Check in SAP transaction `/nSM21` (system log) or `/nSM04` (user sessions) that the request was executed as the mapped SAP user, not a service account.
-
-### Checklist
-
-- [ ] CA cert imported into SAP STRUST
-- [ ] CERTRULE mapping configured (CN → SAP User)
-- [ ] ICM parameter `icm/HTTPS/verify_client = 1` set
-- [ ] arc1 starts without errors with `--pp-ca-key` and `--pp-ca-cert`
-- [ ] Request with OIDC token uses ephemeral cert (check logs)
-- [ ] SAP logs show per-user identity (not service account)
+- [ ] JWT requests use per-user destination
+- [ ] SAP actions are attributed to the individual SAP user
+- [ ] fallback behavior matches `SAP_PP_STRICT` setting
 
 ---
 
-## Phase 4: BTP / Cloud Foundry
+## Phase 4: XSUAA OAuth Proxy (MCP-native)
 
-### Unit Tests
+Prerequisites:
 
-```bash
-npm test
-```
+- XSUAA service bound
+- `SAP_XSUAA_AUTH=true`
 
-### Manual Integration Test
-
-**To test on BTP Cloud Foundry:**
-
-**1. Deploy to CF:**
+### Verify
 
 ```bash
-# Build Docker image
-docker build -t arc1 .
-# Push to CF (see phase4-btp-deployment.md)
-cf push
+curl -s https://<app-url>/.well-known/oauth-authorization-server | jq .
 ```
 
-**2. Verify app is running** (check app logs):
+Checklist:
 
-```bash
-cf logs arc1 --recent | grep "BTP"
-# Expected: Log messages showing parsed XSUAA and Destination bindings
-```
-
-**3. Verify health:**
-
-```bash
-cf ssh arc1 -c "curl -s http://localhost:8080/health"
-# Expected: {"status":"ok"}
-```
-
-### Checklist
-
-- [ ] BTP config → OAuth config conversion works
-- [ ] App starts on CF without errors
-- [ ] Health endpoint returns 200
+- [ ] OAuth discovery endpoint is available
+- [ ] MCP-native client can complete browser login
+- [ ] authenticated MCP requests succeed
 
 ---
 
-## Full Regression Suite
-
-Run all tests:
+## Regression Smoke Test
 
 ```bash
-# All unit tests
 npm test
-
-# Integration tests (requires SAP credentials)
 npm run test:integration
-```
-
----
-
-## Quick Smoke Test
-
-For a quick check that nothing is broken after code changes:
-
-```bash
-npm test
-# Expected: All tests pass, no failures
 ```

--- a/docs/btp-abap-environment.md
+++ b/docs/btp-abap-environment.md
@@ -16,7 +16,7 @@ If you don't have a BTP ABAP Environment instance yet, you can create one on the
 
 ### Prerequisites for Free Tier
 
-- A SAP BTP trial or pay-as-you-go account
+- A SAP BTP global account with free-tier eligible entitlements (trial is optional)
 - Cloud Foundry enabled in your subaccount (with an org and space)
 - The `abap` / `free` entitlement assigned to your subaccount
 
@@ -61,14 +61,13 @@ EOF
 cf create-service abap free my-abap-instance -c params.json
 ```
 
-**Important notes:**
+**Important notes (verified April 7, 2026):**
 - `admin_email` must be a valid email address (the one you use to log into BTP)
 - `sap_system_name` is a 3-character SID (e.g., `H01`, `DEV`, `Z01`)
-- Free tier is only available in certain regions (`eu10`, `us10`, `ap10`)
+- Free tier availability depends on your region and commercial model; check SAP Discovery Center and your subaccount entitlements for current region support
 - Only **one** free instance per global account
 - Provisioning takes **30-60 minutes** — check status with `cf service my-abap-instance`
-- Free tier instances are **stopped each night** — restart via Landscape Portal or BTP Cockpit
-- Free tier has a **90-day time limit**
+- Recent SAP ABAP environment updates changed free-tier system sizing (for example, 0.5 ACU provisioning); verify current limits in SAP Help before planning capacity
 
 ### Common Error: admin_email Validation
 
@@ -417,10 +416,16 @@ When `SAP_SYSTEM_TYPE=btp` is set (or auto-detected), tool definitions and behav
 ### Free tier provisioning fails
 
 - **Entitlement missing**: Assign `abap` / `free` in Global Account > Entitlements
-- **Region not supported**: Free tier is only in `eu10`, `us10`, `ap10`
+- **Region not supported**: Free plan might not be available in your region/commercial model
 - **Already have an instance**: Only one free instance per global account
 - **CF not enabled**: Enable Cloud Foundry in your subaccount first
 
 ## Architecture Details
 
 For the research report covering authentication options, competitor analysis, and design decisions, see [docs/reports/btp-abap-environment-connectivity.md](reports/btp-abap-environment-connectivity.md).
+
+## External References
+
+- [Using Free Service Plans (SAP BTP)](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/524e1081d8dc4b0f9d055a6bec383ec3.html) — commercial model and entitlement requirements
+- [Lifecycle Management (SAP BTP ABAP Environment)](https://help.sap.com/docs/ABAP_ENVIRONMENT/36609a00dcea4e6fa7c4ca2f2868e972/3b19c2bc43854d7cb49a6522d5f9442a.html) — recent free-tier and region updates
+- [Selecting a Service Plan for the Web Access for ABAP](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/2859cc59f9ba4976a6d613475d07c9ed.html) — booster note and entitlement flow

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -39,7 +39,7 @@ Start the MCP server. This is the default command when no subcommand is given.
 arc1
 
 # HTTP Streamable transport (for VS Code, Copilot Studio)
-arc1 --transport http-streamable --port 3000
+arc1 --transport http-streamable --http-addr 0.0.0.0:3000
 ```
 
 ### search
@@ -111,7 +111,7 @@ arc1 --transport http-streamable --api-key "my-secret-key"
 # OIDC authentication
 arc1 --transport http-streamable \
   --oidc-issuer "https://login.microsoftonline.com/..." \
-  --oidc-audience "api://arc1"
+  --oidc-audience "<expected-aud-claim>"
 
 # BTP Destination
 SAP_BTP_DESTINATION=SAP_TRIAL arc1

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -269,8 +269,6 @@ prefix. CLI flags map 1:1 to env vars:
 | `--allowed-packages` | `SAP_ALLOWED_PACKAGES` | |
 | `--allow-transportable-edits` | `SAP_ALLOW_TRANSPORTABLE_EDITS` | `false` |
 | `--enable-transports` | `SAP_ENABLE_TRANSPORTS` | `false` |
-| `--transport-read-only` | `SAP_TRANSPORT_READ_ONLY` | `false` |
-| `--allowed-transports` | `SAP_ALLOWED_TRANSPORTS` | |
 | `--feature-abapgit` | `SAP_FEATURE_ABAPGIT` | `auto` |
 | `--feature-rap` | `SAP_FEATURE_RAP` | `auto` |
 | `--feature-amdp` | `SAP_FEATURE_AMDP` | `auto` |
@@ -279,17 +277,16 @@ prefix. CLI flags map 1:1 to env vars:
 | `--feature-hana` | `SAP_FEATURE_HANA` | `auto` |
 | `--transport` | `SAP_TRANSPORT` | `http-streamable` *(image default)* |
 | `--http-addr` | `SAP_HTTP_ADDR` | `0.0.0.0:8080` *(image default)* |
-| `--terminal-id` | `SAP_TERMINAL_ID` | |
 | `--verbose` | `SAP_VERBOSE` | `false` |
 | **MCP Client Auth** | | |
 | `--api-key` | `ARC1_API_KEY` | |
 | `--oidc-issuer` | `SAP_OIDC_ISSUER` | |
 | `--oidc-audience` | `SAP_OIDC_AUDIENCE` | |
-| `--oidc-username-claim` | `SAP_OIDC_USERNAME_CLAIM` | `preferred_username` |
-| `--oidc-user-mapping` | `SAP_OIDC_USER_MAPPING` | |
-| `--pp-ca-key` | `SAP_PP_CA_KEY` | |
-| `--pp-ca-cert` | `SAP_PP_CA_CERT` | |
-| `--pp-cert-ttl` | `SAP_PP_CERT_TTL` | `5m` |
+| `--xsuaa-auth` | `SAP_XSUAA_AUTH` | `false` |
+| `--pp-enabled` | `SAP_PP_ENABLED` | `false` |
+| `--pp-strict` | `SAP_PP_STRICT` | `false` |
+| *(BTP destination)* | `SAP_BTP_DESTINATION` | |
+| *(BTP PP destination)* | `SAP_BTP_PP_DESTINATION` | |
 
 ---
 
@@ -317,12 +314,12 @@ When running arc1 as a shared server, protect it with API key or OAuth:
 
 # OAuth/OIDC JWT validation (enterprise)
 -e SAP_OIDC_ISSUER='https://login.microsoftonline.com/{tenant}/v2.0' \
--e SAP_OIDC_AUDIENCE='api://arc1-sap-connector'
+-e SAP_OIDC_AUDIENCE='<expected-aud-claim>'
 
-# Principal Propagation (per-user SAP auth, requires OIDC)
--e SAP_PP_CA_KEY=/secrets/ca.key \
--e SAP_PP_CA_CERT=/secrets/ca.crt \
--v /path/to/secrets:/secrets:ro
+# Principal Propagation (BTP Destination + Cloud Connector path)
+-e SAP_BTP_DESTINATION=SAP_TRIAL \
+-e SAP_BTP_PP_DESTINATION=SAP_TRIAL_PP \
+-e SAP_PP_ENABLED=true
 ```
 
 See the [Authentication guides](enterprise-auth.md) for detailed setup.
@@ -479,14 +476,6 @@ CTS transport tools are **disabled by default** to prevent accidental releases.
 ```bash
 # Enable transport tools
 -e SAP_ENABLE_TRANSPORTS=true
-
-# Enable but restrict to read-only (list, view — no create/release/delete)
--e SAP_ENABLE_TRANSPORTS=true
--e SAP_TRANSPORT_READ_ONLY=true
-
-# Enable and restrict to specific transports (wildcards OK)
--e SAP_ENABLE_TRANSPORTS=true
--e SAP_ALLOWED_TRANSPORTS="A4HK*"
 ```
 
 ---
@@ -522,21 +511,6 @@ Use `on` or `off` to skip the probe and force the behavior:
 
 Setting features to `off` reduces the number of registered MCP tools, which
 keeps the AI's tool list shorter and lowers token usage.
-
----
-
-### Debugger
-
-To share breakpoints with SAP GUI (cross-tool debugging), configure the same
-terminal ID that SAP GUI uses:
-
-```bash
--e SAP_TERMINAL_ID=D0C586D015974B75BFB2A306A4A13AEA
-```
-
-SAP GUI stores its terminal ID at:
-- **Windows:** Registry `HKCU\Software\SAP\ABAP Debugging\TerminalID`
-- **Linux/Mac:** `~/.SAP/ABAPDebugging/terminalId`
 
 ---
 

--- a/docs/enterprise-auth.md
+++ b/docs/enterprise-auth.md
@@ -1,520 +1,189 @@
 # Enterprise Authentication Guide
 
-This document describes the authentication methods available in arc1 for connecting
-to SAP ABAP systems. It covers setup, configuration, and SAP-side requirements
-for each method.
+This guide documents the authentication options that are currently implemented in ARC-1 (`v0.3.x`).
 
-For centralized deployments (arc1 as a shared server), also see the phased setup guides:
+ARC-1 has two independent authentication hops:
 
-- [Phase 1: API Key Authentication](phase1-api-key-setup.md) — Shared token, simplest setup
-- [Phase 2: OAuth / JWT Authentication](phase2-oauth-setup.md) — OIDC identity with auto-discovery
-- [Phase 3: Principal Propagation](phase3-principal-propagation-setup.md) — Per-user SAP auth via ephemeral certs
-- [Phase 4: BTP Cloud Foundry Deployment](phase4-btp-deployment.md) — XSUAA + Destination Service
-- [Auth Test Process](auth-test-process.md) — Step-by-step verification for each phase
+1. **MCP client -> ARC-1** (who can call the MCP endpoint)
+2. **ARC-1 -> SAP** (how ARC-1 authenticates to SAP ADT)
 
 ---
 
-## Authentication Methods Overview
+## 1) MCP Client -> ARC-1
 
-| Method | Use Case | Security Level | SAP-Side Setup |
-|--------|----------|---------------|----------------|
-| **API Key** | Shared server, POC | Low (shared token) | None |
-| **Basic auth** | Local dev, POC | Low (password in config) | None |
-| **Cookie auth** | Reuse browser session | Low (manual, expires) | None |
-| **OAuth2/XSUAA** | BTP/Cloud systems | Medium (service-to-service) | Service key in BTP cockpit |
-| **X.509 mTLS** | Enterprise, cert-based SSO | High (no password) | STRUST + CERTRULE |
-| **OIDC + Principal Propagation** | Multi-user enterprise | Highest (zero stored credentials) | STRUST + CERTRULE + EntraID |
+### Option A: No auth (local only)
 
-**Rule: only one SAP auth method at a time.** ARC-1 validates this at startup.
-MCP client auth (API Key or OIDC) is independent and can be combined with any SAP auth method.
+Use for local `stdio` setups only.
 
----
-
-## 1. Basic Authentication
-
-The simplest method. Username and password are sent with every HTTP request.
+### Option B: API key
 
 ```bash
-# CLI flags
-arc1 --url https://sap-host:443 --user DEVELOPER --password 'ABAPtr2023#00'
+arc1 --transport http-streamable --http-addr 0.0.0.0:8080 --api-key "your-secret"
+```
 
-# Environment variables
-export SAP_URL=https://sap-host:443
+Or:
+
+```bash
+export ARC1_API_KEY=your-secret
+```
+
+### Option C: OIDC JWT validation (Entra ID, Cognito, Keycloak, ...)
+
+```bash
+arc1 --transport http-streamable --http-addr 0.0.0.0:8080 \
+  --oidc-issuer "https://login.microsoftonline.com/<tenant-id>/v2.0" \
+  --oidc-audience "<expected-audience>"
+```
+
+Or:
+
+```bash
+export SAP_OIDC_ISSUER="https://login.microsoftonline.com/<tenant-id>/v2.0"
+export SAP_OIDC_AUDIENCE="<expected-audience>"
+```
+
+Notes:
+- `SAP_OIDC_AUDIENCE` must match the token `aud` claim.
+- For Entra v2 access tokens, `aud` is often the API application's client ID (GUID). Validate with a real token in your tenant.
+
+### Option D: XSUAA OAuth proxy (BTP Cloud Foundry)
+
+When `SAP_XSUAA_AUTH=true` and an XSUAA service binding is present, ARC-1 exposes OAuth discovery + proxy endpoints for MCP-native clients.
+
+```bash
+export SAP_XSUAA_AUTH=true
+```
+
+See [Phase 5: XSUAA setup](phase5-xsuaa-setup.md).
+
+---
+
+## 2) ARC-1 -> SAP
+
+ARC-1 supports the following SAP authentication modes.
+
+### Option A: Basic auth (most common for on-prem/dev)
+
+```bash
+arc1 --url https://sap-host:44300 --user DEVELOPER --password 'secret'
+```
+
+Or:
+
+```bash
+export SAP_URL=https://sap-host:44300
 export SAP_USER=DEVELOPER
-export SAP_PASSWORD='ABAPtr2023#00'
+export SAP_PASSWORD='secret'
+```
+
+### Option B: Cookie auth
+
+```bash
+arc1 --url https://sap-host:44300 --cookie-file ./cookies.txt
+# or
+arc1 --url https://sap-host:44300 --cookie-string "MYSAPSSO2=...; SAP_SESSIONID_...=..."
+```
+
+### Option C: BTP ABAP Environment (service key + browser OAuth)
+
+```bash
+export SAP_BTP_SERVICE_KEY_FILE=/path/to/service-key.json
+export SAP_SYSTEM_TYPE=btp
 arc1
-
-# .env file (auto-loaded)
-SAP_URL=https://sap-host:443
-SAP_USER=DEVELOPER
-SAP_PASSWORD=ABAPtr2023#00
 ```
 
-**When to use:** Local development, sandbox systems, CI/CD pipelines with secrets.
-**Security:** Password is in plaintext in config/env. Not suitable for production
-multi-user deployments.
+ARC-1 opens a browser for OAuth Authorization Code flow and caches tokens.
+
+See [BTP ABAP environment setup](btp-abap-environment.md).
+
+### Option D: BTP Destination Service (shared technical user)
+
+Use on BTP Cloud Foundry when connecting to on-prem SAP through Connectivity + Cloud Connector.
+
+```bash
+export SAP_BTP_DESTINATION=SAP_TRIAL
+```
+
+Destination values override `SAP_URL` / `SAP_USER` / `SAP_PASSWORD`.
+
+### Option E: Principal propagation via BTP Destination + Cloud Connector
+
+Per-user SAP identity for JWT-authenticated users:
+
+```bash
+export SAP_BTP_DESTINATION=SAP_TRIAL
+export SAP_BTP_PP_DESTINATION=SAP_TRIAL_PP
+export SAP_PP_ENABLED=true
+```
+
+Behavior:
+- JWT request -> try per-user destination (`SAP_BTP_PP_DESTINATION`)
+- If PP fails and `SAP_PP_STRICT=false` -> fallback to shared destination/client
+- API key / non-JWT request -> shared destination/client
+
+See [BTP destination setup](btp-destination-setup.md) and [Phase 3 PP setup](phase3-principal-propagation-setup.md).
 
 ---
 
-## 2. Cookie Authentication
+## Supported Config Reference
 
-Reuse session cookies from a browser session (MYSAPSSO2, SAP_SESSIONID).
+### MCP auth config
 
-```bash
-# From a cookie file (Netscape format or key=value)
-arc1 --url https://sap-host:443 --cookie-file cookies.txt
+| CLI flag | Env var |
+|---|---|
+| `--api-key` | `ARC1_API_KEY` |
+| `--oidc-issuer` | `SAP_OIDC_ISSUER` |
+| `--oidc-audience` | `SAP_OIDC_AUDIENCE` |
+| `--xsuaa-auth` | `SAP_XSUAA_AUTH` |
 
-# From a cookie string
-arc1 --url https://sap-host:443 --cookie-string "MYSAPSSO2=abc123; SAP_SESSIONID_A4H_001=xyz"
-```
+### SAP auth config
 
-**When to use:** One-off sessions where you have browser cookies.
-**Security:** Session cookies expire (typically 30 min). Not scalable.
-
----
-
-## 3. OAuth2/XSUAA (BTP/Cloud Systems)
-
-For SAP BTP systems using XSUAA for authentication. Uses OAuth2 client_credentials
-flow to obtain a Bearer token.
-
-### From a Service Key File
-
-```bash
-arc1 --service-key /path/to/servicekey.json
-```
-
-The service key JSON is downloaded from SAP BTP Cockpit and looks like:
-
-```json
-{
-  "url": "https://my-system.abap.eu10.hana.ondemand.com",
-  "systemid": "DEV",
-  "uaa": {
-    "url": "https://my-tenant.authentication.eu10.hana.ondemand.com",
-    "clientid": "sb-clone-abc123",
-    "clientsecret": "secret-value"
-  }
-}
-```
-
-### With Explicit OAuth Parameters
-
-```bash
-arc1 --url https://sap-host:443 \
-    --oauth-url https://tenant.authentication.eu10.hana.ondemand.com/oauth/token \
-    --oauth-client-id sb-clone-abc123 \
-    --oauth-client-secret secret-value
-```
-
-**Token lifecycle:** ARC-1 caches the OAuth token and refreshes it automatically
-60 seconds before expiry. Thread-safe for concurrent requests.
-
-**References:**
-- [SAP BTP: Create Service Keys](https://help.sap.com/docs/btp/sap-business-technology-platform/creating-service-keys)
-- [SAP XSUAA Documentation](https://help.sap.com/docs/btp/sap-business-technology-platform/what-is-sap-authorization-and-trust-management-service)
+| CLI flag | Env var |
+|---|---|
+| `--url` | `SAP_URL` |
+| `--user` | `SAP_USER` |
+| `--password` | `SAP_PASSWORD` |
+| `--cookie-file` | `SAP_COOKIE_FILE` |
+| `--cookie-string` | `SAP_COOKIE_STRING` |
+| `--btp-service-key` | `SAP_BTP_SERVICE_KEY` |
+| `--btp-service-key-file` | `SAP_BTP_SERVICE_KEY_FILE` |
+| `--btp-oauth-callback-port` | `SAP_BTP_OAUTH_CALLBACK_PORT` |
+| `--pp-enabled` | `SAP_PP_ENABLED` |
+| `--pp-strict` | `SAP_PP_STRICT` |
+| *(BTP destination)* | `SAP_BTP_DESTINATION` |
+| *(BTP per-user destination)* | `SAP_BTP_PP_DESTINATION` |
 
 ---
 
-## 4. X.509 Client Certificate Authentication (mTLS)
+## What Is Not in `v0.3.x`
 
-ARC-1 authenticates to SAP using a TLS client certificate. SAP maps the certificate's
-Subject CN (Common Name) to a SAP user via CERTRULE. No username or password is needed.
+These options are **not** available in the current ARC-1 codebase:
 
-### Configuration
+- Local SAP mTLS flags like `--client-cert` / `--client-key` / `--ca-cert`
+- Generic OAuth SAP flags like `--oauth-url` / `--oauth-client-id` / `--oauth-client-secret`
+- Local certificate-generation PP flags like `--pp-ca-key` / `--pp-ca-cert` / `--pp-cert-ttl`
+- OIDC username claim/mapping flags like `--oidc-username-claim` / `--oidc-user-mapping`
 
-```bash
-# CLI flags
-arc1 --url https://sap-host:443 \
-    --client-cert /path/to/client.crt \
-    --client-key /path/to/client.key
-
-# With custom CA (when SAP uses an internal CA)
-arc1 --url https://sap-host:443 \
-    --client-cert /path/to/client.crt \
-    --client-key /path/to/client.key \
-    --ca-cert /path/to/ca.crt
-
-# Environment variables
-export SAP_URL=https://sap-host:443
-export SAP_CLIENT_CERT=/path/to/client.crt
-export SAP_CLIENT_KEY=/path/to/client.key
-export SAP_CA_CERT=/path/to/ca.crt  # optional
-```
-
-### How It Works
-
-```
-arc1 ─── TLS handshake with client certificate ───► SAP ICM
-                                                    │
-                                                    ▼
-                                              CERTRULE engine
-                                              maps Subject CN
-                                              to SAP username
-                                                    │
-                                                    ▼
-                                              Authenticated as
-                                              SAP user = CN
-```
-
-1. ARC-1 loads the client certificate and private key from PEM files
-2. During TLS handshake, arc1 presents the client certificate to SAP ICM
-3. SAP ICM verifies the certificate against trusted CAs in STRUST
-4. SAP's CERTRULE engine maps the certificate's Subject CN to a SAP user
-5. All subsequent requests run as that SAP user
-
-### SAP-Side Setup
-
-#### Step 1: Generate a CA and Client Certificate
-
-```bash
-# Generate CA (self-signed, for testing)
-openssl genrsa -out ca.key 4096
-openssl req -new -x509 -key ca.key -out ca.crt -days 365 \
-  -subj "/CN=arc1-enterprise-ca/O=My Company"
-
-# Generate client certificate for a specific SAP user
-openssl genrsa -out developer.key 2048
-openssl req -new -key developer.key -out developer.csr \
-  -subj "/CN=DEVELOPER"
-openssl x509 -req -in developer.csr -CA ca.crt -CAkey ca.key \
-  -CAcreateserial -out developer.crt -days 365
-```
-
-The certificate's Subject CN (`DEVELOPER`) must match the SAP username.
-
-#### Step 2: Import CA Certificate into SAP STRUST
-
-1. Open transaction `/nSTRUST` in SAP GUI
-2. Navigate to **SSL Server Standard** PSE
-3. If no PSE exists, click **Create** → use defaults → Save
-4. Double-click the PSE entry to open it
-5. In the **Certificate** section, click **Import**
-6. Paste the CA certificate PEM content (`ca.crt`)
-7. Click **Add to Certificate List**
-8. **Save** the PSE
-
-Alternatively, via SAP profile (no GUI needed):
-- Copy `ca.crt` into the container
-- Use `sapgenpse` command-line tool to import
-
-**Reference:** [SAP Help: Maintaining the PSE in STRUST](https://help.sap.com/docs/ABAP_PLATFORM/e73baa71770e4c0ca5fb2a3c17e8e229/4510e4a027c746e8e10000000a421937.html)
-
-#### Step 3: Enable Certificate Login in SAP Profile
-
-Edit the SAP instance profile (e.g., `A4H_D00_vhcala4hci`):
-
-```
-# Enable rule-based certificate mapping
-login/certificate_mapping_rulebased = 1
-
-# Accept client certificates (1 = optional, 2 = required)
-icm/HTTPS/verify_client = 1
-```
-
-Restart the ABAP instance after profile changes.
-
-**Reference:** [SAP Help: ICM HTTPS Parameters](https://help.sap.com/docs/ABAP_PLATFORM/683d6a1797a34730a6e005d1e8de6f22/48e20f476bfb7c6de10000000a42189c.html)
-
-#### Step 4: Configure Certificate Mapping Rule (CERTRULE)
-
-1. Open transaction `/nCERTRULE` (or use `/nCERTMAP` on older systems)
-2. Click **Import Certificate** and upload the client certificate (`developer.crt`)
-3. Create a new rule:
-   - **Certificate Attribute:** `Subject` → `CN`
-   - **Login As:** Select `CN value is used as SAP username`
-4. Save and activate the rule
-
-This tells SAP: "when a client presents a certificate, use the CN as the SAP username."
-
-**Reference:** [SAP Help: Configuring Certificate Login](https://help.sap.com/docs/ABAP_PLATFORM/e73baa71770e4c0ca5fb2a3c17e8e229/4513f2bf27da4ce8e10000000a421937.html)
-
-#### Step 5: Restart ICM
-
-After all configuration changes, restart SAP ICM:
-- Transaction `/nSMICM` → Administration → ICM → **Soft Restart**
-- Or via command line: `sapcontrol -nr 00 -function RestartService`
-
-#### Step 6: Test
-
-```bash
-# Test with curl
-curl --cert developer.crt --key developer.key \
-  https://sap-host:443/sap/bc/adt/core/discovery?sap-client=001
-
-# Test with arc1
-arc1 --url https://sap-host:443 --client-cert developer.crt --client-key developer.key
-```
-
----
-
-## 5. OIDC Token Validation + Principal Propagation
-
-The most secure multi-user authentication. Combines OIDC (Microsoft EntraID) token
-validation with ephemeral X.509 certificate generation.
-
-### How It Works
-
-```
-User (alice@company.com)
-  │
-  ▼
-Copilot Studio / IDE  ──── authenticates via EntraID ───► EntraID
-  │                                                         │
-  │  OIDC Bearer token                                      │
-  ▼                                                         │
-arc1 HTTP endpoint  ◄─── validates token via JWKS ───────────┘
-  │
-  │  1. Extract username from JWT claim
-  │  2. Map: alice@company.com → ALICE (SAP username)
-  │  3. Generate ephemeral X.509 cert: CN=ALICE, valid 5 min
-  │  4. Sign cert with CA key (trusted in SAP STRUST)
-  │
-  ▼
-SAP ABAP System  ◄─── mTLS with ephemeral cert
-  │
-  │  SAP validates cert against STRUST
-  │  CERTRULE maps CN=ALICE to SAP user ALICE
-  │  SAP audit log shows: ALICE executed this action
-  │
-  ▼
-Response to user
-```
-
-**Key properties:**
-- **Zero SAP credentials stored anywhere** — no passwords, no service accounts
-- **Per-user audit trail** — SAP logs show the actual end user
-- **Short-lived certificates** — ephemeral certs expire in 5 minutes
-- **Centralized identity** — uses existing corporate EntraID accounts
-
-### Configuration
-
-```bash
-# OIDC validation (validates incoming Bearer tokens)
-arc1 --url https://sap-host:443 \
-    --oidc-issuer https://login.microsoftonline.com/{tenant-id}/v2.0 \
-    --oidc-audience api://arc1-sap-connector \
-    --oidc-username-claim preferred_username \
-    --pp-ca-key /path/to/ca.key \
-    --pp-ca-cert /path/to/ca.crt \
-    --pp-cert-ttl 5m \
-    --transport http-streamable
-
-# Environment variables
-export SAP_URL=https://sap-host:443
-export SAP_OIDC_ISSUER=https://login.microsoftonline.com/{tenant-id}/v2.0
-export SAP_OIDC_AUDIENCE=api://arc1-sap-connector
-export SAP_OIDC_USERNAME_CLAIM=preferred_username
-export SAP_PP_CA_KEY=/path/to/ca.key
-export SAP_PP_CA_CERT=/path/to/ca.crt
-export SAP_PP_CERT_TTL=5m
-export SAP_TRANSPORT=http-streamable
-```
-
-### Setup Guide
-
-#### Step 1: Create EntraID App Registration
-
-1. Go to [Azure Portal](https://portal.azure.com/) → **Azure Active Directory** → **App registrations**
-2. Click **New registration**
-   - Name: `ARC-1 SAP Connector`
-   - Supported account types: `Accounts in this organizational directory only`
-   - Redirect URI: not needed (server-to-server)
-3. Note the **Application (client) ID** and **Directory (tenant) ID**
-4. Go to **Expose an API**
-   - Set **Application ID URI** (e.g., `api://arc1-sap-connector`)
-   - Add a scope: `SAP.Access`
-5. Go to **Certificates & secrets** (if clients need client credentials, otherwise skip)
-
-**References:**
-- [Microsoft: Register an application](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app)
-- [Microsoft: Expose an API](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis)
-
-#### Step 2: Generate CA Key Pair
-
-```bash
-# Generate a CA key pair (RSA-4096)
-# This CA will sign the ephemeral certificates.
-# The CA certificate must be imported into SAP STRUST.
-openssl genrsa -out pp-ca.key 4096
-openssl req -new -x509 -key pp-ca.key -out pp-ca.crt -days 3650 \
-  -subj "/CN=arc1-principal-propagation-ca/O=My Company"
-```
-
-Keep `pp-ca.key` secure — it is the root of trust. In production, store it in
-Azure Key Vault or a hardware security module (HSM).
-
-#### Step 3: Configure SAP (Same as X.509 mTLS)
-
-Follow the same STRUST + CERTRULE setup from [Section 4](#4-x509-client-certificate-authentication-mtls):
-1. Import `pp-ca.crt` into STRUST (SSL Server Standard PSE)
-2. Set `login/certificate_mapping_rulebased = 1`
-3. Set `icm/HTTPS/verify_client = 1`
-4. Configure CERTRULE to map Subject CN to SAP username
-5. Restart ICM
-
-#### Step 4: Username Mapping (Optional)
-
-If OIDC usernames don't match SAP usernames directly, create a mapping file:
-
-```yaml
-# oidc-user-mapping.yaml
-alice@company.com: ALICE_DEV
-bob.smith@company.com: BSMITH
-admin@company.com: SAP_ADMIN
-```
-
-```bash
-arc1 --oidc-user-mapping oidc-user-mapping.yaml ...
-```
-
-Without a mapping file, ARC-1 extracts the username part before `@` and uppercases it:
-`alice@company.com` → `ALICE`.
-
-#### Step 5: Username Claim Selection
-
-The JWT claim used to extract the SAP username. Common values:
-
-| Claim | Description | Example Value |
-|-------|-------------|---------------|
-| `preferred_username` | EntraID display name (default) | `alice@company.com` |
-| `upn` | User Principal Name | `alice@company.com` |
-| `email` | Email address | `alice@company.com` |
-| `sub` | Subject identifier (opaque ID) | `aAbBcC123...` |
-| `unique_name` | Legacy Azure AD claim | `alice@company.com` |
-
-**Priority chain:** ARC-1 tries the configured claim first, then falls back through
-`preferred_username` → `upn` → `unique_name` → `email` → `sub`.
-
-For email-like claims (`email`, `upn`, `preferred_username`), arc1 automatically
-extracts the part before `@` as the username.
-
----
-
-## Custom CA Certificate
-
-When the SAP system uses a TLS server certificate signed by an internal CA
-(not a public CA like Let's Encrypt), arc1 needs the CA certificate to verify
-the connection.
-
-```bash
-# With any auth method
-arc1 --url https://sap-host:443 --user DEV --password pass \
-    --ca-cert /path/to/internal-ca.crt
-
-# Environment variable
-export SAP_CA_CERT=/path/to/internal-ca.crt
-```
-
-This sets the TLS trust store for the SAP connection. It's independent of the
-client certificate (which is for authentication).
-
-**Alternative:** Use `--insecure` / `SAP_INSECURE=true` to skip TLS verification
-entirely (only for testing, never in production).
-
----
-
-## Configuration Reference
-
-### All Auth-Related Flags
-
-| Flag | Env Var | Description |
-|------|---------|-------------|
-| `--user` | `SAP_USER` | SAP username (basic auth) |
-| `--password` | `SAP_PASSWORD` | SAP password (basic auth) |
-| `--cookie-file` | `SAP_COOKIE_FILE` | Path to cookie file |
-| `--cookie-string` | `SAP_COOKIE_STRING` | Cookie string |
-| `--client-cert` | `SAP_CLIENT_CERT` | Client certificate PEM (mTLS) |
-| `--client-key` | `SAP_CLIENT_KEY` | Client private key PEM (mTLS) |
-| `--ca-cert` | `SAP_CA_CERT` | CA certificate PEM (custom CA) |
-| `--service-key` | `SAP_SERVICE_KEY` | BTP service key JSON file |
-| `--oauth-url` | `SAP_OAUTH_URL` | OAuth2 token endpoint |
-| `--oauth-client-id` | `SAP_OAUTH_CLIENT_ID` | OAuth2 client ID |
-| `--oauth-client-secret` | `SAP_OAUTH_CLIENT_SECRET` | OAuth2 client secret |
-| `--oidc-issuer` | `SAP_OIDC_ISSUER` | OIDC issuer URL |
-| `--oidc-audience` | `SAP_OIDC_AUDIENCE` | Expected token audience |
-| `--oidc-username-claim` | `SAP_OIDC_USERNAME_CLAIM` | JWT claim for username |
-| `--oidc-user-mapping` | `SAP_OIDC_USER_MAPPING` | Username mapping YAML |
-| `--pp-ca-key` | `SAP_PP_CA_KEY` | CA key for principal propagation |
-| `--pp-ca-cert` | `SAP_PP_CA_CERT` | CA cert for principal propagation |
-| `--pp-cert-ttl` | `SAP_PP_CERT_TTL` | Ephemeral cert validity (default: 5m) |
-| `--insecure` | `SAP_INSECURE` | Skip TLS verification |
-
-### Auth Method Priority
-
-Only one authentication method can be active at a time:
-1. Basic auth (`--user` + `--password`)
-2. Cookie auth (`--cookie-file` or `--cookie-string`)
-3. X.509 mTLS (`--client-cert` + `--client-key`)
-4. Service Key (`--service-key`)
-5. OAuth2 (`--oauth-url` + `--oauth-client-id` + `--oauth-client-secret`)
-6. Principal Propagation (`--pp-ca-key` + `--pp-ca-cert`)
-
-OIDC validation (`--oidc-issuer`) is independent — it validates incoming MCP
-requests and is typically combined with principal propagation for the SAP connection.
+If you need these, track roadmap items first before documenting/using them in deployment runbooks.
 
 ---
 
 ## Troubleshooting
 
-### Certificate errors
+### `401` / `403` from ARC-1 on `/mcp`
+- Verify `Authorization: Bearer <token>` is present.
+- Verify `SAP_OIDC_ISSUER` and `SAP_OIDC_AUDIENCE` match real JWT claims.
+- If using API key, confirm exact key match.
 
-**"loading client certificate: ..."**
-- Verify cert and key are valid PEM format: `openssl x509 -in client.crt -text -noout`
-- Verify key matches cert: `openssl x509 -noout -modulus -in client.crt | md5` should equal `openssl rsa -noout -modulus -in client.key | md5`
+### OIDC works locally but not via Copilot Studio
+- Ensure the connector redirect URI from Power Platform is registered in Entra app auth settings.
+- Ensure tenant-specific issuer is used (not a mismatched tenant).
 
-**"CA certificate file contains no valid PEM certificates"**
-- Verify the CA file is PEM-encoded (starts with `-----BEGIN CERTIFICATE-----`)
-- Ensure the file contains the full certificate chain if needed
+### Principal propagation always falls back to shared user
+- Verify `SAP_PP_ENABLED=true`.
+- Verify `SAP_BTP_PP_DESTINATION` authentication type is `PrincipalPropagation`.
+- Verify Cloud Connector + backend certificate mapping configuration.
 
-### SAP returns 401 with certificate auth
-
-- Verify the CA is imported in STRUST (correct PSE: SSL Server Standard)
-- Verify `login/certificate_mapping_rulebased = 1` is active (`/nRZ11`)
-- Verify `icm/HTTPS/verify_client` is `1` or `2` (not `0`)
-- Verify CERTRULE has an active rule mapping the certificate's CN
-- Check ICM trace: `/nSMICM` → Goto → Trace File → Display End
-
-### OIDC token validation fails
-
-**"key ID not found in JWKS"**
-- The token was signed with a key that rotated. JWKS cache refreshes every hour.
-- Verify the `--oidc-issuer` URL is correct (must match the `iss` claim)
-
-**"JWT audience mismatch"**
-- For Entra ID v2.0 tokens (`requestedAccessTokenVersion: 2`), the `aud` claim is the raw client ID GUID
-- For Entra ID v1.0 tokens (default), the `aud` claim is `api://{client-id}`
-- Set `SAP_OIDC_AUDIENCE` to match what your tokens actually contain
-- Check with: `az account get-access-token --scope "api://{client-id}/access_as_user" --query accessToken -o tsv | jwt decode -` (or paste into jwt.ms)
-
-**"JWT issuer mismatch"**
-- EntraID v2.0 issuer format: `https://login.microsoftonline.com/{tenant-id}/v2.0`
-- EntraID v1.0 issuer format: `https://sts.windows.net/{tenant-id}/`
-- Set `requestedAccessTokenVersion: 2` in the app manifest to get v2.0 tokens
-
-### Power Platform / Copilot Studio OAuth errors
-
-**"AADSTS50011" (Reply address mismatch)**
-- Each Power Automate connector generates a unique redirect URI
-- Copy the exact URI from the connector's Security tab → Umleitungs-URL
-- Add it to the Entra ID app registration under Authentication → Web → Redirect URIs
-
-**"AADSTS90009" (Requesting token for itself, use GUID)**
-- When an app requests a token for itself (client ID = resource), the Resource URL must be the raw GUID
-- Change Resource URL from `api://...` to just the client ID GUID
-
-**"AADSTS90008" (Must require Microsoft Graph access)**
-- Add `User.Read` delegated permission from Microsoft Graph
-- Grant admin consent: `az ad app permission admin-consent --id {client-id}`
-
-**"Anmelden nicht möglich" / Login popup opens and closes**
-- Verify Tenant ID in the connector is the actual tenant GUID, not `common`
-- Verify Resource URL is set (not empty)
-- Verify the redirect URI is registered in the app registration
-
-### Principal propagation: SAP rejects ephemeral cert
-
-- Verify the CA cert in STRUST is the same one used with `--pp-ca-cert`
-- Verify CERTRULE works: test with a static cert first (Section 4)
-- Check ephemeral cert content: `openssl x509 -in /tmp/test.crt -text -noout`
-- Enable SAP ICM trace for detailed TLS handshake logging
+### BTP service key flow does not log in
+- Verify service key JSON is valid and includes `uaa.url`, `clientid`, `clientsecret`, and `url`.
+- If browser cannot open, copy the logged authorization URL manually.

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,7 +99,7 @@ Start arc1 as an HTTP server, then point your MCP client to it:
 
 ```bash
 SAP_URL=https://host:44300 SAP_USER=dev SAP_PASSWORD=secret \
-  npx arc-1 --transport http-streamable --port 3000
+  npx arc-1 --transport http-streamable --http-addr 0.0.0.0:3000
 ```
 
 Add to VS Code / Copilot MCP config:
@@ -149,6 +149,7 @@ arc1 --allowed-ops "RSQ"                      # whitelist operations
 | [enterprise-auth.md](enterprise-auth.md) | Enterprise authentication (all methods) |
 | [cli-guide.md](cli-guide.md) | CLI commands and configuration |
 | [sap-trial-setup.md](sap-trial-setup.md) | SAP BTP trial setup |
+| [reports/documentation-audit-2026-04-07.md](reports/documentation-audit-2026-04-07.md) | Dated docs audit and drift fixes |
 | [roadmap.md](roadmap.md) | Planned features |
 
 ## License

--- a/docs/phase1-api-key-setup.md
+++ b/docs/phase1-api-key-setup.md
@@ -131,7 +131,7 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 EXPOSE 8080
-CMD ["node", "dist/index.js", "--transport", "http-streamable", "--port", "8080"]
+CMD ["node", "dist/index.js", "--transport", "http-streamable", "--http-addr", "0.0.0.0:8080"]
 ```
 
 ```bash

--- a/docs/phase2-oauth-setup.md
+++ b/docs/phase2-oauth-setup.md
@@ -1,6 +1,6 @@
 # Phase 2: OAuth / JWT Authentication Setup
 
-Authenticate MCP clients using OAuth 2.1 with an external Identity Provider (EntraID, Cognito, Okta, Keycloak). ARC-1 validates JWT Bearer tokens and extracts user identity.
+Authenticate MCP clients using OAuth 2.1 with an external Identity Provider (Entra ID, Cognito, Okta, Keycloak). ARC-1 validates JWT Bearer tokens.
 
 ## When to Use
 
@@ -29,7 +29,7 @@ Authenticate MCP clients using OAuth 2.1 with an external Identity Provider (Ent
 
 ## Identity Provider Setup
 
-### Microsoft Entra ID (Azure AD)
+### Microsoft Entra ID
 
 1. **Create App Registration:**
    - Azure Portal → Microsoft Entra ID → App registrations → New registration
@@ -52,7 +52,7 @@ Authenticate MCP clients using OAuth 2.1 with an external Identity Provider (Ent
        --url "https://graph.microsoft.com/v1.0/applications/{object-id}" \
        --body '{"api":{"requestedAccessTokenVersion":2}}'
      ```
-   - **Why:** v2.0 tokens use the raw client ID as `aud` claim, while v1.0 uses `api://...` URI. The OIDC validator needs a consistent audience value.
+   - **Why:** ARC-1 validates the token `aud` claim exactly. Use one stable audience value and test with a real token from your tenant.
 
 4. **Add Microsoft Graph User.Read permission:**
    - App registration → API permissions → Add a permission → Microsoft Graph → Delegated → `User.Read`
@@ -104,7 +104,7 @@ arc1 --url https://sap.example.com:44300 \
     --transport http-streamable \
     --http-addr 0.0.0.0:8080 \
     --oidc-issuer 'https://login.microsoftonline.com/{tenant-id}/v2.0' \
-    --oidc-audience 'api://arc1-sap-connector'
+    --oidc-audience '{client-id-guid}'
 ```
 
 ### Environment Variables
@@ -116,47 +116,36 @@ export SAP_PASSWORD=ServicePassword123
 export SAP_TRANSPORT=http-streamable
 export SAP_HTTP_ADDR=0.0.0.0:8080
 export SAP_OIDC_ISSUER='https://login.microsoftonline.com/{tenant-id}/v2.0'
-export SAP_OIDC_AUDIENCE='api://arc1-sap-connector'
-export SAP_OIDC_USERNAME_CLAIM='preferred_username'  # default
-```
-
-### Username Mapping (Optional)
-
-If OIDC usernames don't match SAP usernames, create a mapping file:
-
-```yaml
-# oidc-user-mapping.yaml
-alice: ALICE_DEV
-bob: BOB_ADMIN
-carol@company.com: CAROL
-```
-
-```bash
-arc1 ... --oidc-user-mapping oidc-user-mapping.yaml
+export SAP_OIDC_AUDIENCE='{client-id-guid}'
 ```
 
 ## Client Configuration
 
-### VS Code (with OAuth)
+### Important behavior in Phase 2
 
-VS Code supports MCP OAuth natively. Configure in `.vscode/mcp.json`:
+Phase 2 enables **JWT validation** on `/mcp`, but it does **not** provide OAuth discovery endpoints by itself.
+
+This means:
+
+- Clients that can attach Bearer tokens directly work immediately.
+- For MCP-native OAuth discovery, use [Phase 5 XSUAA](phase5-xsuaa-setup.md) on BTP.
+
+### VS Code / other clients with static headers
+
+If your client supports custom HTTP headers, provide a Bearer token:
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "arc1": {
-      "type": "http",
-      "url": "https://arc1.company.com/mcp"
+      "url": "https://arc1.company.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <access-token>"
+      }
     }
   }
 }
 ```
-
-VS Code will:
-1. Discover the Protected Resource Metadata at `/.well-known/oauth-protected-resource`
-2. Find the Authorization Server (your IdP)
-3. Open browser for OAuth login
-4. Send Bearer tokens automatically
 
 ### Microsoft Copilot Studio / Power Automate
 
@@ -173,18 +162,18 @@ Copilot Studio uses Power Automate custom connectors to connect to MCP servers. 
 #### Step 2: Configure Security Tab
 
 3. **Security tab** → Authentication type: **OAuth 2.0**
-   - Identity Provider: **Azure Active Directory**
+   - Identity Provider: **Microsoft Entra ID** (or **Azure Active Directory**, depending on UI label)
    - Enable **Dienstprinzipal-Unterstützung** (Service Principal support)
    - **Client ID:** `{client-id}` (from Entra ID app registration)
    - **Client secret:** `{client-secret}` (from Entra ID app registration)
    - **Authorization URL:** `https://login.microsoftonline.com`
    - **Tenant ID:** `{tenant-id}` (your actual tenant ID — **NOT** `common`)
-   - **Resource URL:** `{client-id}` (the raw GUID, **NOT** `api://...`)
+   - **Resource URL:** `{client-id}` (raw GUID)
    - **Scope:** `api://{client-id}/access_as_user offline_access`
 
 > **⚠️ Critical:** The **Tenant ID** must be your actual tenant GUID, not `common`. Using `common` fails for single-tenant apps.
 >
-> **⚠️ Critical:** The **Resource URL** must be the raw client ID GUID (e.g., `aa34a3d1-...`), not the `api://` URI. When an app requests a token for itself, Entra ID requires the GUID format.
+> **⚠️ Critical:** Validate with a real token from your connector flow and set `SAP_OIDC_AUDIENCE` to the exact token `aud` claim.
 
 #### Step 3: Create Definition
 
@@ -231,15 +220,19 @@ Copilot Studio uses Power Automate custom connectors to connect to MCP servers. 
 ### Manual Token Testing
 
 ```bash
-# Get a token from your IdP (example with Azure CLI)
-# First, authorize Azure CLI for your app:
-az ad app update --id {client-id} --set "api.preAuthorizedApplications=[{\"appId\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"delegatedPermissionIds\":[\"your-scope-id\"]}]"
-
-# Login with the scope
+# Get a token from Entra ID (example with Azure CLI)
 az login --scope "api://{client-id}/access_as_user"
 
-# Get a token
+# Get access token
 TOKEN=$(az account get-access-token --scope "api://{client-id}/access_as_user" --query accessToken -o tsv)
+
+# Optional: inspect the aud claim and use that value in SAP_OIDC_AUDIENCE
+python3 - "$TOKEN" <<'PY'
+import base64, json, sys
+tok=sys.argv[1].split(".")[1]
+tok += "=" * ((4-len(tok)%4)%4)
+print(json.loads(base64.urlsafe_b64decode(tok))["aud"])
+PY
 
 # Test against arc1
 curl -X POST -H "Authorization: Bearer $TOKEN" \
@@ -250,16 +243,11 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 
 ## How It Works
 
-1. MCP client sends request without token
-2. ARC-1 returns `401` with `WWW-Authenticate: Bearer resource_metadata="..."`
-3. Client fetches Protected Resource Metadata
-4. Client discovers IdP authorization server
-5. Client performs OAuth 2.1 Authorization Code + PKCE flow
-6. Client sends `Authorization: Bearer <jwt>` on every request
-7. ARC-1 validates JWT signature via JWKS (cached 1 hour)
-8. arc1 checks issuer, audience, expiry
-9. ARC-1 extracts username from configured claim
-10. Request proceeds (SAP auth still via service account)
+1. Client obtains access token from your IdP (Entra, Cognito, Keycloak, ...)
+2. Client sends `Authorization: Bearer <jwt>` on `/mcp`
+3. ARC-1 validates JWT signature via JWKS
+4. ARC-1 validates issuer, audience, and expiration
+5. Request proceeds (SAP auth still via shared SAP connection unless Phase 3 PP is enabled)
 
 ## Security Notes
 
@@ -273,7 +261,9 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 
 - [MCP Specification - Authorization](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) — OAuth 2.1 auth for MCP servers
 - [RFC 9728 - OAuth Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728) — Auto-discovery of authorization servers
-- [Microsoft Entra ID - App Registrations](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app) — Azure AD app setup
+- [Microsoft Entra ID - App Registrations](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app) — app registration setup
+- [Authenticate your API and connector with Microsoft Entra ID](https://learn.microsoft.com/en-us/connectors/custom-connectors/azure-active-directory-authentication) — Power Automate/Copilot Studio connector flow
+- [Access token claims reference](https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference) — `aud` claim behavior
 - [AWS Cognito User Pools](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools.html) — AWS IdP setup
 - [Keycloak - Creating a Realm](https://www.keycloak.org/docs/latest/server_admin/#configuring-realms) — Open-source IdP setup
 

--- a/docs/phase3-principal-propagation-setup.md
+++ b/docs/phase3-principal-propagation-setup.md
@@ -1,212 +1,157 @@
 # Phase 3: Principal Propagation Setup
 
-Authenticate each MCP user to SAP with their own identity using ephemeral X.509 certificates. No shared SAP passwords. Full per-user audit trail.
+Use this phase when each authenticated MCP user must run in SAP with their own identity.
+
+This guide covers the principal propagation path that ARC-1 currently supports:
+
+- ARC-1 on BTP Cloud Foundry
+- BTP Destination Service
+- Cloud Connector
+- SAP certificate mapping (CERTRULE / VUSREXTID)
+
+---
 
 ## When to Use
 
-- Enterprise environments requiring per-user SAP authorization
-- Compliance/audit requirements (who did what in SAP)
-- When different users should have different SAP permissions
-- Zero shared credentials architecture
+- You need per-user SAP authorization checks (`S_DEVELOP`, etc.)
+- You need user-level SAP auditability (no shared technical user)
+- You already use JWT-based MCP auth (XSUAA or OIDC)
+
+---
 
 ## Architecture
 
 ```
-┌──────────────────┐     OAuth JWT        ┌──────────────────────────────┐     mTLS (ephemeral cert)   ┌────────────┐
-│  MCP Client      │ ──────────────────► │  arc1 Server                  │ ────────────────────────► │  SAP ABAP  │
-│  (IDE / Copilot) │                     │                              │   CN=<sap-username>      │  System    │
-└──────────────────┘                     │  1. Validate JWT (Phase 2)   │   Signed by trusted CA   │            │
-                                         │  2. Extract username          │                          │  STRUST:   │
-                                         │  3. Generate ephemeral cert   │                          │   CA cert  │
-                                         │  4. mTLS to SAP with cert    │                          │  CERTRULE: │
-                                         └──────────────────────────────┘                          │   CN→User  │
-                                                                                                    └────────────┘
+MCP Client (JWT)
+  -> ARC-1 (/mcp)
+  -> Destination Service lookup with X-User-Token
+  -> Connectivity Proxy
+  -> Cloud Connector (Principal Propagation)
+  -> SAP ICM (client cert)
+  -> CERTRULE / VUSREXTID mapping
+  -> SAP user session (per user)
 ```
+
+---
 
 ## Prerequisites
 
-- Phase 2 (OAuth/JWT) must be configured first
-- SAP admin access for STRUST, CERTRULE, ICM configuration
-- OpenSSL for CA certificate generation
+- [Phase 2 OAuth setup](phase2-oauth-setup.md) working (or [Phase 5 XSUAA](phase5-xsuaa-setup.md))
+- ARC-1 deployed on BTP CF
+- Destination + Connectivity service instances bound
+- Cloud Connector connected to your subaccount
 
-## Step 1: Generate CA Key Pair
+---
 
-This CA signs the ephemeral certificates. SAP must trust this CA.
+## Step 1: Create Two Destinations
 
-```bash
-# Generate CA private key (RSA 2048)
-openssl genrsa -out ca.key 2048
+Use a dual-destination setup:
 
-# Generate CA certificate (valid 10 years)
-openssl req -new -x509 -key ca.key -out ca.crt -days 3650 \
-  -subj "/CN=arc1-principal-propagation-ca/O=YourCompany/C=DE"
+1. `SAP_TRIAL` (or your name): `BasicAuthentication` for shared fallback
+2. `SAP_TRIAL_PP` (or your name): `PrincipalPropagation` for per-user requests
 
-# Verify
-openssl x509 -in ca.crt -text -noout
-```
-
-**Security:** Store `ca.key` in a secrets manager (AWS Secrets Manager, Azure Key Vault, HashiCorp Vault). Never commit to version control.
-
-## Step 2: Configure SAP System
-
-### 2a. Import CA Certificate into STRUST
-
-1. Open transaction **`/nSTRUST`**
-2. Double-click **SSL server Standard** PSE
-3. Switch to Edit mode (pencil icon)
-4. Click **Import certificate** (at bottom of screen)
-5. Paste the contents of `ca.crt` (PEM format)
-6. Click **Add to Certificate List**
-7. **Save**
-
-### 2b. Configure ICM Profile Parameters
-
-1. Open transaction **`/nRZ10`**
-2. Select the **DEFAULT** profile → Extended Maintenance → Change
-3. Add/verify these parameters:
-
-| Parameter | Value | Purpose |
-|-----------|-------|---------|
-| `icm/HTTPS/verify_client` | `1` | Request client certificate (accept) |
-| `login/certificate_mapping_rulebased` | `1` | Enable CERTRULE mapping |
-
-4. **Save** the profile
-
-### 2c. Configure Certificate-to-User Mapping (CERTRULE)
-
-1. Open transaction **`/nCERTRULE`**
-2. Switch to Change mode
-3. Click **Upload Certificate** → import a sample ephemeral cert:
+Set in ARC-1:
 
 ```bash
-# Generate a sample cert to import into CERTRULE
-openssl req -new -x509 -key ca.key -out sample.crt -days 1 \
-  -subj "/CN=DEVELOPER"
-# Upload sample.crt into CERTRULE
+cf set-env arc1-mcp-server SAP_BTP_DESTINATION SAP_TRIAL
+cf set-env arc1-mcp-server SAP_BTP_PP_DESTINATION SAP_TRIAL_PP
 ```
 
-4. Click **Rule** to create a mapping:
-   - **Certificate Entry:** `Subject`
-   - **Certificate Attr:** `CN` (Common Name)
-   - **Login As:** `ID` (SAP User ID)
-5. **Save**
+Why dual destinations:
+- PP destination has no user/password
+- health checks and non-JWT clients still need a shared path
 
-This rule means: any certificate with Subject CN = `DEVELOPER` → log in as SAP user `DEVELOPER`.
+---
 
-### 2d. Restart ICM
+## Step 2: Configure Cloud Connector
 
-1. Open transaction **`/nSMICM`**
-2. Go to **Administration** → **ICM** → **Exit Soft** (or **Exit Hard**)
-3. Wait for ICM to restart (green status)
+In Cloud Connector:
 
-### 2e. For Cloud Connector Deployments (Optional)
+1. Add an HTTPS on-prem system mapping for SAP HTTPS port (typically `50001`)
+2. Set auth mode to principal propagation (`X509_GENERAL`)
+3. Configure subject pattern rule (for example `CN=${name}`)
+4. Add required ADT resources (at least `/sap/bc/adt/*`)
 
-If SAP is on-premise behind BTP Cloud Connector:
+Use your corporate policy for certificate trust and allowlist settings.
 
-1. **Install system certificate** in Cloud Connector:
-   - Cloud Connector Admin UI → Configuration → ON PREMISE → System Certificate
-   - Import the CA certificate (`ca.crt`)
+Detailed walkthrough: [btp-destination-setup.md](btp-destination-setup.md).
 
-2. **Configure trusted reverse proxy** in SAP:
-   ```
-   icm/trusted_reverse_proxy_0 = SUBJECT="CN=SCC, O=SAP, C=DE", ISSUER="CN=arc1-principal-propagation-ca, O=YourCompany, C=DE"
-   ```
+---
 
-3. **Enable principal propagation** in Cloud Connector:
-   - Cloud to On-Premises → system mapping → Allow Principal Propagation
-   - Principal type: X.509 Certificate
+## Step 3: Configure SAP Backend Mapping
 
-## Step 3: Start arc1 with Principal Propagation
+In SAP backend:
+
+1. Import Cloud Connector CA certificate into STRUST (`SSL Server Standard`)
+2. Ensure profile parameters for certificate mapping are enabled
+3. Create user mapping entries (`CERTRULE` or `SM30` view `VUSREXTID`)
+4. Restart ICM
+
+Mapping must match the certificate subject generated by Cloud Connector.
+
+---
+
+## Step 4: Enable Principal Propagation in ARC-1
 
 ```bash
-arc1 --url https://sap.example.com:44300 \
-    --transport http-streamable \
-    --http-addr 0.0.0.0:8080 \
-    --oidc-issuer 'https://login.microsoftonline.com/{tenant-id}/v2.0' \
-    --oidc-audience 'api://arc1-sap-connector' \
-    --pp-ca-key ca.key \
-    --pp-ca-cert ca.crt \
-    --pp-cert-ttl 5m \
-    --insecure  # Only for testing with self-signed SAP certs
+cf set-env arc1-mcp-server SAP_PP_ENABLED true
+cf set-env arc1-mcp-server SAP_XSUAA_AUTH true   # if using XSUAA for MCP auth
+cf restage arc1-mcp-server
 ```
 
-### Environment Variables
+Optional strict mode:
 
 ```bash
-export SAP_URL=https://sap.example.com:44300
-export SAP_TRANSPORT=http-streamable
-export SAP_HTTP_ADDR=0.0.0.0:8080
-export SAP_OIDC_ISSUER='https://login.microsoftonline.com/{tenant-id}/v2.0'
-export SAP_OIDC_AUDIENCE='api://arc1-sap-connector'
-export SAP_PP_CA_KEY=/secrets/ca.key
-export SAP_PP_CA_CERT=/secrets/ca.crt
-export SAP_PP_CERT_TTL=5m
+cf set-env arc1-mcp-server SAP_PP_STRICT true
+cf restage arc1-mcp-server
 ```
 
-**Note:** No `SAP_USER` or `SAP_PASSWORD` needed! Authentication is entirely via certificates.
+With `SAP_PP_STRICT=true`, PP failures are returned as errors (no fallback).
 
-## Step 4: Test
+---
+
+## Runtime Behavior
+
+When `SAP_PP_ENABLED=true`:
+
+- JWT token present -> ARC-1 attempts per-user destination
+- If per-user auth fails:
+  - `SAP_PP_STRICT=false` -> fallback to shared destination/client
+  - `SAP_PP_STRICT=true` -> return error
+- No JWT (for example API key token) -> shared destination/client
+
+---
+
+## Verification
+
+### ARC-1 logs
 
 ```bash
-# Get an OAuth token
-TOKEN=$(az account get-access-token --resource api://arc1-sap-connector --query accessToken -o tsv)
-
-# Call arc1 — it will generate an ephemeral cert for your user and authenticate to SAP
-curl -H "Authorization: Bearer $TOKEN" https://arc1.company.com/mcp \
-  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+cf logs arc1-mcp-server --recent | grep -E "Principal propagation|per-user|BTP destination"
 ```
 
-## How It Works (Per Request)
+### SAP audit and user mapping
 
-1. MCP client sends request with `Authorization: Bearer <jwt>`
-2. ARC-1 validates JWT signature, issuer, audience, expiry
-3. ARC-1 extracts SAP username from JWT claim (e.g., `preferred_username`)
-4. ARC-1 generates ephemeral X.509 certificate:
-   - Subject CN = SAP username (e.g., `DEVELOPER`)
-   - Valid for 5 minutes
-   - Signed by the CA key
-5. ARC-1 creates a per-request HTTPS client with the ephemeral cert
-6. SAP receives the mTLS connection, verifies the cert against STRUST
-7. SAP maps Subject CN to SAP user via CERTRULE
-8. SAP processes the ADT request as that user
-9. Ephemeral cert is discarded (never stored)
+- `SM20`: verify the individual SAP user appears
+- `SM30` / `VUSREXTID`: verify subject-to-user mapping
+- `SU01`: verify mapped user exists and has required roles
+
+---
 
 ## Troubleshooting
 
-### SAP Returns 401
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| PP always falls back to shared user | PP destination not configured or not `PrincipalPropagation` | Check `SAP_BTP_PP_DESTINATION` and destination auth type |
+| `User token validation failed` from Destination Service | JWT issuer not trusted by BTP | Configure BTP trust for your IdP |
+| SAP `401/403` with PP path | Missing cert trust or mapping | Recheck STRUST + CERTRULE/VUSREXTID |
+| Strict mode errors for API key calls | API key is not JWT | Use JWT auth or disable `SAP_PP_STRICT` |
 
-1. **Check STRUST:** Is the CA cert in the SSL Server Standard certificate list?
-2. **Check ICM:** Is `icm/HTTPS/verify_client = 1`? (check via `/nSMICM` → Goto → Parameters → Display)
-3. **Check CERTRULE:** Does a rule mapping CN → User exist?
-4. **Check ICM trace:** Set trace level 2 in SMICM, reproduce the error, check dev_icm trace file
-5. **Check user exists:** Does the SAP user matching the CN exist and is unlocked?
+---
 
-### Certificate Mapping Not Working
+## Related Docs
 
-1. Open transaction **`/nCERTRULE`**
-2. Upload the actual ephemeral cert (from arc1 verbose logs) to test the mapping
-3. Verify the rule matches
-
-### Cloud Connector Issues
-
-1. Check Cloud Connector logs (All/Payload trace)
-2. Verify `icm/trusted_reverse_proxy` parameter matches CC system certificate
-3. Ensure principal propagation is enabled in CC access control
-
-## Security Notes
-
-- **CA key is the crown jewel** — protect it like a root password
-- Ephemeral certs are valid for only 5 minutes (configurable via `--pp-cert-ttl`)
-- RSA-2048 key pair generated per request (~2ms overhead)
-- No SAP passwords stored anywhere
-- Full audit trail: SAP logs show which user performed each action
-- CERTRULE can restrict which usernames are allowed (not just wildcard CN mapping)
-
-## SAP Documentation References
-
-- [Authenticating Users Against On-Premise Systems](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/authenticating-users-against-on-premise-systems) — Principal Propagation via Cloud Connector
-- [Setting Up Trust Between Identity Provider and SAP](https://help.sap.com/docs/btp/sap-business-technology-platform/principal-propagation) — BTP principal propagation overview
-- [STRUST - Trust Manager (SAP Help)](https://help.sap.com/doc/saphelp_nw75/7.5.25/en-us/4c/61a6c6364e11d3963800a0c9e1edf3/frameset.htm) — Importing trusted CA certificates
-- [CERTRULE - Rule-Based Certificate Mapping (SAP Note 2275087)](https://me.sap.com/notes/2275087) — Rule-based certificate-to-user mapping
-- [ICM Profile Parameters](https://help.sap.com/doc/saphelp_nw75/7.5.25/en-us/48/21f839a44c3d65e10000000a42189c/frameset.htm) — ICM HTTPS client cert parameters
-- [Cloud Connector - Principal Propagation](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/configuring-principal-propagation) — Cloud Connector principal propagation setup
+- [BTP destination setup](btp-destination-setup.md)
+- [Phase 2 OAuth/JWT setup](phase2-oauth-setup.md)
+- [Phase 4 BTP deployment](phase4-btp-deployment.md)
+- [Enterprise auth guide](enterprise-auth.md)

--- a/docs/reports/documentation-audit-2026-04-07.md
+++ b/docs/reports/documentation-audit-2026-04-07.md
@@ -1,0 +1,63 @@
+# Documentation Audit — April 7, 2026
+
+Scope: `docs/` with focus on setup, auth, and external dependencies (Microsoft + SAP).
+
+## Summary
+
+The docs had high-impact drift between documented flags and the current ARC-1 implementation (`v0.3.x`).  
+Main risk before this audit: users could follow commands that do not exist in code.
+
+This audit corrected the highest-impact docs and aligned primary setup/auth paths with the current CLI/env surface.
+
+## High-Impact Issues Found
+
+1. `--port` / `SAP_PORT` used across docs, but ARC-1 supports `--http-addr` / `SAP_HTTP_ADDR`.
+2. Auth docs referenced unsupported local cert flags (`--client-cert`, `--pp-ca-key`, etc.).
+3. Setup docs referenced unsupported SAP OAuth env vars (`SAP_XSUAA_URL`, `SAP_XSUAA_CLIENT_ID`, `SAP_XSUAA_CLIENT_SECRET`).
+4. OIDC docs mixed audience guidance (`api://...` vs GUID) and included unsupported username mapping flags.
+5. Test process doc expected behavior/endpoints inconsistent with current HTTP auth implementation.
+
+## Files Updated
+
+- `docs/index.md`
+- `docs/setup-guide.md`
+- `docs/cli-guide.md`
+- `docs/phase1-api-key-setup.md`
+- `docs/phase2-oauth-setup.md`
+- `docs/phase3-principal-propagation-setup.md` (rewritten)
+- `docs/enterprise-auth.md` (rewritten)
+- `docs/auth-test-process.md` (rewritten)
+- `docs/docker.md`
+- `docs/btp-abap-environment.md`
+- `docs/sap-trial-setup.md`
+
+## External Research Notes (Verified April 7, 2026)
+
+### SAP BTP ABAP Environment
+
+- Free-tier usage is tied to SAP BTP commercial model + entitlements, not only trial accounts.
+- Free-tier details evolve over time (for example, SAP lifecycle notes mention 0.5 ACU provisioning updates in March 2026).
+- "Prepare an Account for ABAP Development" booster and Web Access entitlement guidance remains relevant.
+
+References:
+
+- [Using Free Service Plans (SAP BTP)](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/524e1081d8dc4b0f9d055a6bec383ec3.html)
+- [Lifecycle Management (SAP BTP ABAP Environment)](https://help.sap.com/docs/ABAP_ENVIRONMENT/36609a00dcea4e6fa7c4ca2f2868e972/3b19c2bc43854d7cb49a6522d5f9442a.html)
+- [Selecting a Service Plan for the Web Access for ABAP](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/2859cc59f9ba4976a6d613475d07c9ed.html)
+
+### Microsoft Entra / Power Platform
+
+- Custom connector OAuth setup for Power Automate/Copilot Studio remains based on Entra app registration + redirect URI registration.
+- Audience handling must be validated against a real token `aud` claim and set exactly in `SAP_OIDC_AUDIENCE`.
+
+References:
+
+- [Authenticate your API and connector with Microsoft Entra ID](https://learn.microsoft.com/en-us/connectors/custom-connectors/azure-active-directory-authentication)
+- [Access token claims reference](https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference)
+- [Access tokens in the Microsoft identity platform](https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens)
+
+## Remaining Cleanup (Lower Priority)
+
+1. Add a generated "config reference from source" doc derived from `src/server/config.ts` to prevent drift.
+2. Add CI check to fail if docs reference unknown ARC-1 flags/env vars.
+3. Do a second pass on report/roadmap docs to separate historical design notes from current behavior.

--- a/docs/sap-trial-setup.md
+++ b/docs/sap-trial-setup.md
@@ -889,150 +889,23 @@ do not require `SAP_INSECURE`.
 
 ---
 
-## X.509 Certificate Authentication Setup (mTLS)
+## Certificate-Based SAP Setup (for Cloud Connector Principal Propagation)
 
-This section describes how to configure the SAP trial system for X.509 client
-certificate authentication. This is required for testing mTLS and principal
-propagation features.
+This project still supports principal propagation, but in `v0.3.x` it is done via:
 
-### Generate Test CA and Client Certificate
+- `SAP_PP_ENABLED=true`
+- BTP Destination Service (`SAP_BTP_DESTINATION` + `SAP_BTP_PP_DESTINATION`)
+- Cloud Connector certificate flow
 
-```bash
-# Generate CA (self-signed, for testing only)
-openssl genrsa -out ca.key 4096
-openssl req -new -x509 -key ca.key -out ca.crt -days 365 \
-  -subj "/CN=arc1-test-ca/O=arc1 testing"
+ARC-1 no longer exposes local flags such as `--client-cert`, `--client-key`, `--ca-cert`, `--pp-ca-key`, or `--pp-ca-cert`.
 
-# Generate client certificate for the DEVELOPER user
-openssl genrsa -out developer.key 2048
-openssl req -new -key developer.key -out developer.csr \
-  -subj "/CN=DEVELOPER"
-openssl x509 -req -in developer.csr -CA ca.crt -CAkey ca.key \
-  -CAcreateserial -out developer.crt -days 365
+If you use this trial system as the SAP backend for principal propagation testing:
 
-# Verify the certificate
-openssl x509 -in developer.crt -text -noout | grep Subject
-# Expected: Subject: CN = DEVELOPER
-```
+1. Keep the SAP-side certificate trust and user mapping setup (STRUST + CERTRULE/VUSREXTID).
+2. Configure Cloud Connector principal propagation.
+3. Configure ARC-1 with BTP destinations and `SAP_PP_ENABLED=true`.
 
-### Import CA into SAP STRUST
+Use these docs for the active flow:
 
-The CA certificate must be added to the SAP system's trust store so it can
-verify client certificates signed by this CA.
-
-**Option A: Via SAP GUI (if available)**
-
-1. Open transaction `/nSTRUST`
-2. Navigate to **SSL Server Standard** PSE
-3. Click **Import** in the Certificate section
-4. Paste the content of `ca.crt`
-5. Click **Add to Certificate List**
-6. Save
-
-**Option B: Via HANA SQL (for headless trial system)**
-
-The trial system may not have SAP GUI access. In this case, use the HANA SQL
-approach to insert the certificate directly:
-
-```bash
-docker exec -it a4h bash
-su - a4hadm
-
-# Copy the CA cert content (base64 encoded)
-cat /path/to/ca.crt | base64 -w0
-
-# Use sapgenpse to import (if available)
-# Or use the STRUST-related ABAP program via SM38
-```
-
-> **Note:** Direct STRUST manipulation via SQL is complex. The recommended approach
-> is to use SAP GUI or ADT's STRUST functionality. If you have ADT access from
-> Eclipse, you can use the STRUST transaction there.
-
-### Configure SAP Profile for Certificate Login
-
-Edit the instance profile inside the container:
-
-```bash
-docker exec -it a4h bash
-vi /usr/sap/A4H/SYS/profile/A4H_D00_vhcala4hci
-```
-
-Add these parameters:
-
-```
-# Enable rule-based certificate mapping (allows CERTRULE to work)
-login/certificate_mapping_rulebased = 1
-
-# Accept client certificates during TLS handshake
-# 0 = don't request, 1 = request (optional), 2 = require
-icm/HTTPS/verify_client = 1
-```
-
-### Configure Certificate Mapping Rule (CERTRULE)
-
-This tells SAP how to map the certificate's Subject CN to a SAP user.
-
-1. Open transaction `/nCERTRULE` in SAP GUI or ADT
-2. Import the client certificate (`developer.crt`)
-3. Create a rule:
-   - Certificate Attribute: `Subject CN`
-   - Login As: `Use CN value as SAP username`
-4. Save and activate
-
-### Restart SAP ICM
-
-After profile and CERTRULE changes:
-
-```bash
-# Restart ABAP (not the whole container)
-docker exec a4h /usr/sap/hostctrl/exe/sapcontrol -nr 00 -function Stop
-# Wait ~60s
-docker exec a4h /usr/sap/hostctrl/exe/sapcontrol -nr 00 -function Start
-```
-
-### Test Certificate Authentication
-
-```bash
-# Test with curl (using the HTTPS port)
-curl --cert developer.crt --key developer.key \
-  --cacert ca.crt \
-  "https://<your-subdomain>/sap/bc/adt/core/discovery?sap-client=001"
-
-# Test with arc1
-npx arc-1 --url https://<your-subdomain> \
-  --client-cert developer.crt \
-  --client-key developer.key \
-  --ca-cert ca.crt
-
-# If using the trial system's Let's Encrypt cert (no --ca-cert needed):
-npx arc-1 --url https://<your-subdomain> \
-  --client-cert developer.crt \
-  --client-key developer.key
-```
-
-> **Important:** The `--ca-cert` flag is for trusting the SAP **server** certificate.
-> If your SAP system uses Let's Encrypt (as configured in the HTTPS section above),
-> the system's default CA store already trusts it and `--ca-cert` is not needed.
-> The client certificate (`--client-cert`) is what SAP uses to authenticate the
-> user — these are two different certificates for two different purposes.
-
-### Principal Propagation Test Setup
-
-To test principal propagation (OIDC → ephemeral X.509), the SAP configuration
-is the same as above. The CA in STRUST is the same CA that signs the ephemeral
-certificates.
-
-```bash
-# Test ephemeral cert generation + SAP auth
-npx arc-1 --url https://<your-subdomain> \
-  --pp-ca-key ca.key \
-  --pp-ca-cert ca.crt \
-  --oidc-issuer https://login.microsoftonline.com/{tenant-id}/v2.0 \
-  --oidc-audience api://arc1 \
-  --transport http-streamable
-```
-
-For full OIDC + principal propagation testing, you also need an EntraID app
-registration. See [docs/enterprise-auth.md](enterprise-auth.md) for the
-complete setup guide.
+- [Phase 3: Principal Propagation Setup](phase3-principal-propagation-setup.md)
+- [BTP Destination Setup Guide](btp-destination-setup.md)

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -176,14 +176,14 @@ VS Code and Copilot use HTTP Streamable transport, not stdio. Start arc1 as an H
 
 ```bash
 npx arc-1 --url https://host:44300 --user dev --password secret \
-  --transport http-streamable --port 3000
+  --transport http-streamable --http-addr 0.0.0.0:3000
 ```
 
 With safety controls:
 
 ```bash
 npx arc-1 --url https://host:44300 --user dev --password secret \
-  --transport http-streamable --port 3000 \
+  --transport http-streamable --http-addr 0.0.0.0:3000 \
   --read-only --block-free-sql
 ```
 
@@ -233,7 +233,7 @@ For clients that support **HTTP Streamable**, start the server and connect to th
 
 ```bash
 npx arc-1 --url https://host:44300 --user dev --password secret \
-  --transport http-streamable --port 3000
+  --transport http-streamable --http-addr 0.0.0.0:3000
 # Connect your client to http://localhost:3000/mcp
 ```
 
@@ -383,17 +383,15 @@ docker run -d --name arc1 \
 
 Full guide: **[phase2-oauth-setup.md](phase2-oauth-setup.md)**
 
-### Docker with OAuth2/XSUAA
+### Docker with BTP ABAP service key
 
-For SAP BTP ABAP Environment systems that use XSUAA for authentication:
+For SAP BTP ABAP Environment systems, use a BTP service key (ARC-1 performs browser OAuth):
 
 ```bash
 docker run -d --name arc1 \
   -p 8080:8080 \
-  -e SAP_URL=https://your-abap-env.abap.us10.hana.ondemand.com \
-  -e SAP_XSUAA_URL=https://your-subdomain.authentication.us10.hana.ondemand.com \
-  -e SAP_XSUAA_CLIENT_ID=your-client-id \
-  -e SAP_XSUAA_CLIENT_SECRET=your-client-secret \
+  -e SAP_BTP_SERVICE_KEY='{"uaa":{"url":"...","clientid":"...","clientsecret":"..."},"url":"https://your-system.abap.eu10.hana.ondemand.com"}' \
+  -e SAP_SYSTEM_TYPE=btp \
   ghcr.io/marianfoo/arc-1:latest
 ```
 
@@ -417,9 +415,9 @@ How arc1 authenticates when calling SAP ADT APIs.
 |--------|--------|------------|
 | **Basic Auth** | `--user` + `--password` | Local dev, simple setups |
 | **Cookie** | `--cookie-file` or `--cookie-string` | Reuse browser session (temporary) |
-| **OAuth2/XSUAA** | XSUAA env vars | BTP ABAP Environment |
-| **X.509 mTLS** | `--client-cert` + `--client-key` | Enterprise cert-based auth |
-| **Principal Propagation** | `--pp-enabled` + BTP Destination | Per-user SAP identity via ephemeral X.509 certs |
+| **BTP Service Key OAuth** | `SAP_BTP_SERVICE_KEY` / `SAP_BTP_SERVICE_KEY_FILE` | Direct BTP ABAP Environment |
+| **BTP Destination** | `SAP_BTP_DESTINATION` | BTP CF to on-prem SAP via Destination/Connectivity |
+| **Principal Propagation** | `--pp-enabled` + BTP Destinations | Per-user SAP identity via Cloud Connector |
 
 Only one SAP auth method can be active at a time.
 
@@ -628,7 +626,7 @@ Priority: CLI flags > environment variables > `.env` file > defaults.
 | `--client` | `SAP_CLIENT` | 001 | SAP client number |
 | `--language` | `SAP_LANGUAGE` | EN | SAP logon language |
 | `--transport` | `SAP_TRANSPORT` | stdio | `stdio` or `http-streamable` |
-| `--port` | `SAP_PORT` | 8080 | HTTP server port |
+| `--http-addr` | `SAP_HTTP_ADDR` | 0.0.0.0:8080 | HTTP listen address |
 | `--insecure` | `SAP_INSECURE` | false | Skip TLS certificate verification |
 | `--read-only` | `SAP_READ_ONLY` | false | Block all write operations |
 | `--block-free-sql` | `SAP_BLOCK_FREE_SQL` | false | Block SQL query execution |
@@ -638,6 +636,9 @@ Priority: CLI flags > environment variables > `.env` file > defaults.
 | `--api-key` | `ARC1_API_KEY` | — | API key for HTTP auth |
 | `--oidc-issuer` | `SAP_OIDC_ISSUER` | — | OIDC issuer URL |
 | `--oidc-audience` | `SAP_OIDC_AUDIENCE` | — | OIDC audience |
+| `--btp-service-key` | `SAP_BTP_SERVICE_KEY` | — | Inline BTP service key JSON |
+| `--btp-service-key-file` | `SAP_BTP_SERVICE_KEY_FILE` | — | BTP service key file path |
+| `--btp-oauth-callback-port` | `SAP_BTP_OAUTH_CALLBACK_PORT` | 0 | Local OAuth callback port (0=auto) |
 | `--pp-enabled` | `SAP_PP_ENABLED` | false | Enable principal propagation |
 | `--pp-strict` | `SAP_PP_STRICT` | false | Fail on PP errors (no fallback) |
 


### PR DESCRIPTION
## Summary
- audit and fix high-impact documentation drift in setup/auth guides
- replace invalid flags/env vars with currently supported ARC-1 options
- rewrite enterprise auth, phase 3 principal propagation, and auth test process for v0.3.x
- add dated docs audit report with SAP and Microsoft reference links

## Why
Several docs sections described auth/setup paths that are not implemented in current code (for example legacy cert/oauth flags and outdated HTTP server flags), which made setup error-prone.

## Scope
Documentation-only changes in `docs/`.

## Validation
- checked docs examples against `src/server/config.ts`
- manually grep-verified removal of unsupported flags/env usage from primary setup guides