### PR TITLE
feat: add research-first RAP service generation skill

### DIFF
--- a/.claude/commands/generate-rap-service-researched.md
+++ b/.claude/commands/generate-rap-service-researched.md
@@ -190,11 +190,17 @@ search("RAP value help CDS annotation")
 search("RAP access control authorization")
 ```
 
-**SAP Notes for known issues or recommendations:**
+**SAP standard naming conventions for RAP artifacts:**
 
 ```
-sap_notes_search(q="RAP <specific_topic>")
+search("SAP RAP naming conventions CDS view entity behavior definition")
 ```
+
+```
+search("SAP ABAP development naming guidelines RAP artifacts prefix")
+```
+
+Research the official SAP-recommended naming schema for all RAP artifacts (tables, CDS views, BDEFs, service definitions, behavior pools, etc.). This becomes the default suggestion in Phase 2 — the user can override with system-specific conventions only if they explicitly prefer that.
 
 ### 1f. Research Summary
 
@@ -234,38 +240,54 @@ Based on research findings, ask targeted questions. Only ask what research could
 
 ### Architecture Questions
 
-Present options with a recommendation based on what was found:
+For each question, lead with a concrete recommendation based on the user's spec and research, explain why, then list alternatives with upsides/downsides. **These are foundational decisions — changing them after creation requires rebuilding most artifacts.** Make sure the user understands the trade-offs.
 
 **1. Implementation scenario**
-> Based on [finding], I recommend **managed** / **unmanaged**.
-> - **Managed**: Framework handles CRUD, you focus on business logic (determinations, validations). Best for new greenfield BOs.
-> - **Unmanaged**: You control all persistence. Needed when wrapping existing BAPIs/FMs or complex legacy logic.
-> - **Managed with unmanaged save**: Managed BO but custom save sequence (e.g., calling a BAPI in the save phase).
+> Based on your spec [quote relevant part], I would suggest **managed** because [reason — e.g., "this is a new greenfield BO with no existing persistence logic to wrap"].
 >
-> Which approach fits your needs?
+> Your options:
+> | Option | Upside | Downside |
+> |--------|--------|----------|
+> | **Managed** | Framework handles CRUD automatically, less code, faster to build | Less control over persistence, must follow RAP conventions |
+> | **Unmanaged** | Full control over persistence, can wrap existing BAPIs/FMs | You must implement all CRUD yourself, significantly more code |
+> | **Managed with unmanaged save** | Managed convenience + custom save (e.g., call BAPI in save phase) | More complex, need to understand save sequence |
+>
+> Does managed fit, or do you need to wrap existing logic?
 
 **2. Entity structure**
-> Your requirement suggests [single entity / parent-child hierarchy / multiple related entities].
-> - **Single root entity**: Simple, one table, one CDS stack. Good for flat data.
-> - **Compositions**: Parent-child (e.g., Order → LineItems). Draft-enabled compositions require draft tables for each entity.
-> - **Associations**: Related but independent entities (e.g., Order → Customer lookup).
+> Based on your spec [quote relevant part], I would suggest **[single entity / compositions]** because [reason — e.g., "your description mentions line items which is a classic parent-child pattern"].
 >
-> How many entities do you need, and what are their relationships?
+> Your options:
+> | Option | Upside | Downside |
+> |--------|--------|----------|
+> | **Single root entity** | Simplest, one table, one CDS stack | Cannot model hierarchies |
+> | **Compositions (parent → child)** | Models real business hierarchies (Order → Items), draft cascades to children | Each child entity needs its own table + draft table + CDS stack |
+> | **Associations** | Lightweight references to related entities (e.g., lookup to Customer) | No lifecycle dependency, no cascade delete |
+>
+> How many entities do you need and what are their relationships?
 
 **3. Key strategy**
-> Existing code uses [UUID / semantic keys / number ranges].
-> - **UUID (internal early numbering)**: Auto-generated, no user input needed. Simplest.
-> - **Semantic key**: User-provided (e.g., OrderNumber). Needs uniqueness validation.
-> - **Number range**: Server-assigned sequential numbers. Needs number range object.
+> Based on your spec, I would suggest **UUID (internal early numbering)** because [reason — e.g., "there's no mention of a user-visible business key, and UUID is the simplest and most reliable approach"].
+>
+> Your options:
+> | Option | Upside | Downside |
+> |--------|--------|----------|
+> | **UUID (internal early numbering)** | Auto-generated, no user input, no collision risk, simplest | Keys are not human-readable |
+> | **Semantic key** | User-provided meaningful key (e.g., OrderNumber) | Needs uniqueness validation, user must know the key upfront |
+> | **Number range** | Server-assigned sequential numbers, human-readable | Needs number range object configuration, more setup |
 >
 > Which key strategy fits your use case?
 
-**4. Draft handling**
-> [BTP systems typically use draft / On-prem: depends on Fiori Elements need].
-> - **With draft**: Users can save incomplete data, resume editing later. Required for Fiori Elements "edit" workflow.
-> - **Without draft**: Direct save only. Simpler, fewer artifacts.
+**4. OData version & draft**
+> I recommend **OData V4 with draft** because V4 is the current SAP standard for Fiori Elements applications and draft is the default interaction pattern for V4 transactional services.
 >
-> Do users need to save work-in-progress?
+> **Important context on OData V2 vs V4 and draft:**
+> - **V4 + draft** (recommended default): Standard for Fiori Elements List Report / Object Page. Draft is essentially built-in — V4 transactional services expect draft.
+> - **V2 without draft**: Better suited for non-draft transactional apps and SAP UI5 freestyle applications. V2 is more common in the freestyle world and has broader legacy support.
+> - **V4 without draft**: Not a standard pattern — V4 transactional services are designed around draft. Possible for read-only analytical services, but not for CRUD apps.
+> - **V2 with draft**: Supported but less common. Use only if V2 is required and draft is needed.
+>
+> Unless your requirements specifically suggest a non-draft or freestyle app, V4 with draft is the right choice. Is there any reason to deviate?
 
 ### Data Model Questions
 
@@ -289,29 +311,37 @@ Present options with a recommendation based on what was found:
 ### Naming Questions
 
 **8. Entity naming**
-> Based on existing conventions on your system [`<pattern found>`], I propose:
-> | Artifact | Name |
-> |----------|------|
-> | Table entity | `Z<ENTITY>_D` |
-> | Interface view | `ZI_<Entity>` |
-> | Projection view | `ZC_<Entity>` |
-> | ... | ... |
+> I'm using the **SAP-recommended naming schema** for RAP artifacts [as researched in Phase 1e]:
 >
-> Does this align with your standards? Any name changes?
+> | Artifact | SAP Naming Schema | Proposed Name |
+> |----------|-------------------|---------------|
+> | Database table | `Z<ENTITY>_D` | `Z<ENTITY>_D` |
+> | Interface CDS view | `ZI_<Entity>` | `ZI_<Entity>` |
+> | Projection CDS view | `ZC_<Entity>` | `ZC_<Entity>` |
+> | Interface BDEF | `ZI_<Entity>` | `ZI_<Entity>` |
+> | Projection BDEF | `ZC_<Entity>` | `ZC_<Entity>` |
+> | Metadata extension | `ZC_<Entity>` | `ZC_<Entity>` |
+> | Service definition | `ZSD_<Entity>` | `ZSD_<Entity>` |
+> | Service binding | `ZSB_<Entity>_V4` | `ZSB_<Entity>_V4` |
+> | Behavior pool | `ZBP_I_<Entity>` | `ZBP_I_<Entity>` |
+> | Draft table | `Z<ENTITY>_DD` | `Z<ENTITY>_DD` |
+>
+> [If different patterns were found on the system]: Note: I found existing RAP projects on your system using a different convention (`<pattern found>`). I'm defaulting to SAP standard naming, but if you prefer to match the existing system-wide convention, or use a completely different one, let me know.
+>
+> Any name changes?
 
 ### UI / Service Questions
 
-**9. OData version**
-> [V4 is recommended / V2 if Fiori Launchpad on older system].
-> Which OData version?
+**9. Fiori Elements frontend**
+> Will this service be consumed by a **Fiori Elements** app (auto-generated UI from annotations)?
+>
+> If yes, the metadata extension (DDLX) and UI annotations in the plan will be optimized for Fiori Elements List Report + Object Page (the most common pattern).
+>
+> **Note**: ARC-1 currently does not generate the Fiori Elements frontend application itself — only the backend OData service with proper annotations. The Fiori app can be generated from ADT ("Create Fiori Project..." on the service binding) or via the SAP Fiori tools in VS Code. The plan will include guidance on this as a follow-up step.
+>
+> If no (freestyle UI5 app or non-UI consumer), we can simplify the annotations.
 
-**10. UI layout preferences**
-> For Fiori Elements, which layout pattern?
-> - **List Report + Object Page** (most common): Table view → click row → detail page
-> - **Worklist**: Simple table view, no object page
-> - **Analytical List Page**: For reporting/analytics use cases
-
-**11. Searchable fields**
+**10. Searchable fields**
 > Which fields should be searchable (appear in the search bar)?
 
 ### Business Logic Questions (if applicable)
@@ -375,7 +405,7 @@ Create a comprehensive design table:
 | 7 | BDEF | ZC_<Entity> | Projection behavior definition | #5, #6 |
 | 8 | DDLX | ZC_<Entity> | Metadata extension | #6 |
 | 9 | SRVD | ZSD_<Entity> | Service definition | #6 |
-| 10 | SRVB | ZSB_<Entity>_V4 | Service binding (manual) | #9 |
+| 10 | SRVB | ZSB_<Entity>_V4 | Service binding | #9 |
 
 ### Field Definitions
 | Field | DB Column | CDS Alias | Type | Annotations | Notes |
@@ -414,7 +444,7 @@ Create a comprehensive design table:
 
 ### 3b. Present Plan for Approval
 
-Present the plan clearly and ask:
+Present the plan clearly and ask. **Emphasize that changes after creation are significantly harder:**
 
 > **Implementation Plan Ready**
 >
@@ -422,13 +452,16 @@ Present the plan clearly and ask:
 >
 > [Show the Artifact Stack table and Field Definitions table]
 >
+> **⚠️ Important: Please review carefully before approving.** Once the artifacts are created on the SAP system, changing fundamental decisions (managed vs. unmanaged, key strategy, entity structure, draft yes/no) requires deleting and recreating most artifacts. It is **much easier to change the plan now** than to restructure after creation. If anything is unclear or you're unsure about a decision, ask now.
+>
 > **Please review:**
 > 1. Are the artifact names correct?
 > 2. Are the fields complete and correctly typed?
 > 3. Is the architecture (managed/draft/keys) what you need?
-> 4. Any changes before I start creating?
+> 4. Any questions about the design decisions?
+> 5. Any changes before I start creating?
 >
-> **Say "approve" to proceed, or tell me what to change.**
+> **Say "approve" to proceed, or ask questions / tell me what to change.**
 
 Do NOT proceed until the user explicitly approves.
 
@@ -520,28 +553,35 @@ Fix any issues found. Re-activate if needed.
 
 ### 4e. Service Binding
 
-ARC-1 cannot create service bindings (SRVB) via ADT API. Instruct the user:
+Create the service binding:
 
-> **Manual step required: Create Service Binding**
->
-> In ADT:
-> 1. Right-click package → New → Other ABAP Repository Object
-> 2. Search "Service Binding" → Next
-> 3. Name: `ZSB_<ENTITY>_V4`
-> 4. Description: `<Entity> OData V4 Service`
-> 5. Binding Type: OData V4 - UI
-> 6. Service Definition: `ZSD_<ENTITY>`
-> 7. Finish → Activate
+```
+SAPWrite(action="create", type="SRVB", name="ZSB_<entity>_V4", package="<package>", transport="<transport>", source="<srvb_source>")
+```
 
-After the user creates and activates the binding:
+Activate and publish the service binding:
+
+```
+SAPActivate(type="SRVB", name="ZSB_<entity>_V4")
+```
 
 ```
 SAPActivate(action="publish_srvb", name="ZSB_<entity>_V4")
 ```
 
+Verify the publish status and service URL:
+
 ```
 SAPRead(type="SRVB", name="ZSB_<entity>_V4")
 ```
+
+### 4f. Preview the Service
+
+After the service binding is published, the RAP service can be previewed directly. In ADT, the user can open the service binding, select an entity (e.g., "Root"), and click "Preview..." to launch the Fiori Elements preview in a browser. This generates a preview URL via the ADT business services endpoint.
+
+Inform the user:
+
+> **Your service is live!** Open the service binding `ZSB_<ENTITY>_V4` in ADT, select the root entity, and click "Preview..." to see the auto-generated Fiori Elements List Report + Object Page.
 
 ---
 
@@ -569,7 +609,8 @@ RAP Service Generation Complete!
   [x] Metadata extension: ZC_<Entity>
   [x] Service definition: ZSD_<Entity>
   [x] Behavior pool class: ZBP_I_<Entity>
-  [ ] Service binding: ZSB_<Entity>_V4 → create manually (see above)
+  [x] Service binding: ZSB_<Entity>_V4
+  [x] Service binding published
 
 ## Quality Checks
   [x] All artifacts activated successfully
@@ -590,16 +631,15 @@ Offer follow-up actions based on the plan:
 ```
 ## Recommended Next Steps
 
