### PR TITLE
docs: fix outdated flags and remove unsupported auth methods

### DIFF
--- a/docs/api-key-setup.md
+++ b/docs/api-key-setup.md
@@ -196,7 +196,7 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 EXPOSE 8080
-CMD ["node", "dist/index.js", "--transport", "http-streamable", "--port", "8080"]
+CMD ["node", "dist/index.js", "--transport", "http-streamable", "--http-addr", "0.0.0.0:8080"]
 ```
 
 ```bash

--- a/docs/auth-test-process.md
+++ b/docs/auth-test-process.md
@@ -30,7 +30,7 @@ npm test
 ```bash
 npx arc-1 --url http://your-sap:8000 \
   --user DEVELOPER --password secret --client 001 \
-  --transport http-streamable --port 8080 \
+  --transport http-streamable --http-addr 0.0.0.0:8080 \
   --api-key 'test-key-12345'
 ```
 
@@ -105,7 +105,7 @@ npm test
 ```bash
 npx arc-1 --url http://your-sap:8000 \
   --user DEVELOPER --password secret --client 001 \
-  --transport http-streamable --port 8080 \
+  --transport http-streamable --http-addr 0.0.0.0:8080 \
   --oidc-issuer 'https://your-idp.example.com' \
   --oidc-audience 'your-audience'
 ```
@@ -183,60 +183,37 @@ npm test
 ### Manual Integration Test
 
 **Prerequisites:**
-- Phase 2 (OIDC) configured and working
-- SAP system configured with STRUST, CERTRULE, ICM (see [Principal Propagation Setup](principal-propagation-setup.md))
+- Phase 2 (OIDC or XSUAA) configured and working
+- ARC-1 deployed on BTP CF with Destination + Connectivity services
+- Cloud Connector connected and configured for principal propagation
+- SAP system configured with CERTRULE / VUSREXTID (see [Principal Propagation Setup](principal-propagation-setup.md))
 
-**1. Generate test CA:**
-
-```bash
-openssl genrsa -out /tmp/test-ca.key 2048
-openssl req -new -x509 -key /tmp/test-ca.key -out /tmp/test-ca.crt -days 365 \
-  -subj "/CN=arc1-test-ca/O=Test/C=DE"
-```
-
-**2. Import CA cert into SAP STRUST** (see Phase 3 docs)
-
-**3. Configure CERTRULE** to map `CN=<username>` → SAP user
-
-**4. Start arc1 with PP:**
+**1. Configure ARC-1 with PP:**
 
 ```bash
-npx arc-1 --url https://your-sap:44300 \
-  --transport http-streamable --port 8080 \
-  --oidc-issuer 'https://your-idp.example.com' \
-  --oidc-audience 'your-audience' \
-  --pp-ca-key /tmp/test-ca.key \
-  --pp-ca-cert /tmp/test-ca.crt \
-  --pp-cert-ttl 5m \
-  --insecure
+SAP_BTP_DESTINATION=SAP_TRIAL \
+SAP_BTP_PP_DESTINATION=SAP_TRIAL_PP \
+SAP_PP_ENABLED=true
 ```
 
-**Note:** No `--user` or `--password` needed when PP is active.
+**2. Verify per-user identity in SAP:**
 
-**5. Authenticate and make a request:**
+Check in SAP transaction `SM20` (security audit log) or `SM04` (user sessions) that the request was executed as the mapped SAP user, not a technical account.
+
+**3. Check ARC-1 logs:**
 
 ```bash
-TOKEN=$(az account get-access-token --resource your-audience --query accessToken -o tsv)
-
-curl -s -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  http://localhost:8080/mcp \
-  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"SAPRead","arguments":{"type":"SYSTEM"}},"id":1}'
-# Expected: Response showing SAP system info
+cf logs arc1-mcp-server --recent | grep -E "Principal propagation|per-user|BTP destination"
 ```
-
-**6. Verify per-user identity in SAP:**
-
-Check in SAP transaction `/nSM21` (system log) or `/nSM04` (user sessions) that the request was executed as the mapped SAP user, not a service account.
 
 ### Checklist
 
-- [ ] CA cert imported into SAP STRUST
-- [ ] CERTRULE mapping configured (CN → SAP User)
-- [ ] ICM parameter `icm/HTTPS/verify_client = 1` set
-- [ ] arc1 starts without errors with `--pp-ca-key` and `--pp-ca-cert`
-- [ ] Request with OIDC token uses ephemeral cert (check logs)
-- [ ] SAP logs show per-user identity (not service account)
+- [ ] BTP Destination with `PrincipalPropagation` authentication type configured
+- [ ] Cloud Connector principal propagation enabled
+- [ ] SAP certificate mapping (CERTRULE / VUSREXTID) configured
+- [ ] JWT-authenticated requests use per-user destination
+- [ ] SAP logs show per-user identity (not technical account)
+- [ ] Fallback behavior matches `SAP_PP_STRICT` setting
 
 ---
 

--- a/docs/btp-abap-environment.md
+++ b/docs/btp-abap-environment.md
@@ -16,7 +16,7 @@ If you don't have a BTP ABAP Environment instance yet, you can create one on the
 
 ### Prerequisites for Free Tier
 
-- A SAP BTP trial or pay-as-you-go account
+- A SAP BTP global account with free-tier eligible entitlements (trial or pay-as-you-go)
 - Cloud Foundry enabled in your subaccount (with an org and space)
 - The `abap` / `free` entitlement assigned to your subaccount
 
@@ -64,11 +64,11 @@ cf create-service abap free my-abap-instance -c params.json
 **Important notes:**
 - `admin_email` must be a valid email address (the one you use to log into BTP)
 - `sap_system_name` is a 3-character SID (e.g., `H01`, `DEV`, `Z01`)
-- Free tier is only available in certain regions (`eu10`, `us10`, `ap10`)
+- Free tier availability depends on your region and commercial model; check SAP Discovery Center and your subaccount entitlements for current region support
 - Only **one** free instance per global account
 - Provisioning takes **30-60 minutes** — check status with `cf service my-abap-instance`
-- Free tier instances are **stopped each night** — restart via Landscape Portal or BTP Cockpit
-- Free tier has a **90-day time limit**
+- Free tier instances may be **stopped periodically** — restart via Landscape Portal or BTP Cockpit
+- Check current free-tier limits (system sizing, expiry) in SAP Help before planning capacity
 
 ### Common Error: admin_email Validation
 
@@ -417,7 +417,7 @@ When `SAP_SYSTEM_TYPE=btp` is set (or auto-detected), tool definitions and behav
 ### Free tier provisioning fails
 
 - **Entitlement missing**: Assign `abap` / `free` in Global Account > Entitlements
-- **Region not supported**: Free tier is only in `eu10`, `us10`, `ap10`
+- **Region not supported**: Free plan may not be available in your region/commercial model
 - **Already have an instance**: Only one free instance per global account
 - **CF not enabled**: Enable Cloud Foundry in your subaccount first
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -39,7 +39,7 @@ Start the MCP server. This is the default command when no subcommand is given.
 arc1
 
 # HTTP Streamable transport (for VS Code, Copilot Studio)
