### PR TITLE
docs: add test reliability audit and hardening plan (points 2-7)

### DIFF
--- a/docs/plans/high-risk-transport-write-compatibility.md
+++ b/docs/plans/high-risk-transport-write-compatibility.md
@@ -1,0 +1,232 @@
+# High-Risk Transport and Write-Path Compatibility Hardening
+
+## Overview
+This plan resolves the four P1 upstream-derived risks in ARC-1: issue #9 (406 Accept mismatch on CTS), issue #26 (`getTransport` false-negative / wrong media type), issue #70 (`createTransport` media-type + namespace incompatibility), and issue #56 (missing `corrNr` propagation on transportable package writes).
+
+The design keeps ARC-1 safety defaults intact while hardening protocol compatibility: endpoint-specific transport media types, one-time 406/415 negotiation fallback, and automatic reuse of lock-provided `corrNr` when the caller omits `transport`. The implementation is validated across unit, integration, and MCP e2e tiers.
+
+The plan also includes full artifact updates required by the ralphex workflow: technical docs, end-user docs, roadmap/feature matrix, `CLAUDE.md`, and affected `.claude/commands` skills.
+
+Implementation status tracker (update in-place as work finishes):
+- Issue #9 (406 Accept mismatch on CTS): `PLANNED` -> set to `COMPLETED` when Tasks 1, 2, 5, and 6 pass.
+- Issue #26 (`getTransport` not found due to media-type mismatch): `PLANNED` -> set to `COMPLETED` when Tasks 1, 2, 5, and 6 pass.
+- Issue #70 (`createTransport` endpoint/media-type/payload compatibility): `PLANNED` -> set to `COMPLETED` when Tasks 1, 2, 5, and 6 pass.
+- Issue #56 (missing auto-`corrNr` propagation on write path): `PLANNED` -> set to `COMPLETED` when Tasks 3, 4, 5, and 6 pass.
+
+## Context
+
+### Current State
+- `src/adt/transport.ts` currently uses `application/vnd.sap.adt.transportorganizertree.v1+xml` for both list and get, and uses generic `application/xml` plus `http://www.sap.com/cts/transports` payload namespace for create.
+- `src/adt/http.ts` retries only on CSRF 403 and broken DB session; it has no generic 406/415 content negotiation fallback.
+- `src/adt/crud.ts` parses lock `corrNr` in `lockObject()` but `safeUpdateSource()` does not reuse it when `transport` is omitted.
+- `src/handlers/intent.ts` delete flow (`handleSAPWrite` around `lockObject` + `deleteObject`) currently forwards only caller-provided `transport`, not lock-derived `corrNr`.
+- Unit tests exist in `tests/unit/adt/transport.test.ts`, `tests/unit/adt/http.test.ts`, and `tests/unit/adt/crud.test.ts`, but they do not yet assert the specific fallback behavior needed for these P1 scenarios.
+- Integration coverage in `tests/integration/adt.integration.test.ts` currently focuses on read/write smoke in `$TMP`; it does not explicitly verify transport endpoint media-type compatibility or lock-driven `corrNr` propagation in transportable packages.
+- E2E coverage (`tests/e2e/rap.e2e.test.ts`) has a skipped SAPWrite lifecycle path and no dedicated SAPTransport compatibility suite.
+
+### Target State
+- `listTransports`, `getTransport`, and `createTransport` use endpoint-appropriate media types and payload namespace, with robust one-retry fallback for SAP-version variance.
+- `safeUpdateSource()` and delete flows automatically reuse lock `corrNr` when no `transport` argument is supplied, while preserving explicit `transport` override precedence.
+- 406/415 negotiation fallback is centrally handled in `src/adt/http.ts` (max one retry, deterministic header mutation, auditable behavior).
+- Unit tests enforce all new behaviors, and live integration/e2e tests validate the exact scenarios reproduced on A4H (`Z_LLM_TEST_PACKAGE`).
+- Documentation and skills no longer imply a hard transport parameter requirement for every write; they correctly describe auto-propagation behavior and remaining constraints.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/transport.ts` | CTS list/get/create/release implementation; media-type + payload compatibility |
+| `src/adt/http.ts` | Central request pipeline; 403 retry and new 406/415 negotiation retry |
+| `src/adt/crud.ts` | Lock/update/delete primitives and `safeUpdateSource()` orchestration |
+| `src/handlers/intent.ts` | SAPWrite/SAPTransport tool handling and error hint shaping |
+| `src/adt/errors.ts` | ADT error model used for retry and hint classification |
+| `tests/unit/adt/transport.test.ts` | Unit coverage for transport headers/body/parsing |
+| `tests/unit/adt/http.test.ts` | Unit coverage for retry logic and header mutation |
+| `tests/unit/adt/crud.test.ts` | Unit coverage for lock result use and write URL construction |
+| `tests/unit/handlers/intent.test.ts` | Unit coverage for SAPWrite/SAPTransport tool behavior and hints |
+| `tests/integration/adt.integration.test.ts` | Live SAP integration tests (A4H) for write + transport behavior |
+| `tests/integration/helpers.ts` | Integration env wiring (`TEST_SAP_*`) and client setup |
+| `tests/e2e/rap.e2e.test.ts` | Existing MCP end-to-end write lifecycle suite |
+| `tests/e2e/helpers.ts` | MCP client and tool-call helpers for e2e additions |
+| `docs/tools.md` | Tool contract and parameter semantics for SAPWrite/SAPTransport |
+| `docs/authorization.md` | Scope/safety explanation of transport-related operations |
+| `docs/cli-guide.md` | User-facing CLI safety/transport behavior summary |
+| `docs/index.md` | High-level capability and safety statements |
+| `README.md` | Public feature positioning and transport safety claims |
+| `docs/roadmap.md` | FEAT-08 status/source links and priority alignment |
+| `compare/00-feature-matrix.md` | Capability matrix + “Key Gaps to Close” status |
+| `CLAUDE.md` | AI-assistant reference for code patterns/tests/config |
+| `.claude/commands/migrate-custom-code.md` | Skill guidance currently treating transport as always mandatory |
+| `.claude/commands/generate-abap-unit-test.md` | Skill examples for create/update transport usage expectations |
+| `.claude/commands/generate-rap-service.md` | Skill workflow and transport guidance for generated writes |
+| `.claude/commands/generate-rap-service-researched.md` | Research-first skill transport assumptions |
+
+### Design Principles
+1. Prefer protocol-correct headers first, fallback second: deterministic primary media types plus one bounded retry for variance.
+2. Keep safety model unchanged: no bypass of package restrictions, operation guards, or transport enablement gates.
+3. Treat lock metadata as authoritative: if SAP returns `corrNr`, reuse it unless the caller explicitly overrides.
+4. Avoid hidden retry loops: max one negotiation retry per request, with clear audit visibility.
+5. Test each failure mode at the lowest practical tier first (unit), then prove on live SAP (integration), then full MCP path (e2e).
+6. Keep docs and skills aligned with runtime truth to reduce operator and LLM misguidance.
+
+## Development Approach
+Implement in layers: transport module correctness, shared HTTP retry mechanism, CRUD/handler propagation, then test expansion and documentation alignment. For live tests, gate transportable-package scenarios behind explicit env configuration to keep CI-safe behavior (auto-skip when env is absent) while still supporting repeatable validation against A4H from `INFRASTRUCTURE.md` and `.env.infrastructure`.
+
+## Validation Commands
+- `npm run typecheck`
+- `npm run lint`
+- `npm test -- tests/unit/adt/transport.test.ts tests/unit/adt/http.test.ts tests/unit/adt/crud.test.ts tests/unit/handlers/intent.test.ts`
+- `npm run test:integration -- tests/integration/adt.integration.test.ts`
+- `TEST_TRANSPORT_PACKAGE=Z_LLM_TEST_PACKAGE npm run test:integration -- tests/integration/adt.integration.test.ts`
+- `npm run test:e2e -- tests/e2e/rap.e2e.test.ts`
+- `npm test`
+
+### Task 1: Fix CTS Endpoint Media Types and Payload Namespace (Issues #9, #26, #70)
+
+**Files:**
+- Modify: `src/adt/transport.ts`
+- Modify: `tests/unit/adt/transport.test.ts`
+- (Optional fixture additions) Modify: `tests/fixtures/xml/*` if needed for realistic error/response samples
+
+`getTransport()` currently sends tree media type (around `src/adt/transport.ts` lines 31-40), and `createTransport()` uses generic XML + legacy namespace (lines 55-62). This task makes transport calls protocol-correct per operation and preserves backward compatibility with a bounded fallback path where required.
+
+- [ ] Define explicit constants for CTS media types and namespaces (tree vs organizer) and use them consistently in list/get/create paths.
+- [ ] Keep list on organizer-tree media type, move get/create to organizer media type, and ensure create payload root namespace is `http://www.sap.com/cts/adt/tm`.
+- [ ] Preserve/verify create endpoint behavior on `/sap/bc/adt/cts/transportrequests`; only add endpoint fallback if concrete status/body indicates alternate endpoint requirement.
+- [ ] Ensure response parsing still handles attribute order variance (`request`/`task` attributes) without regressions.
+- [ ] Add unit tests (~8 tests): exact Accept assertions for list/get, create Content-Type/Accept assertions, payload namespace assertion, and response parsing non-regression.
+- [ ] Run `npm test -- tests/unit/adt/transport.test.ts`.
+
+### Task 2: Add One-Retry 406/415 Content Negotiation in ADT HTTP Layer
+
+**Files:**
+- Modify: `src/adt/http.ts`
+- Modify: `tests/unit/adt/http.test.ts`
+- Modify: `src/adt/errors.ts` only if helper methods are needed for safe parsing
+
+Transport compatibility issues recur across endpoints and SAP versions. Implement the retry in the shared request layer (`src/adt/http.ts` request flow around lines 156-339) so all callers benefit without duplicating logic.
+
+- [ ] Add a dedicated negotiation-retry helper that activates only for status `406`/`415`, mutates headers deterministically, and retries exactly once.
+- [ ] Implement Accept fallback strategy (primary configured Accept → inferred accepted type from SAP error text when available → wildcard fallback as last resort).
+- [ ] Implement Content-Type fallback strategy for modifying requests (preserve existing behavior unless 415 indicates media-type rejection).
+- [ ] Ensure retry logic works in both direct fetch and proxy mode without duplicating request construction.
+- [ ] Emit audit/debug metadata indicating retry attempt and effective fallback headers (without leaking sensitive values).
+- [ ] Add unit tests (~10 tests): 406 GET Accept fallback success, 415 POST Content-Type fallback success, no retry on non-406/415 errors, no infinite retry loop, and preservation of CSRF/cookie behavior.
+- [ ] Run `npm test -- tests/unit/adt/http.test.ts`.
+
+### Task 3: Auto-Propagate Lock `corrNr` for Update/Delete Write Paths (Issue #56)
+
+**Files:**
+- Modify: `src/adt/crud.ts`
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/adt/crud.test.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+`lockObject()` already returns `corrNr` (`src/adt/crud.ts` lines 37-43), but `safeUpdateSource()` and delete handling do not consume it when `transport` is omitted. This task closes that gap while keeping explicit transport override precedence.
+
+- [ ] In `safeUpdateSource()`, derive `effectiveTransport = transport ?? lock.corrNr || undefined` and pass that to `updateSource()`.
+- [ ] In SAPWrite delete flow (`src/handlers/intent.ts` around lines 1162-1166), pass `transport ?? lock.corrNr || undefined` to `deleteObject()`.
+- [ ] Keep explicit `transport` argument authoritative when supplied by caller.
+- [ ] Preserve existing lock→modify→unlock try/finally safety behavior and stateful session guarantees.
+- [ ] Add unit tests (~8 tests): auto `corrNr` propagation on update, explicit transport override, no `corrNr` when lock returns empty, delete-path fallback propagation, and no regression for `$TMP` flows.
+- [ ] Run `npm test -- tests/unit/adt/crud.test.ts tests/unit/handlers/intent.test.ts`.
+
+### Task 4: Improve User-Facing Error Hints for Transport/CorrNr Failures
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+When fallback still cannot resolve a write (e.g., transport not assignable, missing authorization, package mismatch), the error should guide the operator immediately instead of returning generic ADT failures.
+
+- [ ] Extend `formatErrorForLLM()` (`src/handlers/intent.ts` around lines 165-181) to detect common transport/corrNr failure signatures and add specific remediation hints (`SE09` transport check, package/allowlist reminder, provide explicit `transport`).
+- [ ] Keep existing not-found/auth/network hints intact and non-duplicative.
+- [ ] Ensure hints never leak raw XML or internal stack traces.
+- [ ] Add unit tests (~4 tests): corrNr-missing hint, transport authorization hint, and non-transport errors remain unchanged.
+- [ ] Run `npm test -- tests/unit/handlers/intent.test.ts`.
+
+### Task 5: Add Live Integration Tests for CTS Compatibility and CorrNr Propagation
+
+**Files:**
+- Modify: `tests/integration/adt.integration.test.ts` (or create a focused `tests/integration/transport.integration.test.ts`)
+- Modify: `tests/integration/helpers.ts` if additional env helpers are needed
+- (If needed) Add: `tests/fixtures/abap/*` transient fixture sources for transport-package writes
+
+This task validates the exact real-system scenarios reproduced on A4H: media-type-sensitive `get/create transport` and write/update on a transportable package (`Z_LLM_TEST_PACKAGE`) without explicit `transport`.
+
+- [ ] Add env-gated integration scenario for transportable package writes (skip when `TEST_TRANSPORT_PACKAGE` is unset).
+- [ ] Add integration test for `getTransport` returning expected transport details with corrected Accept behavior.
+- [ ] Add integration test for `createTransport` succeeding with corrected payload namespace/media type and returning transport id.
+- [ ] Add integration test for create+update in transportable package where update succeeds without caller-supplied transport due to lock `corrNr` propagation.
+- [ ] Add deterministic cleanup strategy (best-effort delete with lock handling; never release created test transports automatically).
+- [ ] Run `npm run test:integration -- tests/integration/adt.integration.test.ts` and the env-gated variant with `TEST_TRANSPORT_PACKAGE=Z_LLM_TEST_PACKAGE`.
+
+### Task 6: Add MCP E2E Coverage for SAPTransport + Transportable SAPWrite
+
+**Files:**
+- Modify: `tests/e2e/rap.e2e.test.ts` and/or add `tests/e2e/saptransport.e2e.test.ts`
+- Modify: `tests/e2e/helpers.ts` (only if additional helpers are needed)
+- Modify: `tests/e2e/README.md` for new env prerequisites
+
+Integration tests prove ADT behavior; this task proves full MCP JSON-RPC behavior via ARC-1 tool handlers.
+
+- [ ] Add e2e test for SAPTransport `create` + `get` with assertions on returned IDs/details and no raw XML leakage.
+- [ ] Add env-gated e2e test for SAPWrite update in a transportable package without explicit transport, asserting successful completion (or clear skip message when env missing).
+- [ ] Keep existing skipped lifecycle tests untouched unless this work directly unblocks them; avoid introducing flaky cleanup dependencies.
+- [ ] Document required env variables (`E2E_MCP_URL`, `TEST_TRANSPORT_PACKAGE`, credentials) for local execution.
+- [ ] Run `npm run test:e2e -- tests/e2e/rap.e2e.test.ts` (plus new e2e file if created).
+
+### Task 7: Update Technical and User Documentation, Roadmap, and Feature Matrix
+
+**Files:**
+- Modify: `docs/tools.md`
+- Modify: `docs/authorization.md`
+- Modify: `docs/cli-guide.md`
+- Modify: `docs/index.md`
+- Modify: `docs/architecture.md` (if request/flow narrative changes)
+- Modify: `README.md`
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+
+Docs must reflect the new runtime truth: transport parameters remain supported, but update/delete on transportable objects can auto-use lock-provided `corrNr` when available.
+
+- [ ] Update tool docs to clarify transport parameter semantics (optional vs recommended, auto-propagation behavior, failure cases requiring explicit transport).
+- [ ] Update user-facing safety language so it no longer implies a mandatory manual transport parameter for every write.
+- [ ] Update roadmap entries for FEAT-08 and linked VSP high-risk items to reflect implemented status/scope.
+- [ ] Update feature matrix “Last updated” date and gap/status statements for 415/406 retry hardening.
+- [ ] Update `CLAUDE.md` sections affected by new behavior (key files, CRUD pattern notes, test counts/coverage references if changed).
+- [ ] Include bonus stale-doc correction spotted during research: resolve any scope/tool mapping inconsistency in roadmap text versus `docs/authorization.md`.
+- [ ] Run `npm run lint` to verify markdown style consistency where applicable.
+
+### Task 8: Align `.claude/commands` Skills with New Transport Behavior
+
+**Files:**
+- Modify: `.claude/commands/migrate-custom-code.md`
+- Modify: `.claude/commands/generate-abap-unit-test.md`
+- Modify: `.claude/commands/generate-rap-service.md`
+- Modify: `.claude/commands/generate-rap-service-researched.md`
+- Review: other `.claude/commands/*.md` for transport requirement phrasing
+
+Skill instructions currently assume transport must always be manually supplied for transportable writes. After implementing lock-based auto-propagation, these instructions must be accurate to avoid over-constraining user flows.
+
+- [ ] Update skill guidance from “transport always required” to “explicit transport recommended; ARC-1 may auto-propagate lock `corrNr` for update/delete when available.”
+- [ ] Keep create-flow guidance explicit: transport may still be required depending on package/system behavior.
+- [ ] Ensure examples remain valid and do not claim unsupported transport management automation.
+- [ ] Run `npm run lint` to catch formatting issues in edited markdown/docs files.
+
+### Task 9: Final Verification and Plan Closure
+
+**Files:**
+- Modify: `docs/plans/high-risk-transport-write-compatibility.md` (mark notes if needed before archival)
+- Move: `docs/plans/high-risk-transport-write-compatibility.md` → `docs/plans/completed/high-risk-transport-write-compatibility.md`
+
+This task confirms all code/tests/docs/skills updates are complete and reproducible before closing the plan.
+
+- [ ] Run full unit suite: `npm test`.
+- [ ] Run integration suite: `npm run test:integration` (with and without `TEST_TRANSPORT_PACKAGE` where applicable).
+- [ ] Run e2e suite for affected scenarios: `npm run test:e2e`.
+- [ ] Run typecheck: `npm run typecheck`.
+- [ ] Run lint: `npm run lint`.
+- [ ] Perform one live smoke check against A4H using documented infrastructure config (transport get/create + transportable update flow).
+- [ ] Move this plan to `docs/plans/completed/`.

--- a/docs/plans/test-reliability-audit-points-2-7-hardening.md
+++ b/docs/plans/test-reliability-audit-points-2-7-hardening.md
@@ -1,0 +1,269 @@
+# Test Reliability Hardening Plan (Audit Points 2-7)
+
+## Overview
+
+This plan hardens test reliability for the exact gaps identified in `docs/research/test-reliability-audit-points-2-7.md`: skip misuse, missing coverage telemetry, low-signal `try/catch`, pseudo-skips via early return, incomplete CRUD lifecycle validation, and dormant BTP checks. The objective is to make green pipelines mean real behavioral evidence, not just test volume.
+
+The plan keeps rollout risk low by separating informational telemetry from enforcement. Point 3 (coverage) remains non-blocking initially, while skip/try-catch/CRUD corrections focus on correctness and observability. BTP work is split into CI-capable smoke and local-only extended paths to reflect real infrastructure constraints.
+
+The implementation also updates workflow governance and project documentation so current behavior is accurately described in `README.md`, `docs/index.md`, `docs/roadmap.md`, `compare/00-feature-matrix.md`, `CLAUDE.md`, and `.claude/commands/ralphex-plan.md`.
+
+## Context
+
+### Current State
+
+The audit baseline (2026-04-10) shows the following reliability issues:
+
+- CI workflow policy skips runtime jobs on push to main (`.github/workflows/test.yml:41-43`, `:71-73`), confirmed by run `24213793920` where `integration` and `e2e` were skipped.
+- Runtime regressions are real when jobs execute, confirmed by run `24212490295` (`integration` and `e2e` both failed).
+- Coverage script exists (`package.json:38`) but provider dependency is missing and no workflow publishes coverage artifacts.
+- Multiple test paths pass without proving behavior:
+  - try/catch swallow patterns in `tests/integration/adt.integration.test.ts:220-225`, `:269-274`, `:283-290`, `:431-447`
+  - pseudo-skips via early return in `tests/integration/context.integration.test.ts:277-330` and `tests/e2e/cds-context.e2e.test.ts:54-100`
+- Declared CRUD lifecycle test is a placeholder (`tests/integration/adt.integration.test.ts:299-309`) and does not execute full create/update/delete assertions.
+- BTP suite is gated local-only by design (`tests/integration/btp-abap.integration.test.ts:7-13`, `:58`) and not wired into CI secrets/workflows.
+- Branch protection is not enforced on `main` (GitHub API returns `404 Branch not protected`).
+
+### Target State
+
+A green CI run should provide trustworthy evidence that critical runtime behavior was actually exercised:
+
+- Internal PRs and `push` to `main` execute unit + integration + e2e (unless infra outage is explicitly classified).
+- Skips are explicit, reasoned, and measurable; pseudo-skip passes are eliminated.
+- Coverage is collected and published as informational telemetry in CI and release workflows.
+- Integration/e2e tests assert deterministic contracts even in variable SAP environments.
+- CRUD lifecycle has at least one required full roundtrip test with strict cleanup semantics.
+- BTP tests are split into stable CI smoke and local-only extended checks with documented ownership and failure taxonomy.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `docs/research/test-reliability-audit-points-2-7.md` | Audit baseline and evidence source for points 2-7 |
+| `.github/workflows/test.yml` | Main CI test orchestration and current skip policy |
+| `.github/workflows/release.yml` | Release-time test/coverage confidence gate |
+| `package.json` | Test scripts, coverage command, and profile entry points |
+| `vitest.config.ts` | Unit test and coverage configuration |
+| `vitest.integration.config.ts` | Integration execution behavior |
+| `tests/e2e/vitest.e2e.config.ts` | E2E execution/reporting behavior |
+| `tests/integration/helpers.ts` | Shared integration credential/skip helpers |
+| `tests/integration/adt.integration.test.ts` | Largest integration hotspot for skip/try-catch/CRUD issues |
+| `tests/integration/context.integration.test.ts` | Early-return pseudo-skip hotspot |
+| `tests/integration/btp-abap.integration.test.ts` | BTP local-only gating and permissive assertions |
+| `tests/e2e/cds-context.e2e.test.ts` | E2E pseudo-skip hotspot |
+| `tests/e2e/diagnostics.e2e.test.ts` | Complex fallback chains with low-signal pass risk |
+| `tests/e2e/navigate.e2e.test.ts` | Example of valid explicit runtime skipping (`ctx.skip`) |
+| `tests/e2e/rap.e2e.test.ts` | Long-lived lifecycle `it.skip` gap |
+| `tests/e2e/setup.ts` | Fixture provisioning utilities currently drifting from usage |
+| `tests/e2e/README.md` | E2E setup claims and fixture behavior documentation |
+| `README.md` | Public test confidence claims (currently stale counts/matrix wording) |
+| `docs/index.md` | User-facing documentation index and quality claims |
+| `docs/roadmap.md` | Project status matrix and CI/testing status entries |
+| `compare/00-feature-matrix.md` | Comparative quality/testing matrix |
+| `CLAUDE.md` | Contributor/testing conventions and file map |
+| `.claude/commands/ralphex-plan.md` | Autonomous planning template with stale testing references |
+
+### Design Principles
+
+1. Reliability over raw pass count: a pass must prove a concrete contract or be marked as an explicit skip with reason.
+2. Explicit precondition model: missing credentials, fixtures, or environment features must produce `ctx.skip('reason')`, never silent success.
+3. Non-blocking telemetry first: introduce visibility (coverage, executed/skipped ratios) before adding hard gates.
+4. Isolate unstable surfaces: keep BTP and cross-tenant variability in dedicated lanes with failure classification.
+5. Enforce cleanup invariants for write tests: create/update/delete tests must leave system state clean and report cleanup failure clearly.
+6. Keep CI semantics aligned with documentation and branch governance.
+
+## Development Approach
+
+Implement in phased, verifiable slices mapped directly to points 2-7. Start with policy and observability (skip taxonomy, telemetry, reporting), then refactor low-signal tests (`try/catch`, early returns), then add deterministic CRUD lifecycle coverage, and finally split BTP into stable smoke vs extended local checks. Each phase includes targeted tests and workflow updates, with docs/roadmap/matrix/skills synced before final closure.
+
+## Validation Commands
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm test`
+- `npm run test:integration`
+- `npm run test:e2e`
+- `npm run test:coverage`
+
+### Task 1: Build Reliability Telemetry Foundation (Executed/Skipped/Reasons)
+
+**Files:**
+- Modify: `.github/workflows/test.yml`
+- Modify: `package.json`
+- Create: `scripts/ci/collect-test-reliability.mjs`
+- Create: `scripts/ci/assert-required-test-execution.mjs`
+- Modify: `tests/e2e/vitest.e2e.config.ts`
+- Modify: `vitest.integration.config.ts`
+
+Create CI-visible reliability telemetry that reports executed/passed/skipped test counts and skip reasons per suite, without failing builds initially except for malformed reports.
+
+- [ ] Add machine-readable integration/e2e outputs (Vitest JSON/JUnit artifacts) in CI and persist them as workflow artifacts.
+- [ ] Implement `scripts/ci/collect-test-reliability.mjs` to parse artifacts and publish a Markdown summary to `GITHUB_STEP_SUMMARY`.
+- [ ] Implement `scripts/ci/assert-required-test-execution.mjs` with configurable minimum executed tests per profile (`required`, `optional`, `local`) but default it to warning-only mode.
+- [ ] Add `package.json` scripts for reliability report generation (local reproducibility of CI parsing).
+- [ ] Ensure telemetry includes explicit visibility of skipped suites in push/PR runs so policy drift is immediately visible.
+- [ ] Add unit tests (~8 tests) for parser and threshold logic under `tests/unit/` for deterministic CI signal.
+- [ ] Run `npm test` — all tests must pass.
+
+### Task 2: Point 2 Hardening — Valid Skip Policy vs Lazy Green
+
+**Files:**
+- Modify: `tests/integration/helpers.ts`
+- Modify: `tests/integration/adt.integration.test.ts`
+- Modify: `tests/integration/context.integration.test.ts`
+- Modify: `tests/e2e/cds-context.e2e.test.ts`
+- Modify: `tests/e2e/diagnostics.e2e.test.ts`
+- Modify: `.github/workflows/test.yml`
+- Create: `tests/helpers/skip-policy.ts`
+- Create: `docs/testing-skip-policy.md`
+
+Replace implicit skip behavior with explicit policy, and ensure workflow-level skips are limited to valid secret-boundary cases rather than event type alone.
+
+- [ ] Introduce a shared skip helper (`requireOrSkip` / `skipWithReason`) that standardizes runtime skip reasons across integration and e2e suites.
+- [ ] Refactor tests using implicit pass-as-skip to call explicit skip APIs with concrete reason text.
+- [ ] Update workflow `if:` logic so internal `push` to `main` runs integration/e2e (maintain fork PR protection checks).
+- [ ] Add reliability report section listing top skip reasons and their counts per run.
+- [ ] Document valid skip taxonomy in `docs/testing-skip-policy.md` with examples from current suites.
+- [ ] Add unit tests (~10 tests) for skip helper behavior and reason formatting.
+- [ ] Run `npm run test:integration` — no pseudo-skips should remain in targeted files.
+- [ ] Run `npm test` — all tests must pass.
+
+### Task 3: Point 3 Hardening — Coverage as Informational CI Signal
+
+**Files:**
+- Modify: `package.json`
+- Modify: `vitest.config.ts`
+- Modify: `.github/workflows/test.yml`
+- Modify: `.github/workflows/release.yml`
+- Create: `scripts/ci/coverage-summary.mjs`
+
+Enable coverage reporting as non-blocking telemetry in both test and release workflows.
+
+- [ ] Add `@vitest/coverage-v8` as dev dependency and ensure `npm run test:coverage` works locally.
+- [ ] Configure coverage provider/reporters in `vitest.config.ts` (`text-summary`, `json-summary`, `lcov`) without thresholds.
+- [ ] Add workflow step to run coverage and always publish report artifacts (`coverage/`) and concise job summary.
+- [ ] Keep coverage step informational-only (`continue-on-error: true` initially) and explicitly label it as non-blocking.
+- [ ] Mirror informational coverage collection in `release.yml` so publish runs include visibility into tested surface.
+- [ ] Add unit tests (~4 tests) for `coverage-summary.mjs` parser behavior on missing/partial files.
+- [ ] Run `npm run test:coverage` — command must complete and generate reports.
+- [ ] Run `npm test` — all tests must pass.
+
+### Task 4: Point 4 Hardening — try/catch Signal Quality Refactor
+
+**Files:**
+- Modify: `tests/integration/adt.integration.test.ts`
+- Modify: `tests/integration/btp-abap.integration.test.ts`
+- Modify: `tests/e2e/diagnostics.e2e.test.ts`
+- Create: `tests/helpers/expected-error.ts`
+- Modify: `CLAUDE.md`
+
+Classify and refactor `try/catch` usage so catches either enforce expected error contracts or remain explicitly marked as best-effort cleanup.
+
+- [ ] Convert low-signal catches in `adt.integration.test.ts` to dual-path assertions: success contract OR explicit expected error signature.
+- [ ] Refactor permissive BTP restriction tests to assert known failure categories (e.g., 403/404/not-released) instead of generic truthy errors.
+- [ ] Rewrite diagnostics fallback chains to fail when no validated outcome was proven, unless explicitly skipped with reason.
+- [ ] Add helper assertions (`expectSapFailureClass`) to centralize allowed error-shape contracts.
+- [ ] Keep cleanup catches allowed only when preceded by comment tag such as `best-effort-cleanup` and no hidden product assertion.
+- [ ] Update `CLAUDE.md` testing conventions with do/don’t rules for try/catch in tests.
+- [ ] Add unit tests (~12 tests) covering expected-error helper and representative integration/e2e message patterns.
+- [ ] Run `npm run test:integration` and `npm run test:e2e` — targeted suites must still pass under real environment variability.
+
+### Task 5: Point 5 Hardening — Remove Early-Return Pseudo-Skips
+
+**Files:**
+- Modify: `tests/integration/context.integration.test.ts`
+- Modify: `tests/e2e/cds-context.e2e.test.ts`
+- Modify: `tests/integration/adt.integration.test.ts`
+- Modify: `tests/e2e/README.md`
+- Modify: `tests/e2e/setup.ts`
+
+Eliminate `if (!x) return;` behavior in tests and align fixture discovery/setup contracts with actual runtime behavior.
+
+- [ ] Replace all targeted early-return pseudo-skips with `ctx.skip('reason')` plus actionable reason text.
+- [ ] Separate discovery/precondition logic into helper functions that return explicit outcomes (`ready`, `missing-fixture`, `backend-unsupported`).
+- [ ] Reconcile `tests/e2e/README.md` setup claims with actual usage; either wire `ensureTestObjects()` into relevant suites or correct docs and add explicit opt-in helper usage.
+- [ ] Add a lightweight lint/check script that fails CI if new `return;`-based pseudo-skip patterns appear in `tests/integration` or `tests/e2e`.
+- [ ] Add tests (~6 tests) for precondition helper behavior and pseudo-skip detector script.
+- [ ] Run `npm run test:integration` — converted tests should appear as skipped, not passed, when prerequisites are absent.
+- [ ] Run `npm run test:e2e` — converted tests should remain deterministic in CI environment.
+
+### Task 6: Point 6 Hardening — Real CRUD Lifecycle Execution and Cleanup Guarantees
+
+**Files:**
+- Create: `tests/integration/crud.lifecycle.integration.test.ts`
+- Modify: `tests/integration/adt.integration.test.ts`
+- Create: `tests/integration/crud-harness.ts`
+- Modify: `package.json`
+- Modify: `.github/workflows/test.yml`
+
+Replace placeholder CRUD coverage with deterministic, required lifecycle tests that create, read, update, activate, delete, and verify deletion with strong cleanup guarantees.
+
+- [ ] Add `crud-harness.ts` for unique name generation, created-object registry, lock/delete retry, and post-test cleanup diagnostics.
+- [ ] Implement `crud.lifecycle.integration.test.ts` to assert full roundtrip behavior (`create -> read -> update -> activate -> delete -> read 404`).
+- [ ] Convert placeholder CRUD section in `adt.integration.test.ts:299-309` into either explicit deprecation note or redirect to lifecycle suite.
+- [ ] Add profile scripts (`test:integration:required`, `test:integration:crud`) and workflow wiring so CRUD smoke runs on internal PR and push-to-main.
+- [ ] Ensure cleanup failures are visible and fail required profile runs instead of being silently ignored.
+- [ ] Add unit tests (~10 tests) for CRUD harness naming, retry, and cleanup reporting logic.
+- [ ] Run `npm run test:integration:crud` — lifecycle test must execute (not skip) in configured CI profile.
+- [ ] Run `npm run test:integration` — all integration tests must pass with updated structure.
+
+### Task 7: Point 7 Hardening — BTP Stability Model (CI Smoke + Local Extended)
+
+**Files:**
+- Modify: `tests/integration/btp-abap.integration.test.ts`
+- Create: `tests/integration/btp-abap.smoke.integration.test.ts`
+- Modify: `package.json`
+- Modify: `.github/workflows/test.yml`
+- Create: `.github/workflows/btp-smoke.yml`
+- Modify: `docs/btp-abap-environment.md`
+
+Retain local extended BTP checks while adding a stable, non-interactive BTP smoke lane that can run in CI and report flakiness by class.
+
+- [ ] Split BTP tests into `smoke` (CI-capable, deterministic) and `extended` (local interactive/non-deterministic) suites.
+- [ ] Define strict smoke contracts (connectivity, system info shape, released-object read/search) and explicit skip criteria for missing BTP secrets.
+- [ ] Add `test:integration:btp:smoke` and `test:integration:btp:extended` scripts.
+- [ ] Add `btp-smoke.yml` scheduled + workflow_dispatch pipeline with artifacted logs and failure taxonomy summary.
+- [ ] Keep smoke lane non-blocking initially, but ensure visibility in PR dashboard/reporting.
+- [ ] Document BTP stability requirements, tenant assumptions, and escalation path for flaky infrastructure in `docs/btp-abap-environment.md`.
+- [ ] Add unit tests (~6 tests) for BTP precondition/failure taxonomy helper logic.
+- [ ] Run `npm run test:integration:btp:smoke` in a configured environment and capture baseline skip/fail behavior.
+
+### Task 8: Documentation, Roadmap, Matrix, and Skill Artifact Alignment
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/index.md`
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+- Modify: `.claude/commands/ralphex-plan.md`
+- Modify: `docs/research/test-reliability-audit-points-2-7.md`
+
+Update all user/developer planning artifacts so test behavior, CI policy, and reliability metrics are current and internally consistent.
+
+- [ ] Update README and docs index testing sections to reflect current Node matrix, suite behavior, and reliability telemetry outputs.
+- [ ] Update roadmap CI/testing status rows to match actual workflow behavior and planned hardening milestones.
+- [ ] Refresh feature matrix testing row values and last-updated date after implementation.
+- [ ] Update `CLAUDE.md` test conventions and key files references for new reliability scripts/profiles.
+- [ ] Update `.claude/commands/ralphex-plan.md` stale testing references (counts, profile expectations, infrastructure assumptions).
+- [ ] Append implementation evidence and post-change run comparisons into `docs/research/test-reliability-audit-points-2-7.md`.
+- [ ] Run `npm test` and `npm run lint` to ensure docs/code references remain consistent with repository scripts.
+
+### Task 9: Final Verification and Rollout Gate
+
+**Files:**
+- Modify: `.github/workflows/test.yml`
+- Modify: `.github/workflows/release.yml`
+- Modify: `docs/plans/test-reliability-audit-points-2-7-hardening.md`
+
+Complete end-to-end validation of new reliability model and close the plan.
+
+- [ ] Run full unit suite: `npm test` — all tests pass.
+- [ ] Run integration suite: `npm run test:integration` — required profile executes and reports executed/skipped counts.
+- [ ] Run E2E suite: `npm run test:e2e` — report includes executed/skipped counts and explicit skip reasons.
+- [ ] Run coverage: `npm run test:coverage` — coverage summary and artifacts produced without blocking failure policy.
+- [ ] Run typecheck: `npm run typecheck` — no errors.
+- [ ] Run lint: `npm run lint` — no errors.
+- [ ] Validate GitHub Actions on an internal PR and on `push` to `main` to confirm integration/e2e are no longer silently skipped by event policy.
+- [ ] Verify BTP smoke workflow emits classified outcomes and does not hide instability as success.
+- [ ] Move this plan to `docs/plans/completed/` once all tasks are done.

--- a/docs/research/test-reliability-audit-points-2-7.md
+++ b/docs/research/test-reliability-audit-points-2-7.md
@@ -1,0 +1,501 @@
+# Test Reliability Research (Points 2-7)
+
+Date: 2026-04-10  
+Scope: Deep-dive on points 2-7 from the external test setup review request.
+
+## Executive Summary
+
+The repository has a large and valuable test corpus, but several mechanisms currently allow green results without proving key runtime behavior:
+
+- Integration tests can report green with most tests skipped (`21 passed | 132 skipped` in current local run).
+- Coverage collection is configured as an npm script but not actually operational (missing provider dependency).
+- Some integration/e2e tests intentionally absorb failures (`try/catch` with no assertion), which reduces signal.
+- Some tests use early returns as implicit skip, which records as pass (not skipped).
+- The declared CRUD lifecycle test does not run CRUD; real create/delete checks exist elsewhere but are partial.
+- BTP integration tests are intentionally local-only and effectively dormant in CI by design.
+
+This document separates valid skip/fallback patterns from lazy green patterns and outlines practical hardening options.
+
+## Evidence Base
+
+Commands and results used for this analysis:
+
+- `npm test`: `46 files, 1251 passed`
+- `npm run test:integration`: `1 passed file | 5 skipped files`, `21 passed | 132 skipped`
+- `npm run test:integration -- --reporter=verbose`: confirmed only `tests/integration/elicitation.integration.test.ts` runs in this environment.
+- `npm run test:e2e`: fails fast if MCP server preflight is unreachable.
+- `npm run test:eval`: fails if configured local model is unavailable.
+- `npm run test:coverage`: fails because `@vitest/coverage-v8` is missing.
+- `gh api repos/marianfoo/arc-1/actions/runs/<run-id>/jobs`: used to extract exact job conclusions for requested workflow runs.
+- `gh run view <run-id> --repo marianfoo/arc-1 --log-failed`: used to extract failed test names and stack traces.
+- `gh api repos/marianfoo/arc-1/branches/main/protection`: used to verify whether required checks are enforced at branch level.
+
+Key files reviewed:
+
+- `.github/workflows/test.yml`
+- `.github/workflows/release.yml`
+- `package.json`
+- `vitest*.config.ts`
+- `tests/integration/*.test.ts`
+- `tests/e2e/*.test.ts`
+- `tests/evals/*.ts`
+- `scripts/e2e-*.sh`
+
+### GitHub Actions Run Audit (requested runs)
+
+Runs requested for detailed workflow behavior review:
+
+- [24213793920](https://github.com/marianfoo/arc-1/actions/runs/24213793920)
+- [24212490295](https://github.com/marianfoo/arc-1/actions/runs/24212490295)
+- [24197428731](https://github.com/marianfoo/arc-1/actions/runs/24197428731)
+
+| Run | Event / Branch | Job outcomes | Reliability signal |
+|---|---|---|---|
+| 24213793920 | `push` on `main` | `test (22)` success, `test (24)` success, `integration` skipped, `e2e` skipped | Main branch push did **not** execute runtime integration/e2e checks. |
+| 24212490295 | `pull_request` (`claude/exciting-joliot`) | unit jobs success, `integration` failure, `e2e` failure | Real runtime failures detected when integration/e2e were executed. |
+| 24197428731 | `pull_request` (`phase2-publish-srvb`) | all four jobs success | Confirms integration/e2e can run green on healthy backend state. |
+
+Detailed failure/skip counts from logs:
+
+- Run 24212490295 (`integration`): `121 passed | 28 skipped | 4 failed` (153 total).
+- Run 24212490295 (`e2e`): `54 passed | 5 skipped | 4 failed` (63 total).
+- Run 24197428731 (`integration`): `125 passed | 28 skipped` (153 total).
+- Run 24197428731 (`e2e`): `58 passed | 5 skipped` (63 total).
+
+Observed failing area in 24212490295:
+
+- All four failing tests were in runtime diagnostics dump listing/detail flows.
+- Failure signature: `Entity expansion limit exceeded: <n> > 1000`.
+- Trace path: `src/adt/xml-parser.ts` -> `src/adt/diagnostics.ts` -> `tests/integration/adt.integration.test.ts`.
+
+Branch protection state (as checked 2026-04-10):
+
+- `main` branch protection endpoint returns `404 Branch not protected`.
+- Implication: required checks are currently not enforced by branch protection rules.
+
+---
+
+## 2) Skip Analysis: Valid Reasons vs Lazy Green
+
+### Current Skip Mechanisms
+
+1. Suite-level conditional skip (`describe.skip` via env gating):
+   - `tests/integration/adt.integration.test.ts`
+   - `tests/integration/audit-logging.integration.test.ts`
+   - `tests/integration/cache.integration.test.ts`
+   - `tests/integration/context.integration.test.ts`
+   - `tests/integration/btp-abap.integration.test.ts`
+
+2. Explicit test skip:
+   - `tests/e2e/rap.e2e.test.ts` has `it.skip` for write lifecycle.
+
+3. Runtime skip:
+   - `tests/e2e/navigate.e2e.test.ts` uses `ctx.skip()` when custom objects are missing.
+
+4. Implicit skip by early return (reported as pass, not skipped):
+   - `tests/integration/context.integration.test.ts`
+   - `tests/e2e/cds-context.e2e.test.ts`
+   - `tests/integration/adt.integration.test.ts` (runtime diagnostics user-dependent branch)
+
+5. Workflow/job-level skip by event policy:
+   - `.github/workflows/test.yml` skips `integration` and `e2e` for `push` to `main`.
+
+### Skip Evidence Matrix (current code)
+
+| Location | Mechanism | Trigger | Classification |
+|---|---|---|---|
+| `tests/integration/adt.integration.test.ts:17` | `describe.skip` gate | no SAP creds | Valid |
+| `tests/integration/audit-logging.integration.test.ts:22` | `describe.skip` gate | no SAP creds | Valid |
+| `tests/integration/cache.integration.test.ts:33` | `describe.skip` gate | no SAP creds | Valid |
+| `tests/integration/context.integration.test.ts:24` | `describe.skip` gate | no SAP creds | Valid |
+| `tests/integration/btp-abap.integration.test.ts:58` | `describe.skip` gate | no BTP service key | Valid (by design), but creates dormant suite in CI |
+| `tests/e2e/navigate.e2e.test.ts:59` etc | `ctx.skip()` | custom fixtures missing | Valid/transparent |
+| `tests/e2e/rap.e2e.test.ts:159` | `it.skip` | known lifecycle bug | Risky long-term gap |
+| `tests/e2e/cds-context.e2e.test.ts:54` etc | `return` (implicit pass) | no DDLS found | Problematic |
+| `tests/integration/context.integration.test.ts:277` etc | `return` (implicit pass) | no DDLS found | Problematic |
+| `tests/integration/adt.integration.test.ts:476` | `return` (implicit pass) | user env empty | Problematic (should be explicit skip) |
+| `.github/workflows/test.yml:41-43` | job-level `if` | non-PR events | Risky for main-branch confidence |
+| `.github/workflows/test.yml:71-73` | job-level `if` | non-PR events | Risky for main-branch confidence |
+
+### Classification: Valid vs Problematic
+
+#### Valid / Reasonable
+
+- Skipping whole integration suites when SAP credentials are absent is valid for local developer experience.
+- Skipping BTP suite without BTP credentials is valid given dedicated infrastructure needs.
+- Using `ctx.skip()` for optional custom-object scenarios is valid and transparent.
+- Skipping cleanup failures in `afterAll` is usually acceptable if cleanup is best-effort and does not hide product behavior failures.
+
+#### Problematic / Lazy Green
+
+- Early returns inside test bodies for prerequisite absence (`if (!x) return;`) create false pass signal.
+- Large suite-level skipping without guardrails in CI means “green” does not guarantee runtime coverage.
+- Hard-coded `it.skip` on a key lifecycle flow (write+activate+read+delete) leaves a persistent gap.
+- Main push workflow green can still mean integration/e2e never ran (as seen in run 24213793920).
+
+### What “Correct Skipping” Should Mean
+
+A skip should only happen when a precondition outside product behavior is missing and the test should state that reason in test output.
+
+Good examples:
+
+- Missing credentials/secrets.
+- Feature absent on target backend version.
+- Optional fixture absent in shared test system (with explicit `ctx.skip('reason')`).
+
+Not good:
+
+- Returning early without marking skip.
+- Catching any failure and continuing as pass.
+- Permanent skip for a known bug with no enforcement deadline/owner.
+
+### Practical Improvements for Point 2
+
+- Replace early-return pseudo-skips with explicit `ctx.skip('...')`.
+- Add CI guardrail: fail if executed integration tests are below minimum threshold for internal PRs.
+- Split tests into:
+  - `integration:required` (must run in CI)
+  - `integration:optional` (allowed to skip with explicit reasons)
+- Track long-lived `it.skip` tests with issue IDs and expiry checks.
+
+---
+
+## 3) Coverage as Informational Signal (Non-Blocking)
+
+### Current State
+
+- `package.json` includes `test:coverage: "vitest run --coverage"`.
+- Running it fails due to missing provider dependency:
+  - `MISSING DEPENDENCY Cannot find dependency '@vitest/coverage-v8'`.
+- No coverage provider config or thresholds in vitest config.
+- CI workflow does not collect or publish coverage metrics.
+
+### Workflow-Level Coverage Gap
+
+Current workflows do not run coverage at all:
+
+- `.github/workflows/test.yml` runs lint, typecheck, `npm test`, integration, e2e.
+- `.github/workflows/release.yml` runs `npm test` before publish.
+- Neither workflow has a coverage collection or artifact step.
+- In audited runs (24197428731, 24212490295, 24213793920), no coverage artifact/summary was produced.
+
+Implication: coverage is invisible in both PR quality checks and release flow.
+
+### Why This Matters
+
+Without coverage telemetry, large pass counts can still hide unexercised areas. Coverage should not block yet (as requested), but it should be visible per run.
+
+### Recommended Informational-Only Setup
+
+1. Add dev dependency:
+   - `@vitest/coverage-v8`
+
+2. Add coverage config (unit test config):
+   - Provider: `v8`
+   - Reporters: `text-summary`, `json-summary`, `lcov`
+   - No thresholds initially.
+
+3. Add workflow step after unit tests:
+   - Run coverage with `continue-on-error: true` (informational only).
+   - Parse `coverage/coverage-summary.json`.
+   - Publish summary in GitHub Job Summary.
+   - Upload `coverage/` as artifact.
+
+4. Optional:
+   - Add PR comment bot for trend (delta vs base branch), still non-blocking.
+
+### Suggested rollout phases
+
+- Phase 1: Collect and publish only.
+- Phase 2: Define target baselines by package/module.
+- Phase 3: Add soft gates (warning only).
+- Phase 4: Enforce hard thresholds selectively on critical modules.
+
+---
+
+## 4) try/catch Audit: Relevant vs Non-Relevant
+
+### Inventory
+
+Observed `try/catch` markers across integration/e2e/eval areas: 33+ occurrences (excluding production code). Highest concentration:
+
+- `tests/integration/adt.integration.test.ts`
+- `tests/integration/btp-abap.integration.test.ts`
+- `tests/e2e/diagnostics.e2e.test.ts`
+
+### Classification
+
+#### Category A: Relevant and acceptable
+
+Patterns where catch transforms technical failure into explicit setup/runtime failure or best-effort cleanup:
+
+- E2E helper wrappers that rethrow with richer context.
+- Global preflight health checks that fail suite explicitly.
+- Cleanup blocks in `afterAll` where failure should not mask prior assertion outcomes.
+
+These generally improve observability and are not “lazy green.”
+
+#### Category B: Context-dependent, needs stronger assertion
+
+Patterns that accept variability but should still assert outcome class:
+
+- BTP restriction tests that accept both success and failure (`try` success path and catch path both pass).
+- Optional backend behavior differences (e.g., include availability) without asserting expected error type.
+
+These can remain flexible but should assert at least one expected contract, e.g.:
+
+- On failure: assert error class/status pattern.
+- On success: assert required response fields.
+
+#### Category C: Low-signal / lazy-green
+
+Patterns where catch swallows failure and test passes without proving behavior:
+
+- `tests/integration/adt.integration.test.ts`
+  - interface operation and function module operation blocks.
+  - edge-case tests that treat both throw and no-throw as pass.
+- `tests/e2e/diagnostics.e2e.test.ts`
+  - dump trigger path has multiple fallback catches and can finish with “no dumps” as pass.
+
+### try/catch Detail Matrix
+
+| File | Example lines | Pattern | Signal quality |
+|---|---|---|---|
+| `tests/e2e/helpers.ts` | 56-62, 67-77, 88-108 | rethrow with context | High (good) |
+| `tests/e2e/global-setup.ts` | 20-60 | fail-fast preflight | High (good) |
+| `tests/integration/adt.integration.test.ts` | 220-225 | include read catch-ignore | Medium/low |
+| `tests/integration/adt.integration.test.ts` | 269-274 | interface read catch-ignore | Low |
+| `tests/integration/adt.integration.test.ts` | 283-290 | FM search catch-ignore | Low |
+| `tests/integration/adt.integration.test.ts` | 431-437, 441-447 | both throw/no-throw accepted | Low |
+| `tests/e2e/diagnostics.e2e.test.ts` | 173-214 | create/update/activate fallback chain | Medium/low |
+| `tests/integration/btp-abap.integration.test.ts` | 194-232 | both outcomes accepted for restriction tests | Medium/low |
+| `tests/integration/context.integration.test.ts` | helper discovery catches | fallback discovery | Medium |
+
+Recommended treatment:
+
+- Keep high-signal catch blocks (rethrow/fail-fast/cleanup).
+- Refactor low-signal catches into explicit expected-failure assertions or explicit skips.
+
+### Recommendation for Point 4
+
+- Keep Category A.
+- Refactor Category B to “assert success OR assert specific expected failure shape.”
+- Replace Category C with deterministic contracts or explicit skip/fail semantics.
+- Add a linting rule/check for empty catch in tests unless annotated (e.g., `// acceptable best-effort cleanup`).
+
+---
+
+## 5) Early Return Instead of Skip: Why It Exists and How to Improve
+
+### Observed Pattern
+
+Examples:
+
+- `tests/integration/context.integration.test.ts`: multiple `if (!ddlSource || !cdsName) return;`
+- `tests/e2e/cds-context.e2e.test.ts`: `if (!cdsName) return;`
+- `tests/integration/adt.integration.test.ts`: user-dependent diagnostics branch.
+
+### Exact Early-Return Locations
+
+- `tests/e2e/cds-context.e2e.test.ts:54,64,87,99`
+- `tests/integration/context.integration.test.ts:277,288,308,318,325`
+- `tests/integration/adt.integration.test.ts:476`
+
+These currently inflate pass counts while hiding missing prerequisites.
+
+### Why This Was Likely Done
+
+- Cross-system variability (object availability differs by SAP tenant).
+- Desire to avoid flaky failures on shared environments.
+- Developer convenience during local runs.
+
+### Why It Is Risky
+
+- Early return is counted as pass, not skipped.
+- Dashboards show higher pass rates without proving feature behavior.
+- Teams lose visibility into missing prerequisites and dormant test paths.
+
+### Better Pattern
+
+- Convert to explicit runtime skip:
+  - `ctx.skip('No DDLS candidate found on system')`
+- Emit skip reason consistently.
+- Separate fixture discovery from assertions; if discovery fails in a required test profile, fail early.
+
+### Suggested policy
+
+- For optional tests: explicit skip with reason.
+- For required CI profile: missing prerequisite is test failure unless explicitly quarantined.
+
+---
+
+## 6) CRUD Test Does Not Actually Run CRUD
+
+### Current Situation
+
+The section named `CRUD operations` in `tests/integration/adt.integration.test.ts` does not execute create/update/delete. It only performs a search and asserts absence. The file itself documents this limitation in comments.
+
+At the same time, a later section (`batch create in $TMP`) does create and delete programs using lower-level CRUD helpers. So write-path coverage exists, but not as a full lifecycle contract of the declared CRUD test.
+
+### CRUD Evidence Matrix
+
+| Location | What it does today | Gap |
+|---|---|---|
+| `tests/integration/adt.integration.test.ts:299-309` | only `searchObject` and assert empty | not CRUD |
+| `tests/integration/adt.integration.test.ts:571-593` | create two programs + read back | no update/asserted delete in same test |
+| `tests/integration/adt.integration.test.ts:553-569` | cleanup delete in `afterAll` (best-effort catch-ignore) | delete success not asserted |
+| `src/adt/client.ts` | read-oriented API | no first-class lifecycle test surface |
+| `src/adt/crud.ts` | low-level CRUD primitives exist | lifecycle contract not tested end-to-end as one required test |
+
+### Why This Happened
+
+- `AdtClient` is focused on read APIs; write lifecycle is mainly in `src/adt/crud.ts` and handler paths.
+- Lifecycle tests are harder on shared SAP systems (cleanup reliability, collision risk, auth/safety constraints).
+- Existing test appears to have been left as placeholder to keep suite green.
+
+### Risks
+
+- Misleading test naming creates false confidence.
+- No strict assertion of full create -> read -> update -> activate -> delete -> verify-delete lifecycle in one deterministic test.
+- Cleanup reliability risk if creation succeeds and deletion fails silently.
+
+### Improvement Path (important for your priority)
+
+1. Create dedicated `integration/crud.lifecycle.integration.test.ts`:
+   - Use unique names: `ZARC1_IT_<runId>_<case>`.
+   - Package: default `$TMP` or configurable dedicated package.
+   - Explicit full lifecycle assertions:
+     - create succeeds
+     - read matches content
+     - update succeeds
+     - read reflects update
+     - activate succeeds (if required)
+     - delete succeeds
+     - read returns 404 after delete
+
+2. Hard cleanup guarantees:
+   - Maintain created object registry.
+   - Retry delete with lock recovery.
+   - Fail test if cleanup fails in required CI profile (or mark quarantine job).
+
+3. Pre-flight capability checks:
+   - verify write permissions and allowed package before lifecycle starts.
+   - skip with explicit reason only in non-required profile.
+
+4. Split profiles:
+   - `crud:smoke` in CI internal PRs.
+   - `crud:full` nightly with extra cases and mutation scenarios.
+
+---
+
+## 7) Why BTP Checks Are Skipped and How to Improve Stability
+
+### Current Reality
+
+BTP integration test file is intentionally local-only in practice:
+
+- It is env-gated via service-key presence.
+- Comments document reasons:
+  - free-tier nightly stop,
+  - 90-day deletion,
+  - OAuth browser interaction requirement.
+- CI workflow does not provide BTP service key env vars for this suite.
+
+Result: BTP checks are effectively not exercised in standard CI runs.
+
+Confirmed in requested workflow runs:
+
+- `integration` jobs still show `28 skipped` tests attributable to BTP env gating (both passing and failing PR runs).
+- These BTP skips are constant background skip debt and are currently independent from the runtime diagnostics failures.
+
+### BTP Skip Evidence
+
+| Evidence | Observation |
+|---|---|
+| `tests/integration/btp-abap.integration.test.ts:7-13` | local-only rationale documented (free-tier stop/delete + interactive OAuth) |
+| `tests/integration/btp-abap.integration.test.ts:58` | suite gated by service-key env |
+| `.github/workflows/test.yml` | integration job only injects `TEST_SAP_*`, no BTP env |
+| `npm run test:integration -- --reporter=verbose` | all BTP tests skipped in current run |
+
+### Why BTP flakiness is currently structural
+
+- The suite assumes environment characteristics that are not CI-stable:
+  - interactive-first OAuth expectations,
+  - ephemeral/free-tier lifecycle,
+  - object availability variance.
+- The workflow is therefore intentionally configured to avoid running BTP tests automatically.
+
+### Why This Is Understandable
+
+- BTP free-tier instability and lifecycle constraints are real.
+- Interactive OAuth is not CI-friendly.
+- Keeping these tests out of mandatory CI avoids frequent false negatives.
+
+### But the consequence
+
+- BTP behavior regressions can go undetected for long periods.
+- Product surface claims for BTP may drift from reality.
+
+### Stability-focused Improvement Strategy
+
+1. Split BTP testing into two tiers:
+   - Tier A (CI-capable, non-interactive, stable smoke):
+     - 5-10 high-value checks with deterministic objects/contracts.
+     - Use non-interactive token flow (pre-provisioned token path/service principal) where possible.
+   - Tier B (manual/interactive extended):
+     - current broader suite, still local.
+
+2. Infrastructure recommendations:
+   - avoid ephemeral free-tier for CI gating; use persistent paid/test tenant for scheduled runs.
+   - isolate test artifacts in dedicated package namespace.
+
+3. Pipeline model:
+   - keep Tier A non-blocking initially (informational scheduled workflow).
+   - after stability period, promote to required check for BTP-labeled PRs.
+
+4. Flakiness controls:
+   - retry wrapper only for known transient classes.
+   - classify failures (auth, connectivity, backend unavailable, assertion).
+   - publish detailed failure reasons as artifacts.
+
+---
+
+## Cross-Cutting Observations for Planning
+
+1. E2E fixture setup drift:
+   - `tests/e2e/setup.ts` defines `ensureTestObjects`, but active e2e suites do not call it.
+   - `tests/e2e/README.md` claims beforeAll setup auto-creates persistent objects, which does not match current usage in test files.
+   - This mismatch likely contributes to runtime `ctx.skip()` behavior for custom-object tests.
+
+2. Release confidence gap:
+   - Release workflow runs unit tests only.
+   - Runtime-system regressions can pass release pipeline.
+   - Push-to-main test workflow can also pass without running integration/e2e (event gating).
+
+3. Branch governance gap:
+   - `main` is currently not protected; required checks are not enforced server-side.
+
+4. Metric integrity:
+   - Pass count alone is not meaningful without:
+     - executed-vs-skipped visibility,
+     - explicit skip reasons,
+     - coverage telemetry.
+
+---
+
+## Planning Inputs (for follow-up implementation plans)
+
+For each point (2-7), the later implementation plan should define:
+
+1. Target profile:
+   - required CI / optional CI / local-only
+2. Precondition contract:
+   - explicit skip conditions and reason text
+3. Signal contract:
+   - what exactly must be asserted to count as pass
+4. Flakiness policy:
+   - retry, quarantine, or fail-fast
+5. Rollout phases:
+   - informational first, then enforcement
+6. Success metrics:
+   - executed test count, skip ratio, coverage visibility, defect detection lead time


### PR DESCRIPTION
## Summary\n- add a detailed external audit document for test reliability points 2-7\n- add a strict ralphex-compatible execution plan for hardening skip behavior, coverage telemetry, try/catch signal quality, early-return pseudo-skips, CRUD lifecycle tests, and BTP stability\n- include workflow-specific findings from requested GitHub Actions runs\n\n## Added files\n- docs/research/test-reliability-audit-points-2-7.md\n- docs/plans/test-reliability-audit-points-2-7-hardening.md\n\n## Notes\n- this PR is documentation/planning only (no runtime code changes yet)