-1. **Create service binding** (manual step above)
-2. **Publish and test** the service in Fiori Elements preview
-3. **Add business logic** → use `generate-rap-logic` skill:
+1. **Preview the service** in Fiori Elements (ADT → Service Binding → select entity → Preview...)
+2. **Add business logic** → use `generate-rap-logic` skill:
    - Determinations: [list from plan]
    - Validations: [list from plan]
-4. **Add value helps** for reference fields
-5. **Add access control** (DCLS) for authorization
-6. **Add custom actions** if needed (e.g., Approve, Release)
-7. **Generate unit tests** → use `generate-abap-unit-test` skill
-8. **Add compositions** for child entities (if multi-entity scenario planned for Phase 2)
+3. **Add value helps** for reference fields
+4. **Add access control** (DCLS) for authorization
+5. **Add custom actions** if needed (e.g., Approve, Release)
+6. **Generate unit tests** → use `generate-abap-unit-test` skill
+7. **Add compositions** for child entities (if multi-entity scenario planned for Phase 2)
 ```
 
 ---

--- a/.claude/commands/generate-rap-service-researched.md
+++ b/.claude/commands/generate-rap-service-researched.md
@@ -190,17 +190,7 @@ search("RAP value help CDS annotation")
 search("RAP access control authorization")
 ```
 