-arc1 --transport http-streamable --port 3000
+arc1 --transport http-streamable --http-addr 0.0.0.0:3000
 ```
 
 ### search
@@ -111,7 +111,7 @@ arc1 --transport http-streamable --api-key "my-secret-key"
 # OIDC authentication
 arc1 --transport http-streamable \
   --oidc-issuer "https://login.microsoftonline.com/..." \
-  --oidc-audience "api://arc1"
+  --oidc-audience "<expected-aud-claim>"
 
 # BTP Destination
 SAP_BTP_DESTINATION=SAP_TRIAL arc1

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -269,8 +269,6 @@ prefix. CLI flags map 1:1 to env vars:
 | `--allowed-packages` | `SAP_ALLOWED_PACKAGES` | |
 | `--allow-transportable-edits` | `SAP_ALLOW_TRANSPORTABLE_EDITS` | `false` |
 | `--enable-transports` | `SAP_ENABLE_TRANSPORTS` | `false` |
-| `--transport-read-only` | `SAP_TRANSPORT_READ_ONLY` | `false` |
-| `--allowed-transports` | `SAP_ALLOWED_TRANSPORTS` | |
 | `--feature-abapgit` | `SAP_FEATURE_ABAPGIT` | `auto` |
 | `--feature-rap` | `SAP_FEATURE_RAP` | `auto` |
 | `--feature-amdp` | `SAP_FEATURE_AMDP` | `auto` |
@@ -279,17 +277,18 @@ prefix. CLI flags map 1:1 to env vars:
 | `--feature-hana` | `SAP_FEATURE_HANA` | `auto` |
 | `--transport` | `SAP_TRANSPORT` | `http-streamable` *(image default)* |
 | `--http-addr` | `SAP_HTTP_ADDR` | `0.0.0.0:8080` *(image default)* |
-| `--terminal-id` | `SAP_TERMINAL_ID` | |
 | `--verbose` | `SAP_VERBOSE` | `false` |
 | **MCP Client Auth** | | |
 | `--api-key` | `ARC1_API_KEY` | |
+| `--api-keys` | `ARC1_API_KEYS` | |
 | `--oidc-issuer` | `SAP_OIDC_ISSUER` | |
 | `--oidc-audience` | `SAP_OIDC_AUDIENCE` | |
-| `--oidc-username-claim` | `SAP_OIDC_USERNAME_CLAIM` | `preferred_username` |
-| `--oidc-user-mapping` | `SAP_OIDC_USER_MAPPING` | |
-| `--pp-ca-key` | `SAP_PP_CA_KEY` | |
-| `--pp-ca-cert` | `SAP_PP_CA_CERT` | |
-| `--pp-cert-ttl` | `SAP_PP_CERT_TTL` | `5m` |
+| `--xsuaa-auth` | `SAP_XSUAA_AUTH` | `false` |
+| `--pp-enabled` | `SAP_PP_ENABLED` | `false` |
+| `--pp-strict` | `SAP_PP_STRICT` | `false` |
+| `--profile` | `ARC1_PROFILE` | |
+| *(BTP destination)* | `SAP_BTP_DESTINATION` | |
+| *(BTP PP destination)* | `SAP_BTP_PP_DESTINATION` | |
 
 ---
 
@@ -317,12 +316,12 @@ When running arc1 as a shared server, protect it with API key or OAuth:
 
 # OAuth/OIDC JWT validation (enterprise)
 -e SAP_OIDC_ISSUER='https://login.microsoftonline.com/{tenant}/v2.0' \
--e SAP_OIDC_AUDIENCE='api://arc1-sap-connector'
+-e SAP_OIDC_AUDIENCE='<expected-aud-claim>'
 
-# Principal Propagation (per-user SAP auth, requires OIDC)
--e SAP_PP_CA_KEY=/secrets/ca.key \
--e SAP_PP_CA_CERT=/secrets/ca.crt \
--v /path/to/secrets:/secrets:ro
+# Principal Propagation (BTP Destination + Cloud Connector path)
+-e SAP_BTP_DESTINATION=SAP_TRIAL \
+-e SAP_BTP_PP_DESTINATION=SAP_TRIAL_PP \
+-e SAP_PP_ENABLED=true
 ```
 
 See the [Authentication guides](enterprise-auth.md) for detailed setup.
@@ -479,14 +478,6 @@ CTS transport tools are **disabled by default** to prevent accidental releases.
 ```bash
 # Enable transport tools
 -e SAP_ENABLE_TRANSPORTS=true
-
-# Enable but restrict to read-only (list, view — no create/release/delete)
--e SAP_ENABLE_TRANSPORTS=true
--e SAP_TRANSPORT_READ_ONLY=true
-
-# Enable and restrict to specific transports (wildcards OK)
--e SAP_ENABLE_TRANSPORTS=true
--e SAP_ALLOWED_TRANSPORTS="A4HK*"
 ```
 
 ---
@@ -522,21 +513,6 @@ Use `on` or `off` to skip the probe and force the behavior:
 
 Setting features to `off` reduces the number of registered MCP tools, which
 keeps the AI's tool list shorter and lowers token usage.
-
----
-
-### Debugger
-
-To share breakpoints with SAP GUI (cross-tool debugging), configure the same
-terminal ID that SAP GUI uses:
-
-```bash
--e SAP_TERMINAL_ID=D0C586D015974B75BFB2A306A4A13AEA
-```
-
-SAP GUI stores its terminal ID at:
-- **Windows:** Registry `HKCU\Software\SAP\ABAP Debugging\TerminalID`
-- **Linux/Mac:** `~/.SAP/ABAPDebugging/terminalId`
 
 ---
 

--- a/docs/enterprise-auth.md
+++ b/docs/enterprise-auth.md
@@ -13,8 +13,8 @@ For **what users can do** after authenticating (scopes, roles, safety controls),
 ┌─────────────┐      MCP Client Auth       ┌─────────┐      SAP Auth        ┌─────────────┐
 │  AI Client  │ ──────────────────────────► │  ARC-1  │ ──────────────────► │ SAP System  │
 │  (Claude,   │  API Key, OIDC/JWT,        │  Server │  Basic Auth,        │ (ABAP, BTP) │
-│   Cursor)   │  or XSUAA OAuth            │         │  OAuth/XSUAA,       │             │
-└─────────────┘                            └─────────┘  mTLS, or PP        └─────────────┘
+│   Cursor)   │  or XSUAA OAuth            │         │  Service Key,       │             │
+└─────────────┘                            └─────────┘  Destination, or PP └─────────────┘
 ```
 
 ---
@@ -44,7 +44,7 @@ For **what users can do** after authenticating (scopes, roles, safety controls),
 **Do you need per-user SAP identity?**
 
 - **No** (most setups): ARC-1 connects to SAP with a single shared user. Simpler to set up, but all operations appear as one SAP user in logs.
-- **Yes** (audit, compliance): Use [Principal Propagation](principal-propagation-setup.md). Each MCP user maps to their SAP user. Full audit trail, per-user SAP authorization. Requires Cloud Connector or mTLS setup.
+- **Yes** (audit, compliance): Use [Principal Propagation](principal-propagation-setup.md). Each MCP user maps to their SAP user. Full audit trail, per-user SAP authorization. Requires BTP + Cloud Connector setup.
 
 **Where does ARC-1 run?**
 
@@ -143,35 +143,19 @@ For SAP BTP ABAP Environment systems, ARC-1 uses a service key for OAuth2 authen
 arc1 --btp-service-key-file /path/to/service-key.json
 ```
 
