### PR TITLE
fix: improve LLM guidance for SAPSearch empty results and SAPContext CDS usage

### DIFF
--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -616,6 +616,14 @@ async function handleSAPSearch(client: AdtClient, args: Record<string, unknown>)
   }
 
   const results = await client.searchObject(query, maxResults);
+  if (Array.isArray(results) && results.length === 0) {
+    return textResult(
+      '[]' +
+        '\n\nNo objects found. If searching for custom objects, try Z* or Y* prefixes (e.g., "Z*ESTIM*"). ' +
+        'For German SAP systems, try German business terms. ' +
+        'If you already found objects in a package, use SAPRead with type=DEVC to list all package contents instead of more searches.',
+    );
+  }
   return textResult(JSON.stringify(results, null, 2));
 }
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -128,7 +128,10 @@ const SAPCONTEXT_DESC_ONPREM =
   'Filtering: SAP standard objects (CL_ABAP_*, IF_ABAP_*, CX_SY_*) are excluded — the LLM already knows standard SAP APIs. ' +
   'Custom objects (Z*, Y*) are prioritized.\n\n' +
   'Use SAPContext BEFORE writing code that modifies or extends existing objects. ' +
-  'Use SAPRead to get the full source of the target object, then SAPContext to understand its dependencies.';
+  'Use SAPRead to get the full source of the target object, then SAPContext to understand its dependencies.\n\n' +
+  'For CDS analysis: Use SAPContext instead of reading each view in the dependency chain individually. ' +
+  'A single SAPContext call on a consumption view (e.g., ZC_*) returns all dependent interface views, tables, and associations — ' +
+  'replacing 5-10 separate SAPRead calls. Only use targeted SAPRead for metadata extensions (DDLX) or service bindings (SRVB) that SAPContext does not cover.';
 
 const SAPCONTEXT_DESC_BTP =
   'Get compressed dependency context for an ABAP object or CDS entity (BTP ABAP Environment). Returns only the public API contracts ' +
@@ -141,7 +144,10 @@ const SAPCONTEXT_DESC_BTP =
   "Each dependency's full source is included. Essential for CDS unit test generation.\n\n" +
   'On BTP: released SAP objects (CL_ABAP_*, IF_ABAP_*) are included since they form the primary development API surface. ' +
   'Custom objects (Z*, Y*) are also included.\n\n' +
-  'Use SAPContext BEFORE writing code that modifies or extends existing objects.';
+  'Use SAPContext BEFORE writing code that modifies or extends existing objects.\n\n' +
+  'For CDS analysis: Use SAPContext instead of reading each view in the dependency chain individually. ' +
+  'A single SAPContext call on a consumption view returns all dependent interface views, tables, and associations — ' +
+  'replacing 5-10 separate SAPRead calls.';
 
 // ─── SAPQuery ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add a hint to empty SAPSearch object results suggesting Z*/Y* prefixes, German business terms, and `SAPRead DEVC` as alternatives to repeated search attempts
- Enhance SAPContext tool descriptions (both onprem and BTP) to explicitly recommend using it for CDS dependency chains instead of multiple individual SAPRead calls

## Test plan
- [x] Build passes
- [x] All 1146 unit tests pass
- [ ] Verify empty SAPSearch results include the new hint text
- [ ] Verify SAPContext tool description includes CDS analysis guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)