### PR TITLE
fix: correct Accept headers and entity expansion limit for ADT APIs

### DIFF
--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -201,7 +201,7 @@ export async function runUnitTests(
     body,
     'application/vnd.sap.adt.abapunit.testruns.config.v4+xml',
     {
-      Accept: 'application/xml',
+      Accept: 'application/vnd.sap.adt.abapunit.testruns.result.v2+xml',
     },
   );
 

--- a/src/adt/transport.ts
+++ b/src/adt/transport.ts
@@ -23,7 +23,7 @@ export async function listTransports(
     url += `?user=${encodeURIComponent(user)}`;
   }
 
-  const resp = await http.get(url, { Accept: 'application/xml' });
+  const resp = await http.get(url, { Accept: 'application/vnd.sap.adt.transportorganizertree.v1+xml' });
   return parseTransportList(resp.body);
 }
 
@@ -36,7 +36,7 @@ export async function getTransport(
   checkTransport(safety, transportId, 'GetTransport', false);
 
   const resp = await http.get(`/sap/bc/adt/cts/transportrequests/${encodeURIComponent(transportId)}`, {
-    Accept: 'application/xml',
+    Accept: 'application/vnd.sap.adt.transportorganizertree.v1+xml',
   });
 
   const transports = parseTransportList(resp.body);

--- a/src/adt/xml-parser.ts
+++ b/src/adt/xml-parser.ts
@@ -68,6 +68,11 @@ const parser = new XMLParser({
   },
   parseAttributeValue: false, // Keep attributes as strings
   parseTagValue: false, // Keep tag values as strings (prevents "001" → 1)
+  // SAP ADT responses use only standard XML entities (&amp; &lt; &gt; &quot;).
+  // Dump listings (ST22) can contain thousands of entity references in stack traces.
+  // fast-xml-parser v5 defaults to maxTotalExpansions=1000 which is too low.
+  // Disable custom entity processing — standard entities are handled regardless.
+  processEntities: false,
 });
 
 /** Parse raw XML string to a JS object */


### PR DESCRIPTION
## Summary

Fixes three pre-existing issues found during the ADT API audit (PR #65) verification against the live SAP A4H test system:

- **XML entity expansion limit**: SAP dump listings (ST22) can contain 5000+ XML entity references in stack traces. fast-xml-parser v5 defaults to `maxTotalExpansions=1000`, causing parse failures. Fix: disable custom entity processing since SAP only uses standard XML entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`), which are handled regardless.

- **Unit test Accept header**: `runUnitTests()` used `Accept: application/xml` but SAP requires `application/vnd.sap.adt.abapunit.testruns.result.v2+xml` (returns 406 otherwise).

- **Transport list Accept header**: `listTransports()` and `getTransport()` used `Accept: application/xml` but SAP requires `application/vnd.sap.adt.transportorganizertree.v1+xml` (returns 406 otherwise).

## Test plan

- [x] All 1251 unit tests pass
- [x] All 125 integration tests pass against live SAP A4H (was 4 failures before this fix)
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)