### PR TITLE
docs: revise Phase 4 plan to use @sap/generator-fiori headless mode

### DIFF
--- a/docs/plans/fiori-deployment-api-reference.md
+++ b/docs/plans/fiori-deployment-api-reference.md
@@ -620,6 +620,30 @@ HEAD /sap/opu/odata/UI5/ABAP_REPOSITORY_SRV
 
 ### Detect UI5 Version on Target System
 
+**Primary method (recommended): SAP_UI component mapping**
+
+ARC-1 already fetches `/sap/bc/adt/system/components` at startup. Extract the `SAP_UI` component release and map to the UI5 LTS version:
+
+```typescript
+const SAP_UI_TO_UI5: Record<string, string> = {
+    '816': '1.136.0',    // FES 2025 for S/4HANA, EOM Q4/2032
+    '758': '1.120.0',    // FES 2023 for S/4HANA, EOM Q4/2030
+    '757': '1.108.0',    // FES 2022 for S/4HANA, EOM Q4/2030
+    '756': '1.96.0',     // FES 2021 for S/4HANA, EOM Q4/2026
+    '755': '1.84.0',     // FES 2020 (out of maintenance)
+    '754': '1.71.0',     // Fiori FES 6.0, EOM Q4/2030
+    '753': '1.60.0',     // Fiori FES 5.0 (out of maintenance)
+};
+```
+
+This mapping is stable — SAP_UI versions are fixed releases. It only changes when SAP ships a new SAP_UI version (~annually). Source: `https://ui5.sap.com/versionoverview.json`.
+
+Always use `.0` patch level (e.g., `1.120.0` not `1.120.17`) — `minUI5Version` is a minimum requirement.
+
+For BTP systems (detected via `SAP_CLOUD` component), default to `1.136.0` (latest LTS). UI5 on BTP is loaded from CDN, not from the ABAP server.
+
+**Fallback method (less reliable):**
+
 ```
 GET /sap/public/bc/ui5_ui5/bootstrap_info.json
 ```
@@ -629,7 +653,15 @@ Response:
 { "Version": "1.120.0" }
 ```
 
-Use this to set `minUI5Version` in the generated `manifest.json`.
+Not available on BTP ABAP Environment (UI5 loaded from CDN) and not always present on-premise. Use only as fallback.
+
+**External reference endpoint:**
+
+```
+GET https://ui5.sap.com/versionoverview.json
+```
+
+Returns JSON with `activeVersion`, plus an array of all UI5 versions with `sapuiversion` (SAP_UI component version), `lts` flag, `support` status, and `eom`/`eocp` dates. Can be used to build/update the mapping dynamically at build time.
 
 ### Detect ATO Settings (Cloud vs On-Prem)
 
@@ -639,3 +671,148 @@ Accept: application/*
 ```
 
 Returns XML with `operationsType`: `C` (Cloud) or `P` (Premise). Useful for determining if transport is required and which development package to use.
+
+---
+
+## Part 8: Fiori Elements App Generation via `@sap/generator-fiori`
+
+### 8.1 Overview
+
+Instead of generating manifest.json/Component.js templates in-memory (fragile, version-sensitive), ARC-1 uses SAP's official `@sap/generator-fiori` package in **headless mode**. This is the same approach used by SAP's own `@sap-ux/fiori-mcp-server`.
+
+**Package:** `@sap/generator-fiori` (public npm, Apache-2.0, ~10 MB)
+**Mechanism:** Shell out to `npx -y yo@4 @sap/fiori:headless <config.json> --force --skipInstall`
+**Output:** Complete Fiori Elements project; only `webapp/` subfolder is ZIPped for deployment
+
+### 8.2 Headless Config JSON (Version 0.2)
+
+The config `version` field **must be `"0.2"`** — validated, throws on mismatch.
+
+**Minimal config for a RAP LROP app with CDS annotations:**
+
+```json
+{
+    "version": "0.2",
+    "floorplan": "FE_LROP",
+    "project": {
+        "name": "zbooking-app",
+        "description": "Booking Management",
+        "targetFolder": "/tmp/fiori-gen-abc123",
+        "ui5Version": "1.120.0",
+        "sapux": true
+    },
+    "service": {
+        "host": "https://my-sap:443",
+        "servicePath": "/sap/opu/odata4/sap/zsb_booking/srvd_a2x/sap/zsd_booking/0001/",
+        "client": "100",
+        "edmx": "<?xml version=\"1.0\"?><edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">...</edmx:Edmx>"
+    },
+    "entityConfig": {
+        "mainEntity": {
+            "entityName": "Booking"
+        },
+        "generateFormAnnotations": false,
+        "generateLROPAnnotations": false
+    },
+    "telemetryData": {
+        "generationSourceName": "arc-1",
+        "generationSourceVersion": "1.0.0"
+    }
+}
+```
+
+**Important fields:**
+
+| Field | Required | Constraints |
+|-------|----------|-------------|
+| `version` | Yes | Must be `"0.2"` |
+| `floorplan` | Yes | Enum key: `"FE_LROP"`, `"FE_FPM"`, `"FE_OVP"`, `"FE_ALP"`, `"FE_FEOP"`, `"FE_WORKLIST"`, `"FF_SIMPLE"` |
+| `project.name` | Yes | `/^[a-z0-9-]+$/` — lowercase + dashes only, no underscores |
+| `project.targetFolder` | Yes | Absolute path — generator creates `{name}/` subfolder here |
+| `project.sapux` | Yes | `true` for all FE floorplans, `false` only for `FF_SIMPLE` |
+| `project.description` | Recommended | Used in package.json + i18n |
+| `project.ui5Version` | Recommended | Defaults to latest if omitted; set from SAP_UI mapping |
+| `service.edmx` | Yes (FE) | Full EDMX XML string — throws `Missing required property: edmx` without it |
+| `service.host` | Yes | SAP system URL |
+| `service.servicePath` | Yes | OData service path |
+| `entityConfig.mainEntity.entityName` | Yes (FE) | EntitySet name from EDMX |
+| `entityConfig.generateFormAnnotations` | No | Default `true`. Set `false` when CDS DDLX handles annotations |
+| `entityConfig.generateLROPAnnotations` | No | Default `true`. Set `false` when CDS DDLX handles annotations |
+
+### 8.3 EDMX Metadata Acquisition
+
+The generator needs the full OData EDMX XML. ARC-1 fetches it from the published service binding.
+
+**OData V4 (typical for RAP):**
+```
+GET /sap/opu/odata4/sap/{service_binding_name}/srvd_a2x/sap/{service_definition_name}/0001/$metadata
+Accept: application/xml
+```
+
+**OData V2:**
+```
+GET /sap/opu/odata/sap/{service_binding_name}/$metadata
+Accept: application/xml
+```
+
+The service URL pattern and OData version are available from `getSrvb()` which returns `odataVersion`, `serviceDefinition`, and other metadata. The service must be published first (`publishServiceBinding()`).
+
+### 8.4 Generated Output
+
+```
+{project.name}/
+├── package.json               # Not needed for deployment
+├── ui5.yaml                   # Not needed for deployment
+├── ui5-local.yaml             # Not needed for deployment
+├── README.md                  # Not needed for deployment
+├── .gitignore                 # Not needed for deployment
+└── webapp/                    # ← ZIP this folder for deployment
+    ├── manifest.json          # Routing, datasource, models, FLP config
+    ├── Component.js           # ~6 lines (extends sap/fe/core/AppComponent)
+    ├── i18n/
+    │   └── i18n.properties    # appTitle, appDescription
+    └── test/
+        └── flpSandbox.html    # FLP sandbox
+```
+
+Only the `webapp/` folder contents go into the ZIP archive for ABAP deployment. Files must be at the ZIP root level (no `webapp/` parent folder in the archive).
+
+### 8.5 ARC-1 Integration Flow
+
+```
+1. Read SRVB metadata (getSrvb) → get odataVersion, serviceDefinition
+2. Detect UI5 version from SAP_UI component → e.g., "1.120.0"
+3. Fetch $metadata EDMX from published service
+4. Read projection CDS entity → get main entity name
+5. Derive project.name from BSP name (lowercase + dashes: "ZAPP_BOOKING" → "zapp-booking")
+6. Build headless config JSON
+7. Write config to temp file
+8. Run: npx -y yo@4 @sap/fiori:headless config.json --force --skipInstall
+9. ZIP contents of {targetFolder}/{project.name}/webapp/ using adm-zip
+10. Deploy ZIP via ABAP_REPOSITORY_SRV (POST or PUT)
+11. Cleanup temp directory
+12. Return app URL: /sap/bc/ui5_ui5/sap/{bspName.toLowerCase()}?sap-client={client}
+```
+
+### 8.6 Error Handling
+
+| Scenario | Generator Behavior | ARC-1 Should |
+|----------|-------------------|--------------|
+| Config version wrong | `Error('App config version mismatch, supported: 0.2')` | Hard-code `"0.2"`, never hits |
+| Missing EDMX | `Error('Missing required property: edmx')` | Always provide — validate before calling |
+| Invalid project.name | Validation error | Validate `/^[a-z0-9-]+$/` before calling |
+| Folder exists (no --force) | `Error('A folder already exists')` | Always use `--force` |
+| npx not found | ENOENT process error | Check Node.js available, report to user |
+| First run delay | ~30-60s (downloads yo + @sap/generator-fiori ~100MB) | Warn user in skill, not a code issue |
+| Generator crash | Exit code 1, error on stderr | Parse stderr, return to user |
+
+### 8.7 Gotchas
+
+1. **`project.name` must be lowercase-dashes** — ABAP names like `ZAPP_BOOKING` won't work as project names. Derive: `zapp-booking`. The BSP name for deployment remains uppercase.
+2. **`floorplan` uses enum keys** — `"FE_LROP"` not `"lrop"`
+3. **First run is slow** (~30-60s) — npx downloads Yeoman + `@sap/generator-fiori`. Subsequent runs are fast (cached).
+4. **Only `webapp/` gets ZIPped** — not the root project folder
+5. **EDMX must be the full XML document** — not a subset
+6. **`service.host` should be HTTPS** — the generator validates this for OData projects
+7. **Yeoman version pinned to v4** — `yo@4` specifically (fiori-mcp-server pins this)
+8. **Timeout consideration** — add a timeout guard (~120s) for the npx process; first run can be slow but shouldn't hang indefinitely