-**SAP standard naming conventions for RAP artifacts:**
-
-```
-search("SAP RAP naming conventions CDS view entity behavior definition")
-```
-
-```
-search("SAP ABAP development naming guidelines RAP artifacts prefix")
-```
-
-Research the official SAP-recommended naming schema for all RAP artifacts (tables, CDS views, BDEFs, service definitions, behavior pools, etc.). This becomes the default suggestion in Phase 2 — the user can override with system-specific conventions only if they explicitly prefer that.
+No need to research naming conventions at runtime — the official SAP naming schema is documented below in the "SAP Official Naming Conventions" reference section. Use it directly as the default.
 
 ### 1f. Research Summary
 
@@ -311,20 +301,20 @@ For each question, lead with a concrete recommendation based on the user's spec 
 ### Naming Questions
 
 **8. Entity naming**
-> I'm using the **SAP-recommended naming schema** for RAP artifacts [as researched in Phase 1e]:
+> I'm using the **official SAP naming conventions** (see reference section below). For an entity named e.g. `Travel`:
 >
-> | Artifact | SAP Naming Schema | Proposed Name |
-> |----------|-------------------|---------------|
-> | Database table | `Z<ENTITY>_D` | `Z<ENTITY>_D` |
-> | Interface CDS view | `ZI_<Entity>` | `ZI_<Entity>` |
-> | Projection CDS view | `ZC_<Entity>` | `ZC_<Entity>` |
-> | Interface BDEF | `ZI_<Entity>` | `ZI_<Entity>` |
-> | Projection BDEF | `ZC_<Entity>` | `ZC_<Entity>` |
-> | Metadata extension | `ZC_<Entity>` | `ZC_<Entity>` |
-> | Service definition | `ZSD_<Entity>` | `ZSD_<Entity>` |
-> | Service binding | `ZSB_<Entity>_V4` | `ZSB_<Entity>_V4` |
-> | Behavior pool | `ZBP_I_<Entity>` | `ZBP_I_<Entity>` |
-> | Draft table | `Z<ENTITY>_DD` | `Z<ENTITY>_DD` |
+> | Artifact | SAP Convention | Proposed Name |
+> |----------|---------------|---------------|
+> | Active persistence table | `A_` prefix | `ZA_TRAVEL` |
+> | Draft table | `D_` prefix | `ZD_TRAVEL` |
+> | Base/interface CDS view | `R_` or `I_` prefix, `TP` suffix | `ZR_TravelTP` |
+> | Projection CDS view | `C_` prefix | `ZC_Travel` |
+> | Interface BDEF | Same as root entity | `ZR_TravelTP` |
+> | Projection BDEF | Same as projection view | `ZC_Travel` |
+> | Metadata extension | Same as CDS entity it annotates | `ZC_Travel` |
+> | Service definition | `UI_` prefix (if UI service) | `ZUI_Travel` |
+> | Service binding | `UI_` prefix, `_O4` suffix | `ZUI_Travel_O4` |
+> | Behavior pool class | `BP_` prefix | `ZBP_R_TravelTP` |
 >
 > [If different patterns were found on the system]: Note: I found existing RAP projects on your system using a different convention (`<pattern found>`). I'm defaulting to SAP standard naming, but if you prefer to match the existing system-wide convention, or use a completely different one, let me know.
 >
@@ -703,3 +693,83 @@ This skill prioritizes **correctness and consistency** over speed. The extra res
 | `generate-abap-unit-test` | Follow-up — generate tests for the behavior pool |
 | `explain-abap-code` | Can be used during research to understand existing RAP projects found on the system |
 | `implement-feature` | For implementing non-RAP features in the arc-1 codebase itself |