-### X.509 Client Certificate (mTLS)
-
-ARC-1 authenticates to SAP using a TLS client certificate. SAP maps the certificate's Subject CN to a SAP user via CERTRULE. No username or password needed.
-
-**Upsides:** No stored passwords. Strong cryptographic identity. Per-user certificates possible.
-**Downsides:** Requires PKI setup (CA, certificate generation). SAP-side setup (STRUST, CERTRULE).
-**When to use:** Enterprise environments requiring certificate-based authentication.
-**Prerequisites:** CA infrastructure, SAP STRUST and CERTRULE configuration.
-
-```bash
-arc1 --url https://sap:443 --client-cert client.crt --client-key client.key
-```
-
-See the detailed configuration in the [Enterprise Authentication Reference](#detailed-sap-authentication-reference) section below.
-
 ### Principal Propagation (Per-User SAP Identity)
 
-The most complete authentication model. Each MCP user's identity flows through to SAP, so every request runs as the real SAP user — not a shared technical account.
+The most complete authentication model. Each MCP user's identity flows through to SAP via BTP Destination Service and Cloud Connector, so every request runs as the real SAP user — not a shared technical account.
 
 **Upsides:** Full per-user audit trail. SAP-level authorization per user. Zero stored SAP credentials. No shared accounts.
-**Downsides:** Most complex setup (Cloud Connector or mTLS + CERTRULE). Requires OIDC or XSUAA on the client side.
+**Downsides:** Most complex setup (BTP + Cloud Connector + CERTRULE). Requires OIDC or XSUAA on the client side.
 **When to use:** Enterprise deployments requiring audit compliance, per-user SAP authorization, or regulatory requirements.
-**Prerequisites:** Cloud Connector (on-premise SAP) or direct mTLS (cloud SAP). CERTRULE configuration. OIDC or XSUAA for user identity.
+**Prerequisites:** BTP Cloud Foundry, Destination + Connectivity services, Cloud Connector, SAP certificate mapping.
 
 **Setup:** [Principal Propagation Setup](principal-propagation-setup.md)
 
 ```
-MCP Client ──OIDC/XSUAA──► ARC-1 ──X.509 cert (per user)──► Cloud Connector ──► SAP
-                                    generated from user JWT
+MCP Client ──OIDC/XSUAA──► ARC-1 ──X-User-Token──► BTP Destination ──► Cloud Connector ──► SAP
 ```
 
 ### BTP Destination Service
@@ -219,7 +203,7 @@ Per-user scopes control what each person can do in ARC-1, but all requests use t
 OIDC or XSUAA (MCP auth) → Principal Propagation (per-user SAP identity)
 ```
 
-Gold standard. Per-user scopes in ARC-1 + per-user SAP authorization + full audit trail. Requires Cloud Connector or mTLS setup.
+Gold standard. Per-user scopes in ARC-1 + per-user SAP authorization + full audit trail. Requires BTP + Cloud Connector setup.
 
 ### BTP Cloud Foundry (Production)
 
@@ -295,15 +279,20 @@ arc1 --url https://sap-host:443 --cookie-string "MYSAPSSO2=abc123; SAP_SESSIONID
 
 ---
 
-## 3. OAuth2/XSUAA (BTP/Cloud Systems)
+## 3. BTP ABAP Environment (Service Key + Browser OAuth)
 
-For SAP BTP systems using XSUAA for authentication. Uses OAuth2 client_credentials
-flow to obtain a Bearer token.
+For SAP BTP ABAP Environment systems. ARC-1 uses a service key for OAuth2 Authorization Code flow with interactive browser login.
 
 ### From a Service Key File
 
 ```bash
-arc1 --service-key /path/to/servicekey.json
+arc1 --btp-service-key-file /path/to/service-key.json
+```
+
+Or inline:
+
+```bash
+arc1 --btp-service-key '{"uaa":{"url":"...","clientid":"...","clientsecret":"..."},"url":"https://..."}'
 ```
 
 The service key JSON is downloaded from SAP BTP Cockpit and looks like:
@@ -320,319 +309,59 @@ The service key JSON is downloaded from SAP BTP Cockpit and looks like:
 }
 ```
 
-### With Explicit OAuth Parameters
-
-```bash
-arc1 --url https://sap-host:443 \
-    --oauth-url https://tenant.authentication.eu10.hana.ondemand.com/oauth/token \
-    --oauth-client-id sb-clone-abc123 \
-    --oauth-client-secret secret-value
-```
-
-**Token lifecycle:** ARC-1 caches the OAuth token and refreshes it automatically
-60 seconds before expiry. Thread-safe for concurrent requests.
+**Token lifecycle:** ARC-1 opens a browser for initial OAuth login, then caches and refreshes tokens automatically.
 
 **References:**
 - [SAP BTP: Create Service Keys](https://help.sap.com/docs/btp/sap-business-technology-platform/creating-service-keys)
-- [SAP XSUAA Documentation](https://help.sap.com/docs/btp/sap-business-technology-platform/what-is-sap-authorization-and-trust-management-service)
+- [BTP ABAP Environment Setup](btp-abap-environment.md)
 
 ---
 
-## 4. X.509 Client Certificate Authentication (mTLS)
+## 4. BTP Destination Service
 
-ARC-1 authenticates to SAP using a TLS client certificate. SAP maps the certificate's
-Subject CN (Common Name) to a SAP user via CERTRULE. No username or password is needed.
-
-### Configuration
+For BTP Cloud Foundry deployments connecting to on-premise SAP systems via Cloud Connector.
 
 ```bash
-# CLI flags
-arc1 --url https://sap-host:443 \
-    --client-cert /path/to/client.crt \
-    --client-key /path/to/client.key
-
-# With custom CA (when SAP uses an internal CA)
-arc1 --url https://sap-host:443 \
-    --client-cert /path/to/client.crt \
-    --client-key /path/to/client.key \
-    --ca-cert /path/to/ca.crt
-
-# Environment variables
-export SAP_URL=https://sap-host:443
-export SAP_CLIENT_CERT=/path/to/client.crt
-export SAP_CLIENT_KEY=/path/to/client.key
-export SAP_CA_CERT=/path/to/ca.crt  # optional
+export SAP_BTP_DESTINATION=SAP_TRIAL
 ```
 
-### How It Works
-
-```
-arc1 ─── TLS handshake with client certificate ───► SAP ICM
-                                                    │
-                                                    ▼
-                                              CERTRULE engine
-                                              maps Subject CN
-                                              to SAP username
-                                                    │
-                                                    ▼
-                                              Authenticated as
-                                              SAP user = CN
-```
-
-1. ARC-1 loads the client certificate and private key from PEM files
-2. During TLS handshake, arc1 presents the client certificate to SAP ICM
-3. SAP ICM verifies the certificate against trusted CAs in STRUST
-4. SAP's CERTRULE engine maps the certificate's Subject CN to a SAP user
-5. All subsequent requests run as that SAP user
-
-### SAP-Side Setup
-
-#### Step 1: Generate a CA and Client Certificate
-
-```bash
-# Generate CA (self-signed, for testing)
-openssl genrsa -out ca.key 4096
-openssl req -new -x509 -key ca.key -out ca.crt -days 365 \
-  -subj "/CN=arc1-enterprise-ca/O=My Company"
-
-# Generate client certificate for a specific SAP user
-openssl genrsa -out developer.key 2048
-openssl req -new -key developer.key -out developer.csr \
-  -subj "/CN=DEVELOPER"
-openssl x509 -req -in developer.csr -CA ca.crt -CAkey ca.key \
-  -CAcreateserial -out developer.crt -days 365
-```
-
-The certificate's Subject CN (`DEVELOPER`) must match the SAP username.
-
-#### Step 2: Import CA Certificate into SAP STRUST
-
-1. Open transaction `/nSTRUST` in SAP GUI
-2. Navigate to **SSL Server Standard** PSE
-3. If no PSE exists, click **Create** → use defaults → Save
-4. Double-click the PSE entry to open it
-5. In the **Certificate** section, click **Import**
-6. Paste the CA certificate PEM content (`ca.crt`)
-7. Click **Add to Certificate List**
-8. **Save** the PSE
-
-Alternatively, via SAP profile (no GUI needed):
-- Copy `ca.crt` into the container
-- Use `sapgenpse` command-line tool to import
-
-**Reference:** [SAP Help: Maintaining the PSE in STRUST](https://help.sap.com/docs/ABAP_PLATFORM/e73baa71770e4c0ca5fb2a3c17e8e229/4510e4a027c746e8e10000000a421937.html)
-
-#### Step 3: Enable Certificate Login in SAP Profile
-
-Edit the SAP instance profile (e.g., `A4H_D00_vhcala4hci`):
-
-```
-# Enable rule-based certificate mapping
-login/certificate_mapping_rulebased = 1
-
-# Accept client certificates (1 = optional, 2 = required)
-icm/HTTPS/verify_client = 1
-```
-
-Restart the ABAP instance after profile changes.
-
-**Reference:** [SAP Help: ICM HTTPS Parameters](https://help.sap.com/docs/ABAP_PLATFORM/683d6a1797a34730a6e005d1e8de6f22/48e20f476bfb7c6de10000000a42189c.html)
-
-#### Step 4: Configure Certificate Mapping Rule (CERTRULE)
-
-1. Open transaction `/nCERTRULE` (or use `/nCERTMAP` on older systems)
-2. Click **Import Certificate** and upload the client certificate (`developer.crt`)
-3. Create a new rule:
-   - **Certificate Attribute:** `Subject` → `CN`
-   - **Login As:** Select `CN value is used as SAP username`
-4. Save and activate the rule
-
-This tells SAP: "when a client presents a certificate, use the CN as the SAP username."
-
-**Reference:** [SAP Help: Configuring Certificate Login](https://help.sap.com/docs/ABAP_PLATFORM/e73baa71770e4c0ca5fb2a3c17e8e229/4513f2bf27da4ce8e10000000a421937.html)
-
-#### Step 5: Restart ICM
-
-After all configuration changes, restart SAP ICM:
-- Transaction `/nSMICM` → Administration → ICM → **Soft Restart**
-- Or via command line: `sapcontrol -nr 00 -function RestartService`
-
-#### Step 6: Test
-
-```bash
-# Test with curl
-curl --cert developer.crt --key developer.key \
-  https://sap-host:443/sap/bc/adt/core/discovery?sap-client=001
-
-# Test with arc1
-arc1 --url https://sap-host:443 --client-cert developer.crt --client-key developer.key
-```
+The Destination Service handles connection details, credentials, and optionally Principal Propagation. See [BTP Destination Setup](btp-destination-setup.md).
 
 ---
 
-## 5. OIDC Token Validation + Principal Propagation
+## 5. Principal Propagation (BTP Destination + Cloud Connector)
 
-The most secure multi-user authentication. Combines OIDC (Microsoft EntraID) token
-validation with ephemeral X.509 certificate generation.
-
-### How It Works
-
-```
-User (alice@company.com)
-  │
-  ▼
-Copilot Studio / IDE  ──── authenticates via EntraID ───► EntraID
-  │                                                         │
-  │  OIDC Bearer token                                      │
-  ▼                                                         │
-arc1 HTTP endpoint  ◄─── validates token via JWKS ───────────┘
-  │
-  │  1. Extract username from JWT claim
-  │  2. Map: alice@company.com → ALICE (SAP username)
-  │  3. Generate ephemeral X.509 cert: CN=ALICE, valid 5 min
-  │  4. Sign cert with CA key (trusted in SAP STRUST)
-  │
-  ▼
-SAP ABAP System  ◄─── mTLS with ephemeral cert
-  │
-  │  SAP validates cert against STRUST
-  │  CERTRULE maps CN=ALICE to SAP user ALICE
-  │  SAP audit log shows: ALICE executed this action
-  │
-  ▼
-Response to user
-```
-
-**Key properties:**
-- **Zero SAP credentials stored anywhere** — no passwords, no service accounts
-- **Per-user audit trail** — SAP logs show the actual end user
-- **Short-lived certificates** — ephemeral certs expire in 5 minutes
-- **Centralized identity** — uses existing corporate EntraID accounts
-
-### Configuration
+Per-user SAP identity for JWT-authenticated users via BTP Destination Service.
 
 ```bash
-# OIDC validation (validates incoming Bearer tokens)
-arc1 --url https://sap-host:443 \
-    --oidc-issuer https://login.microsoftonline.com/{tenant-id}/v2.0 \
-    --oidc-audience api://arc1-sap-connector \
-    --oidc-username-claim preferred_username \
-    --pp-ca-key /path/to/ca.key \
-    --pp-ca-cert /path/to/ca.crt \
-    --pp-cert-ttl 5m \
-    --transport http-streamable
-
-# Environment variables
-export SAP_URL=https://sap-host:443
-export SAP_OIDC_ISSUER=https://login.microsoftonline.com/{tenant-id}/v2.0
-export SAP_OIDC_AUDIENCE=api://arc1-sap-connector
-export SAP_OIDC_USERNAME_CLAIM=preferred_username
-export SAP_PP_CA_KEY=/path/to/ca.key
-export SAP_PP_CA_CERT=/path/to/ca.crt
-export SAP_PP_CERT_TTL=5m
-export SAP_TRANSPORT=http-streamable
+export SAP_BTP_DESTINATION=SAP_TRIAL
+export SAP_BTP_PP_DESTINATION=SAP_TRIAL_PP
+export SAP_PP_ENABLED=true
 ```
 
-### Setup Guide
+**How it works:** ARC-1 passes the user's JWT as `X-User-Token` to BTP Destination Service, which resolves the per-user destination. Cloud Connector propagates the user identity via client certificate. SAP maps the certificate to a SAP user via CERTRULE / VUSREXTID.
 
-#### Step 1: Create EntraID App Registration
+**Fallback behavior:**
+- `SAP_PP_STRICT=false` (default): falls back to shared destination on PP failure
+- `SAP_PP_STRICT=true`: returns error on PP failure, no fallback
 
-1. Go to [Azure Portal](https://portal.azure.com/) → **Azure Active Directory** → **App registrations**
-2. Click **New registration**
-   - Name: `ARC-1 SAP Connector`
-   - Supported account types: `Accounts in this organizational directory only`
-   - Redirect URI: not needed (server-to-server)
-3. Note the **Application (client) ID** and **Directory (tenant) ID**
-4. Go to **Expose an API**
-   - Set **Application ID URI** (e.g., `api://arc1-sap-connector`)
-   - Add a scope: `SAP.Access`
-5. Go to **Certificates & secrets** (if clients need client credentials, otherwise skip)
-
-**References:**
-- [Microsoft: Register an application](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app)
-- [Microsoft: Expose an API](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-expose-web-apis)
-
-#### Step 2: Generate CA Key Pair
-
-```bash
-# Generate a CA key pair (RSA-4096)
-# This CA will sign the ephemeral certificates.
-# The CA certificate must be imported into SAP STRUST.
-openssl genrsa -out pp-ca.key 4096
-openssl req -new -x509 -key pp-ca.key -out pp-ca.crt -days 3650 \
-  -subj "/CN=arc1-principal-propagation-ca/O=My Company"
-```
-
-Keep `pp-ca.key` secure — it is the root of trust. In production, store it in
-Azure Key Vault or a hardware security module (HSM).
-
-#### Step 3: Configure SAP (Same as X.509 mTLS)
-
-Follow the same STRUST + CERTRULE setup from [Section 4](#4-x509-client-certificate-authentication-mtls):
-1. Import `pp-ca.crt` into STRUST (SSL Server Standard PSE)
-2. Set `login/certificate_mapping_rulebased = 1`
-3. Set `icm/HTTPS/verify_client = 1`
-4. Configure CERTRULE to map Subject CN to SAP username
-5. Restart ICM
-
-#### Step 4: Username Mapping (Optional)
-
-If OIDC usernames don't match SAP usernames directly, create a mapping file:
-
-```yaml
-# oidc-user-mapping.yaml
-alice@company.com: ALICE_DEV
-bob.smith@company.com: BSMITH
-admin@company.com: SAP_ADMIN
-```
-
-```bash
-arc1 --oidc-user-mapping oidc-user-mapping.yaml ...
-```
-
-Without a mapping file, ARC-1 extracts the username part before `@` and uppercases it:
-`alice@company.com` → `ALICE`.
-
-#### Step 5: Username Claim Selection
-
-The JWT claim used to extract the SAP username. Common values:
-
-| Claim | Description | Example Value |
-|-------|-------------|---------------|
-| `preferred_username` | EntraID display name (default) | `alice@company.com` |
-| `upn` | User Principal Name | `alice@company.com` |
-| `email` | Email address | `alice@company.com` |
-| `sub` | Subject identifier (opaque ID) | `aAbBcC123...` |
-| `unique_name` | Legacy Azure AD claim | `alice@company.com` |
-
-**Priority chain:** ARC-1 tries the configured claim first, then falls back through
-`preferred_username` → `upn` → `unique_name` → `email` → `sub`.
-
-For email-like claims (`email`, `upn`, `preferred_username`), arc1 automatically
-extracts the part before `@` as the username.
+See [Principal Propagation Setup](principal-propagation-setup.md) for complete setup.
 
 ---
 
-## Custom CA Certificate
+## Custom TLS Trust
 
 When the SAP system uses a TLS server certificate signed by an internal CA
-(not a public CA like Let's Encrypt), arc1 needs the CA certificate to verify
-the connection.
+(not a public CA like Let's Encrypt), use `--insecure` or mount the CA certificate
+into the Node.js trust store via `NODE_EXTRA_CA_CERTS`.
 
 ```bash
-# With any auth method
-arc1 --url https://sap-host:443 --user DEV --password pass \
-    --ca-cert /path/to/internal-ca.crt
+# Skip TLS verification (development only)
+arc1 --url https://sap-host:443 --user DEV --password pass --insecure
 
-# Environment variable
-export SAP_CA_CERT=/path/to/internal-ca.crt
+# Mount custom CA (production)
+NODE_EXTRA_CA_CERTS=/path/to/internal-ca.crt arc1 --url https://sap-host:443 ...
 ```
-
-This sets the TLS trust store for the SAP connection. It's independent of the
-client certificate (which is for authentication).
-
-**Alternative:** Use `--insecure` / `SAP_INSECURE=true` to skip TLS verification
-entirely (only for testing, never in production).
 
 ---
 
@@ -642,62 +371,49 @@ entirely (only for testing, never in production).
 
 | Flag | Env Var | Description |
 |------|---------|-------------|
+| **MCP Client Auth** | | |
 | `--api-key` | `ARC1_API_KEY` | Single API key (full scopes) |
 | `--api-keys` | `ARC1_API_KEYS` | Multiple API keys with profiles (`key:profile,...`) |
+| `--oidc-issuer` | `SAP_OIDC_ISSUER` | OIDC issuer URL |
+| `--oidc-audience` | `SAP_OIDC_AUDIENCE` | Expected token audience |
+| `--xsuaa-auth` | `SAP_XSUAA_AUTH` | Enable XSUAA OAuth proxy (`true`/`false`) |
+| `--profile` | `ARC1_PROFILE` | Safety profile shortcut (`viewer`, `developer`, etc.) |
+| **SAP Auth** | | |
 | `--user` | `SAP_USER` | SAP username (basic auth) |
 | `--password` | `SAP_PASSWORD` | SAP password (basic auth) |
 | `--cookie-file` | `SAP_COOKIE_FILE` | Path to cookie file |
 | `--cookie-string` | `SAP_COOKIE_STRING` | Cookie string |
-| `--client-cert` | `SAP_CLIENT_CERT` | Client certificate PEM (mTLS) |
-| `--client-key` | `SAP_CLIENT_KEY` | Client private key PEM (mTLS) |
-| `--ca-cert` | `SAP_CA_CERT` | CA certificate PEM (custom CA) |
-| `--service-key` | `SAP_SERVICE_KEY` | BTP service key JSON file |
-| `--oauth-url` | `SAP_OAUTH_URL` | OAuth2 token endpoint |
-| `--oauth-client-id` | `SAP_OAUTH_CLIENT_ID` | OAuth2 client ID |
-| `--oauth-client-secret` | `SAP_OAUTH_CLIENT_SECRET` | OAuth2 client secret |
-| `--oidc-issuer` | `SAP_OIDC_ISSUER` | OIDC issuer URL |
-| `--oidc-audience` | `SAP_OIDC_AUDIENCE` | Expected token audience |
-| `--oidc-username-claim` | `SAP_OIDC_USERNAME_CLAIM` | JWT claim for username |
-| `--oidc-user-mapping` | `SAP_OIDC_USER_MAPPING` | Username mapping YAML |
-| `--pp-ca-key` | `SAP_PP_CA_KEY` | CA key for principal propagation |
-| `--pp-ca-cert` | `SAP_PP_CA_CERT` | CA cert for principal propagation |
-| `--pp-cert-ttl` | `SAP_PP_CERT_TTL` | Ephemeral cert validity (default: 5m) |
+| `--btp-service-key` | `SAP_BTP_SERVICE_KEY` | Inline BTP service key JSON |
+| `--btp-service-key-file` | `SAP_BTP_SERVICE_KEY_FILE` | Path to BTP service key file |
+| `--btp-oauth-callback-port` | `SAP_BTP_OAUTH_CALLBACK_PORT` | OAuth callback port (0=auto) |
+| — | `SAP_BTP_DESTINATION` | BTP Destination name (shared) |
+| — | `SAP_BTP_PP_DESTINATION` | BTP PP Destination name (per-user) |
+| `--pp-enabled` | `SAP_PP_ENABLED` | Enable principal propagation |
+| `--pp-strict` | `SAP_PP_STRICT` | Fail on PP errors (no fallback) |
 | `--insecure` | `SAP_INSECURE` | Skip TLS verification |
 
-### Auth Method Priority
+### SAP Auth Method Priority
 
-Only one authentication method can be active at a time:
+Only one SAP authentication method can be active at a time:
 1. Basic auth (`--user` + `--password`)
 2. Cookie auth (`--cookie-file` or `--cookie-string`)
-3. X.509 mTLS (`--client-cert` + `--client-key`)
-4. Service Key (`--service-key`)
-5. OAuth2 (`--oauth-url` + `--oauth-client-id` + `--oauth-client-secret`)
-6. Principal Propagation (`--pp-ca-key` + `--pp-ca-cert`)
+3. BTP Service Key (`--btp-service-key` / `--btp-service-key-file`)
+4. BTP Destination (`SAP_BTP_DESTINATION`)
 
-OIDC validation (`--oidc-issuer`) is independent — it validates incoming MCP
-requests and is typically combined with principal propagation for the SAP connection.
+MCP client auth (API Key, OIDC, XSUAA) is independent and can be combined with any SAP auth method.
+
+### What's NOT Implemented
+
+These flags from older documentation do **not** exist in the current ARC-1 codebase:
+
+- `--client-cert` / `--client-key` / `--ca-cert` (local mTLS)
+- `--service-key` / `--oauth-url` / `--oauth-client-id` / `--oauth-client-secret` (generic OAuth)
+- `--oidc-username-claim` / `--oidc-user-mapping` (username mapping)
+- `--pp-ca-key` / `--pp-ca-cert` / `--pp-cert-ttl` (local ephemeral cert generation)
 
 ---
 
 ## Troubleshooting
-
-### Certificate errors
-
-**"loading client certificate: ..."**
-- Verify cert and key are valid PEM format: `openssl x509 -in client.crt -text -noout`
-- Verify key matches cert: `openssl x509 -noout -modulus -in client.crt | md5` should equal `openssl rsa -noout -modulus -in client.key | md5`
-
-**"CA certificate file contains no valid PEM certificates"**
-- Verify the CA file is PEM-encoded (starts with `-----BEGIN CERTIFICATE-----`)
-- Ensure the file contains the full certificate chain if needed
-
-### SAP returns 401 with certificate auth
-
-- Verify the CA is imported in STRUST (correct PSE: SSL Server Standard)
-- Verify `login/certificate_mapping_rulebased = 1` is active (`/nRZ11`)
-- Verify `icm/HTTPS/verify_client` is `1` or `2` (not `0`)
-- Verify CERTRULE has an active rule mapping the certificate's CN
-- Check ICM trace: `/nSMICM` → Goto → Trace File → Display End
 
 ### OIDC token validation fails
 
@@ -736,9 +452,9 @@ requests and is typically combined with principal propagation for the SAP connec
 - Verify Resource URL is set (not empty)
 - Verify the redirect URI is registered in the app registration
 
-### Principal propagation: SAP rejects ephemeral cert
+### Principal propagation always falls back to shared user
 
-- Verify the CA cert in STRUST is the same one used with `--pp-ca-cert`
-- Verify CERTRULE works: test with a static cert first (Section 4)
-- Check ephemeral cert content: `openssl x509 -in /tmp/test.crt -text -noout`
-- Enable SAP ICM trace for detailed TLS handshake logging
+- Verify `SAP_PP_ENABLED=true` is set
+- Verify `SAP_BTP_PP_DESTINATION` authentication type is `PrincipalPropagation` in BTP Cockpit
+- Verify Cloud Connector + backend certificate mapping configuration
+- Check Cloud Connector logs for PP errors

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,7 +99,7 @@ Start arc1 as an HTTP server, then point your MCP client to it:
 
 ```bash
 SAP_URL=https://host:44300 SAP_USER=dev SAP_PASSWORD=secret \
-  npx arc-1 --transport http-streamable --port 3000
+  npx arc-1 --transport http-streamable --http-addr 0.0.0.0:3000
 ```
 
 Add to VS Code / Copilot MCP config:

--- a/docs/oauth-jwt-setup.md
+++ b/docs/oauth-jwt-setup.md
@@ -104,7 +104,7 @@ arc1 --url https://sap.example.com:44300 \
     --transport http-streamable \
     --http-addr 0.0.0.0:8080 \
     --oidc-issuer 'https://login.microsoftonline.com/{tenant-id}/v2.0' \
-    --oidc-audience 'api://arc1-sap-connector'
+    --oidc-audience '{client-id-guid}'
 ```
 
 ### Environment Variables
@@ -116,24 +116,10 @@ export SAP_PASSWORD=ServicePassword123
 export SAP_TRANSPORT=http-streamable
 export SAP_HTTP_ADDR=0.0.0.0:8080
 export SAP_OIDC_ISSUER='https://login.microsoftonline.com/{tenant-id}/v2.0'
-export SAP_OIDC_AUDIENCE='api://arc1-sap-connector'
-export SAP_OIDC_USERNAME_CLAIM='preferred_username'  # default
+export SAP_OIDC_AUDIENCE='{client-id-guid}'
 ```
 
-### Username Mapping (Optional)
-
-If OIDC usernames don't match SAP usernames, create a mapping file:
-
-```yaml
-# oidc-user-mapping.yaml
-alice: ALICE_DEV
-bob: BOB_ADMIN
-carol@company.com: CAROL
-```
-
-```bash
-arc1 ... --oidc-user-mapping oidc-user-mapping.yaml
-```
+> **Note:** `SAP_OIDC_AUDIENCE` must match the exact `aud` claim in your tokens. For Entra ID v2 access tokens, this is typically the raw client ID GUID. Validate with a real token from your tenant.
 
 ## Client Configuration
 

--- a/docs/principal-propagation-setup.md
+++ b/docs/principal-propagation-setup.md
@@ -1,6 +1,6 @@
-# Phase 3: Principal Propagation Setup
+# Principal Propagation Setup
 
-Authenticate each MCP user to SAP with their own identity using ephemeral X.509 certificates. No shared SAP passwords. Full per-user audit trail.
+Authenticate each MCP user to SAP with their own identity via BTP Destination Service and Cloud Connector. No shared SAP passwords. Full per-user audit trail.
 
 ## When to Use
 
@@ -12,201 +12,161 @@ Authenticate each MCP user to SAP with their own identity using ephemeral X.509 
 ## Architecture
 
 ```
-┌──────────────────┐     OAuth JWT        ┌──────────────────────────────┐     mTLS (ephemeral cert)   ┌────────────┐
-│  MCP Client      │ ──────────────────► │  arc1 Server                  │ ────────────────────────► │  SAP ABAP  │
-│  (IDE / Copilot) │                     │                              │   CN=<sap-username>      │  System    │
-└──────────────────┘                     │  1. Validate JWT (Phase 2)   │   Signed by trusted CA   │            │
-                                         │  2. Extract username          │                          │  STRUST:   │
-                                         │  3. Generate ephemeral cert   │                          │   CA cert  │
-                                         │  4. mTLS to SAP with cert    │                          │  CERTRULE: │
-                                         └──────────────────────────────┘                          │   CN→User  │
-                                                                                                    └────────────┘
+MCP Client (JWT)
+  │
+  ▼
+ARC-1 (/mcp)
+  │  validates JWT (OIDC or XSUAA)
+  │  passes X-User-Token to Destination Service
+  ▼
+BTP Destination Service
+  │  resolves per-user destination (PrincipalPropagation type)
+  ▼
+Connectivity Proxy
+  │
+  ▼
+Cloud Connector
+  │  propagates user identity via client certificate
+  ▼
+SAP ICM
+  │  CERTRULE / VUSREXTID maps certificate to SAP user
+  ▼
+SAP user session (per-user)
 ```
 
 ## Prerequisites
 
-- Phase 2 (OAuth/JWT) must be configured first
-- SAP admin access for STRUST, CERTRULE, ICM configuration
-- OpenSSL for CA certificate generation
+- JWT-based MCP auth working ([OIDC setup](oauth-jwt-setup.md) or [XSUAA setup](xsuaa-setup.md))
+- ARC-1 deployed on BTP Cloud Foundry
+- Destination + Connectivity service instances bound to ARC-1 app
+- Cloud Connector connected to your BTP subaccount
+- SAP system reachable from Cloud Connector
 
-## Step 1: Generate CA Key Pair
+## Step 1: Create Two BTP Destinations
 
-This CA signs the ephemeral certificates. SAP must trust this CA.
+Create a dual-destination setup in BTP Cockpit (Connectivity → Destinations):
 
-```bash
-# Generate CA private key (RSA 2048)
-openssl genrsa -out ca.key 2048
+### Shared destination (fallback)
 
-# Generate CA certificate (valid 10 years)
-openssl req -new -x509 -key ca.key -out ca.crt -days 3650 \
-  -subj "/CN=arc1-principal-propagation-ca/O=YourCompany/C=DE"
+| Property | Value |
+|----------|-------|
+| Name | `SAP_TRIAL` (your choice) |
+| Type | HTTP |
+| URL | `http://<sap-host>:<sap-port>` |
+| Authentication | BasicAuthentication |
+| User | Technical SAP user |
+| Password | Technical SAP password |
 
-# Verify
-openssl x509 -in ca.crt -text -noout
-```
+### Per-user destination (principal propagation)
 
-**Security:** Store `ca.key` in a secrets manager (AWS Secrets Manager, Azure Key Vault, HashiCorp Vault). Never commit to version control.
+| Property | Value |
+|----------|-------|
+| Name | `SAP_TRIAL_PP` (your choice) |
+| Type | HTTP |
+| URL | `http://<sap-host>:<sap-port>` |
+| Authentication | PrincipalPropagation |
 
-## Step 2: Configure SAP System
+## Step 2: Configure Cloud Connector
 
-### 2a. Import CA Certificate into STRUST
+1. Open Cloud Connector Admin UI
+2. Add the SAP system mapping (Cloud to On-Premise → Add)
+3. Enable **Principal Propagation** in the access control for the mapping
+4. Configure the system certificate for signing principal propagation certificates
 
-1. Open transaction **`/nSTRUST`**
-2. Double-click **SSL server Standard** PSE
-3. Switch to Edit mode (pencil icon)
-4. Click **Import certificate** (at bottom of screen)
-5. Paste the contents of `ca.crt` (PEM format)
-6. Click **Add to Certificate List**
-7. **Save**
+## Step 3: Configure SAP System
 
-### 2b. Configure ICM Profile Parameters
+The SAP system must trust Cloud Connector's certificates and map them to SAP users.
 
-1. Open transaction **`/nRZ10`**
-2. Select the **DEFAULT** profile → Extended Maintenance → Change
-3. Add/verify these parameters:
+### Certificate trust (STRUST)
+
+1. Import the Cloud Connector system certificate into STRUST (SSL Server Standard PSE → Certificate List)
+
+### Certificate mapping (CERTRULE or VUSREXTID)
+
+Configure how the certificate's subject is mapped to a SAP user:
+
+- **CERTRULE** (transaction `/nCERTRULE`): Rule-based mapping (e.g., Subject CN → SAP User ID)
+- **VUSREXTID** (table `VUSREXTID` via SM30): Explicit user-to-certificate subject mapping
+
+### ICM parameters
+
+Verify these profile parameters (transaction `/nRZ10`):
 
 | Parameter | Value | Purpose |
 |-----------|-------|---------|
-| `icm/HTTPS/verify_client` | `1` | Request client certificate (accept) |
+| `icm/HTTPS/verify_client` | `1` | Accept client certificates |
 | `login/certificate_mapping_rulebased` | `1` | Enable CERTRULE mapping |
 
-4. **Save** the profile
-
-### 2c. Configure Certificate-to-User Mapping (CERTRULE)
-
-1. Open transaction **`/nCERTRULE`**
-2. Switch to Change mode
-3. Click **Upload Certificate** → import a sample ephemeral cert:
+## Step 4: Configure ARC-1
 
 ```bash
-# Generate a sample cert to import into CERTRULE
-openssl req -new -x509 -key ca.key -out sample.crt -days 1 \
-  -subj "/CN=DEVELOPER"
-# Upload sample.crt into CERTRULE
+export SAP_BTP_DESTINATION=SAP_TRIAL
+export SAP_BTP_PP_DESTINATION=SAP_TRIAL_PP
+export SAP_PP_ENABLED=true
 ```
 
-4. Click **Rule** to create a mapping:
-   - **Certificate Entry:** `Subject`
-   - **Certificate Attr:** `CN` (Common Name)
-   - **Login As:** `ID` (SAP User ID)
-5. **Save**
+### Behavior
 
-This rule means: any certificate with Subject CN = `DEVELOPER` → log in as SAP user `DEVELOPER`.
+- **JWT request** → ARC-1 uses the per-user destination (`SAP_BTP_PP_DESTINATION`), passing the JWT as `X-User-Token`
+- **PP failure + `SAP_PP_STRICT=false`** (default) → falls back to shared destination
+- **PP failure + `SAP_PP_STRICT=true`** → returns error, no fallback
+- **API key / non-JWT request** → uses shared destination
 
-### 2d. Restart ICM
+### All PP-related config
 
-1. Open transaction **`/nSMICM`**
-2. Go to **Administration** → **ICM** → **Exit Soft** (or **Exit Hard**)
-3. Wait for ICM to restart (green status)
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `--pp-enabled` | `SAP_PP_ENABLED` | `false` | Enable principal propagation |
+| `--pp-strict` | `SAP_PP_STRICT` | `false` | Fail on PP errors (no fallback) |
+| — | `SAP_BTP_DESTINATION` | — | Shared (fallback) destination name |
+| — | `SAP_BTP_PP_DESTINATION` | — | Per-user PP destination name |
 
-### 2e. For Cloud Connector Deployments (Optional)
+## Step 5: Test
 
-If SAP is on-premise behind BTP Cloud Connector:
-
-1. **Install system certificate** in Cloud Connector:
-   - Cloud Connector Admin UI → Configuration → ON PREMISE → System Certificate
-   - Import the CA certificate (`ca.crt`)
-
-2. **Configure trusted reverse proxy** in SAP:
-   ```
-   icm/trusted_reverse_proxy_0 = SUBJECT="CN=SCC, O=SAP, C=DE", ISSUER="CN=arc1-principal-propagation-ca, O=YourCompany, C=DE"
+1. **Check logs** after a JWT-authenticated request:
+   ```bash
+   cf logs arc1-mcp-server --recent | grep -E "Principal propagation|per-user|BTP destination"
    ```
 
-3. **Enable principal propagation** in Cloud Connector:
-   - Cloud to On-Premises → system mapping → Allow Principal Propagation
-   - Principal type: X.509 Certificate
-
-## Step 3: Start arc1 with Principal Propagation
-
-```bash
-arc1 --url https://sap.example.com:44300 \
-    --transport http-streamable \
-    --http-addr 0.0.0.0:8080 \
-    --oidc-issuer 'https://login.microsoftonline.com/{tenant-id}/v2.0' \
-    --oidc-audience 'api://arc1-sap-connector' \
-    --pp-ca-key ca.key \
-    --pp-ca-cert ca.crt \
-    --pp-cert-ttl 5m \
-    --insecure  # Only for testing with self-signed SAP certs
-```
-
-### Environment Variables
-
-```bash
-export SAP_URL=https://sap.example.com:44300
-export SAP_TRANSPORT=http-streamable
-export SAP_HTTP_ADDR=0.0.0.0:8080
-export SAP_OIDC_ISSUER='https://login.microsoftonline.com/{tenant-id}/v2.0'
-export SAP_OIDC_AUDIENCE='api://arc1-sap-connector'
-export SAP_PP_CA_KEY=/secrets/ca.key
-export SAP_PP_CA_CERT=/secrets/ca.crt
-export SAP_PP_CERT_TTL=5m
-```
-
-**Note:** No `SAP_USER` or `SAP_PASSWORD` needed! Authentication is entirely via certificates.
-
-## Step 4: Test
-
-```bash
-# Get an OAuth token
-TOKEN=$(az account get-access-token --resource api://arc1-sap-connector --query accessToken -o tsv)
-
-# Call arc1 — it will generate an ephemeral cert for your user and authenticate to SAP
-curl -H "Authorization: Bearer $TOKEN" https://arc1.company.com/mcp \
-  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
-```
-
-## How It Works (Per Request)
-
-1. MCP client sends request with `Authorization: Bearer <jwt>`
-2. ARC-1 validates JWT signature, issuer, audience, expiry
-3. ARC-1 extracts SAP username from JWT claim (e.g., `preferred_username`)
-4. ARC-1 generates ephemeral X.509 certificate:
-   - Subject CN = SAP username (e.g., `DEVELOPER`)
-   - Valid for 5 minutes
-   - Signed by the CA key
-5. ARC-1 creates a per-request HTTPS client with the ephemeral cert
-6. SAP receives the mTLS connection, verifies the cert against STRUST
-7. SAP maps Subject CN to SAP user via CERTRULE
-8. SAP processes the ADT request as that user
-9. Ephemeral cert is discarded (never stored)
+2. **Check SAP** for per-user identity:
+   - Transaction `SM20` (security audit log) — verify the individual SAP user appears
+   - Transaction `SM04` (user sessions) — check for per-user sessions
 
 ## Troubleshooting
 
-### SAP Returns 401
+### PP always falls back to shared user
 
-1. **Check STRUST:** Is the CA cert in the SSL Server Standard certificate list?
-2. **Check ICM:** Is `icm/HTTPS/verify_client = 1`? (check via `/nSMICM` → Goto → Parameters → Display)
-3. **Check CERTRULE:** Does a rule mapping CN → User exist?
-4. **Check ICM trace:** Set trace level 2 in SMICM, reproduce the error, check dev_icm trace file
-5. **Check user exists:** Does the SAP user matching the CN exist and is unlocked?
+1. Verify `SAP_PP_ENABLED=true` is set
+2. Verify `SAP_BTP_PP_DESTINATION` authentication type is `PrincipalPropagation` in BTP Cockpit
+3. Check Cloud Connector logs for principal propagation errors
+4. Verify the JWT contains a valid user identity
 
-### Certificate Mapping Not Working
+### SAP returns 401 for propagated user
 
-1. Open transaction **`/nCERTRULE`**
-2. Upload the actual ephemeral cert (from arc1 verbose logs) to test the mapping
-3. Verify the rule matches
+1. **Check STRUST:** Is the Cloud Connector system cert in the certificate list?
+2. **Check ICM:** Is `icm/HTTPS/verify_client = 1`?
+3. **Check certificate mapping:** Does CERTRULE or VUSREXTID map the certificate subject to a valid SAP user?
+4. **Check user exists:** Does the SAP user exist and is it unlocked?
 
-### Cloud Connector Issues
+### Cloud Connector issues
 
 1. Check Cloud Connector logs (All/Payload trace)
-2. Verify `icm/trusted_reverse_proxy` parameter matches CC system certificate
-3. Ensure principal propagation is enabled in CC access control
+2. Verify `icm/trusted_reverse_proxy` parameter matches Cloud Connector system certificate
+3. Ensure principal propagation is enabled in Cloud Connector access control
 
-## Security Notes
+## What's NOT supported
 
-- **CA key is the crown jewel** — protect it like a root password
-- Ephemeral certs are valid for only 5 minutes (configurable via `--pp-cert-ttl`)
-- RSA-2048 key pair generated per request (~2ms overhead)
-- No SAP passwords stored anywhere
-- Full audit trail: SAP logs show which user performed each action
-- CERTRULE can restrict which usernames are allowed (not just wildcard CN mapping)
+ARC-1 does **not** support local ephemeral X.509 certificate generation. The following flags do not exist:
+
+- `--pp-ca-key`, `--pp-ca-cert`, `--pp-cert-ttl`
+- `--client-cert`, `--client-key`
+- `--oidc-username-claim`, `--oidc-user-mapping`
+
+Principal propagation is exclusively via BTP Destination Service + Cloud Connector.
 
 ## SAP Documentation References
 
 - [Authenticating Users Against On-Premise Systems](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/authenticating-users-against-on-premise-systems) — Principal Propagation via Cloud Connector
 - [Setting Up Trust Between Identity Provider and SAP](https://help.sap.com/docs/btp/sap-business-technology-platform/principal-propagation) — BTP principal propagation overview
-- [STRUST - Trust Manager (SAP Help)](https://help.sap.com/doc/saphelp_nw75/7.5.25/en-us/4c/61a6c6364e11d3963800a0c9e1edf3/frameset.htm) — Importing trusted CA certificates
 - [CERTRULE - Rule-Based Certificate Mapping (SAP Note 2275087)](https://me.sap.com/notes/2275087) — Rule-based certificate-to-user mapping
-- [ICM Profile Parameters](https://help.sap.com/doc/saphelp_nw75/7.5.25/en-us/48/21f839a44c3d65e10000000a42189c/frameset.htm) — ICM HTTPS client cert parameters
 - [Cloud Connector - Principal Propagation](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/configuring-principal-propagation) — Cloud Connector principal propagation setup

--- a/docs/sap-trial-setup.md
+++ b/docs/sap-trial-setup.md
@@ -889,150 +889,19 @@ do not require `SAP_INSECURE`.
 
 ---
 
-## X.509 Certificate Authentication Setup (mTLS)
+## Certificate-Based SAP Setup (for Cloud Connector Principal Propagation)
 
-This section describes how to configure the SAP trial system for X.509 client
-certificate authentication. This is required for testing mTLS and principal
-propagation features.
+ARC-1 supports principal propagation via BTP Destination Service and Cloud Connector. The following local flags do **not** exist:
 
-### Generate Test CA and Client Certificate
+- `--client-cert` / `--client-key` / `--ca-cert`
+- `--pp-ca-key` / `--pp-ca-cert` / `--pp-cert-ttl`
 
-```bash
-# Generate CA (self-signed, for testing only)
-openssl genrsa -out ca.key 4096
-openssl req -new -x509 -key ca.key -out ca.crt -days 365 \
-  -subj "/CN=arc1-test-ca/O=arc1 testing"
+If you use this trial system as the SAP backend for principal propagation testing:
 
-# Generate client certificate for the DEVELOPER user
-openssl genrsa -out developer.key 2048
-openssl req -new -key developer.key -out developer.csr \
-  -subj "/CN=DEVELOPER"
-openssl x509 -req -in developer.csr -CA ca.crt -CAkey ca.key \
-  -CAcreateserial -out developer.crt -days 365
+1. Keep the SAP-side certificate trust and user mapping setup (STRUST + CERTRULE/VUSREXTID)
+2. Configure Cloud Connector principal propagation
+3. Configure ARC-1 with BTP destinations and `SAP_PP_ENABLED=true`
 
-# Verify the certificate
-openssl x509 -in developer.crt -text -noout | grep Subject
-# Expected: Subject: CN = DEVELOPER
-```
-
-### Import CA into SAP STRUST
-
-The CA certificate must be added to the SAP system's trust store so it can
-verify client certificates signed by this CA.
-
-**Option A: Via SAP GUI (if available)**
-
-1. Open transaction `/nSTRUST`
-2. Navigate to **SSL Server Standard** PSE
-3. Click **Import** in the Certificate section
-4. Paste the content of `ca.crt`
-5. Click **Add to Certificate List**
-6. Save
-
-**Option B: Via HANA SQL (for headless trial system)**
-
-The trial system may not have SAP GUI access. In this case, use the HANA SQL
-approach to insert the certificate directly:
-
-```bash
-docker exec -it a4h bash
-su - a4hadm
-
-# Copy the CA cert content (base64 encoded)
-cat /path/to/ca.crt | base64 -w0
-
-# Use sapgenpse to import (if available)
-# Or use the STRUST-related ABAP program via SM38
-```
-
-> **Note:** Direct STRUST manipulation via SQL is complex. The recommended approach
-> is to use SAP GUI or ADT's STRUST functionality. If you have ADT access from
-> Eclipse, you can use the STRUST transaction there.
-
-### Configure SAP Profile for Certificate Login
-
-Edit the instance profile inside the container:
-
-```bash
-docker exec -it a4h bash
-vi /usr/sap/A4H/SYS/profile/A4H_D00_vhcala4hci
-```
-
-Add these parameters:
-
-```
-# Enable rule-based certificate mapping (allows CERTRULE to work)
-login/certificate_mapping_rulebased = 1
-
-# Accept client certificates during TLS handshake
-# 0 = don't request, 1 = request (optional), 2 = require
-icm/HTTPS/verify_client = 1
-```
-
-### Configure Certificate Mapping Rule (CERTRULE)
-
-This tells SAP how to map the certificate's Subject CN to a SAP user.
-
-1. Open transaction `/nCERTRULE` in SAP GUI or ADT
-2. Import the client certificate (`developer.crt`)
-3. Create a rule:
-   - Certificate Attribute: `Subject CN`
-   - Login As: `Use CN value as SAP username`
-4. Save and activate
-
-### Restart SAP ICM
-
-After profile and CERTRULE changes:
-
-```bash
-# Restart ABAP (not the whole container)
-docker exec a4h /usr/sap/hostctrl/exe/sapcontrol -nr 00 -function Stop
-# Wait ~60s
-docker exec a4h /usr/sap/hostctrl/exe/sapcontrol -nr 00 -function Start
-```
-
-### Test Certificate Authentication
-
-```bash
-# Test with curl (using the HTTPS port)
-curl --cert developer.crt --key developer.key \
-  --cacert ca.crt \
-  "https://<your-subdomain>/sap/bc/adt/core/discovery?sap-client=001"
-
-# Test with arc1
-npx arc-1 --url https://<your-subdomain> \
-  --client-cert developer.crt \
-  --client-key developer.key \
-  --ca-cert ca.crt
-
-# If using the trial system's Let's Encrypt cert (no --ca-cert needed):
-npx arc-1 --url https://<your-subdomain> \
-  --client-cert developer.crt \
-  --client-key developer.key
-```
-
-> **Important:** The `--ca-cert` flag is for trusting the SAP **server** certificate.
-> If your SAP system uses Let's Encrypt (as configured in the HTTPS section above),
-> the system's default CA store already trusts it and `--ca-cert` is not needed.
-> The client certificate (`--client-cert`) is what SAP uses to authenticate the
-> user — these are two different certificates for two different purposes.
-
-### Principal Propagation Test Setup
-
-To test principal propagation (OIDC → ephemeral X.509), the SAP configuration
-is the same as above. The CA in STRUST is the same CA that signs the ephemeral
-certificates.
-
-```bash
-# Test ephemeral cert generation + SAP auth
-npx arc-1 --url https://<your-subdomain> \
-  --pp-ca-key ca.key \
-  --pp-ca-cert ca.crt \
-  --oidc-issuer https://login.microsoftonline.com/{tenant-id}/v2.0 \
-  --oidc-audience api://arc1 \
-  --transport http-streamable
-```
-
-For full OIDC + principal propagation testing, you also need an EntraID app
-registration. See [docs/enterprise-auth.md](enterprise-auth.md) for the
-complete setup guide.
+See:
+- [Principal Propagation Setup](principal-propagation-setup.md)
+- [BTP Destination Setup](btp-destination-setup.md)

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -176,14 +176,14 @@ VS Code and Copilot use HTTP Streamable transport, not stdio. Start arc1 as an H
 
 ```bash
 npx arc-1 --url https://host:44300 --user dev --password secret \
-  --transport http-streamable --port 3000
+  --transport http-streamable --http-addr 0.0.0.0:3000
 ```
 
 With safety controls:
 
 ```bash
 npx arc-1 --url https://host:44300 --user dev --password secret \
-  --transport http-streamable --port 3000 \
+  --transport http-streamable --http-addr 0.0.0.0:3000 \
   --read-only --block-free-sql
 ```
 
@@ -233,7 +233,7 @@ For clients that support **HTTP Streamable**, start the server and connect to th
 
 ```bash
 npx arc-1 --url https://host:44300 --user dev --password secret \
-  --transport http-streamable --port 3000
+  --transport http-streamable --http-addr 0.0.0.0:3000
 # Connect your client to http://localhost:3000/mcp
 ```
 
@@ -383,17 +383,15 @@ docker run -d --name arc1 \
 
 Full guide: **[oauth-jwt-setup.md](oauth-jwt-setup.md)**
 
-### Docker with OAuth2/XSUAA
+### Docker with BTP ABAP service key
 
-For SAP BTP ABAP Environment systems that use XSUAA for authentication:
+For SAP BTP ABAP Environment systems, use a BTP service key (ARC-1 performs browser OAuth):
 
 ```bash
 docker run -d --name arc1 \
   -p 8080:8080 \
-  -e SAP_URL=https://your-abap-env.abap.us10.hana.ondemand.com \
-  -e SAP_XSUAA_URL=https://your-subdomain.authentication.us10.hana.ondemand.com \
-  -e SAP_XSUAA_CLIENT_ID=your-client-id \
-  -e SAP_XSUAA_CLIENT_SECRET=your-client-secret \
+  -e SAP_BTP_SERVICE_KEY='{"uaa":{"url":"...","clientid":"...","clientsecret":"..."},"url":"https://your-system.abap.eu10.hana.ondemand.com"}' \
+  -e SAP_SYSTEM_TYPE=btp \
   ghcr.io/marianfoo/arc-1:latest
 ```
 
@@ -417,9 +415,9 @@ How arc1 authenticates when calling SAP ADT APIs.
 |--------|--------|------------|
 | **Basic Auth** | `--user` + `--password` | Local dev, simple setups |
 | **Cookie** | `--cookie-file` or `--cookie-string` | Reuse browser session (temporary) |
-| **OAuth2/XSUAA** | XSUAA env vars | BTP ABAP Environment |
-| **X.509 mTLS** | `--client-cert` + `--client-key` | Enterprise cert-based auth |
-| **Principal Propagation** | `--pp-enabled` + BTP Destination | Per-user SAP identity via ephemeral X.509 certs |
+| **BTP Service Key OAuth** | `SAP_BTP_SERVICE_KEY` / `SAP_BTP_SERVICE_KEY_FILE` | Direct BTP ABAP Environment |
+| **BTP Destination** | `SAP_BTP_DESTINATION` | BTP CF to on-prem SAP via Destination/Connectivity |
+| **Principal Propagation** | `--pp-enabled` + BTP Destinations | Per-user SAP identity via Cloud Connector |
 
 Only one SAP auth method can be active at a time.
 
@@ -628,7 +626,7 @@ Priority: CLI flags > environment variables > `.env` file > defaults.
 | `--client` | `SAP_CLIENT` | 001 | SAP client number |
 | `--language` | `SAP_LANGUAGE` | EN | SAP logon language |
 | `--transport` | `SAP_TRANSPORT` | stdio | `stdio` or `http-streamable` |
-| `--port` | `SAP_PORT` | 8080 | HTTP server port |
+| `--http-addr` | `SAP_HTTP_ADDR` | 0.0.0.0:8080 | HTTP listen address |
 | `--insecure` | `SAP_INSECURE` | false | Skip TLS certificate verification |
 | `--read-only` | `SAP_READ_ONLY` | false | Block all write operations |
 | `--block-free-sql` | `SAP_BLOCK_FREE_SQL` | false | Block SQL query execution |
@@ -638,6 +636,11 @@ Priority: CLI flags > environment variables > `.env` file > defaults.
 | `--api-key` | `ARC1_API_KEY` | — | API key for HTTP auth |
 | `--oidc-issuer` | `SAP_OIDC_ISSUER` | — | OIDC issuer URL |
 | `--oidc-audience` | `SAP_OIDC_AUDIENCE` | — | OIDC audience |
+| `--api-keys` | `ARC1_API_KEYS` | — | Multi-key with profiles (e.g. `key1:viewer,key2:developer`) |
+| `--profile` | `ARC1_PROFILE` | — | Safety profile shortcut (`viewer`, `developer`, etc.) |
+| `--block-data` | `SAP_BLOCK_DATA` | false | Block table preview |
+| `--btp-service-key` | `SAP_BTP_SERVICE_KEY` | — | Inline BTP service key JSON |
+| `--btp-service-key-file` | `SAP_BTP_SERVICE_KEY_FILE` | — | BTP service key file path |
 | `--pp-enabled` | `SAP_PP_ENABLED` | false | Enable principal propagation |
 | `--pp-strict` | `SAP_PP_STRICT` | false | Fail on PP errors (no fallback) |
 


### PR DESCRIPTION
## Summary

- Replace `--port`/`SAP_PORT` with `--http-addr`/`SAP_HTTP_ADDR` across all docs (11 files)
- Remove all references to unimplemented flags (`--client-cert`, `--pp-ca-key`, `--oidc-username-claim`, `--terminal-id`, etc.)
- Rewrite `principal-propagation-setup.md` for the actual BTP Destination + Cloud Connector path
- Update `enterprise-auth.md` config reference and auth method descriptions to match v0.4.x codebase
- Add missing flags to config tables (`--profile`, `--api-keys`, `--block-data`, `--btp-service-key`)
- Replace hardcoded `api://arc1-sap-connector` audience examples with placeholders
- Remove 130-line mTLS cert setup section from `sap-trial-setup.md` (not implemented)
- Remove debugger/terminal-id section from `docker.md`
- Clarify BTP free tier availability (region-dependent, not hardcoded list)

## Context

PR #46 (`codex/docs-audit-setup-auth-2026-04-08`) identified real documentation drift but was created before PR #48 (authorization model) landed. This PR cherry-picks the valid fixes from #46, extends them to files that were renamed on main (`oauth-jwt-setup.md`, `principal-propagation-setup.md`, `api-key-setup.md`), and accounts for the new authorization model.

**Supersedes #46** — that PR can be closed after this merges.

## What's NOT changed

- `authorization.md` (new from PR #48, already correct)
- `xsuaa-setup.md`, `btp-destination-setup.md` (not touched by #46, appear correct)
- No source code changes

## Test plan

- [ ] Verify no remaining references to `--port`, `--pp-ca-key`, `--client-cert`, `--oidc-username-claim` (except in "What's NOT supported" sections)
- [ ] Spot-check flag names against `src/server/config.ts`
- [ ] Review principal-propagation-setup.md rewrite matches actual BTP Destination implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)