--- a/docs/plans/fiori-deployment-research.md
+++ b/docs/plans/fiori-deployment-research.md
@@ -440,117 +440,412 @@ Discovered in the open-ux-tools monorepo. Uses `@modelcontextprotocol/sdk` 1.29.
 
 ---
 
+## Key Decision: Use `@sap/generator-fiori` Headless Mode (Not In-Memory Templates)
+
+### Why Not Generate Templates In-Memory?
+
+The initial plan proposed generating `manifest.json`, `Component.js`, and `i18n.properties` from scratch in ARC-1. This was rejected because:
+
+1. **manifest.json varies significantly by UI5 version** — routing targets, dependency libs, descriptor version, model settings all change across 1.71, 1.84, 1.96, 1.108, 1.120, 1.136+
+2. **OData V2 vs V4 differences** — V2 uses `sap.suite.ui.generic.template.*`, V4 uses `sap.fe.templates.*`
+3. **Floorplan-specific configuration** — List Report, Worklist, Analytical, Overview Page each have different routing/target structures
+4. **SAP maintains this in `@sap-ux/fiori-elements-writer`** — ~10 packages, EJS templates, version-aware logic. Reimplementing is fragile and will break.
+
+### Three Options Evaluated
+
+| Option | Approach | Pros | Cons |
+|--------|----------|------|------|
+| A: In-memory templates | Generate manifest.json etc. ourselves | No external deps | Fragile, version-sensitive, maintenance burden |
+| B: `@sap/generator-fiori` headless | Shell out to `npx yo @sap/fiori:headless` | SAP-maintained, always correct, simple | Needs Node.js + npx, first-run download ~100MB |
+| C: fiori-mcp-server delegation | Orchestrate via MCP skill prompt | Zero code changes | User must configure 2 MCP servers, `@sap-ux/store` dependency for auth |
+
+### Decision: Option B — `@sap/generator-fiori` Headless Mode
+
+**Rationale:**
+- Single MCP server (no extra user config)
+- Uses ARC-1's existing SAP connection for EDMX fetching (no `@sap-ux/store` dependency)
+- SAP-maintained generator handles all UI5 version/floorplan complexity
+- `@sap/generator-fiori` is on **public npm** (Apache-2.0 license, v1.22.0+)
+- The fiori-mcp-server itself uses this exact approach internally
+
+**Option C as lightweight alternative:** The skill docs can mention that users with `fiori-mcp-server` configured can use it instead. No code needed — pure prompt guidance.
+
+---
+
+## Deep Dive: `@sap/generator-fiori` Headless Mode
+
+### Package Facts
+
+| Property | Value |
+|----------|-------|
+| Package | `@sap/generator-fiori` |
+| Registry | Public npm (npmjs.com) |
+| License | Apache-2.0 |
+| Current version | 1.22.0+ (April 2026) |
+| Size | ~10 MB unpacked, 444 files |
+| Code | Webpack-bundled/minified (closed source), but underlying open-source packages are in `SAP/open-ux-tools` |
+| Dependencies | All bundled (no transitive installs) |
+
+### Invocation
+
+```bash
+npx -y yo@4 @sap/fiori:headless <config-file.json> [--force] [--skipInstall] [--delete]
+```
+
+| Flag | Purpose |
+|------|---------|
+| `-y` | Auto-accept npx install prompt |
+| `yo@4` | Pinned Yeoman version (fiori-mcp-server pins this) |
+| `--force` | Overwrite existing files |
+| `--skipInstall` | Skip `npm install` (we only need `webapp/` for deployment) |
+| `--delete` | Delete config JSON after generation |
+
+### Config JSON Format (Version 0.2)
+
+The config format is versioned. Current version is `"0.2"` — the generator validates this and throws `App config version mismatch, supported: 0.2` on mismatch.
+
+**Complete reference** (from `@sap-ux/fiori-generator-shared` types + fiori-mcp-server Zod schemas):
+
+```typescript
+interface AppConfig {
+    readonly version: string;                    // MUST be "0.2"
+    readonly floorplan: FloorplanKey;           // "FE_LROP" | "FE_FPM" | "FE_OVP" | "FE_ALP" | "FE_FEOP" | "FE_WORKLIST" | "FF_SIMPLE"
+    project: {
+        readonly name: string;                   // MUST match /^[a-z0-9-]+$/ (lowercase + dashes only!)
+        targetFolder?: string;                   // Absolute path — generator creates {name}/ subfolder here
+        readonly namespace?: string;
+        readonly title?: string;
+        readonly description?: string;           // Required by MCP schema
+        readonly ui5Theme?: string;              // e.g. "sap_horizon" (defaults based on UI5 version)
+        readonly ui5Version?: string;            // e.g. "1.120.0" (defaults to latest if omitted)
+        readonly localUI5Version?: string;
+        readonly sapux?: boolean;                // MUST be true for all FE floorplans, false for FF_SIMPLE
+        readonly skipAnnotations?: boolean;
+        readonly enableEslint?: boolean;
+        readonly enableTypeScript?: boolean;
+    };
+    service?: {
+        readonly host?: string;                  // SAP system URL (HTTPS)
+        readonly servicePath?: string;           // OData service path
+        readonly client?: string;                // SAP client number
+        readonly edmx?: string;                  // FULL EDMX XML string (required for FE floorplans!)
+        readonly scp?: boolean;
+        readonly destination?: string;
+        readonly destinationInstance?: string;
+        readonly annotations?: Annotations;
+        readonly capService?: { ... };           // CAP-specific (not used for RAP)
+        readonly apiHubApiKey?: string;
+    };
+    // FE floorplans only:
+    readonly entityConfig?: {
+        mainEntity?: { entityName: string; type?: any };
+        filterEntityType?: string;
+        navigationEntity?: {
+            EntitySet: string;                    // Entity set name for nav target
+            Name: string;                         // Navigation property name (e.g. "_Booking")
+            Role?: string;
+        };
+        generateFormAnnotations?: boolean;        // Default: true. Set false when CDS DDLX handles annotations.
+        generateLROPAnnotations?: boolean;        // Default: true. Set false when CDS DDLX handles annotations.
+        qualifier?: string;
+        tableType?: string;                       // "GridTable" | "AnalyticalTable" | "ResponsiveTable" | "TreeTable"
+        hierarchyQualifier?: string;
+    };
+    deployConfig?: DeployConfig;
+    flpConfig?: FLPConfig;
+    telemetryData?: {
+        generationSourceName?: string;           // e.g. "arc-1"
+        generationSourceVersion?: string;
+    };
+}
+```
+
+### Floorplan Values
+
+The `floorplan` field uses **enum keys** (not values):
+
+| Key (use this) | Internal value | Description |
+|-----------------|----------------|-------------|
+| `FE_LROP` | `lrop` | List Report + Object Page (most common for RAP) |
+| `FE_FPM` | `fpm` | Flexible Programming Model |
+| `FE_OVP` | `ovp` | Overview Page |
+| `FE_ALP` | `alp` | Analytical List Page |
+| `FE_FEOP` | `feop` | Form Entry Object Page |
+| `FE_WORKLIST` | `worklist` | Worklist |
+| `FF_SIMPLE` | `basic` | Freestyle SAPUI5 app (not Fiori Elements) |
+
+### Minimal Config for a RAP Service (Simplest Possible)
+
+For a RAP service with CDS UI annotations (DDLX), we want the **simplest generation** — no local annotations, no TypeScript, no ESLint. The CDS `@UI.LineItem`, `@UI.FieldGroup` etc. annotations drive the UI entirely.
+
+```json
+{
+    "version": "0.2",
+    "floorplan": "FE_LROP",
+    "project": {
+        "name": "zbooking-app",
+        "description": "Booking Management",
+        "targetFolder": "/tmp/fiori-gen-abc123",
+        "sapux": true
+    },
+    "service": {
+        "host": "https://my-sap:443",
+        "servicePath": "/sap/opu/odata4/sap/zsb_booking/srvd_a2x/sap/zsd_booking/0001/",
+        "client": "100",
+        "edmx": "<?xml version=\"1.0\"?><edmx:Edmx ...full metadata...</edmx:Edmx>"
+    },
+    "entityConfig": {
+        "mainEntity": {
+            "entityName": "Booking"
+        },
+        "generateFormAnnotations": false,
+        "generateLROPAnnotations": false
+    },
+    "telemetryData": {
+        "generationSourceName": "arc-1",
+        "generationSourceVersion": "1.0.0"
+    }
+}
+```
+
+Setting `generateFormAnnotations: false` and `generateLROPAnnotations: false` is important — it tells the generator NOT to create local annotation files, relying entirely on backend CDS annotations. This is exactly right for RAP services where DDLX handles everything.
+
+### Output Structure
+
+The generator creates `{targetFolder}/{project.name}/`:
+
+```
+{project.name}/
+├── package.json               # npm package (not needed for deployment)
+├── ui5.yaml                   # UI5 tooling config (not needed for deployment)
+├── ui5-local.yaml             # Local dev config (not needed for deployment)
+├── README.md                  # (not needed for deployment)
+├── .gitignore                 # (not needed for deployment)
+└── webapp/                    # ← THIS is what gets ZIPped and deployed
+    ├── manifest.json          # Critical: routing, datasource, models, FLP config
+    ├── Component.js           # ~6 lines boilerplate (extends sap/fe/core/AppComponent)
+    ├── i18n/
+    │   └── i18n.properties    # appTitle, appDescription
+    └── test/
+        └── flpSandbox.html    # FLP sandbox for local testing
+```
+
+**For ABAP deployment, only the `webapp/` folder is ZIPped** — the root project files (`package.json`, `ui5.yaml`, etc.) are for local development and are not uploaded.
+
+### EDMX Metadata Requirement
+
+The generator requires the full OData EDMX XML as a string in `service.edmx`. Without it, generation throws: `Error('Missing required property: edmx')`.
+
+**How to obtain EDMX from a published RAP service binding:**
+
+For OData V4 (most common for RAP):
+```
+GET /sap/opu/odata4/sap/{service_binding}/srvd_a2x/sap/{service_definition}/0001/$metadata
+Accept: application/xml
+```
+
+For OData V2:
+```
+GET /sap/opu/odata/sap/{service_binding_v2}/$metadata
+Accept: application/xml
+```
+
+The service URL pattern is available from the service binding metadata (ARC-1's `getSrvb()` returns `odataVersion` and can derive the URL). After `publishServiceBinding()`, the service is live and `$metadata` is accessible.
+
+### Error Handling
+
+| Scenario | Error Message | ARC-1 Should |
+|----------|--------------|--------------|
+| Config version wrong | `App config version mismatch, supported: 0.2` | Validate before calling |
+| Missing EDMX | `Missing required property: edmx` | Always provide EDMX |
+| Folder exists (no --force) | `A folder with the application name already exists` | Always use `--force` |
+| Invalid project name | Zod/validation error | Validate `/^[a-z0-9-]+$/` before calling |
+| npx not found | Process error (ENOENT) | Check Node.js available, report |
+| Generator crashes | Exit code 1, stderr | Parse stderr, return to user |
+| First run download | ~30-60s delay | Warn user in skill docs |
+
+### How fiori-mcp-server Calls It (Reference Implementation)
+
+From `packages/fiori-mcp-server/src/tools/functionalities/generate-fiori-ui-application/execute-functionality.ts`:
+
+```typescript
+// 1. Merge with predefined values
+const generatorConfig = {
+    ...PREDEFINED_GENERATOR_VALUES,  // { version: '0.2', telemetryData: {...}, project: { sapux: true } }
+    ...generatorConfigValidated,
+    project: { ...PREDEFINED_GENERATOR_VALUES.project, ...generatorConfigValidated.project }
+};
+
+// 2. Set sapux based on floorplan
+generatorConfig.project.sapux = generatorConfig.floorplan !== 'FF_SIMPLE';
+
+// 3. Read EDMX from file and embed inline
+const metadata = await FSpromises.readFile(metadataPath, { encoding: 'utf8' });
+generatorConfig.service.edmx = metadata;
+
+// 4. Write config to temp file
+const configPath = join(targetDir, `${appName}-generator-config.json`);
+await FSpromises.writeFile(configPath, JSON.stringify(generatorConfig, null, 4), { encoding: 'utf8' });
+
+// 5. Run generator
+const command = `npx -y yo@4 @sap/fiori:headless ${configFileName} --force --skipInstall`;
+const { stdout, stderr } = await runCmd(command, { cwd: targetDir });
+
+// 6. Cleanup
+finally {
+    if (existsSync(configPath)) await FSpromises.unlink(configPath);
+    if (existsSync(metadataPath)) await FSpromises.unlink(metadataPath);
+}
+```
+
+### Two-Layer Architecture
+
+1. **`@sap/generator-fiori`** (closed source, bundled) — Yeoman shell handling CLI, sub-generator composition, headless config parsing
+2. **`@sap-ux/*` packages** (open source in `SAP/open-ux-tools`) — Actual generation logic:
+   - `@sap-ux/fiori-generator-shared` — Shared types including `AppConfig`
+   - `@sap-ux/fiori-elements-writer` — The `generate()` function producing files via mem-fs
+   - `@sap-ux/odata-service-writer` — OData service config in manifest.json
+   - `@sap-ux/ui5-application-writer` — package.json, ui5.yaml scaffolding
+
+The writer packages have a clean programmatic API via `mem-fs-editor` (files generated in memory, not written to disk until `fs.commit()`). However, using them directly would pull ~10 transitive `@sap-ux/*` packages + ejs + i18next + lodash + mem-fs into ARC-1's dependencies. The headless CLI approach avoids this dependency bloat.
+
+---
+
+## UI5 Version Detection: SAP_UI Component Mapping
+
+### The Problem
+
+The headless config needs `project.ui5Version` to generate a correct `manifest.json` with the right `minUI5Version`. Using a version higher than the target system means the app might use APIs that don't exist. Using a version too low means missing newer FE features.
+
+### Solution: Map SAP_UI Component to UI5 Version
+
+ARC-1 already fetches `/sap/bc/adt/system/components` at startup (`src/adt/features.ts:detectSystemFromComponents`). This returns all installed software components including `SAP_UI` with its release number.
+
+**The authoritative mapping** (from `https://ui5.sap.com/versionoverview.json`):
+
+| SAP_UI Release | UI5 LTS Version | Frontend Server | Support End |
+|----------------|------------------|-----------------|-------------|
+| `816` | `1.136.0` | FES 2025 for S/4HANA | Q4/2032 |
+| `758` | `1.120.0` | FES 2023 for S/4HANA | Q4/2030 |
+| `757` | `1.108.0` | FES 2022 for S/4HANA | Q4/2030 |
+| `756` | `1.96.0` | FES 2021 for S/4HANA | Q4/2026 |
+| `755` | `1.84.0` | FES 2020 for S/4HANA | Out of maintenance |
+| `754` | `1.71.0` | Fiori FES 6.0 | Q4/2030 |
+| `753` | `1.60.0` | Fiori FES 5.0 | Out of maintenance |
+
+**Implementation in ARC-1:**
+
+```typescript
+const SAP_UI_TO_UI5: Record<string, string> = {
+    '816': '1.136.0',
+    '758': '1.120.0',
+    '757': '1.108.0',
+    '756': '1.96.0',
+    '755': '1.84.0',
+    '754': '1.71.0',
+    '753': '1.60.0',
+};
+
+// Usage: extract from already-fetched components
+const components = await client.getInstalledComponents();
+const sapUi = components.find(c => c.name.toUpperCase() === 'SAP_UI');
+const ui5Version = sapUi ? SAP_UI_TO_UI5[sapUi.release] ?? '1.120.0' : '1.120.0';
+```
+
+**Why `.0` patch level:** Use `1.120.0` not `1.120.17`. The `minUI5Version` in manifest.json is a minimum requirement — `.0` ensures compatibility regardless of the system's patch level.
+
+**BTP systems:** For BTP (detected via `SAP_CLOUD` component presence), UI5 is loaded from CDN. Default to `1.136.0` (latest LTS).
+
+**This mapping is stable** — SAP_UI versions are fixed releases. SAP_UI 7.58 always ships UI5 1.120.x. The mapping only changes when SAP ships a new SAP_UI version (~annually). Zero additional HTTP requests needed.
+
+**Alternative endpoint** (less reliable): `GET /sap/public/bc/ui5_ui5/bootstrap_info.json` returns `{ "Version": "1.120.0" }` on some systems, but it's not available on BTP ABAP Environment (UI5 loaded from CDN) and not always present on-premise.
+
+**External reference:** `https://ui5.sap.com/versionoverview.json` contains the full mapping and can be fetched at build time or cached if dynamic mapping is ever needed.
+
+---
+
+## SAP fiori-mcp-server Analysis
+
+### What It Is
+
+`@sap-ux/fiori-mcp-server` (v0.6.48, Apache-2.0) is SAP's official MCP server for Fiori app generation. Part of the `SAP/open-ux-tools` monorepo. Actively developed (90+ releases since Sept 2025).
+
+### 5 MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `search_docs` | Vector search across Fiori/UI5 docs (uses LanceDB + Xenova transformers) |
+| `list_fiori_apps` | Scan directory for existing Fiori apps |
+| `list_functionalities` | List available operations |
+| `get_functionality_details` | Get parameter schema for an operation |
+| `execute_functionality` | Execute an operation with parameters |
+
+### 6 Functionalities
+
+1. `generate-fiori-ui-application` — Generate FE app for OData (non-CAP, e.g., RAP)
+2. `generate-fiori-ui-application-cap` — Generate FE app within CAP project
+3. `add-page` — Add pages to existing app
+4. `delete-page` — Delete pages
+5. `create-controller-extension` — Add controller extensions
+6. `fetch-service-metadata` — Fetch EDMX from a live SAP system
+
+### Architecture: Shells Out to Yeoman
+
+Both generation functionalities work by:
+1. Building a JSON config from MCP tool parameters
+2. Writing it to a temp file
+3. Running `npx -y yo@4 @sap/fiori:headless <config>.json --force --skipInstall`
+4. Cleaning up temp files in `finally` block
+
+It does **not** use `@sap-ux/fiori-elements-writer` directly — it delegates to the closed-source `@sap/generator-fiori` Yeoman generator.
+
+### Key Limitation: SAP System Auth
+
+The `fetch-service-metadata` functionality uses `@sap-ux/store` to look up pre-stored SAP systems (saved via VS Code Fiori tools or Business Application Studio). It cannot take credentials from ARC-1's SAP connection. This is the main reason ARC-1 should fetch EDMX itself rather than delegating to fiori-mcp-server.
+
+### Does NOT Handle Deployment
+
+The MCP server only generates and modifies apps. There are no deployment functionalities. ARC-1 still needs its own deploy implementation via ABAP_REPOSITORY_SRV.
+
+### Can Be Used Alongside ARC-1 (Option C)
+
+Both Claude Desktop and Claude Code support multiple MCP servers. A skill/prompt can instruct the LLM to call tools from both servers:
+1. ARC-1 fetches EDMX via `SAPRead`
+2. LLM writes EDMX to temp file
+3. fiori-mcp-server generates app via `execute_functionality`
+4. ARC-1 deploys via `SAPManage(deploy_ui5)`
+
+This works but requires users to configure two MCP servers and pre-store SAP systems in `@sap-ux/store`.
+
+---
+
 ## Revised Implementation Plan
 
-### Phase 1: Publish Service Binding (Effort: XS, half day)
+### Phase 1: ADT Filestore Read Operations (COMPLETED)
+- **Status:** Implemented in `src/adt/client.ts`
+- `listBspApps()`, `getBspAppStructure()`, `getBspFileContent()` are live
+- Uses `/sap/bc/adt/filestore/ui5-bsp/objects` (read-only)
 
-Add `publishServiceBinding()` and `unpublishServiceBinding()` to complete the RAP generation pipeline.
+### Phase 2: Publish Service Binding (COMPLETED)
+- **Status:** Implemented in `src/adt/devtools.ts`
+- `publishServiceBinding()` and `unpublishServiceBinding()` are live
+- Uses `/sap/bc/adt/businessservices/odatav2/publishjobs` and `unpublishjobs`
 
-```
-POST /sap/bc/adt/businessservices/bindings/{name}?action=publish
-POST /sap/bc/adt/businessservices/bindings/{name}?action=unpublish
-```
-
-### Phase 2: ABAP Repository Deployment (Effort: M, 3-5 days)
-
-Implement the OData-based deployment using `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`.
-
-| Task | Details |
-|------|---------|
-| Feature probe | HEAD `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` — detect availability |
-| Get app info | GET `/Repositories('{name}')` — check existence |
-| Deploy new app | POST `/Repositories` — Atom XML with base64 ZIP |
-| Redeploy app | PUT `/Repositories('{name}')` — same payload |
-| Undeploy app | DELETE `/Repositories('{name}')` |
-| Download app | GET `/Repositories('{name}')` with `DownloadFiles='RUNTIME'` |
-| ZIP creation | Use Node.js `archiver` or `adm-zip` to create webapp ZIP |
-| Transport integration | Reuse existing `src/adt/transport.ts` + new CTS check endpoint |
-
-**Note:** This is a separate HTTP endpoint from the ADT APIs (`/sap/opu/odata/` vs `/sap/bc/adt/`). ARC-1's HTTP client may need a small extension to support OData service paths.
-
-### Phase 3: Fiori Elements App Generation (Effort: S, 1-2 days)
-
-Generate the webapp files that get zipped and deployed.
-
-| File | Source |
-|------|--------|
-| `manifest.json` | Template with entity name, service URL, FLP config |
-| `Component.js` | Static boilerplate (~10 lines) |
-| `i18n/i18n.properties` | Entity labels from CDS annotations |
-| `index.html` | Optional FLP sandbox launcher |
-
-The `manifest.json` template (see above) is parameterized by:
-- Entity name (from RAP generation)
-- Service binding name (from RAP generation)
-- Service definition name (from RAP generation)
-- App ID (derived from entity name)
-- Semantic object (user input or derived)
-- UI5 version (from `/sap/public/bc/ui5_ui5/bootstrap_info.json`)
-
-### Phase 4: ADT Filestore Read (Effort: S, 1 day)
-
-Add read-only BSP tools for verifying deployed apps:
-
-| Tool | Endpoint |
-|------|----------|
-| List BSP apps | GET `/sap/bc/adt/filestore/ui5-bsp/objects` |
-| Read app structure | GET `/sap/bc/adt/filestore/ui5-bsp/objects/{name}/content` |
-| Read file content | GET `/sap/bc/adt/filestore/ui5-bsp/objects/{name}/{path}/content` |
-
----
-
-## What a Full "Generate RAP + Fiori + Deploy" Skill Would Look Like
-
-The end goal is a single E2E skill that takes a user from natural language description to a running Fiori Elements app. This extends the existing `generate-rap-service` skill.
-
-```
-Step 1-12:  [Existing] Generate RAP stack (table, CDS, BDEF, SRVD, DDLX, CLAS)
-Step 13:    [Existing] Create service binding (manual — instruct user)
-Step 14:    [Phase 2] Publish service binding → OData service is live, preview URL available
-Step 15:    [Phase 3] Query ABAP_REPOSITORY_SRV → check if BSP app already exists
-Step 16:    [Phase 4] Generate minimal Fiori Elements webapp (manifest.json, Component.js, i18n, index.html)
-Step 17:    [Phase 4] Deploy via ABAP_REPOSITORY_SRV → creates BSP + ICF node automatically
-Step 18:    [Phase 1] Verify deployment via ADT filestore read
-Step 19:    [Done] App accessible at /sap/bc/ui5_ui5/sap/{appName}/index.html (no FLP needed)
-```
-
----
-
-## Implementation Phases (Ordered by Priority)
-
-Each phase is independently valuable and will be tackled one by one. Detailed plans for each phase are in separate documents.
-
-### Phase 1: ADT Filestore Read Operations
-- **Effort:** S (1-2 days)
-- **Impact:** High — enables reading deployed UI5/Fiori apps, browsing webapp files, verifying deployments. Very useful standalone capability even without deployment.
-- **API:** `/sap/bc/adt/filestore/ui5-bsp/objects` (read-only, already feature-probed)
-- **Operations:** List BSP apps, browse file structure, read file content
-- **Implementation:** New methods in `src/adt/client.ts`, new SAPRead types (`BSP`, `BSP_FILE`), XML parser for Atom feeds
-- **Detailed plan:** `docs/plans/phase1-filestore-read.md`
-
-### Phase 2: Publish Service Binding
-- **Effort:** XS (half day)
-- **Impact:** High — eliminates the biggest manual step in RAP generation. Enables Fiori Elements preview URL (like ADT Eclipse "Preview" button) without needing a full BSP deployment.
-- **API:** `POST /sap/bc/adt/businessservices/bindings/{name}?action=publish`
-- **Implementation:** Add `publishServiceBinding()` and `unpublishServiceBinding()` to `src/adt/devtools.ts`, update `generate-rap-service` skill to include publish step
-- **Preview URL:** After publish, the OData service URL can be used with SAP's Fiori Elements preview: `/sap/bc/adt/businessservices/odatav4/{binding}/preview`
-- **Detailed plan:** `docs/plans/phase2-publish-srvb.md`
-
-### Phase 3: ABAP Repository Service (Query/Describe)
-- **Effort:** S (1-2 days)
-- **Impact:** Medium — enables querying deployed BSP apps via OData, checking app existence, downloading app content. Foundation for Phase 4.
-- **API:** `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` (GET operations only)
-- **Key concern:** This is an OData service on a different path than ADT (`/sap/opu/odata/` vs `/sap/bc/adt/`). Needs manual testing to verify CSRF token sharing, cookie behavior, auth headers.
-- **Operations:** Get app info, download app ZIP, feature probe
-- **Implementation:** New `src/adt/ui5-repository.ts` with separate CSRF handling
-- **Detailed plan:** `docs/plans/phase3-repository-query.md`
+### Phase 3: ABAP Repository Service — Query/Describe (COMPLETED)
+- **Status:** `getAppInfo()` implemented (or can use existing BSP read operations)
+- Foundation for Phase 4 deployment
 
 ### Phase 4: Deploy Fiori Elements App (E2E Skill)
-- **Effort:** M-L (5-7 days)
+- **Effort:** M (3-5 days)
 - **Impact:** Very high — completes the Table → RAP → Fiori Elements pipeline. First MCP server to do this.
-- **Approach:** Use SAP's existing `@sap-ux/fiori-elements-writer` patterns to generate a minimal Fiori Elements app. Deploy via ABAP_REPOSITORY_SRV. The deployed app creates its own ICF node and can be opened directly via `index.html` — no FLP/launchpad needed.
-- **Key insight:** Keep the generated app minimal — just enough for a working List Report + Object Page. SAP's Fiori tools packages provide the template patterns, but we generate the files ourselves (no npm dependency needed).
-- **Implementation:** New `generate-fiori-app` skill, ZIP creation with `adm-zip`, deploy via Phase 3 client
+- **Approach:** Use `@sap/generator-fiori` headless mode to generate the app. Deploy via ABAP_REPOSITORY_SRV. Only ZIP the `webapp/` subfolder.
+- **Key components:**
+  1. SAP_UI → UI5 version mapping (easy, data already available)
+  2. EDMX metadata fetching from published SRVB (medium)
+  3. Headless config builder + `npx` child process (medium)
+  4. `webapp/` ZIP creation with `adm-zip` (easy)
+  5. Deploy via ABAP_REPOSITORY_SRV POST/PUT (hard — different HTTP path, separate CSRF, Atom XML)
+  6. Skill/command markdown (easy)
 - **Detailed plan:** `docs/plans/phase4-deploy-fiori-app.md`
 
 ### Out of Scope: FLP Tile/Launchpad Configuration
@@ -558,6 +853,23 @@ FLP configuration varies significantly by system type and setup:
 - **BTP ABAP:** `crossNavigation.inbounds` in manifest.json is auto-registered. Managed App Router handles the rest.
 - **On-prem:** Requires admin to configure catalog/group via FLP Designer (transaction `/UI2/FLPD_CUST`), set up semantic objects (`/UI2/SEMOBJ_SAP`), and assign target mappings.
 - **Recommendation:** After deployment, provide system-specific guidance and link to SAP documentation. The deployed app is accessible directly via its ICF URL + `index.html` without FLP.
+
+---
+
+## What a Full "Generate RAP + Fiori + Deploy" Skill Would Look Like
+
+```
+Step 1-12:  [Existing] Generate RAP stack (table, CDS, BDEF, SRVD, DDLX, CLAS)
+Step 13:    [Existing] Create service binding (manual — instruct user)
+Step 14:    [Done] Publish service binding → OData service is live
+Step 15:    [Phase 4] Detect UI5 version from SAP_UI component
+Step 16:    [Phase 4] Fetch $metadata EDMX from published service
+Step 17:    [Phase 4] Build headless config + run @sap/generator-fiori
+Step 18:    [Phase 4] ZIP webapp/ folder with adm-zip
+Step 19:    [Phase 4] Deploy via ABAP_REPOSITORY_SRV (POST or PUT)
+Step 20:    [Done] Verify via BSP filestore read (already implemented)
+Step 21:    [Done] App accessible at /sap/bc/ui5_ui5/sap/{appName}?sap-client={client}
+```
 
 ---
 

--- a/docs/plans/phase4-deploy-fiori-app.md
+++ b/docs/plans/phase4-deploy-fiori-app.md
@@ -2,35 +2,52 @@
 
 ## Overview
 
-Complete the end-to-end pipeline: Table → RAP → Published Service → Fiori Elements App → Deployed & Accessible. This phase adds the ability to generate a minimal Fiori Elements webapp (manifest.json, Component.js, i18n, index.html), ZIP it, and deploy it to the ABAP system via the ABAP Repository OData Service. The deployed app creates its own ICF node and is accessible directly via `index.html` — no Fiori Launchpad configuration needed.
+Complete the end-to-end pipeline: Table → RAP → Published Service → Fiori Elements App → Deployed & Accessible. This phase uses SAP's official `@sap/generator-fiori` in headless mode to generate a Fiori Elements app, ZIPs the `webapp/` folder, and deploys it to the ABAP system via the ABAP Repository OData Service.
 
-This makes ARC-1 the first MCP server to offer end-to-end RAP + Fiori generation and deployment. The webapp files are generated in-memory based on patterns from SAP's `@sap-ux/fiori-elements-writer` — no npm dependency on SAP Fiori tools packages.
+**Key architectural decision:** App generation is delegated to `@sap/generator-fiori` (headless CLI) instead of generating templates in-memory. The generator handles all UI5 version/floorplan complexity — manifest.json structure varies significantly across UI5 versions, OData V2 vs V4, and floorplan types. See `fiori-deployment-research.md` "Key Decision" section for full rationale.
 
 **Dependencies:** Phase 2 (publish SRVB) and Phase 3 (ABAP Repository query) must be completed first.
 
 ## Context
 
-### Current State
+### Current State (What ARC-1 Already Has)
 
-- Phase 2 provides `publishServiceBinding()` — OData service is live and has a URL
-- Phase 3 provides `getAppInfo()` — can check if BSP app exists (determines POST vs PUT)
-- Phase 3 provides the HTTP foundation for calling the ABAP Repository OData Service
-- No deployment capability exists in ARC-1
-- No Fiori Elements template generation exists
+| Capability | Status | Location |
+|-----------|--------|----------|
+| Publish/unpublish SRVB | Done | `src/adt/devtools.ts:128-163` |
+| Read SRVB metadata (odataVersion, serviceDefinition) | Done | `src/adt/client.ts:268-274` (getSrvb) |
+| List/browse/read BSP apps | Done | `src/adt/client.ts:424-457` |
+| Detect SAP_BASIS version + system type | Done | `src/adt/features.ts:178-193` |
+| SAP component list (includes SAP_UI) | Done | `src/adt/client.ts` (getInstalledComponents) |
+| CSRF token management | Done | `src/adt/http.ts:385-452` |
+| BSP app existence check (getAppInfo) | Done | `src/adt/ui5-repository.ts` |
+
+### What's Missing
+
+| Capability | Complexity | Notes |
+|-----------|------------|-------|
+| SAP_UI → UI5 version mapping | Easy | Hardcoded lookup, data already available |
+| Fetch $metadata EDMX from published SRVB | Medium | GET on OData service URL, V2 vs V4 URL patterns |
+| Headless config builder + npx child process | Medium | Build JSON, shell out, handle errors, cleanup temp dir |
+| ZIP `webapp/` folder with adm-zip | Easy | Standard ZIP library |
+| Deploy via ABAP_REPOSITORY_SRV (POST/PUT) | Hard | Different HTTP path, may need separate CSRF, Atom XML payload |
+| Undeploy via ABAP_REPOSITORY_SRV (DELETE) | Medium | Simpler than deploy but same HTTP concerns |
+| Skill + command markdown | Easy | Prompt template |
 
 ### Target State
 
-- `SAPManage(action="deploy_ui5", name="ZAPP_BOOKING", package="$TMP")` — deploy a UI5 app from a ZIP
-- New skill `generate-fiori-app` — generates and deploys a minimal Fiori Elements app for a RAP service
-- `generate-rap-service` skill extended with optional Fiori app generation as final step
-- App accessible at `/sap/bc/ui5_ui5/sap/{appname}/index.html`
+- `SAPManage(action="deploy_ui5", name="ZAPP_BOOKING", package="$TMP", service_binding="ZSB_BOOKING")` — generates + deploys a Fiori Elements app
+- `SAPManage(action="undeploy_ui5", name="ZAPP_BOOKING")` — removes a deployed app
+- New skill `generate-fiori-app` — orchestrates the full flow
+- App accessible at `/sap/bc/ui5_ui5/sap/{appname}?sap-client={client}`
 
 ### Key Files
 
 | File | Role |
 |------|------|
-| `src/adt/ui5-repository.ts` | Extend with `deployApp()`, `undeployApp()` (from Phase 3) |
-| `src/adt/ui5-templates.ts` | **New** — manifest.json, Component.js, index.html generators |
+| `src/adt/ui5-repository.ts` | Extend with `deployApp()`, `undeployApp()` |
+| `src/adt/fiori-generator.ts` | **New** — headless config builder, npx runner, EDMX fetcher |
+| `src/adt/features.ts` | Add SAP_UI → UI5 version mapping |
 | `src/handlers/intent.ts` | Add deploy/undeploy actions in SAPManage handler |
 | `src/handlers/tools.ts` | Update SAPManage description |
 | `src/handlers/schemas.ts` | Update SAPManage schema |
@@ -38,22 +55,22 @@ This makes ARC-1 the first MCP server to offer end-to-end RAP + Fiori generation
 | `.claude/commands/generate-fiori-app.md` | **New** — Claude Code command |
 | `skills/generate-rap-service.md` | Update to reference generate-fiori-app as next step |
 | `package.json` | Add `adm-zip` dependency |
-| `tests/unit/adt/ui5-repository.test.ts` | Deploy unit tests |
-| `tests/unit/adt/ui5-templates.test.ts` | **New** — template generation tests |
+| `tests/unit/adt/fiori-generator.test.ts` | **New** — generator config + process tests |
+| `tests/unit/adt/ui5-repository.test.ts` | Deploy/undeploy unit tests |
 
 ### Design Principles
 
-1. Generate minimal webapp files in-memory — no dependency on `@sap-ux/fiori-elements-writer` or other SAP npm packages. The manifest.json template is parameterized; Component.js and index.html are static boilerplate.
-2. Use `adm-zip` for ZIP creation — lightweight, no native dependencies, already used by SAP's deploy-tooling.
-3. The deploy workflow follows SAP's pattern exactly: GET (check existence) → POST or PUT (create or update) with Atom XML payload containing base64 ZIP.
-4. Package is uppercased. App name is uppercased. Transport is required for non-`$TMP` packages.
-5. After deploy, the app URL is `/sap/bc/ui5_ui5/sap/{appName.toLowerCase()}/index.html?sap-client={client}`.
-6. FLP tile configuration is out of scope — after deploy, provide system-specific guidance to the user.
-7. The `index.html` uses FLP sandbox to render the Fiori Elements app standalone without launchpad.
+1. **Delegate generation to SAP's tooling** — `@sap/generator-fiori` handles all UI5 version/floorplan complexity. ARC-1 only builds the config JSON and runs the CLI.
+2. **Keep the generated app minimal** — `FE_LROP` floorplan, `generateFormAnnotations: false`, `generateLROPAnnotations: false`. The CDS DDLX annotations drive the UI. The app is just a shell.
+3. **Only ZIP `webapp/`** — the generator produces a full project (package.json, ui5.yaml, etc.) but only the `webapp/` folder contents go into the deployment ZIP. Files at ZIP root level, no parent directory.
+4. **Deploy via ABAP_REPOSITORY_SRV** — the proven OData API, same as SAP Web IDE, BAS, and deploy-tooling. NOT the ADT filestore (which is read-only, returns 405 on writes).
+5. **Use existing SAP connection for EDMX** — ARC-1 fetches `$metadata` directly from the published service. No dependency on `@sap-ux/store` or separate auth config.
+6. **Package is uppercased, BSP name is uppercased** — standard SAP convention.
+7. **FLP tile is out of scope** — after deploy, provide system-specific guidance. The `crossNavigation.inbounds` in manifest.json enables auto-registration on BTP.
 
 ## Development Approach
 
-Test-driven with mock HTTP for deployment. Template generation tests verify manifest.json structure, Component.js content, and i18n properties. Use `adm-zip` to verify ZIP creation produces valid archives. The skill files are prompt templates and don't need automated testing.
+Test-driven with mock HTTP for deployment. Generator tests use fixtures (pre-built config JSON → verify structure). The npx child process is mocked in unit tests. Integration testing of the full flow requires a real SAP system.
 
 ## Validation Commands
 
@@ -61,67 +78,232 @@ Test-driven with mock HTTP for deployment. Template generation tests verify mani
 - `npm run typecheck`
 - `npm run lint`
 
+---
+
 ### Task 1: Add adm-zip dependency
 
-**Files:**
-- Modify: `package.json`
-
-Add the `adm-zip` npm package for ZIP archive creation.
+**Files:** `package.json`
+**Complexity:** Easy
+**Risk:** None
 
 - [ ] Run `npm install adm-zip` and `npm install -D @types/adm-zip`
 - [ ] Verify `package.json` has `adm-zip` in dependencies and `@types/adm-zip` in devDependencies
-- [ ] Run `npm test` — all tests must pass (no regressions from new dependency)
-
-### Task 2: Create Fiori Elements template generator
-
-**Files:**
-- Create: `src/adt/ui5-templates.ts`
-- Create: `tests/unit/adt/ui5-templates.test.ts`
-
-Generate minimal Fiori Elements webapp files from RAP service parameters.
-
-- [ ] Create `src/adt/ui5-templates.ts` with interface `FioriAppConfig { appId: string; appTitle: string; serviceUrl: string; entityName: string; odataVersion: '2.0' | '4.0'; serviceName: string }`
-- [ ] Implement `generateManifest(config: FioriAppConfig): string` — returns a JSON manifest.json string for a Fiori Elements List Report + Object Page. For OData V4: use `sap.fe.templates.ListReport` and `sap.fe.templates.ObjectPage`. For OData V2: use `sap.suite.ui.generic.template.ListReport` and `sap.suite.ui.generic.template.ObjectPage`. Include `crossNavigation.inbounds` with semantic object derived from entity name. Use the complete template from `docs/plans/fiori-deployment-research.md` "Fiori Elements manifest.json Template" section.
-- [ ] Implement `generateComponent(appId: string): string` — returns Component.js boilerplate: `sap.ui.define(["sap/fe/core/AppComponent"], function(AppComponent) { "use strict"; return AppComponent.extend("{appId}.Component", { metadata: { manifest: "json" } }); });`
-- [ ] Implement `generateI18n(appTitle: string, entityLabel: string): string` — returns `i18n.properties` content: `appTitle={appTitle}\nappDescription={entityLabel} List Report\n`
-- [ ] Implement `generateIndexHtml(appId: string): string` — returns FLP sandbox HTML that loads `sap-ui-core.js`, creates a `ComponentContainer` with the app, and mounts it. Use `sap_horizon` theme.
-- [ ] Implement `createWebappZip(config: FioriAppConfig): Buffer` — generates all 4 files, creates a ZIP using `adm-zip`, returns the ZIP buffer
-- [ ] Add unit tests (~10 tests): manifest contains correct service URL, manifest has correct routing with entity, manifest OData V4 uses fe.templates, manifest OData V2 uses generic.template, Component.js contains appId, i18n has correct title, index.html loads sap-ui-core, ZIP contains all 4 files, ZIP entries have correct paths (no parent directory), manifest JSON is valid parseable JSON
 - [ ] Run `npm test` — all tests must pass
 
-### Task 3: Implement deploy and undeploy
+---
+
+### Task 2: Add SAP_UI → UI5 version mapping
+
+**Files:** `src/adt/features.ts`
+**Complexity:** Easy
+**Risk:** Low — additive change, existing feature detection untouched
+
+Add a function to extract the UI5 version from the already-fetched system components.
+
+- [ ] Add `SAP_UI_TO_UI5` mapping constant (see `fiori-deployment-api-reference.md` Part 7 for the full table):
+  ```typescript
+  const SAP_UI_TO_UI5: Record<string, string> = {
+      '816': '1.136.0',
+      '758': '1.120.0',
+      '757': '1.108.0',
+      '756': '1.96.0',
+      '754': '1.71.0',
+  };
+  ```
+- [ ] Add `getUi5Version(components: InstalledComponent[]): string` function that:
+  1. Finds the `SAP_UI` component in the list
+  2. Maps its `release` to UI5 version via `SAP_UI_TO_UI5`
+  3. Falls back to `'1.120.0'` if not found (safe LTS default)
+  4. For BTP systems (detected via `SAP_CLOUD` component), defaults to `'1.136.0'`
+- [ ] Export the function for use in the generator module
+- [ ] Add unit tests (~5 tests): known mappings (816→1.136.0, 758→1.120.0), unknown release falls back, BTP default, missing SAP_UI falls back
+- [ ] Run `npm test` — all tests must pass
+
+---
+
+### Task 3: Create Fiori generator module (EDMX fetch + headless config + npx runner)
+
+**Files:**
+- Create: `src/adt/fiori-generator.ts`
+- Create: `tests/unit/adt/fiori-generator.test.ts`
+
+**Complexity:** Medium
+**Risk:** Medium — child process management, temp file cleanup, EDMX URL construction
+
+This module handles three concerns: fetching EDMX metadata, building the headless config, and running the generator.
+
+#### 3a: EDMX metadata fetching
+
+- [ ] Implement `fetchEdmxMetadata(http, serviceUrl: string): Promise<string>` that:
+  1. GETs `{serviceUrl}/$metadata` with `Accept: application/xml`
+  2. Returns the raw EDMX XML string
+  3. Throws a clear error if the service returns 404 (not published?) or non-XML response
+- [ ] Handle V4 vs V2 URL patterns:
+  - V4: `/sap/opu/odata4/sap/{srvb_name}/srvd_a2x/sap/{srvd_name}/0001/$metadata`
+  - V2: `/sap/opu/odata/sap/{srvb_name}/$metadata`
+  - The service URL can be derived from SRVB metadata (`getSrvb()` returns `odataVersion` and `serviceDefinition`)
+- [ ] Add helper `buildServiceUrl(srvbName: string, srvdName: string, odataVersion: '2.0' | '4.0'): string` to construct the OData service base URL
+- [ ] Add unit tests (~5 tests): V4 URL construction, V2 URL construction, EDMX fetch success, fetch 404 error, non-XML response error
+
+#### 3b: Headless config builder
+
+- [ ] Define `FioriGeneratorConfig` interface:
+  ```typescript
+  interface FioriGeneratorConfig {
+      bspName: string;           // ABAP BSP name (e.g., "ZAPP_BOOKING")
+      description: string;       // App description
+      serviceHost: string;       // SAP system URL
+      servicePath: string;       // OData service path
+      sapClient: string;         // SAP client number
+      edmx: string;              // Full EDMX XML
+      entityName: string;        // Main entity name from CDS projection
+      ui5Version: string;        // From SAP_UI mapping (e.g., "1.120.0")
+  }
+  ```
+- [ ] Implement `buildHeadlessConfig(config: FioriGeneratorConfig): object` that builds the JSON config:
+  - `version: "0.2"` (mandatory, validated by generator)
+  - `floorplan: "FE_LROP"` (List Report + Object Page)
+  - `project.name`: derive from bspName — lowercase, replace underscores with dashes (`ZAPP_BOOKING` → `zapp-booking`). Must match `/^[a-z0-9-]+$/`
+  - `project.sapux: true` (required for FE floorplans)
+  - `project.ui5Version`: from SAP_UI mapping
+  - `service.edmx`: the full EDMX XML string
+  - `entityConfig.generateFormAnnotations: false` (CDS DDLX handles this)
+  - `entityConfig.generateLROPAnnotations: false` (CDS DDLX handles this)
+  - `telemetryData.generationSourceName: "arc-1"`
+- [ ] Add unit tests (~8 tests): config has version 0.2, floorplan is FE_LROP, project name derived correctly (uppercase→lowercase, underscores→dashes), sapux is true, EDMX embedded in service, annotations disabled, telemetry included, invalid BSP name throws
+
+#### 3c: npx process runner
+
+- [ ] Implement `generateFioriApp(config: FioriGeneratorConfig): Promise<string>` that:
+  1. Creates a temp directory (`os.tmpdir()` + random suffix)
+  2. Builds the headless config via `buildHeadlessConfig()`
+  3. Writes config to `{tempDir}/generator-config.json`
+  4. Runs `npx -y yo@4 @sap/fiori:headless generator-config.json --force --skipInstall` with `cwd: tempDir`
+  5. Returns the path to the generated `webapp/` folder: `{tempDir}/{projectName}/webapp`
+  6. On error: parses stderr for known error patterns, throws descriptive error
+  7. Timeout: 120 seconds (first run downloads ~100MB; subsequent runs are fast)
+- [ ] Implement `cleanupGeneratedApp(tempDir: string): Promise<void>` — removes the temp directory
+- [ ] Add unit tests (~5 tests): config written to temp file, npx command constructed correctly, stderr parsed on error, timeout handled, cleanup removes temp dir. **Mock `child_process.exec`** — do not actually run npx in unit tests.
+- [ ] Run `npm test` — all tests must pass
+
+**Note on testing:** The npx invocation cannot be tested in unit tests (requires Node.js + network). Integration tests against a real SAP system would cover the full flow. For unit tests, mock `child_process.exec` and verify the command string and config JSON structure.
+
+---
+
+### Task 4: Implement deploy and undeploy via ABAP Repository Service
 
 **Files:**
 - Modify: `src/adt/ui5-repository.ts`
 - Modify: `tests/unit/adt/ui5-repository.test.ts`
 
-Add write operations to the ABAP Repository module created in Phase 3.
+**Complexity:** Hard — this is the highest-risk task
+**Risk:** High — different HTTP path than ADT, may need separate CSRF token, Atom XML payload
 
-- [ ] Add helper `createAtomPayload(appName: string, packageName: string, description: string, zipBase64: string, serviceUrl: string): string` — builds the Atom XML entry payload. XML-escape name and description. Uppercase the package. Use ISO timestamp for `<updated>`. Include `<d:Name>`, `<d:Package>`, `<d:Description>`, `<d:ZipArchive>`, `<d:Info/>`.
-- [ ] Implement `deployApp(http, safety, config: { name: string; package: string; description: string; archive: Buffer; transport?: string }): Promise<string>` — (1) `checkOperation(safety, OperationType.Create, 'DeployUI5App')`, (2) call `getAppInfo()` to check existence, (3) base64-encode archive, (4) build Atom XML payload, (5) POST (new) or PUT (existing) to `/Repositories` with headers `Content-Type: application/atom+xml; type=entry; charset=UTF-8`, query params `CodePage='UTF8'&CondenseMessagesInHttpResponseHeader=X&format=json`, optional `TransportRequest={transport}`. Return app URL.
-- [ ] Implement retry logic for 408/504 timeout: retry up to 3 times, re-check `getAppInfo()` on retry to determine POST vs PUT
-- [ ] Implement `undeployApp(http, safety, appName: string, transport?: string): Promise<void>` — DELETE `/Repositories('{name}')` with same query params
-- [ ] Parse `sap-message` response header (JSON) for success/error details and log them
-- [ ] Add unit tests (~10 tests): deploy new app (POST), redeploy existing (PUT), undeploy, transport parameter included in query, Atom XML payload structure, base64 encoding, package uppercased, retry on 504, safety check blocks, app URL construction
+See `fiori-deployment-api-reference.md` Parts 1-3 for the complete API specification.
+
+#### 4a: ZIP creation helper
+
+- [ ] Implement `createWebappZip(webappPath: string): Buffer`:
+  1. Walk the `webappPath` directory
+  2. Add each file to a `new AdmZip()` instance with paths relative to `webappPath` (files at ZIP root, no parent folder)
+  3. Return `zip.toBuffer()`
+- [ ] Add unit tests (~3 tests): ZIP contains expected files, paths are relative (no `webapp/` prefix), ZIP buffer is valid
+
+#### 4b: Atom XML payload builder
+
+- [ ] Add helper `createAtomPayload(appName: string, packageName: string, description: string, zipBase64: string): string`:
+  - Builds the Atom XML entry payload per `fiori-deployment-api-reference.md` Section 1.5
+  - XML-escape name and description using the escape map: `& → &amp;`, `" → &quot;`, `' → &apos;`, `< → &lt;`, `> → &gt;`
+  - Uppercase the package name
+  - Use ISO timestamp for `<updated>`
+  - Include `<d:Name>`, `<d:Package>`, `<d:Description>`, `<d:ZipArchive>`, `<d:Info/>`
+- [ ] Add unit tests (~4 tests): XML contains correct name, package uppercased, description escaped, base64 ZIP embedded
+
+#### 4c: CSRF token for OData service
+
+The ABAP Repository OData Service (`/sap/opu/odata/`) is on a different path than ADT (`/sap/bc/adt/`). The existing ADT CSRF token (from HEAD `/sap/bc/adt/core/discovery`) **may not be valid** for the OData service.
+
+- [ ] Implement CSRF fetching for the OData path: piggyback on the `getAppInfo()` GET request by adding `X-Csrf-Token: Fetch` header, then capture the `x-csrf-token` response header
+- [ ] Store the OData CSRF token separately from the ADT CSRF token
+- [ ] If the ADT CSRF token works for OData (needs manual testing), simplify by reusing it
+- [ ] Add unit tests (~2 tests): CSRF token captured from getAppInfo response, token included in subsequent write requests
+
+**Important:** This CSRF concern needs manual testing against a real SAP system to verify. The behavior may differ between on-premise and BTP. Document findings.
+
+#### 4d: Deploy (POST/PUT)
+
+- [ ] Implement `deployApp(http, safety, config: { name: string; package: string; description: string; archive: Buffer; transport?: string }): Promise<string>`:
+  1. `checkOperation(safety, OperationType.Create, 'DeployUI5App')`
+  2. Call `getAppInfo()` to check existence (also fetches CSRF token)
+  3. Base64-encode the archive buffer
+  4. Build Atom XML payload via `createAtomPayload()`
+  5. If app doesn't exist: POST to `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV/Repositories`
+  6. If app exists: PUT to `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV/Repositories('{encodeURIComponent(name)}')`
+  7. Headers: `Content-Type: application/atom+xml; type=entry; charset=UTF-8`, `X-Csrf-Token: {token}`
+  8. Query params: `CodePage='UTF8'&CondenseMessagesInHttpResponseHeader=X&format=json`
+  9. Optional query param: `TransportRequest={transport}` (required for non-$TMP packages)
+  10. Parse `sap-message` response header (JSON) for success/error details
+  11. Return app URL: `/sap/bc/ui5_ui5/sap/{name.toLowerCase()}?sap-client={client}`
+- [ ] Implement retry logic for 408/504 timeout: retry up to 3 times, re-check `getAppInfo()` on each retry (timeout may have partially created the app, switching POST to PUT)
+- [ ] Add unit tests (~8 tests): deploy new app (POST), redeploy existing (PUT), transport param in query, Atom XML structure, base64 encoding, package uppercased, retry on 504, safety check blocks
+
+#### 4e: Undeploy (DELETE)
+
+- [ ] Implement `undeployApp(http, safety, appName: string, transport?: string): Promise<void>`:
+  1. `checkOperation(safety, OperationType.Delete, 'UndeployUI5App')`
+  2. DELETE to `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV/Repositories('{encodeURIComponent(appName)}')`
+  3. Query params: `CodePage='UTF8'&CondenseMessagesInHttpResponseHeader=X&format=json`
+  4. Optional: `TransportRequest={transport}`
+  5. Parse `sap-message` header for confirmation
+- [ ] Add unit tests (~3 tests): undeploy sends DELETE, transport param included, safety check blocks
+
 - [ ] Run `npm test` — all tests must pass
 
-### Task 4: Wire up SAPManage handler
+---
+
+### Task 5: Wire up SAPManage handler
 
 **Files:**
 - Modify: `src/handlers/schemas.ts`
 - Modify: `src/handlers/tools.ts`
 - Modify: `src/handlers/intent.ts`
 
-Expose deploy/undeploy via the SAPManage tool.
+**Complexity:** Medium
+**Risk:** Low — follows established handler patterns
 
-- [ ] Add `deploy_ui5` and `undeploy_ui5` to SAPManage action enum in `src/handlers/schemas.ts`. Add fields: `archive_base64: z.string().optional()` (for raw ZIP upload), `service_binding: z.string().optional()` (for auto-generation from SRVB)
-- [ ] Update SAPManage description in `src/handlers/tools.ts` to include: `deploy_ui5: deploy a UI5/Fiori app to the ABAP system (provide service_binding to auto-generate from a published RAP service, or archive_base64 for a pre-built ZIP). undeploy_ui5: remove a deployed UI5 app.`
-- [ ] Add `deploy_ui5` case in `handleSAPManage` at `src/handlers/intent.ts`: if `service_binding` is provided, read SRVB metadata, read projection CDS entity name, call `createWebappZip()` to generate the app, then call `deployApp()`. If `archive_base64` is provided, decode it and call `deployApp()` directly. Return the app URL.
+- [ ] Add `deploy_ui5` and `undeploy_ui5` to SAPManage action enum in `src/handlers/schemas.ts`. Add fields:
+  - `service_binding: z.string().optional()` — SRVB name for auto-generation
+  - `archive_base64: z.string().optional()` — for pre-built ZIP upload (advanced use case)
+- [ ] Update SAPManage description in `src/handlers/tools.ts`:
+  ```
+  deploy_ui5: deploy a UI5/Fiori app to the ABAP system. Provide service_binding to auto-generate
+  a Fiori Elements app from a published RAP service, or archive_base64 for a pre-built ZIP.
+  undeploy_ui5: remove a deployed UI5/Fiori app.
+  ```
+- [ ] Add `deploy_ui5` case in `handleSAPManage` at `src/handlers/intent.ts`:
+  1. If `service_binding` provided:
+     a. Read SRVB metadata via `getSrvb()` → get odataVersion, serviceDefinition
+     b. Detect UI5 version from SAP_UI component via `getUi5Version()`
+     c. Build service URL via `buildServiceUrl()`
+     d. Fetch EDMX via `fetchEdmxMetadata()`
+     e. Read projection CDS entity for main entity name
+     f. Call `generateFioriApp()` → get webapp path
+     g. Call `createWebappZip()` → get ZIP buffer
+     h. Call `deployApp()` → get app URL
+     i. Call `cleanupGeneratedApp()` → remove temp dir
+     j. Return app URL
+  2. If `archive_base64` provided:
+     a. Decode base64 to Buffer
+     b. Call `deployApp()` directly
+     c. Return app URL
+  3. If neither provided: return error
 - [ ] Add `undeploy_ui5` case: call `undeployApp()` with name and optional transport
-- [ ] Add handler unit tests (~5 tests): deploy from service binding, deploy from archive, undeploy, missing name error, deploy returns URL
+- [ ] Add handler unit tests (~5 tests): deploy from service binding (mock all dependencies), deploy from archive, undeploy, missing name error, deploy returns URL
 - [ ] Run `npm test` — all tests must pass
 
-### Task 5: Create generate-fiori-app skill
+---
+
+### Task 6: Create generate-fiori-app skill
 
 **Files:**
 - Create: `skills/generate-fiori-app.md`
@@ -130,20 +312,66 @@ Expose deploy/undeploy via the SAPManage tool.
 - Modify: `.claude/commands/generate-rap-service.md`
 - Modify: `skills/README.md`
 
-Create the skill prompt template and update existing skills.
+**Complexity:** Easy
+**Risk:** None — markdown only
 
-- [ ] Create `skills/generate-fiori-app.md` with the following steps: (1) Read SRVB metadata, (2) Read projection CDS view for entity name, (3) Read DDLX for UI annotation labels, (4) Call `SAPManage(action="deploy_ui5", service_binding="ZSB_...", name="ZAPP_...", package="$TMP")`, (5) Present the app URL. Include input section (service binding name required, BSP name optional, package optional, transport optional).
+- [ ] Create `skills/generate-fiori-app.md` with the following flow:
+  1. **Input:** Service binding name (required), BSP app name (optional, derived from SRVB if not given), package (optional, defaults to `$TMP`), transport (optional)
+  2. **Step 1:** Read SRVB metadata → confirm published, get odataVersion
+  3. **Step 2:** Read projection CDS view for entity name
+  4. **Step 3:** Read DDLX metadata annotations for UI annotation labels (informational)
+  5. **Step 4:** Call `SAPManage(action="deploy_ui5", service_binding="ZSB_...", name="ZAPP_...", package="$TMP")`
+  6. **Step 5:** Present the app URL to the user
+  7. **Notes section:** Document first-run delay (~60s for npx download), FLP guidance (BTP: auto-registered via crossNavigation; on-prem: `/UI2/FLPD_CUST`), alternative with fiori-mcp-server
 - [ ] Create `.claude/commands/generate-fiori-app.md` with same content
-- [ ] Update `skills/generate-rap-service.md` Step 14 to add: "Next step: Generate a Fiori Elements app with the generate-fiori-app skill" with a reference to the new skill
+- [ ] Update `skills/generate-rap-service.md` to add: "Next step: Generate a Fiori Elements app with the generate-fiori-app skill"
 - [ ] Update `.claude/commands/generate-rap-service.md` with same reference
 - [ ] Add `generate-fiori-app` to the skills table in `skills/README.md`
 - [ ] Run `npm test` — all tests must pass (skill changes are markdown, just verify no regressions)
 
-### Task 6: Final verification
+---
+
+### Task 7: Final verification
 
 - [ ] Run full test suite: `npm test` — all tests pass
 - [ ] Run typecheck: `npm run typecheck` — no errors
 - [ ] Run lint: `npm run lint` — no errors
-- [ ] Verify the complete E2E flow works conceptually: `generate-rap-service` → manual SRVB creation → `SAPActivate(action="publish_srvb")` → `generate-fiori-app` → app URL returned
-- [ ] Document FLP guidance in skill: for BTP point to crossNavigation auto-registration, for on-prem point to `/UI2/FLPD_CUST` transaction and SAP documentation
+- [ ] Verify the complete E2E flow works conceptually:
+  ```
+  generate-rap-service → manual SRVB creation
+  → SAPActivate(action="publish_srvb")
+  → generate-fiori-app skill
+  → SAPManage(action="deploy_ui5", service_binding="ZSB_...")
+  → app URL returned
+  → verify via SAPRead(type="BSP")
+  ```
+- [ ] Document FLP guidance in skill: for BTP point to crossNavigation auto-registration, for on-prem point to `/UI2/FLPD_CUST` transaction
 - [ ] Move this plan to `docs/plans/completed/`
+
+---
+
+## Risk Assessment
+
+| Task | Risk | Why | Mitigation |
+|------|------|-----|------------|
+| Task 1 (adm-zip) | None | Standard npm dependency | — |
+| Task 2 (UI5 mapping) | Low | Hardcoded lookup, stable data | Fallback to 1.120.0 |
+| Task 3a (EDMX fetch) | Medium | V2 vs V4 URL patterns, service must be published | Derive URL from SRVB metadata |
+| Task 3b (config builder) | Low | Pure data transformation | Comprehensive unit tests |
+| Task 3c (npx runner) | Medium | Child process, temp files, first-run delay, Docker? | Timeout guard, cleanup in finally |
+| Task 4a (ZIP) | Low | adm-zip is straightforward | — |
+| Task 4b (Atom XML) | Low | String construction, well-documented format | Test against reference in api-reference.md |
+| Task 4c (CSRF) | **High** | Unknown if ADT CSRF works for OData path | Needs manual testing, implement fallback |
+| Task 4d (deploy POST/PUT) | **High** | Complex flow, retry logic, transport handling | Thorough unit tests, integration test |
+| Task 4e (undeploy) | Medium | Simpler than deploy but same HTTP concerns | — |
+| Task 5 (handler) | Low | Follows established patterns | — |
+| Task 6 (skill) | None | Markdown only | — |
+
+**Testing priority:** Task 4 (deploy/undeploy) needs the most thorough testing. Task 3c (npx runner) needs integration testing with a real SAP system. Everything else can be well-covered by unit tests alone.
+
+---
+
+## Reference Documents
+
+- `docs/plans/fiori-deployment-research.md` — Full research: options evaluated, generator analysis, fiori-mcp-server analysis, UI5 version detection
+- `docs/plans/fiori-deployment-api-reference.md` — API specs: ABAP Repository OData Service, ADT Filestore, transport handling, ZIP creation, headless generator config format


### PR DESCRIPTION
## Summary

- **Rewrote Phase 4 plan** to use `@sap/generator-fiori` headless CLI instead of fragile in-memory template generation. manifest.json varies significantly across UI5 versions/floorplans — SAP's generator handles this correctly.
- **Added UI5 version detection strategy** — map SAP_UI component release (already fetched at startup) to UI5 LTS version via hardcoded lookup table. Zero additional HTTP calls.
- **Added complete headless config reference** to API reference doc — config JSON format (v0.2), field constraints, EDMX acquisition, output structure, error handling, gotchas.
- **Added fiori-mcp-server analysis** to research doc — architecture (shells out to Yeoman), 5 tools/6 functionalities, limitations (`@sap-ux/store` auth dependency), can be used alongside ARC-1 as alternative.
- **Risk assessment** identifies CSRF token handling and ABAP Repository deploy as highest-risk items needing real-system testing.

## Test plan

- [ ] No code changes — documentation only, `npm test` unaffected
- [ ] Review headless config format against SAP/open-ux-tools source
- [ ] Verify SAP_UI → UI5 mapping against https://ui5.sap.com/versionoverview.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)