+
+---
+
+## Reference: SAP Official Naming Conventions for RAP Artifacts
+
+Source: [SAP Help — Naming Conventions for Development Objects](https://help.sap.com/docs/ABAP_Cloud/f055b8bf582d4f34b91da667bc1fcce6/8b8f9d8f3cb948b2841d6045a255e503.html)
+
+### General Rule
+
+```
+[/<namespace>/][<prefix>]_<object_name>_[<suffix>]
+```
+
+- Use your own namespace reserved for your organization (Z* or Y* for customer objects)
+- The `/DMO/` namespace is reserved for SAP demo purposes only — never use it in productive development
+- Prefixes convey semantic differences between types of the same object kind
+- Suffixes add secondary differentiation (e.g., OData version, development guide variant)
+
+### ABAP Dictionary Objects
+
+| Object | Convention | Example (customer namespace) |
+|--------|-----------|------------------------------|
+| **Active persistence table** | `A_` prefix | `ZA_TRAVEL` |
+| **Draft table** | `D_` prefix | `ZD_TRAVEL` |
+
+### CDS Objects
+
+| Object | Convention | Notes | Example |
+|--------|-----------|-------|---------|
+| **Base/Root CDS view entity** | `R_` prefix | The base BO entity. Use `TP` suffix to indicate transactional processing relevance | `ZR_TravelTP` |
+| **Interface CDS view** | `I_` prefix | Reusable interface view layer (alternative to R_ in some patterns) | `ZI_Travel` |
+| **Projection CDS view** | `C_` prefix | `C` = consumption layer. If multiple projections exist, the name should represent the projection role | `ZC_Travel` |
+| **Extension include view** | `E_` prefix | For extensibility | `ZE_Travel` |
+| **Behavior definition** | Same name as root entity | BDEF always shares the name of the CDS view it belongs to | `ZR_TravelTP` (interface), `ZC_Travel` (projection) |
+| **Metadata extension** | Same name as CDS entity | If multiple extensions for one entity, add numbered suffix | `ZC_Travel`, `ZC_Travel_2` |
+
+### Business Services
+
+| Object | Convention | Notes | Example |
+|--------|-----------|-------|---------|
+| **Service definition** | No mandatory prefix | If not reused across UI/API, may use `UI_` or `API_` prefix | `ZUI_Travel` or `Z_Travel` |
+| **Service binding (UI)** | `UI_` prefix | For Fiori Elements / UI consumption | `ZUI_Travel_O4` |
+| **Service binding (Web API)** | `API_` prefix | For programmatic / integration consumption | `ZAPI_Travel_O4` |
+| **OData V2 suffix** | `_O2` | | `ZUI_Travel_O2` |
+| **OData V4 suffix** | `_O4` | | `ZUI_Travel_O4` |
+
+### Source Code Objects
+
+| Object | Convention | Notes | Example |
+|--------|-----------|-------|---------|
+| **Behavior pool class** | `BP_` prefix | Global class implementing BO behavior | `ZBP_R_TravelTP` |
+| **Local handler class** | `LHC_` prefix | Local class within behavior pool | `LHC_Travel_Create` |
+| **Local saver class** | `LSC_` prefix | Local class within behavior pool | `LSC_Travel` |
+
+### Complete Example: "Travel" Entity (V4, UI, Draft, Managed)
+
+| # | Object Type | SAP Naming | Name |
+|---|-------------|-----------|------|
+| 1 | Database table (active) | `A_` prefix | `ZA_TRAVEL` |
+| 2 | Database table (draft) | `D_` prefix | `ZD_TRAVEL` |
+| 3 | Base CDS view entity | `R_` prefix + `TP` suffix | `ZR_TravelTP` |
+| 4 | Projection CDS view | `C_` prefix | `ZC_Travel` |
+| 5 | Interface BDEF | = root entity name | `ZR_TravelTP` |
+| 6 | Projection BDEF | = projection view name | `ZC_Travel` |
+| 7 | Metadata extension | = projection view name | `ZC_Travel` |
+| 8 | Service definition | `UI_` prefix (optional) | `ZUI_Travel` |
+| 9 | Service binding | `UI_` prefix + `_O4` suffix | `ZUI_Travel_O4` |
+| 10 | Behavior pool class | `BP_` prefix | `ZBP_R_TravelTP` |
+
+### Notes on R_ vs I_ Prefix
+
+- **`R_`** (base/root view entity): Used in the SAP standard RAP development guides (managed, unmanaged, draft). This is the **current SAP recommendation** for new RAP development.
+- **`I_`** (interface view): Historically used and still common. Represents a reusable interface layer. Many existing tutorials and older projects use `I_` instead of `R_`.
+- Both are valid. Default to `R_` for new projects following SAP's latest guides. If existing code on the system uses `I_`, match that for consistency.
+
+### Notes on Table Naming
+
+- SAP uses `A_` and `D_` prefixes for active and draft tables respectively
+- Some older tutorials and community patterns use `_D` suffix for the table and `_DD` for draft — this is **not** the official SAP convention but is widely seen in practice
+- The SAP "OData UI Service from Scratch" wizard generates tables with these prefixes automatically

--- a/.claude/commands/generate-rap-service-researched.md
+++ b/.claude/commands/generate-rap-service-researched.md
@@ -1,0 +1,665 @@
+# Generate RAP OData Service — Research-First
+
+Generate a production-quality RAP OData service through deep system research, best-practice analysis, and iterative planning before writing a single line of code. This is the "measure twice, cut once" counterpart to the vibe-coding `generate-rap-service` skill.
+
+This skill produces an A+ implementation plan informed by the target SAP system's actual capabilities, existing code patterns, SAP documentation, and user requirements — then executes it only after explicit user approval.
+
+## When to Use This Skill vs. `generate-rap-service`
+
+| Use `generate-rap-service` (vibe code) | Use THIS skill (research-first) |
+|---|---|
+| Quick prototyping / proof of concept | Production-quality service |
+| Simple CRUD with standard patterns | Complex domain with specific requirements |
+| User knows exactly what they want | User has a high-level idea, needs guidance |
+| `$TMP` / throwaway package | Transportable / long-lived code |
+| Single root entity, managed, UUID | May need unmanaged, compositions, custom keys |
+
+## Input
+
+The user provides a natural language description of the business requirement. This can range from vague ("I need something to track maintenance orders") to detailed ("REST API for plant maintenance with equipment hierarchy, work orders, and time recording").
+
+Gather initial context — do NOT over-interview at this stage. Research will surface the right questions later.
+
+- **Business requirement** (required) — what the service should do
+- **Package** (optional — default: `$TMP`)
+- **Transport request** (optional — only if package is transportable)
+- **Any known constraints** (optional — e.g., "must use existing table ZMAINT_ORDER", "needs to integrate with PM module")
+
+If the user provides just a description, proceed directly to research. Questions come AFTER research, when you know enough to ask the right ones.
+
+---
+
+## Phase 1: Deep System Research
+
+Research the target system thoroughly before designing anything. Every finding informs the plan.
+
+### 1a. System Capabilities & Version
+
+Detect what the system supports — this determines available RAP features, syntax, and patterns.
+
+```
+SAPManage(action="features")
+```
+
+Extract and note:
+- **System type**: BTP ABAP Environment vs. On-Premise (and release level: 7.52, 7.54, 7.57, S/4HANA 2020+, etc.)
+- **ABAP language version**: Cloud (strict, released APIs only) vs. Standard (full ABAP)
+- **RAP support level**: Managed, unmanaged, abstract BOs? Draft support? Late numbering? Determination on modify vs. save?
+- **CDS capabilities**: View entities vs. classic views? Table entities? Metadata extensions? Access control?
+- **Available features**: ATC, syntax check, unit test runner, transport management
+
+### 1b. Existing RAP Projects — Pattern Mining
+
+Search for existing RAP artifacts to understand the system's established patterns. This is critical for consistency.
+
+```
+SAPSearch(query="BDEF Z*", maxResults=20)
+```
+
+```
+SAPSearch(query="SRVD Z*", maxResults=20)
+```
+
+```
+SAPSearch(query="SRVB Z*", maxResults=20)
+```
+
+If results are found, read 2-3 representative RAP stacks to extract the team's patterns:
+
+```
+SAPRead(type="BDEF", name="<found_bdef>")
+```
+
+```
+SAPRead(type="DDLS", name="<found_interface_view>")
+```
+
+```
+SAPRead(type="DDLS", name="<found_projection_view>")
+```
+
+```
+SAPRead(type="DDLX", name="<found_metadata_ext>")
+```
+
+```
+SAPContext(type="DDLS", name="<found_interface_view>")
+```
+
+From these, extract:
+- **Naming conventions**: What prefix pattern? `ZI_`/`ZC_`/`ZR_`? Entity suffix patterns? Table naming?
+- **Architecture style**: Managed vs. unmanaged? Draft enabled? `strict ( 2 )` or `strict`?
+- **Annotation patterns**: Which `@UI` annotation style? Header info pattern? Facet structure?
+- **Field naming**: CamelCase aliases? Underscore style? Abbreviation patterns?
+- **Admin field patterns**: Which timestamp/user field types are used? (`syuname` vs `abp_creation_user`, `timestampl` vs `abp_creation_tstmpl`)
+- **Key strategy**: UUID (`sysuuid_x16`)? Semantic keys? Number ranges?
+- **Behavior patterns**: Which determinations/validations are standard? Authorization pattern?
+- **Draft handling**: `with draft` present? Draft table naming? Draft actions included?
+- **OData version**: V2 or V4 bindings?
+
+### 1c. Existing Database Tables & Domain Objects
+
+If the user mentioned existing tables or business objects, read them:
+
+```
+SAPSearch(query="<mentioned_table_or_object>")
+```
+
+```
+SAPRead(type="TABL", name="<found_table>")
+```
+
+```
+SAPContext(type="TABL", name="<found_table>")
+```
+
+Also search for related SAP standard objects in the domain:
+
+```
+SAPSearch(query="<domain_keyword>", maxResults=10)
+```
+
+Check if there are existing CDS views or tables the new service should build on rather than duplicating data.
+
+### 1d. Code Guidelines & Quality Standards
+
+Check if the system has ATC configuration or custom check variants that indicate code quality standards:
+
+```
+SAPDiagnose(action="atc", type="CLAS", name="<any_existing_class>", variant="DEFAULT")
+```
+
+If existing RAP classes were found in 1b, run lint on one to understand the baseline:
+
+```
+SAPLint(type="CLAS", name="<found_bp_class>")
+```
+
+This reveals what lint rules and strictness levels are enforced.
+
+### 1e. Best Practices Research — SAP Documentation
+
+Use the SAP documentation MCP server to research current RAP best practices relevant to the user's request.
+
+**Core RAP patterns:**
+
+```
+search("RAP managed business object implementation best practices")
+```
+
+```
+search("RAP behavior definition managed scenario CDS view entity")
+```
+
+**Domain-specific patterns** (based on user's business requirement):
+
+```
+search("<business_domain> RAP example SAP")
+```
+
+For example, if the user wants a travel app:
+```
+search("RAP travel booking managed scenario example")
+```
+
+**Architecture decisions:**
+
+```
+search("RAP managed vs unmanaged scenario when to use")
+```
+
+```
+search("RAP draft handling best practices Fiori Elements")
+```
+
+```
+search("RAP compositions parent child entity")
+```
+
+**If the requirement suggests specific patterns:**
+
+```
+search("RAP custom actions determination validation")
+```
+
+```
+search("RAP value help CDS annotation")
+```
+
+```
+search("RAP access control authorization")
+```
+
+**SAP Notes for known issues or recommendations:**
+
+```
+sap_notes_search(q="RAP <specific_topic>")
+```
+
+### 1f. Research Summary
+
+Before proceeding, compile a structured research summary. Present this to the user:
+
+```
+## System Research Summary
+
+### System Profile
+- Type: [BTP / On-Prem S/4HANA 20XX / ECC with ABAP Platform]
+- ABAP Version: [Cloud / Standard ABAP 7.5X]
+- RAP Support: [Full managed+draft / Managed only / Basic]
+
+### Existing Code Patterns Found
+- Naming: [e.g., "ZI_ prefix for interface views, ZC_ for projections, Z prefix + _D suffix for tables"]
+- Architecture: [e.g., "All existing BOs use managed with draft, strict(2), UUID keys"]
+- Field Style: [e.g., "CamelCase aliases, abp_ admin field types on BTP"]
+- Annotation Style: [e.g., "Metadata extensions for all UI annotations, facet-based layout"]
+- N existing RAP services found: [list names]
+
+### Domain Research
+- Related existing objects: [tables, views, classes found]
+- SAP standard objects in domain: [relevant standard CDS views, BAPIs]
+- Best practices from docs: [key findings]
+
+### Quality Baseline
+- ATC variant: [DEFAULT / custom]
+- Lint findings: [clean / N issues on existing code]
+- Strictness: [strict(2) / strict / none]
+```
+
+---
+
+## Phase 2: Clarifying Questions
+
+Based on research findings, ask targeted questions. Only ask what research couldn't answer. Group questions by category and provide recommendations based on findings.
+
+### Architecture Questions
+
+Present options with a recommendation based on what was found:
+
+**1. Implementation scenario**
+> Based on [finding], I recommend **managed** / **unmanaged**.
+> - **Managed**: Framework handles CRUD, you focus on business logic (determinations, validations). Best for new greenfield BOs.
+> - **Unmanaged**: You control all persistence. Needed when wrapping existing BAPIs/FMs or complex legacy logic.
+> - **Managed with unmanaged save**: Managed BO but custom save sequence (e.g., calling a BAPI in the save phase).
+>
+> Which approach fits your needs?
+
+**2. Entity structure**
+> Your requirement suggests [single entity / parent-child hierarchy / multiple related entities].
+> - **Single root entity**: Simple, one table, one CDS stack. Good for flat data.
+> - **Compositions**: Parent-child (e.g., Order → LineItems). Draft-enabled compositions require draft tables for each entity.
+> - **Associations**: Related but independent entities (e.g., Order → Customer lookup).
+>
+> How many entities do you need, and what are their relationships?
+
+**3. Key strategy**
+> Existing code uses [UUID / semantic keys / number ranges].
+> - **UUID (internal early numbering)**: Auto-generated, no user input needed. Simplest.
+> - **Semantic key**: User-provided (e.g., OrderNumber). Needs uniqueness validation.
+> - **Number range**: Server-assigned sequential numbers. Needs number range object.
+>
+> Which key strategy fits your use case?
+
+**4. Draft handling**
+> [BTP systems typically use draft / On-prem: depends on Fiori Elements need].
+> - **With draft**: Users can save incomplete data, resume editing later. Required for Fiori Elements "edit" workflow.
+> - **Without draft**: Direct save only. Simpler, fewer artifacts.
+>
+> Do users need to save work-in-progress?
+
+### Data Model Questions
+
+**5. Fields and types**
+> Based on your description, I've identified these business fields:
+> | Field | Proposed Type | Notes |
+> |-------|--------------|-------|
+> | ... | ... | ... |
+>
+> Are these correct? Any fields to add, remove, or change types?
+
+**6. Value helps / fixed values**
+> Which fields need dropdowns or value helps?
+> - Status field → fixed values (e.g., New/Open/Completed)?
+> - Reference fields → value help from other CDS views?
+
+**7. Existing data sources**
+> [If tables/views were found in research]
+> Should this service read from existing table `<TABLE>` or create a new table?
+
+### Naming Questions
+
+**8. Entity naming**
+> Based on existing conventions on your system [`<pattern found>`], I propose:
+> | Artifact | Name |
+> |----------|------|
+> | Table entity | `Z<ENTITY>_D` |
+> | Interface view | `ZI_<Entity>` |
+> | Projection view | `ZC_<Entity>` |
+> | ... | ... |
+>
+> Does this align with your standards? Any name changes?
+
+### UI / Service Questions
+
+**9. OData version**
+> [V4 is recommended / V2 if Fiori Launchpad on older system].
+> Which OData version?
+
+**10. UI layout preferences**
+> For Fiori Elements, which layout pattern?
+> - **List Report + Object Page** (most common): Table view → click row → detail page
+> - **Worklist**: Simple table view, no object page
+> - **Analytical List Page**: For reporting/analytics use cases
+
+**11. Searchable fields**
+> Which fields should be searchable (appear in the search bar)?
+
+### Business Logic Questions (if applicable)
+
+**12. Validations needed**
+> Which business rules should be enforced?
+> - Mandatory fields?
+> - Cross-field validations (e.g., start date < end date)?
+> - Status transition rules?
+
+**13. Determinations needed**
+> Which values should be auto-calculated?
+> - Default values on create?
+> - Derived fields (e.g., total = price × quantity)?
+
+**14. Custom actions**
+> Beyond standard CRUD, do you need actions like "Approve", "Release", "Cancel"?
+
+**Important**: Don't ask all 14 questions. Research should have answered many of them. Only ask what's genuinely needed. Group remaining questions and present them concisely. Provide your recommendations for each.
+
+Wait for the user to answer before proceeding.
+
+---
+
+## Phase 3: Implementation Plan
+
+Based on research + user answers, create a detailed implementation plan.
+
+### 3a. Design the Complete Artifact Stack
+
+Create a comprehensive design table:
+
+```
+## RAP Service Implementation Plan: <Service Name>
+
+### Architecture Decisions
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Scenario | Managed / Unmanaged | [why] |
+| Draft | Yes / No | [why] |
+| Key strategy | UUID / Semantic / NumberRange | [why] |
+| OData version | V4 / V2 | [why] |
+| Strict mode | strict(2) / strict | [system dependent] |
+| Admin fields | syuname+timestampl / abp_* types | [system dependent] |
+
+### Entity Model
+| Entity | Role | Key Fields | Business Fields |
+|--------|------|-----------|-----------------|
+| <Root> | Root entity | key_uuid | field1, field2, ... |
+| <Child> | Composition of Root | key_uuid, parent_uuid | field_a, field_b, ... |
+
+### Artifact Stack
+| # | Type | Name | Description | Dependencies |
+|---|------|------|-------------|-------------|
+| 1 | DDLS | <table> | Database table entity | — |
+| 2 | DDLS | <draft_table> | Draft table (if draft) | — |
+| 3 | DDLS | ZI_<Entity> | Interface CDS view | #1 |
+| 4 | CLAS | ZBP_I_<Entity> | Behavior pool class | #3 |
+| 5 | BDEF | ZI_<Entity> | Interface behavior definition | #3, #4 |
+| 6 | DDLS | ZC_<Entity> | Projection CDS view | #3 |
+| 7 | BDEF | ZC_<Entity> | Projection behavior definition | #5, #6 |
+| 8 | DDLX | ZC_<Entity> | Metadata extension | #6 |
+| 9 | SRVD | ZSD_<Entity> | Service definition | #6 |
+| 10 | SRVB | ZSB_<Entity>_V4 | Service binding (manual) | #9 |
+
+### Field Definitions
+| Field | DB Column | CDS Alias | Type | Annotations | Notes |
+|-------|-----------|-----------|------|-------------|-------|
+| Key | key_uuid | KeyUuid | sysuuid_x16 | @Semantics | Internal numbering |
+| ... | ... | ... | ... | ... | ... |
+
+### Behavior Definition Spec
+- Scenario: managed
+- Draft: with draft / without draft
+- ETag: LocalLastChangedAt
+- Lock: master [total etag LastChangedAt]
+- Numbering: managed (KeyUuid)
+- Read-only fields: KeyUuid, CreatedBy, CreatedAt, LastChangedBy, LastChangedAt, LocalLastChangedAt
+- Draft actions: Resume, Edit, Activate (optimized), Discard, Prepare
+- Determinations (Phase 1): [list with triggers]
+- Validations (Phase 1): [list with triggers]
+- Custom actions (Phase 1): [list or "none — add later"]
+
+### UI Annotations Spec
+- Header: typeName="<Entity>", title=<MainField>, description=<SecondaryField>
+- Facets: [list facet structure]
+- List columns: [ordered list with position, importance]
+- Selection fields: [filter bar fields]
+- Search fields: [searchable fields]
+
+### Naming Convention Used
+<Document which convention was followed and why — matches existing code / SAP standard / user preference>
+
+### Quality Checks Planned
+- Lint validation before each write (automatic via arc-1)
+- Syntax check after each activation
+- ATC check after full stack activation
+- [If behavior logic]: Unit test skeleton
+```
+
+### 3b. Present Plan for Approval
+
+Present the plan clearly and ask:
+
+> **Implementation Plan Ready**
+>
+> I've designed a [managed/unmanaged] RAP service with [N] entities, [with/without] draft, using [naming convention].
+>
+> [Show the Artifact Stack table and Field Definitions table]
+>
+> **Please review:**
+> 1. Are the artifact names correct?
+> 2. Are the fields complete and correctly typed?
+> 3. Is the architecture (managed/draft/keys) what you need?
+> 4. Any changes before I start creating?
+>
+> **Say "approve" to proceed, or tell me what to change.**
+
+Do NOT proceed until the user explicitly approves.
+
+---
+
+## Phase 4: Implementation
+
+After approval, create the artifacts. Use batch creation when possible.
+
+### 4a. Batch Creation (Preferred)
+
+If the system supports it and the artifact stack is straightforward:
+
+```
+SAPWrite(action="batch_create", objects=[
+  {type: "DDLS", name: "<table>", description: "<desc>", source: "<ddl>"},
+  {type: "DDLS", name: "ZI_<entity>", description: "<desc>", source: "<ddl>"},
+  {type: "DDLS", name: "ZC_<entity>", description: "<desc>", source: "<ddl>"},
+  {type: "BDEF", name: "ZI_<entity>", description: "<desc>", source: "<bdef>"},
+  {type: "BDEF", name: "ZC_<entity>", description: "<desc>", source: "<bdef>"},
+  {type: "DDLX", name: "ZC_<entity>", description: "<desc>", source: "<ddlx>"},
+  {type: "SRVD", name: "ZSD_<entity>", description: "<desc>", source: "<srvd>"},
+  {type: "CLAS", name: "ZBP_I_<entity>", description: "<desc>", source: "<class>"}
+], package="<package>", transport="<transport>")
+```
+
+Objects are created in array order — put dependencies first.
+
+### 4b. Sequential Fallback
+
+If batch creation fails or the stack is complex (compositions, multiple entities), create sequentially following the dependency order from the plan:
+
+1. **Table entity/entities** → Create + Activate each
+2. **Draft table(s)** (if draft) → Create + Activate each
+3. **Interface CDS view(s)** → Create + Activate each
+4. **Behavior pool class(es)** → Create + Activate
+5. **Interface behavior definition(s)** → Create (do NOT activate individually — depends on class)
+6. **Projection CDS view(s)** → Create + Activate
+7. **Projection behavior definition(s)** → Create (do NOT activate individually)
+8. **Metadata extension(s)** → Create + Activate
+9. **Service definition** → Create + Activate
+
+After all artifacts are created, batch activate the interdependent ones:
+
+```
+SAPActivate(objects=[
+  {type: "CLAS", name: "ZBP_I_<entity>"},
+  {type: "BDEF", name: "ZI_<entity>"},
+  {type: "BDEF", name: "ZC_<entity>"}
+])
+```
+
+### 4c. Source Code Templates
+
+Use the source code templates from the plan. Adapt them based on research findings:
+
+- **BTP systems**: Use `abp_*` admin field types, ABAP Cloud syntax, `strict ( 2 )`
+- **On-Prem systems**: Use `syuname`/`timestampl` types, classic or Cloud syntax depending on what existing code uses
+- **Follow existing patterns**: If existing RAP projects use a specific annotation style or field naming pattern, match it exactly
+- **Draft**: Include draft table, draft actions in interface BDEF, `use draft` in projection BDEF
+
+### 4d. Post-Creation Validation
+
+After all artifacts are created and activated:
+
+1. **Syntax check** the behavior pool:
+   ```
+   SAPDiagnose(action="syntax", type="CLAS", name="ZBP_I_<entity>")
+   ```
+
+2. **ATC check** the full stack (if ATC is available):
+   ```
+   SAPDiagnose(action="atc", type="BDEF", name="ZI_<entity>")
+   ```
+
+3. **Read back** key artifacts to confirm they're correct:
+   ```
+   SAPRead(type="BDEF", name="ZI_<entity>")
+   SAPRead(type="DDLS", name="ZI_<entity>")
+   SAPRead(type="SRVD", name="ZSD_<entity>")
+   ```
+
+4. **Lint check** the behavior pool:
+   ```
+   SAPLint(type="CLAS", name="ZBP_I_<entity>")
+   ```
+
+Fix any issues found. Re-activate if needed.
+
+### 4e. Service Binding
+
+ARC-1 cannot create service bindings (SRVB) via ADT API. Instruct the user:
+
+> **Manual step required: Create Service Binding**
+>
+> In ADT:
+> 1. Right-click package → New → Other ABAP Repository Object
+> 2. Search "Service Binding" → Next
+> 3. Name: `ZSB_<ENTITY>_V4`
+> 4. Description: `<Entity> OData V4 Service`
+> 5. Binding Type: OData V4 - UI
+> 6. Service Definition: `ZSD_<ENTITY>`
+> 7. Finish → Activate
+
+After the user creates and activates the binding:
+
+```
+SAPActivate(action="publish_srvb", name="ZSB_<entity>_V4")
+```
+
+```
+SAPRead(type="SRVB", name="ZSB_<entity>_V4")
+```
+
+---
+
+## Phase 5: Verification & Summary
+
+### 5a. Final Verification Checklist
+
+```
+RAP Service Generation Complete!
+
+## Architecture
+- Scenario: [managed/unmanaged]
+- Draft: [enabled/disabled]
+- Key strategy: [UUID/semantic/number range]
+- OData version: [V4/V2]
+- Followed conventions from: [existing code / SAP standard]
+
+## Created Artifacts
+  [x] Database table entity: <table_name>
+  [x] Draft table entity: <draft_table> (if applicable)
+  [x] Interface CDS view: ZI_<Entity>
+  [x] Interface behavior definition: ZI_<Entity>
+  [x] Projection CDS view: ZC_<Entity>
+  [x] Projection behavior definition: ZC_<Entity>
+  [x] Metadata extension: ZC_<Entity>
+  [x] Service definition: ZSD_<Entity>
+  [x] Behavior pool class: ZBP_I_<Entity>
+  [ ] Service binding: ZSB_<Entity>_V4 → create manually (see above)
+
+## Quality Checks
+  [x] All artifacts activated successfully
+  [x] Syntax check: clean
+  [x] Lint check: clean
+  [x] ATC check: [clean / N findings noted]
+
+## Consistency with Existing Code
+  [x] Naming matches existing convention: [pattern]
+  [x] Annotation style matches: [pattern]
+  [x] Admin fields match: [pattern]
+```
+
+### 5b. Next Steps
+
+Offer follow-up actions based on the plan:
+
+```
+## Recommended Next Steps
+
+1. **Create service binding** (manual step above)
+2. **Publish and test** the service in Fiori Elements preview
+3. **Add business logic** → use `generate-rap-logic` skill:
+   - Determinations: [list from plan]
+   - Validations: [list from plan]
+4. **Add value helps** for reference fields
+5. **Add access control** (DCLS) for authorization
+6. **Add custom actions** if needed (e.g., Approve, Release)
+7. **Generate unit tests** → use `generate-abap-unit-test` skill
+8. **Add compositions** for child entities (if multi-entity scenario planned for Phase 2)
+```
+
+---
+
+## Error Recovery
+
+### If Research Finds No Existing RAP Projects
+
+This is fine — the system may be new to RAP. Fall back to SAP standard naming conventions and best practices from documentation. Note this in the plan:
+
+> "No existing RAP projects found on system. Using SAP standard naming conventions and current best practices from documentation."
+
+### If System Doesn't Support Required Features
+
+If research reveals the system lacks a feature the user needs (e.g., draft on old on-prem, table entities pre-7.55):
+
+1. Inform the user of the limitation
+2. Propose an alternative (e.g., classic DDIC table instead of table entity, without draft)
+3. Adjust the plan accordingly
+
+### If Batch Creation Fails
+
+Fall back to sequential creation (Phase 4b). Report which objects succeeded and which failed. Fix the failing object and retry.
+
+### Common Issues
+
+| Error | Cause | Fix |
+|---|---|---|
+| Object already exists | Name collision | Search existing object, propose different name or offer to update |
+| Feature not supported | System version too old | Adapt plan to available features |
+| Activation error | Dependency order wrong | Use batch activation or sequential in dependency order |
+| Lint blocks write | Code doesn't match lint rules | Adjust generated code to pass lint, or check if lint config is too strict |
+| BDEF syntax error | Wrong field aliases or entity references | Cross-check CDS aliases with BDEF field references |
+
+---
+
+## Notes
+
+### Philosophy
+
+This skill prioritizes **correctness and consistency** over speed. The extra research time (5-10 minutes) pays off by:
+- Avoiding naming conflicts with existing code
+- Following established team conventions automatically
+- Catching system limitations before hitting errors
+- Producing code that looks like it belongs in the codebase
+- Giving the user confidence in the architecture before committing
+
+### What This Skill Does NOT Do (yet)
+
+- **Multi-entity compositions** in a single run (plan them, create root entity, suggest Phase 2)
+- **Unmanaged save** implementation (plan it, implement the managed wrapper, note the save handler as a follow-up)
+- **Custom CDS functions/actions** (plan them, implement standard CRUD, add as follow-up)
+- **Fiori app generation** (generates the OData service; Fiori Elements app is auto-generated from annotations)
+
+### Relationship to Other Skills
+
+| Skill | Relationship |
+|---|---|
+| `generate-rap-service` | Vibe code version — faster, less thorough, good for prototypes |
+| `generate-rap-logic` | Natural follow-up — implement determinations/validations identified in the plan |
+| `generate-abap-unit-test` | Follow-up — generate tests for the behavior pool |
+| `explain-abap-code` | Can be used during research to understand existing RAP projects found on the system |
+| `implement-feature` | For implementing non-RAP features in the arc-1 codebase itself |

--- a/.claude/commands/generate-rap-service.md
+++ b/.claude/commands/generate-rap-service.md
@@ -2,6 +2,8 @@
 
 Generate a complete RAP OData UI service from a natural language description of a business object. Creates the full artifact stack: database table, CDS views, behavior definitions, metadata extension, service definition, and behavior pool class.
 
+This is the **"vibe code"** mode — starts creating immediately with sensible defaults. For production-quality services that need deep system research, existing code analysis, architecture decisions, and user-approved plans first, use `generate-rap-service-researched` instead.
+
 This skill replicates SAP Joule's "RAP Service Generation" capability by combining ARC-1 (SAP system access) with mcp-sap-docs (documentation & best practices).
 
 **v1 Guardrails** (matching SAP Joule): managed scenario only, UUID internal early numbering, single root entity (no compositions), standard CRUD only (no custom actions/determinations/validations), draft optional, OData V4 preferred.
@@ -596,9 +598,14 @@ ARC-1 cannot create service bindings (SRVB) via ADT API. Instruct the user:
 5. **Binding Type**: OData V4 - UI (or OData V2 - UI if V2 was chosen)
 6. **Service Definition**: `ZSD_<ENTITY>`
 7. **Finish** and **Activate**
-8. Click **Publish** to register the service
 
-After publishing, verify with:
+After the service binding is created and activated, publish it:
+
+```
+SAPActivate(action="publish_srvb", name="ZSB_<entity>_V4")
+```
+
+Then verify the publish status and service URL:
 ```
 SAPRead(type="SRVB", name="ZSB_<entity>_V4")
 ```
@@ -629,6 +636,7 @@ Created artifacts:
   [x] Service definition: ZSD_<Entity>
   [x] Behavior pool class: ZBP_I_<Entity>
   [ ] Service binding: ZSB_<Entity>_V4 (create manually — see Step 13)
+  [x] Service binding published
 
 Next steps:
   - Create the service binding and publish it


### PR DESCRIPTION
## Summary

- Adds `generate-rap-service-researched` skill — a research-first counterpart to the existing vibe-coding `generate-rap-service` skill
- The new skill follows a 5-phase approach: deep system research → targeted clarifying questions → user-approved implementation plan → execution → verification
- Research phase mines existing RAP projects on the system for naming conventions, architecture patterns, and code guidelines; queries SAP docs for best practices; and detects system capabilities
- Adds cross-reference in existing `generate-rap-service` skill so users know both modes exist

## Test plan

- [ ] Verify `generate-rap-service-researched` skill appears in skill listing
- [ ] Run the skill against a test system and verify research phase discovers existing RAP patterns
- [ ] Verify clarifying questions are relevant and based on research findings
- [ ] Verify implementation plan is comprehensive and requires user approval before proceeding
- [ ] Verify existing `generate-rap-service` skill still works and shows cross-reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)