### PR TITLE
fix: add pre-cleanup for stale E2E write object

### DIFF
--- a/tests/e2e/rap.e2e.test.ts
+++ b/tests/e2e/rap.e2e.test.ts
@@ -157,6 +157,18 @@ describe('E2E RAP Completeness Tests', () => {
     const WRITE_NAME = 'ZARC1_E2E_WRITE';
 
     it('creates a program, updates source, activates, reads back, deletes', async () => {
+      // Pre-cleanup: delete stale object from a previous run that failed mid-lifecycle
+      try {
+        await callTool(client, 'SAPWrite', {
+          action: 'delete',
+          type: 'PROG',
+          name: WRITE_NAME,
+        });
+        console.log(`    [cleanup] Deleted stale ${WRITE_NAME} from previous run`);
+      } catch {
+        // best-effort-cleanup: object may not exist — that's the happy path
+      }
+
       // Step 1: Create the transient program
       const createResult = await callTool(client, 'SAPWrite', {
         action: 'create',


### PR DESCRIPTION
## Summary
- The E2E write lifecycle test (`rap.e2e.test.ts`) has been failing on main since ~19:42 UTC because `ZARC1_E2E_WRITE` was left on the SAP system by a previous run that failed mid-lifecycle
- Adds a best-effort delete before the create step, matching the resilient pattern already used in `diagnostics.e2e.test.ts` for `ZARC1_E2E_DUMP`
- This is a pre-existing issue unrelated to any feature branch — the same failure appears on `main`, `claude/sweet-solomon`, and `test-reliability-hardening`

## Test plan
- [ ] CI E2E job passes (the test that has been failing since run 24260918563)
- [ ] Verify cleanup log line appears when stale object exists: `[cleanup] Deleted stale ZARC1_E2E_WRITE from previous run`
- [ ] Verify test still works on a clean system (no stale object — delete is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)