### PR TITLE
docs: deep dive for compare analysis

### DIFF
--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -2,7 +2,7 @@
 
 A comprehensive comparison of all SAP ADT/MCP projects against ARC-1.
 
-_Last updated: 2026-04-12 (post fr0ster v5.0.0 feed tools analysis)_
+_Last updated: 2026-04-12 (added sapcli column, post fr0ster v5.0.0 feed tools analysis)_
 
 ## Legend
 - ✅ = Supported
@@ -14,210 +14,210 @@ _Last updated: 2026-04-12 (post fr0ster v5.0.0 feed tools analysis)_
 
 ## 1. Core Architecture
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| Language | TypeScript | Go 1.24 | TypeScript | TypeScript | Python 3.12 | TypeScript | TypeScript | JavaScript (compiled TS) |
-| Tool count | 11 intent-based | 1-99 (3 modes) | ~15 | 13 | 15 | 287 (4 tiers) | 3 (hierarchical) | 25 |
-| ADT client | Custom (undici/fetch) | Custom (Go) | abap-adt-api | Custom (axios) | Custom (aiohttp) | Custom (axios) | SAP Cloud SDK | abap-adt-api |
-| npm package | ✅ `arc-1` | ❌ (binary) | ❌ | ❌ | ❌ | ✅ `@mcp-abap-adt/core` | ❌ | ❌ (MCPB) |
-| Docker image | ✅ ghcr.io | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| Stars | — | 242 | 109 | 103 | 29 | 26 | 119 | 0 (new) |
-| Active development | ✅ | ✅ Very (v2.39.0+) | ❌ Dormant (Jan 2025) | ❌ Dormant | ⚠️ Stale (Jan 2025) | ✅ Very (v4.8.7) | ⚠️ Moderate | ✅ New (Mar 2026) |
-| Release count | — | 32+ | — | — | — | 85+ (5 months) | — | 1 |
-| NPM monthly downloads | — | N/A | — | — | — | 3,625 | — | N/A |
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| Language | TypeScript | Go 1.24 | TypeScript | TypeScript | Python 3.12 | TypeScript | TypeScript | JavaScript (compiled TS) | Python 3.10+ |
+| Tool count | 11 intent-based | 1-99 (3 modes) | ~15 | 13 | 15 | 287 (4 tiers) | 3 (hierarchical) | 25 | 28+ CLI commands (not MCP) |
+| ADT client | Custom (undici/fetch) | Custom (Go) | abap-adt-api | Custom (axios) | Custom (aiohttp) | Custom (axios) | SAP Cloud SDK | abap-adt-api | Custom (requests) |
+| npm package | ✅ `arc-1` | ❌ (binary) | ❌ | ❌ | ❌ | ✅ `@mcp-abap-adt/core` | ❌ | ❌ (MCPB) | N/A (Python, git install) |
+| Docker image | ✅ ghcr.io | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Stars | — | 242 | 109 | 103 | 29 | 26 | 119 | 0 (new) | 77 |
+| Active development | ✅ | ✅ Very (v2.39.0+) | ❌ Dormant (Jan 2025) | ❌ Dormant | ⚠️ Stale (Jan 2025) | ✅ Very (v4.8.7) | ⚠️ Moderate | ✅ New (Mar 2026) | ✅ Very (since 2018) |
+| Release count | — | 32+ | — | — | — | 85+ (5 months) | — | 1 | rolling "latest" |
+| NPM monthly downloads | — | N/A | — | — | — | 3,625 | — | N/A | N/A |
 
 ## 2. MCP Transport
 
-| Transport | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|-----------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| stdio | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
-| HTTP Streamable | ✅ | ✅ (v2.38.0) | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
-| SSE | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ⚠️ | ❌ |
-| TLS/HTTPS | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ (v4.6.0) | ❌ | ❌ |
+| Transport | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|-----------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| stdio | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | N/A (CLI) |
+| HTTP Streamable | ✅ | ✅ (v2.38.0) | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | N/A |
+| SSE | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ⚠️ | ❌ | N/A |
+| TLS/HTTPS | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ (v4.6.0) | ❌ | ❌ | N/A |
 
 ## 3. Authentication
 
-| Auth Method | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|-------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| Basic Auth | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Cookie-based | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| API Key (MCP) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| OIDC/JWT (MCP) | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
-| XSUAA OAuth | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
-| BTP Service Key | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| Principal Propagation | ✅ | ❌ | ❌ | ❌ | ✅ (X.509) | ✅ | ✅ | ❌ |
-| SAML | ❌ | ✅ (v2.39.0+, PR #97) | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
-| X.509 Certificates | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| Device Flow (OIDC) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| Browser login page | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
-| Auth providers total | 4 | 2 | 1 | 1 | 5+ | 9 | 2 | 2 |
+| Auth Method | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|-------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| Basic Auth | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Cookie-based | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ (requests.Session) |
+| API Key (MCP) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A |
+| OIDC/JWT (MCP) | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| XSUAA OAuth | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| BTP Service Key | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Principal Propagation | ✅ | ❌ | ❌ | ❌ | ✅ (X.509) | ✅ | ✅ | ❌ | ❌ |
+| SAML | ❌ | ✅ (v2.39.0+, PR #97) | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| X.509 Certificates | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Device Flow (OIDC) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Browser login page | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ |
+| Auth providers total | 4 | 2 | 1 | 1 | 5+ | 9 | 2 | 2 | 1 (Basic) |
 
 ## 4. Safety & Security
 
-| Safety Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|----------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| Read-only mode | ✅ | ✅ | ❌ | N/A (read-only) | ❌ | ⚠️ exposition tiers | ❌ | ❌ |
-| Op whitelist/blacklist | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Package restrictions | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Block free SQL | ✅ | ✅ | ❌ | ❌ | N/A | ❌ | ❌ | ❌ |
-| Transport gating | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Dry-run mode | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Audit logging | ✅ | ❌ | ❌ | ❌ | ✅ (CloudWatch) | ❌ | ❌ | ❌ |
-| Input sanitization | ✅ (Zod) | ✅ | ❌ | ⚠️ | ✅ (defusedxml) | ✅ (Zod) | ✅ (Zod) | ⚠️ |
-| MCP elicitation | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (7 flows) |
-| Try-finally lock safety | ✅ | ✅ | ❌ | N/A | ✅ | ✅ (v4.5.0) | N/A | ⚠️ (abap-adt-api) |
-| MCP scope system (OAuth) | ✅ (2D: scopes+roles+safety) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Safety Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|----------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| Read-only mode | ✅ | ✅ | ❌ | N/A (read-only) | ❌ | ⚠️ exposition tiers | ❌ | ❌ | ❌ |
+| Op whitelist/blacklist | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Package restrictions | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Block free SQL | ✅ | ✅ | ❌ | ❌ | N/A | ❌ | ❌ | ❌ | ❌ |
+| Transport gating | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Dry-run mode | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Audit logging | ✅ | ❌ | ❌ | ❌ | ✅ (CloudWatch) | ❌ | ❌ | ❌ | ❌ |
+| Input sanitization | ✅ (Zod) | ✅ | ❌ | ⚠️ | ✅ (defusedxml) | ✅ (Zod) | ✅ (Zod) | ⚠️ | ⚠️ (argparse) |
+| MCP elicitation | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (7 flows) | N/A |
+| Try-finally lock safety | ✅ | ✅ | ❌ | N/A | ✅ | ✅ (v4.5.0) | N/A | ⚠️ (abap-adt-api) | ✅ |
+| MCP scope system (OAuth) | ✅ (2D: scopes+roles+safety) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A |
 
 ## 5. ABAP Read Operations
 
-| Read Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|-------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| Programs (PROG) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ |
-| Classes (CLAS) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ |
-| Interfaces (INTF) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ |
-| Function modules (FUNC) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ |
-| Function groups (FUGR) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ (bulk) |
-| Includes (INCL) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ |
-| CDS views (DDLS) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
-| Behavior defs (BDEF) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ✅ |
-| Service defs (SRVD) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
-| Service bindings (SRVB) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ |
-| Tables (DDIC) | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | N/A | ✅ |
-| Table contents | ✅ | ✅ | ✅ | ⚠️ Z-service | ❌ | ✅ | N/A | ✅ |
-| Packages (DEVC) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ |
-| Metadata ext (DDLX) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
-| Structures | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ❌ |
-| Domains | ✅ | ❌ | ✅ | ⚠️ | ❌ | ✅ | N/A | ❌ |
-| Data elements | ✅ | ❌ | ✅ | ⚠️ | ❌ | ✅ | N/A | ❌ |
-| Enhancements | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
-| Transactions | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | N/A | ❌ |
-| Free SQL | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
-| System info / components | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
-| BOR business objects | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Messages (T100) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Text elements | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Variants | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Structured class decomposition (metadata + includes) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| GetProgFullCode (include traversal) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
+| Read Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|-------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| Programs (PROG) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ | ✅ |
+| Classes (CLAS) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ | ✅ (incl. locals, test) |
+| Interfaces (INTF) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ | ✅ |
+| Function modules (FUNC) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ | ✅ (auto-group) |
+| Function groups (FUGR) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ (bulk) | ✅ |
+| Includes (INCL) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ✅ | ✅ |
+| CDS views (DDLS) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ | ✅ |
+| Behavior defs (BDEF) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ✅ | ✅ |
+| Service defs (SRVD) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ | ✅ |
+| Service bindings (SRVB) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ | ✅ |
+| Tables (DDIC) | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | N/A | ✅ | ✅ |
+| Table contents | ✅ | ✅ | ✅ | ⚠️ Z-service | ❌ | ✅ | N/A | ✅ | ✅ (freestyle SQL) |
+| Packages (DEVC) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | ✅ | ✅ |
+| Metadata ext (DDLX) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ❌ |
+| Structures | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | N/A | ❌ | ✅ |
+| Domains | ✅ | ❌ | ✅ | ⚠️ | ❌ | ✅ | N/A | ❌ | ⚠️ (PR #149 in progress) |
+| Data elements | ✅ | ❌ | ✅ | ⚠️ | ❌ | ✅ | N/A | ❌ | ✅ |
+| Enhancements | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ✅ (BAdI/enhancement impl) |
+| Transactions | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | N/A | ❌ | ❌ |
+| Free SQL | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ | ✅ |
+| System info / components | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ✅ |
+| BOR business objects | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Messages (T100) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Text elements | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Variants | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Structured class decomposition (metadata + includes) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ✅ (locals_def/imp/test/macros) |
+| GetProgFullCode (include traversal) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ❌ |
 
 ## 6. Write / CRUD Operations
 
-| Write Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|--------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| Create objects | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
-| Update source | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
-| Delete objects | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
-| Activate | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
-| Batch activate | ✅ | ✅ | ✅ | ❌ | ✅ (with dep resolution) | ✅ | N/A | ✅ (v2.0, Apr 2026) |
-| Lock/unlock | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
-| EditSource (surgical) | ✅ (edit_method) | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ (edit_method, Apr 2026) |
-| CloneObject | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Execute ABAP | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ✅ |
-| RAP CRUD (BDEF, SRVD, DDLX, SRVB) | ✅ (DDLS, DDLX, BDEF, SRVD write) | ⚠️ (some) | ❌ | ❌ | ✅ (BDEF, SRVD, SRVB) | ✅ (all incl. DDLX) | N/A | ❌ |
-| Multi-object batch creation | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| AFF schema validation (pre-create) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Type auto-mappings (CLAS→CLAS/OC) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ |
-| Create test class | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ |
+| Write Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|--------------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| Create objects | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ | ✅ |
+| Update source | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ | ✅ |
+| Delete objects | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ | ❌ |
+| Activate | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ | ✅ |
+| Batch activate | ✅ | ✅ | ✅ | ❌ | ✅ (with dep resolution) | ✅ | N/A | ✅ (v2.0, Apr 2026) | ✅ (mass activation) |
+| Lock/unlock | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ | ✅ |
+| EditSource (surgical) | ✅ (edit_method) | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ (edit_method, Apr 2026) | ❌ |
+| CloneObject | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Execute ABAP | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ✅ | ✅ (abap run) |
+| RAP CRUD (BDEF, SRVD, DDLX, SRVB) | ✅ (DDLS, DDLX, BDEF, SRVD write) | ⚠️ (some) | ❌ | ❌ | ✅ (BDEF, SRVD, SRVB) | ✅ (all incl. DDLX) | N/A | ❌ | ⚠️ (DDLS, DCL, BDEF write; SRVB publish) |
+| Multi-object batch creation | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| AFF schema validation (pre-create) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Type auto-mappings (CLAS→CLAS/OC) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ | ✅ (ADTObjectType) |
+| Create test class | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ | ✅ (class write test_classes) |
 
 ## 7. Code Intelligence
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| Find definition | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ (Apr 2026) |
-| Find references | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
-| Code completion | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Context compression | ✅ (SAPContext, 7-30x) | ✅ (auto, 7-30x) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Method-level surgery | ✅ (95% reduction) | ✅ (95% reduction) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| ABAP AST / parser | ⚠️ (abaplint for lint) | ✅ (native Go port) | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
-| Semantic analysis | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
-| Call graph analysis | ❌ | ✅ (5 tools) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Type hierarchy | ✅ (via SQL) | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| CDS dependencies | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| Find definition | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ (Apr 2026) | ❌ |
+| Find references | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ | ✅ (where-used with scope) |
+| Code completion | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Context compression | ✅ (SAPContext, 7-30x) | ✅ (auto, 7-30x) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Method-level surgery | ✅ (95% reduction) | ✅ (95% reduction) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| ABAP AST / parser | ⚠️ (abaplint for lint) | ✅ (native Go port) | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ❌ |
+| Semantic analysis | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ❌ |
+| Call graph analysis | ❌ | ✅ (5 tools) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Type hierarchy | ✅ (via SQL) | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| CDS dependencies | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
 
 ## 8. Code Quality
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| Syntax check | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
-| ATC checks | ✅ | ✅ | ✅ | ❌ | ✅ (with summary) | ❌ | N/A | ✅ (severity grouping) |
-| abaplint (local offline) | ✅ | ✅ (native Go port, 8 rules) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Unit tests | ✅ | ✅ | ✅ | ❌ | ✅ (with coverage) | ✅ | N/A | ❌ |
-| CDS unit tests | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
-| API release state (clean core) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Fix proposals | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
-| PrettyPrint | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Migration analysis | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | N/A | ❌ |
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| Syntax check | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ | ✅ |
+| ATC checks | ✅ | ✅ | ✅ | ❌ | ✅ (with summary) | ❌ | N/A | ✅ (severity grouping) | ✅ (checkstyle/codeclimate) |
+| abaplint (local offline) | ✅ | ✅ (native Go port, 8 rules) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Unit tests | ✅ | ✅ | ✅ | ❌ | ✅ (with coverage) | ✅ | N/A | ❌ | ✅ (with coverage + JUnit4/sonar) |
+| CDS unit tests | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ❌ |
+| API release state (clean core) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Fix proposals | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| PrettyPrint | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Migration analysis | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | N/A | ❌ | ❌ |
 
 ## 9. Transport / CTS
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| List transports | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ |
-| Create transport | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
-| Release transport | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ |
-| Transport contents | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ |
-| Transport assign | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ |
-| Transport gating | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Inactive objects list | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| List transports | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | N/A | ✅ | ✅ (-r/-rr/-rrr detail) |
+| Create transport | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ | ✅ (5 types: K/W/T/S/R) |
+| Release transport | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ | ✅ (recursive) |
+| Transport contents | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ | ✅ (-rrr objects) |
+| Transport assign | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ | ✅ (reassign owner) |
+| Transport gating | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Inactive objects list | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ✅ |
 
 ## 10. Diagnostics & Runtime
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| Short dumps (ST22) | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
-| ABAP profiler traces | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ❌ |
-| System messages (SM02) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (v5.0.0) | N/A | ❌ |
-| Gateway error log (IWFND) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (v5.0.0, on-prem) | N/A | ❌ |
-| ADT feed reader (unified) | ⚠️ (dumps+traces) | ❌ | ❌ | ❌ | ❌ | ✅ (v5.0.0, 5 types) | N/A | ❌ |
-| SQL traces | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
-| ABAP debugger | ❌ | ✅ (8 tools) | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
-| AMDP/HANA debugger | ❌ | ✅ (7 tools) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
-| Execute with profiling | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ |
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| Short dumps (ST22) | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ | ❌ |
+| ABAP profiler traces | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ❌ | ❌ |
+| System messages (SM02) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (v5.0.0) | N/A | ❌ | ❌ |
+| Gateway error log (IWFND) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (v5.0.0, on-prem) | N/A | ❌ | ❌ |
+| ADT feed reader (unified) | ⚠️ (dumps+traces) | ❌ | ❌ | ❌ | ❌ | ✅ (v5.0.0, 5 types) | N/A | ❌ | ❌ |
+| SQL traces | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| ABAP debugger | ❌ | ✅ (8 tools) | ✅ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| AMDP/HANA debugger | ❌ | ✅ (7 tools) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Execute with profiling | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ❌ |
 
 ## 11. Advanced Features
 
-| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| Feature auto-detection | ✅ (6 probes) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Caching (SQLite) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| UI5/Fiori BSP | ❌ | ⚠️ (3 read-only; 4 write tools disabled — ADT filestore returns 405) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| abapGit/gCTS | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ |
-| BTP Destination Service | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| Cloud Connector proxy | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Multi-system support | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
-| OData bridge | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Lua scripting engine | ❌ | ✅ (50+ bindings) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| WASM-to-ABAP compiler | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| MCP client configurator | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (11 clients) | ❌ | ❌ |
-| CLI mode (non-MCP) | ❌ | ✅ (28 commands) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Health endpoint | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ (v4.3.0) | ❌ | ✅ |
-| RFC connectivity | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (sap-rfc-lite) | ❌ | ❌ |
-| MCPB one-click install | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Lock registry / recovery | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| Batch HTTP operations | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (multipart/mixed) | ❌ | ❌ |
-| RAG-optimized tool descriptions | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (v4.4.0) | ❌ | ❌ |
-| Embeddable server (library mode) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| Error intelligence (hints) | ⚠️ (LLM hints) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| Feature auto-detection | ✅ (6 probes) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (ADT discovery/MIME) |
+| Caching (SQLite) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| UI5/Fiori BSP | ❌ | ⚠️ (3 read-only; 4 write tools disabled — ADT filestore returns 405) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (OData upload/download) |
+| abapGit/gCTS | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ | ✅ (full gCTS + checkout/checkin) |
+| BTP Destination Service | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| Cloud Connector proxy | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Multi-system support | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ (kubeconfig contexts) |
+| OData bridge | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ (BSP, FLP via OData) |
+| Lua scripting engine | ❌ | ✅ (50+ bindings) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| WASM-to-ABAP compiler | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| MCP client configurator | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (11 clients) | ❌ | ❌ | ❌ |
+| CLI mode (non-MCP) | ❌ | ✅ (28 commands) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (28+ commands, primary mode) |
+| Health endpoint | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ (v4.3.0) | ❌ | ✅ | ❌ |
+| RFC connectivity | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (sap-rfc-lite) | ❌ | ❌ | ✅ (PyRFC, optional) |
+| MCPB one-click install | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Lock registry / recovery | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Batch HTTP operations | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (multipart/mixed) | ❌ | ❌ | ❌ |
+| RAG-optimized tool descriptions | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (v4.4.0) | ❌ | ❌ | ❌ |
+| Embeddable server (library mode) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Error intelligence (hints) | ⚠️ (LLM hints) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ (typed error hierarchy) |
 
 ## 12. Token Efficiency
 
-| Feature | ARC-1 | vibing-steampunk | fr0ster |
-|---------|-------|-----------------|---------|
-| Schema token cost | ~200 (hyperfocused) / ~moderate (11 tools) | ~200 (hyperfocused) / ~14K (focused) / ~40K (expert) | ~high (287 tools) |
-| Context compression | ✅ SAPContext (7-30x) | ✅ Auto-append (7-30x) | ❌ |
-| Method-level surgery | ✅ (95% source reduction) | ✅ (95% source reduction) | ❌ |
-| Hyperfocused mode (1 tool) | ✅ (~200 tokens) | ✅ (~200 tokens) | ❌ |
-| Compact/intent mode | ✅ (11 intent tools) | N/A | ✅ (22 compact tools) |
+| Feature | ARC-1 | vibing-steampunk | fr0ster | sapcli |
+|---------|-------|-----------------|---------|--------|
+| Schema token cost | ~200 (hyperfocused) / ~moderate (11 tools) | ~200 (hyperfocused) / ~14K (focused) / ~40K (expert) | ~high (287 tools) | N/A (CLI) |
+| Context compression | ✅ SAPContext (7-30x) | ✅ Auto-append (7-30x) | ❌ | N/A |
+| Method-level surgery | ✅ (95% source reduction) | ✅ (95% source reduction) | ❌ | N/A |
+| Hyperfocused mode (1 tool) | ✅ (~200 tokens) | ✅ (~200 tokens) | ❌ | N/A |
+| Compact/intent mode | ✅ (11 intent tools) | N/A | ✅ (22 compact tools) | N/A |
 
 ## 13. Testing & Quality
 
-| Metric | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb |
-|--------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
-| Unit tests | 1315 | 222 | 0 | 0 | 0 | Yes (Jest) | 0 | 163 |
-| Integration tests | ✅ (on-prem CI + BTP scheduled smoke) | ✅ | ❌ | 13 (live SAP) | ❌ | ✅ | ❌ | ⚠️ scaffold |
-| CI/CD | ✅ (release-please + reliability telemetry) | ✅ (GoReleaser) | ❌ | ❌ | ❌ | ⚠️ (Husky + lint-staged) | ❌ | ❌ |
-| Input validation | Zod v4 | Custom | Untyped | Untyped | Pydantic | Zod v4 | Zod | Manual |
-| Linter | Biome | — | — | — | — | Biome | — | — |
+| Metric | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
+|--------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
+| Unit tests | 1315 | 222 | 0 | 0 | 0 | Yes (Jest) | 0 | 163 | ~90 files (unittest) |
+| Integration tests | ✅ (on-prem CI + BTP scheduled smoke) | ✅ | ❌ | 13 (live SAP) | ❌ | ✅ | ❌ | ⚠️ scaffold | ✅ (shell scripts) |
+| CI/CD | ✅ (release-please + reliability telemetry) | ✅ (GoReleaser) | ❌ | ❌ | ❌ | ⚠️ (Husky + lint-staged) | ❌ | ❌ | ✅ (GitHub Actions + codecov) |
+| Input validation | Zod v4 | Custom | Untyped | Untyped | Pydantic | Zod v4 | Zod | Manual | argparse |
+| Linter | Biome | — | — | — | — | Biome | — | — | pylint + flake8 + mypy |
 
 ---
 

--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -276,7 +276,7 @@ The following items were incorrectly marked in the previous version and have sin
 - ~~Token efficiency~~ → method-level surgery, hyperfocused mode, context compression
 
 **P0 — production blockers:**
-- ~~415/406 content-type auto-retry (SAP version compatibility)~~ — ✅ Implemented: one-retry negotiation fallback in `src/adt/http.ts`, endpoint-specific CTS media types, lock `corrNr` auto-propagation
+- ~~415/406 content-type auto-retry (SAP version compatibility)~~ — ✅ Implemented: one-retry negotiation fallback in `src/adt/http.ts`, endpoint-specific CTS media types, lock `corrNr` auto-propagation. fr0ster v4.5.0 added per-endpoint header caching (P3 optimization ARC-1 doesn't need yet). [Deep dive](fr0ster/evaluations/v4.5.0-release-deep-dive.md)
 - 401 session timeout auto-retry (centralized gateway idle)
 - TLS/HTTPS for HTTP Streamable (enterprise deployment without reverse proxy)
 

--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -2,7 +2,7 @@
 
 A comprehensive comparison of all SAP ADT/MCP projects against ARC-1.
 
-_Last updated: 2026-04-10 (post transport/write hardening)_
+_Last updated: 2026-04-12 (post fr0ster v5.0.0 feed tools analysis)_
 
 ## Legend
 - ✅ = Supported
@@ -166,6 +166,9 @@ _Last updated: 2026-04-10 (post transport/write hardening)_
 |---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|
 | Short dumps (ST22) | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ |
 | ABAP profiler traces | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ❌ |
+| System messages (SM02) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (v5.0.0) | N/A | ❌ |
+| Gateway error log (IWFND) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (v5.0.0, on-prem) | N/A | ❌ |
+| ADT feed reader (unified) | ⚠️ (dumps+traces) | ❌ | ❌ | ❌ | ❌ | ✅ (v5.0.0, 5 types) | N/A | ❌ |
 | SQL traces | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
 | ABAP debugger | ❌ | ✅ (8 tools) | ✅ | ❌ | ❌ | ❌ | N/A | ❌ |
 | AMDP/HANA debugger | ❌ | ✅ (7 tools) | ❌ | ❌ | ❌ | ❌ | N/A | ❌ |
@@ -264,7 +267,7 @@ The following items were incorrectly marked in the previous version and have sin
 
 ### Biggest Competitive Threats
 1. **vibing-steampunk** (242 stars) — Community favorite. Now has Streamable HTTP (v2.38.0). Massive Apr sprint: i18n, gCTS, API release state, version history, code coverage, health analysis, rename preview, dead code analysis. Still lacks BTP/enterprise auth but rapidly closing feature gaps.
-2. **fr0ster** (v4.8.7, 85+ releases) — Closest enterprise competitor. 287 tools, 9 auth providers, TLS, RFC, embeddable. Search TSV format optimization. Complex multi-repo but ambitious.
+2. **fr0ster** (v5.0.1, 90+ releases) — Closest enterprise competitor. 289 tools, 9 auth providers, TLS, RFC, embeddable. v5.0.0 added unified feed tools (SM02, gateway errors), adt-clients 4.0 factory API. Complex multi-repo but ambitious.
 3. **btp-odata-mcp** (119 stars) — Different category (OData not ADT) but high adoption. Could expand into ADT territory.
 
 ### Key Gaps to Close
@@ -287,6 +290,8 @@ The following items were incorrectly marked in the previous version and have sin
 - Documentation (Copilot Studio guide, Basis Admin guide)
 
 **P2+ — future gaps:**
+- System messages (SM02) — AI agent situational awareness. fr0ster v5.0.0 added this.
+- Gateway error log (IWFND) — OData/Gateway debugging with source code + call stack. fr0ster v5.0.0, on-prem only.
 - SQL traces, PrettyPrint, inactive objects, transport contents, source versions
 - Cloud readiness assessment, gCTS/abapGit, enhancement framework
 - Multi-system routing, rate limiting

--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -46,7 +46,7 @@ _Last updated: 2026-04-12 (post fr0ster v5.0.0 feed tools analysis)_
 | XSUAA OAuth | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
 | BTP Service Key | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | Principal Propagation | ✅ | ❌ | ❌ | ❌ | ✅ (X.509) | ✅ | ✅ | ❌ |
-| SAML | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| SAML | ❌ | ✅ (v2.39.0+, PR #97) | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
 | X.509 Certificates | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Device Flow (OIDC) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | Browser login page | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
@@ -266,7 +266,7 @@ The following items were incorrectly marked in the previous version and have sin
 9. **npm + Docker + release-please** — Most professional distribution pipeline.
 
 ### Biggest Competitive Threats
-1. **vibing-steampunk** (242 stars) — Community favorite. Now has Streamable HTTP (v2.38.0). Massive Apr sprint: i18n, gCTS, API release state, version history, code coverage, health analysis, rename preview, dead code analysis. Still lacks BTP/enterprise auth but rapidly closing feature gaps.
+1. **vibing-steampunk** (242 stars) — Community favorite. Now has Streamable HTTP (v2.38.0), SAML SSO (v2.39.0+, PR #97). Massive Apr sprint: i18n, gCTS, API release state, version history, code coverage, health analysis, rename preview, dead code analysis, package safety hardening. Now defaults to hyperfocused mode (1 tool). Still lacks BTP OAuth / Destination Service but adding auth options.
 2. **fr0ster** (v5.0.1, 90+ releases) — Closest enterprise competitor. 289 tools, 9 auth providers, TLS, RFC, embeddable. v5.0.0 added unified feed tools (SM02, gateway errors), adt-clients 4.0 factory API. Complex multi-repo but ambitious.
 3. **btp-odata-mcp** (119 stars) — Different category (OData not ADT) but high adoption. Could expand into ADT territory.
 

--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -280,8 +280,9 @@ The following items were incorrectly marked in the previous version and have sin
 
 **P0 — production blockers:**
 - ~~415/406 content-type auto-retry (SAP version compatibility)~~ — ✅ Implemented: one-retry negotiation fallback in `src/adt/http.ts`, endpoint-specific CTS media types, lock `corrNr` auto-propagation. fr0ster v4.5.0 added per-endpoint header caching (P3 optimization ARC-1 doesn't need yet). [Deep dive](fr0ster/evaluations/v4.5.0-release-deep-dive.md)
+- ADT service discovery / MIME negotiation (FEAT-38) — probe once at startup, eliminate 415/406 guesswork
 - 401 session timeout auto-retry (centralized gateway idle)
-- TLS/HTTPS for HTTP Streamable (enterprise deployment without reverse proxy)
+- ~~TLS/HTTPS for HTTP Streamable~~ — downgraded to P3: most deployments use reverse proxy (BTP gorouter, nginx, K8s Ingress)
 
 **P1 — high-value gaps:**
 - Where-Used analysis, fix proposals

--- a/compare/01-vibing-steampunk.md
+++ b/compare/01-vibing-steampunk.md
@@ -2,7 +2,7 @@
 
 > **Repository**: https://github.com/oisee/vibing-steampunk
 > **Language**: Go 1.24 | **License**: MIT | **Stars**: 242
-> **Status**: Very Active (v2.32.0, daily commits in March 2026)
+> **Status**: Very Active (v2.39.0+, daily commits through April 2026, 495+ total commits)
 > **Relationship**: ARC-1's upstream/origin — forked and rewritten in TypeScript
 
 ---
@@ -195,6 +195,11 @@ mcp-go v0.17.0, Cobra, Viper, go-sqlite3, godotenv, yaml.v3, Gopher-Lua, WebSock
 
 | Date | Upstream Change | Relevant? | Decision | Status |
 |------|----------------|-----------|----------|--------|
+| 2026-04-12 | **CRITICAL: Package safety bypass on mutations (#101)** — `SAP_ALLOWED_PACKAGES` not enforced on update/delete. **ARC-1 has same bug.** | **Critical** | **Fix immediately** — checkPackage() missing on update/delete/edit_method | [Eval](vibing-steampunk/evaluations/0713d75-package-safety-mutations.md) |
+| 2026-04-12 | SAML SSO auth for S/4HANA Public Cloud (#97) — programmatic + browser + credential-cmd | Low | Defer — ARC-1 uses BTP OAuth / Destination Service | [Eval](vibing-steampunk/evaluations/e62c7d5-saml-sso-auth.md) |
+| 2026-04-12 | HANA database detection from S4CORE component (#100) | Low | Consider — system info enhancement | — |
+| 2026-04-10 | API release state bug fix — C0-C4 structure (#95) | Medium | Verify ARC-1 getApiReleaseState | [Eval](vibing-steampunk/evaluations/a66bcd5-release-state-bugfix.md) |
+| 2026-04-09 | Default mode → hyperfocused (1 tool), transport/CR boundary analysis, batch IN-clause fix | Low | Market signal — validates intent-based approach | — |
 | 2026-04-08 | v2.39.0 — Side effect extraction, LUW classification, boundary crossing | Review | Consider future — novel analysis capabilities | [Eval](vibing-steampunk/evaluations/11c2253-side-effects-luw.md) |
 | 2026-04-07 | v2.38.1 — Auth headers on redirects, stateful lock sessions | Yes | Verify — check ARC-1 http.ts redirect behavior | [Verify](vibing-steampunk/evaluations/27d4d7c-auth-redirect-stateful.md) |
 | 2026-04-06 | v2.38.0 — Health analysis, rename preview, dead code, API surface | Review | Rename: consider (#18). Others: defer. | [Eval](vibing-steampunk/evaluations/dcaa358-rename-refactoring.md) |
@@ -213,4 +218,4 @@ mcp-go v0.17.0, Cobra, Viper, go-sqlite3, godotenv, yaml.v3, Gopher-Lua, WebSock
 
 > **Detailed commit-level tracking**: See [`compare/vibing-steampunk/`](vibing-steampunk/) for per-commit and per-issue evaluations.
 
-_Last updated: 2026-04-08_
+_Last updated: 2026-04-12_

--- a/compare/05-fr0ster-mcp-abap-adt.md
+++ b/compare/05-fr0ster-mcp-abap-adt.md
@@ -2,7 +2,7 @@
 
 > **Repository**: https://github.com/fr0ster/mcp-abap-adt
 > **Language**: TypeScript | **License**: MIT | **Stars**: 26
-> **Status**: Very Active (v4.8.1, 85+ releases in 5 months, 770+ commits)
+> **Status**: Very Active (v5.0.1, 90+ releases in 5 months, 799+ commits)
 > **NPM**: `@mcp-abap-adt/core` — 3,625 monthly downloads
 > **Relationship**: Independent TypeScript ADT MCP server with most advanced auth system
 
@@ -10,7 +10,7 @@
 
 ## Project Overview
 
-A multi-package monorepo MCP server for SAP ADT with 287 tools organized across 4 exposition tiers (read-only 52, high-level 113, low-level 122, compact 22). Features the most comprehensive authentication system of any project (9 providers including SAML, OIDC device flow, token exchange). Strict interface isolation via separate npm packages.
+A multi-package monorepo MCP server for SAP ADT with 289 tools organized across 4 exposition tiers (read-only 55, high-level 113, low-level 122, compact 22). v5.0.0 added unified ADT feed tools (SM02 messages, gateway errors, feed reader) and migrated to adt-clients 4.0 factory API. Features the most comprehensive authentication system of any project (9 providers including SAML, OIDC device flow, token exchange). Strict interface isolation via separate npm packages.
 
 Key differentiator: "AI Pairing, Not Vibing (AIPNV)" philosophy — positioned as pair programming assistant, not autopilot.
 
@@ -121,7 +121,9 @@ Dev: Biome, Jest, TypeScript, Express, Husky
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
-| v4.8.0-4.8.1 | Apr 2, 2026 | Structured dump list, dump lookup by datetime+user, from/to time filters |
+| v5.0.0-5.0.1 | Apr 11-12, 2026 | RuntimeListFeeds (unified ADT feed reader), RuntimeListSystemMessages (SM02), RuntimeGetGatewayErrorLog (/IWFND/ERROR_LOG with detail view), adt-clients 4.0 factory API migration. Removed compact wrappers in v5.0.1 (LLM confusion). [Deep dive](fr0ster/evaluations/v5.0.0-release-deep-dive.md) |
+| v4.9.0 | Apr 9, 2026 | Minor release between v4.8.x and v5.0.0 |
+| v4.8.0-4.8.7 | Apr 2-8, 2026 | Structured dump list, dump lookup by datetime+user, from/to time filters, search TSV format |
 | v4.7.0-4.7.1 | Apr 1, 2026 | Replaced archived `node-rfc` with `@mcp-abap-adt/sap-rfc-lite` |
 | v4.6.0 | Mar 31, 2026 | HTTPS/TLS support for MCP server |
 | v4.5.0-4.5.2 | Mar 26-27, 2026 | try-finally lock fix (9 handlers), 415/406 Content-Type auto-retry via adt-clients 3.12.0 (per-endpoint caching), ListTransports Accept negotiation rewrite, RAG-optimized SearchObject description, auth priority fix. [Deep dive](fr0ster/evaluations/v4.5.0-release-deep-dive.md) |
@@ -132,7 +134,7 @@ Dev: Biome, Jest, TypeScript, Express, Husky
 | v2.x | Dec 30, 2025 - Feb 23, 2026 | ~20 releases |
 | v1.1.0 | Nov 21, 2025 | First release |
 
-**Total: 85+ releases in ~5 months. Average: ~4 releases/week.**
+**Total: 90+ releases in ~5 months. Average: ~4 releases/week.**
 
 ## Known Issues
 
@@ -154,6 +156,9 @@ Dev: Biome, Jest, TypeScript, Express, Husky
 
 | Feature | Priority | Effort | Notes |
 |---------|----------|--------|-------|
+| **SM02 system messages** (RuntimeListSystemMessages) | Medium | 0.5d | AI agent situational awareness (maintenance windows, system announcements) |
+| **Gateway error log** (RuntimeGetGatewayErrorLog) | Medium | 1d | /IWFND/ERROR_LOG with detail view — essential for OData debugging. On-prem only. |
+| **Unified ADT feed reader** (RuntimeListFeeds) | Low | 0.5d | Feed descriptor/variant discovery. ARC-1 already has dump + trace feeds. |
 | **9 auth providers** (SAML, OIDC device flow, etc.) | Low | 5d+ | Only if enterprise demand |
 | **TLS/HTTPS for MCP server** | Critical | 1d | Required for production without reverse proxy |
 | **sap-rfc-lite** (RFC connectivity) | Low | 3d | Alternative to ADT HTTP |
@@ -200,6 +205,9 @@ Dev: Biome, Jest, TypeScript, Express, Husky
 
 | Date | Change | Relevant? | Action for ARC-1 | Status |
 |------|--------|-----------|-------------------|--------|
+| 2026-04-12 | v5.0.1 — Removed compact feed wrappers (LLM confusion, 292→289 tools) | Lesson | Validates ARC-1's intent-based approach — duplicate tools confuse LLMs | Done |
+| 2026-04-11 | v5.0.0 — RuntimeListFeeds, RuntimeListSystemMessages (SM02), RuntimeGetGatewayErrorLog (/IWFND/ERROR_LOG), adt-clients 4.0 factory API | **Medium** | Add `system_messages` + `gateway_errors` actions to SAPDiagnose | [Eval](fr0ster/evaluations/v5.0.0-release-deep-dive.md) |
+| 2026-04-09 | v4.9.0 — Minor release | No | — | — |
 | 2026-04-08 | v4.8.2-4.8.7 — Merge RuntimeAnalyzeDump into RuntimeGetDumpById, search TSV format (#40) | Medium | Search TSV format: consider for SAPSearch optimization | [Eval](fr0ster/evaluations/8a22669-search-tsv-format.md) |
 | 2026-04-02 | v4.8.0-4.8.1 — Structured dump list, datetime+user lookup, from/to filters | Medium | Defer — ARC-1 SAPDiagnose dumps work fine as-is | Evaluated |
 | 2026-04-01 | v4.7.0-4.7.1 — sap-rfc-lite replaces node-rfc | No | ARC-1 uses HTTP only | — |
@@ -218,6 +226,6 @@ Dev: Biome, Jest, TypeScript, Express, Husky
 | 2026-03-04 | v3.1.0-3.2.0 — Create/Update separation, table contents | Medium | Keep current combined create+write. Table contents: already have RunQuery | Evaluated |
 | 2026-02-09 | v2.2.0 — MCP client auto-configurator | Medium | Implement lightweight `arc-1 config` snippet printer | TODO |
 
-_Last updated: 2026-04-11_
+_Last updated: 2026-04-12_
 
 > **Detailed commit-level tracking**: See [fr0ster/commits.json](fr0ster/commits.json) and [fr0ster/evaluations/](fr0ster/evaluations/) for per-commit analysis.

--- a/compare/05-fr0ster-mcp-abap-adt.md
+++ b/compare/05-fr0ster-mcp-abap-adt.md
@@ -124,7 +124,7 @@ Dev: Biome, Jest, TypeScript, Express, Husky
 | v4.8.0-4.8.1 | Apr 2, 2026 | Structured dump list, dump lookup by datetime+user, from/to time filters |
 | v4.7.0-4.7.1 | Apr 1, 2026 | Replaced archived `node-rfc` with `@mcp-abap-adt/sap-rfc-lite` |
 | v4.6.0 | Mar 31, 2026 | HTTPS/TLS support for MCP server |
-| v4.5.0-4.5.2 | Mar 26-27, 2026 | try-finally lock fix, RAG-optimized descriptions, auth priority fix |
+| v4.5.0-4.5.2 | Mar 26-27, 2026 | try-finally lock fix (9 handlers), 415/406 Content-Type auto-retry via adt-clients 3.12.0 (per-endpoint caching), ListTransports Accept negotiation rewrite, RAG-optimized SearchObject description, auth priority fix. [Deep dive](fr0ster/evaluations/v4.5.0-release-deep-dive.md) |
 | v4.4.0 | Mar 22, 2026 | Tool descriptions enriched for embedding-based discovery |
 | v4.3.0 | Mar 19, 2026 | `/mcp/health` endpoint, improved request logging |
 | v4.0.0-4.1.1 | Mar 13, 2026 | Major version bump (v3→v4) |
@@ -139,7 +139,7 @@ Dev: Biome, Jest, TypeScript, Express, Husky
 | Issue | Description | Relevant to ARC-1? |
 |-------|-------------|-------------------|
 | #22 | Lock leak — try-catch instead of try-finally for unlock | **Resolved** — ARC-1 already uses try-finally |
-| #22, #23, #25 | 415 Content-Type errors — SAP needs specific Accept/Content-Type | **Yes** — add 415 retry logic ([evaluation](fr0ster/evaluations/415-content-type-retry.md)) |
+| #22, #23, #25 | 415 Content-Type errors — SAP needs specific Accept/Content-Type | **Resolved** — ARC-1 already has 406/415 auto-retry in http.ts ([evaluation](fr0ster/evaluations/415-content-type-retry.md), [deep dive](fr0ster/evaluations/v4.5.0-release-deep-dive.md)) |
 | #24 | SAP_JWT_TOKEN overrides SAP_AUTH_TYPE | **No action** — ARC-1 infers auth type from credentials, no priority conflict ([evaluation](fr0ster/evaluations/dce44ca-auth-type-priority.md)) |
 | #7, #6 | 409 conflict details not propagated to LLM | **Verify** — check ARC-1 AdtApiError includes SAP error body ([evaluation](fr0ster/evaluations/issue-7-6-409-error-details.md)) |
 | #13 | Check runs fail with non-EN languages | **Verify** — check ARC-1 syntax check/ATC parsing uses language-independent attributes ([evaluation](fr0ster/evaluations/issue-13-i18n-check-handling.md)) |
@@ -167,7 +167,7 @@ Dev: Biome, Jest, TypeScript, Express, Husky
 | **CDS unit testing** (create/run/check) | Medium | 1d | Extend SAPDiagnose |
 | **Embeddable server** (EmbeddableMcpServer) | Low | 1d | SDK/library use case |
 | **GetProgFullCode** (recursive includes) | High | 1d | Reduces round trips |
-| **Content-Type 415 auto-retry** | Critical | 0.5d | Robustness improvement |
+| ~~**Content-Type 415 auto-retry**~~ | ~~Critical~~ | ~~0.5d~~ | ✅ **Done** — ARC-1 has 406/415 auto-retry in http.ts. Only gap: per-endpoint caching (P3 optimization). [Deep dive](fr0ster/evaluations/v4.5.0-release-deep-dive.md) |
 | **Compact mode** (22 tools) | Low | 2d | ARC-1 already has intent-based |
 | **RAG-optimized tool descriptions** | Medium | 1d | Improve embedding discoverability |
 | **DDLX/Metadata Extension** (read + CRUD) | Critical | 1d | RAP completeness |
@@ -204,9 +204,11 @@ Dev: Biome, Jest, TypeScript, Express, Husky
 | 2026-04-02 | v4.8.0-4.8.1 — Structured dump list, datetime+user lookup, from/to filters | Medium | Defer — ARC-1 SAPDiagnose dumps work fine as-is | Evaluated |
 | 2026-04-01 | v4.7.0-4.7.1 — sap-rfc-lite replaces node-rfc | No | ARC-1 uses HTTP only | — |
 | 2026-03-31 | v4.6.0 — TLS/HTTPS support | **Critical** | Add TLS support for HTTP Streamable | TODO |
-| 2026-03-27 | v4.5.2 — Content-Type negotiation fixes | **Critical** | Add 415 retry logic to ARC-1 HTTP | TODO |
-| 2026-03-26 | v4.5.0 — Lock leak fix (try-finally) | Resolved | ARC-1 already uses try-finally | Done |
-| 2026-03-26 | RAG-optimized tool descriptions | No | Not relevant — ARC-1 uses intent routing, not RAG discovery | Evaluated |
+| 2026-03-27 | v4.5.2 — Husky + lint-staged pre-commit hook | No | ARC-1 already has Biome pre-commit | Done |
+| 2026-03-26 | v4.5.1 — ListTransports Accept negotiation rewrite | **Resolved** | Covered by ARC-1's global 415/406 retry in http.ts | Done |
+| 2026-03-26 | v4.5.0 — adt-clients 3.12.0 (415/406 auto-retry + per-endpoint caching) | **Resolved** | ARC-1 already has 415/406 retry. Per-endpoint caching is P3 optimization. [Deep dive](fr0ster/evaluations/v4.5.0-release-deep-dive.md) | Done |
+| 2026-03-26 | v4.4.2 — Lock leak fix (try-finally in 9 handlers) | Resolved | ARC-1 already uses try-finally via centralized `safeUpdateSource()`. [Eval](fr0ster/evaluations/32ab9d4-try-finally-unlock.md) | Done |
+| 2026-03-26 | v4.4.1 — RAG-optimized SearchObject description | No | Not relevant — ARC-1 uses intent routing, not RAG discovery | Evaluated |
 | 2026-03-26 | Auth priority fix (#24) | No | ARC-1 infers auth from credentials — no priority conflict | Evaluated |
 | 2026-03-22 | v4.4.0 — Embedding-optimized descriptions | No | Same as above — RAG not applicable | Evaluated |
 | 2026-03-19 | v4.3.0 — /mcp/health endpoint | No | ARC-1 already has /health | — |
@@ -216,6 +218,6 @@ Dev: Biome, Jest, TypeScript, Express, Husky
 | 2026-03-04 | v3.1.0-3.2.0 — Create/Update separation, table contents | Medium | Keep current combined create+write. Table contents: already have RunQuery | Evaluated |
 | 2026-02-09 | v2.2.0 — MCP client auto-configurator | Medium | Implement lightweight `arc-1 config` snippet printer | TODO |
 
-_Last updated: 2026-04-08_
+_Last updated: 2026-04-11_
 
 > **Detailed commit-level tracking**: See [fr0ster/commits.json](fr0ster/commits.json) and [fr0ster/evaluations/](fr0ster/evaluations/) for per-commit analysis.

--- a/compare/09-sapcli.md
+++ b/compare/09-sapcli.md
@@ -1,0 +1,398 @@
+# jfilak/sapcli
+
+> **Repository**: https://github.com/jfilak/sapcli
+> **Language**: Python 3.10+ | **License**: Apache-2.0 | **Stars**: 77 | **Forks**: 28
+> **Status**: Very active — last commit 2026-04-09, 488 commits by primary author
+> **Type**: CLI tool (not MCP), CI/CD-focused ABAP development automation
+
+---
+
+## Project Overview
+
+sapcli is a **Python 3 command-line interface** for SAP ABAP development, primarily targeting the ADT REST API. Created in 2018 by Jakub Filak, it's one of the oldest open-source ADT clients and focuses on **CI/CD automation**: running unit tests, ATC checks, managing transports, deploying via abapGit, and round-tripping ABAP objects to/from filesystem in abapGit format.
+
+Not an MCP server — it's a traditional CLI tool with argparse-based subcommands. Designed for scripting and pipeline use, not LLM integration. However, it has the **deepest ADT API coverage** of any non-SAP open-source project and several mature patterns worth studying.
+
+## Architecture
+
+```
+sap/
+  adt/              # ADT REST API client layer
+    core.py         # Connection class (HTTP, CSRF, sessions)
+    objects.py      # ADTObject base class (all types inherit)
+    annotations.py  # XML-to-object mapper (metaclass + decorators)
+    marshalling.py  # XML serialization/deserialization
+    programs.py     # PROG, INCL
+    oo.py           # CLAS, INTF
+    function.py     # FUGR, FUMO
+    datadefinition.py  # DDLS, DCL, SRVD, SRVB
+    businessobj.py  # BDEF
+    package.py      # DEVC
+    dataelement.py  # DTEL
+    structure.py    # STRU
+    table.py        # TABL
+    checks.py       # Syntax check, ATC
+    aunit.py        # ABAP Unit tests + coverage
+    activation.py   # Mass activation
+    cts.py          # CTS transport management
+    search.py       # Quick object search
+    whereused.py    # Where-used analysis
+    abapgit.py      # abapGit ADT plugin API
+    discovery.py    # ADT service discovery (MIME version negotiation)
+    errors.py       # Typed error hierarchy
+    enhancement_implementation.py  # BAdI, enhancements
+    feature_toggle.py  # Feature toggle management
+  cli/              # CLI command groups (one file per group)
+    core.py         # CommandGroup pattern
+    __init__.py     # Command registry
+    _entry.py       # Entry point, connection dispatch
+    program.py, classs.py, interface.py, ddl.py, dcl.py, bdef.py
+    package.py, aunit.py, atc.py, cts.py, gcts.py
+    checkout.py     # Export to filesystem (abapGit format)
+    checkin.py      # Import from filesystem
+    datapreview.py  # Free SQL
+    abap.py         # Run ABAP snippets, search, system info
+    rap.py          # Publish service bindings
+    bsp.py          # BSP applications
+    flp.py          # Fiori Launchpad
+    startrfc.py     # RFC function modules
+    user.py         # User management
+    strust.py       # SSL certificate management
+    activation.py   # Mass activation
+    config.py       # kubeconfig-style configuration
+  rest/             # Generic REST (gCTS)
+  rfc/              # RFC via PyRFC (optional)
+  odata/            # OData client (BSP, FLP)
+  platform/         # DDIC builders, abapGit format, language codes
+  config.py         # kubeconfig-style YAML config
+  flp/              # Fiori Launchpad service/builder
+```
+
+**Key design patterns:**
+
+1. **ADTObject base class**: All ABAP types inherit from `ADTObject`. Each declares `OBJTYPE` as `ADTObjectType(code, basepath, xmlns, mimetype, ...)`. CRUD is uniform across all types.
+
+2. **XML-to-Object mapper**: Custom annotation system via Python metaclasses (`OrderedClassMembers`) and decorators (`@xml_attribute`, `@xml_element`). Preserves XML element order during round-trip serialization. Most sophisticated XML→Python mapping in any open-source ADT client.
+
+3. **CommandGroup pattern**: Each CLI module defines a `CommandGroup` subclass. Commands registered via `@CommandGroup.command()` + `@CommandGroup.argument()` decorators. Four connection types: ADT, REST, RFC, OData.
+
+4. **Connection abstraction**: Separate connection classes per protocol — ADT (HTTP+CSRF), REST (gCTS), OData (BSP/FLP), RFC (PyRFC). Each has its own auth and session management.
+
+## Tool Inventory (28+ command groups)
+
+### Source CRUD
+| Command | Objects | Operations |
+|---------|---------|------------|
+| `program` | PROG | read, write, create, activate |
+| `include` | INCL | read, write, create |
+| `class` | CLAS | read, write, create, activate (incl. locals_def, locals_imp, test_classes, macros) |
+| `interface` | INTF | read, write, create, activate |
+| `functiongroup` | FUGR | read, write |
+| `functionmodule` | FUMO | read, write (auto-resolves parent group) |
+| `ddl` | DDLS | read, write, create |
+| `dcl` | DCL | read, write |
+| `bdef` | BDEF | read, write |
+
+### DDIC & Auth (Read-only metadata)
+| Command | Objects |
+|---------|---------|
+| `dataelement` | DTEL |
+| `structure` | STRU |
+| `table` | TABL |
+| `authorizationfield` | AUTH (read, where-used, activate — new Apr 2026) |
+
+### DevOps / Quality
+| Command | Description |
+|---------|-------------|
+| `aunit` | Run ABAP Unit tests with coverage; output: human, JUnit4, sonar |
+| `atc` | Run ATC checks; output: human, checkstyle, codeclimate |
+| `activation` | Mass activate objects |
+| `rap` | Publish service bindings |
+
+### Transport (CTS)
+| Command | Description |
+|---------|-------------|
+| `cts create` | Create transport/task (Workbench/K, Customizing/W, ToC/T, DevCorr/S, Repair/R) |
+| `cts release` | Release transport/task (with recursive option) |
+| `cts delete` | Delete transport/task (with recursive option) |
+| `cts reassign` | Change owner (with recursive) |
+| `cts list` | List transports (-r/-rr/-rrr for detail levels, incl. objects) |
+
+### abapGit / gCTS
+| Command | Description |
+|---------|-------------|
+| `checkout` | Export objects to filesystem in abapGit XML format |
+| `checkin` | Import objects from filesystem to SAP |
+| `gcts` | Full gCTS lifecycle: clone/pull/checkout/branches/config/activities/tasks |
+
+### Data / SQL
+| Command | Description |
+|---------|-------------|
+| `datapreview` | Free SQL via ADT freestyle data preview |
+
+### ABAP Utilities
+| Command | Description |
+|---------|-------------|
+| `abap run` | Execute arbitrary ABAP via temp IF_OO_ADT_CLASSRUN class |
+| `abap find` | Quick object search with type/max-results |
+| `abap systeminfo` | System information |
+
+### External Systems (RFC / OData)
+| Command | Description |
+|---------|-------------|
+| `startrfc` | Execute arbitrary RFC function modules |
+| `user` | Create/read/modify SAP users |
+| `strust` | SSL certificate management |
+| `bsp` | BSP application management (upload/download/list) |
+| `flp` | Fiori Launchpad (catalogs, groups, tile config) |
+
+### Configuration
+| Command | Description |
+|---------|-------------|
+| `config` | kubeconfig-style YAML: connections, users, contexts, switching |
+
+## Authentication
+
+| Method | Supported |
+|--------|-----------|
+| HTTP Basic Auth | ✅ (requests.HTTPBasicAuth) |
+| CSRF token management | ✅ (auto-fetch, auto-refresh on 403) |
+| Session management | ✅ (requests.Session, keep-alive) |
+| kubeconfig YAML | ✅ (named connections/users/contexts) |
+| Custom CA certificate | ✅ (ssl_server_cert config) |
+| Skip TLS verification | ✅ (SAP_SSL_VERIFY=no) |
+| RFC authentication | ✅ (PyRFC, user/pass or SNC) |
+| OAuth / XSUAA | ❌ |
+| BTP Destination Service | ❌ |
+| Principal Propagation | ❌ |
+| OIDC / JWT | ❌ |
+| API Key | ❌ |
+
+**Strictly on-premise.** No BTP cloud support whatsoever.
+
+## Safety/Security
+
+**No safety system.** No read-only mode, no operation filtering, no package restrictions, no SQL blocking. All commands always available. Designed as a developer/CI tool, not a managed service.
+
+## Transport (Protocol)
+
+Not applicable — sapcli is a CLI tool, not an MCP server. No stdio/HTTP/SSE transport. Communicates directly with SAP via HTTP.
+
+## Testing
+
+| Aspect | Details |
+|--------|---------|
+| Framework | Python `unittest` (not pytest) |
+| Test files | ~90 files in `test/unit/` |
+| Coverage | Tracked via codecov |
+| Mock infra | Custom `Connection` mock in `test/unit/mock.py` — records HTTP requests, returns pre-configured responses |
+| Fixtures | XML fixtures in `test/unit/fixtures_*.py` (one per module) |
+| System tests | `test/system/` — shell scripts for live SAP integration |
+| CI | GitHub Actions with codecov |
+| Pattern | Each `sap/adt/foo.py` → `test/unit/test_sap_adt_foo.py` |
+
+## Dependencies
+
+**Runtime (minimal):**
+- `requests >= 2.20.0` — HTTP client
+- `pyodata >= 1.7.0` — OData client
+- `PyYAML >= 6.0.1` — Config files
+- `PyRFC` — Optional RFC connectivity
+
+**Dev:** pytest, coverage, pylint, flake8, mypy
+
+Notable: uses Python's built-in `xml.sax` + `xml.etree.ElementTree` for XML — no third-party XML library. Intentionally minimal dependency footprint.
+
+## ADT Endpoints Used
+
+The most comprehensive open-source ADT endpoint coverage:
+
+**Object CRUD (via ADTObject base):**
+- `GET/POST/PUT/DELETE /sap/bc/adt/{basepath}/{name}` — metadata CRUD
+- `GET/PUT /sap/bc/adt/{basepath}/{name}/source/main` — source read/write
+- `POST ...?_action=LOCK/UNLOCK` — object locking
+
+**Object-specific basepaths:**
+- `/programs/programs`, `/programs/includes` — PROG, INCL
+- `/oo/classes`, `/oo/interfaces` — CLAS, INTF
+- `/ddic/ddl/sources`, `/dcl/sources` — CDS DDL, DCL
+- `/ddic/srvd/sources` — SRVD
+- `/businessservices/bindings` — SRVB (incl. `/publishjobs`)
+- `/functions/groups`, `/functions/groups/{group}/fmodules` — FUGR, FUMO
+- `/packages` — DEVC
+- `/ddic/tables`, `/ddic/structures`, `/ddic/dataelements` — DDIC
+- `/sfw/featuretoggles` — Feature toggles
+- `/enhancements/implementations` — Enhancement implementations
+- `/authorizationfields` — Authorization Fields (new Apr 2026)
+
+**Quality:**
+- `POST /sap/bc/adt/abapunit/testruns` — ABAP Unit
+- `POST /sap/bc/adt/runtime/traces/coverage/measurements/{id}` — Test coverage
+- `GET /sap/bc/adt/atc/customizing` + `POST .../atc/runs` + `GET .../atc/worklists/{id}` — ATC
+- `POST /sap/bc/adt/checks/syntaxCheck` — Syntax check
+
+**Intelligence:**
+- `POST /sap/bc/adt/repository/informationsystem/usageReferences/scope` — Where-used scope
+- `POST /sap/bc/adt/repository/informationsystem/usageReferences` — Where-used search
+- `GET /sap/bc/adt/repository/informationsystem/search` — Quick search
+
+**Transport:**
+- `GET/POST/DELETE /sap/bc/adt/cts/transportrequests` — CTS CRUD
+- `POST .../transportrequests/{number}/newreleasejobs` — Release
+- `GET /sap/bc/adt/inactivectsobjects` — Inactive objects list
+
+**Workbench:**
+- `POST /sap/bc/adt/activation` — Mass activation
+- `POST /sap/bc/adt/oo/classrun/{name}` — Execute IF_OO_ADT_CLASSRUN
+- `POST /sap/bc/adt/datapreview/freestyle` — Free SQL
+- `GET /sap/bc/adt/discovery` — Service discovery (MIME version negotiation)
+- `GET /sap/bc/adt/system/info` — System info
+
+**gCTS:**
+- `/sap/bc/cts_abapvcs/repository` — gCTS CRUD, clone, pull, branches, config
+
+**OData:**
+- `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` — BSP apps
+- `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` — FLP customization
+
+## Known Issues / Limitations
+
+| Issue | Description | Relevant to ARC-1? |
+|-------|-------------|-------------------|
+| No BTP/Cloud | Basic auth only, no OAuth/XSUAA/PP | ARC-1 already covers this |
+| No MCP protocol | CLI only, no LLM integration | Different category |
+| No safety system | No read-only, no op filter | ARC-1 has this |
+| No caching | Every operation hits SAP | ARC-1 has SQLite + memory |
+| No async | Synchronous `requests` throughout | ARC-1 uses async undici |
+| Not on PyPI | Install from git only | ARC-1 is on npm |
+| No audit logging | No structured audit trail | ARC-1 has this |
+| SAX XML parsing | Complex custom mapper, hard to extend | ARC-1 uses fast-xml-parser |
+
+---
+
+## Features This Project Has That ARC-1 Lacks
+
+| Feature | Priority | Effort | Status (2026-04-10) |
+|---------|----------|--------|---------------------|
+| `abap run` (execute ABAP via IF_OO_ADT_CLASSRUN) | Medium | 2d | Not implemented — needs safety design (also in dassian-adt, vibing-steampunk) |
+| checkout/checkin in abapGit format (filesystem round-trip) | Medium | 3d | Not implemented — enables Git workflows without abapGit on server |
+| gCTS integration (full lifecycle: clone/pull/branches/config) | Low | 3d | Not implemented — feature flag exists |
+| ABAP Unit test coverage (statement-level, paginated) | High | 1d | Not implemented — currently runs tests but no coverage data |
+| ATC output formats (JUnit4, sonar, checkstyle, codeclimate) | Medium | 1d | Not implemented — ATC results are raw |
+| Where-used with configurable scope (per-object-type filtering) | Medium | 0.5d | Partial — ARC-1 has where-used but scope config may differ |
+| ADT service discovery / MIME version negotiation | High | 1d | Not implemented — would solve 415/406 compatibility issues |
+| Function module auto-group-resolution | Low | 0.5d | Not implemented — must know FUGR name |
+| Mass activation with inactive objects list | Medium | 0.5d | Partial — batch activation exists, but no inactive objects query |
+| Transport type selection (K/W/T/S/R) | Low | 0.5d | Not implemented — always creates Workbench requests |
+| Transport reassign (change owner) | Low | 0.5d | Not implemented |
+| Transport recursive release (tasks first) | Low | 0.5d | Not implemented |
+| Transport detail levels (-r/-rr/-rrr objects) | Medium | 0.5d | Partial — transport contents not fully exposed |
+| BSP application management (upload/download/list) | Low | 2d | Not implemented — different from ADT |
+| FLP customization (catalogs, groups, tiles) | Low | 2d | Not implemented — OData-based |
+| Feature toggle management | Low | 1d | Not implemented |
+| Enhancement implementation / BAdI read | Low | 1d | Not implemented |
+| kubeconfig-style multi-connection config | N/A | — | Not applicable — ARC-1 uses env vars / CLI flags |
+| System info endpoint | Medium | 0.5d | Partial — system type detection exists but no full systeminfo |
+| Class include granularity (locals_def, locals_imp, test_classes, macros) | Medium | 1d | Partial — structured class decomposition exists but write granularity differs |
+| Service binding publish | Medium | 0.5d | Not implemented — SRVB read exists but no publish job |
+
+## Features ARC-1 Has That This Project Lacks
+
+MCP protocol (LLM integration), safety system (read-only, op filter, pkg filter, SQL blocking), BTP support (XSUAA, Destination Service, PP, Cloud Connector), API key / OIDC / JWT auth, audit logging, caching (SQLite + memory), intent-based routing (11 tools), context compression (SAPContext 7-30x), method-level surgery (95% reduction), hyperfocused mode (~200 tokens), Zod input validation, MCP elicitation, MCP scope system (OAuth), abaplint integration, AFF schema validation, npm distribution, Docker image, HTTP Streamable transport, multi-client support.
+
+---
+
+## Applicable Improvements for ARC-1
+
+### High Priority — Direct improvements
+
+1. **ADT Service Discovery / MIME Version Negotiation** (`sap/adt/discovery.py`)
+   - sapcli calls `GET /sap/bc/adt/discovery` at startup to learn which MIME type versions the system supports
+   - This would **directly solve ARC-1's P0 415/406 content-type auto-retry issue** — instead of guessing and retrying, probe once and cache
+   - **Files to modify**: `src/adt/http.ts`, `src/adt/features.ts`
+   - **Pattern**: Fetch discovery doc → parse accepted MIME types per endpoint → cache → use correct Content-Type headers
+
+2. **ABAP Unit Test Coverage** (`sap/adt/aunit.py`)
+   - sapcli fetches coverage via `POST /sap/bc/adt/runtime/traces/coverage/measurements/{id}` with paginated `rel=next` follow-up
+   - Statement-level coverage granularity
+   - **Files to modify**: `src/adt/devtools.ts`, `src/handlers/intent.ts`
+
+3. **ATC Output Formats** (`sap/cli/atc.py`)
+   - JUnit4, sonar, checkstyle, codeclimate formatters for ATC results
+   - Useful for CI/CD integration and structured error reporting to LLMs
+   - **Files to modify**: `src/adt/devtools.ts` or new formatter module
+
+### Medium Priority — Feature adoption
+
+4. **Where-Used Scope Configuration** (`sap/adt/whereused.py`)
+   - Two-step: `get_scope()` fetches default scope config from ADT, then `get_where_used()` with per-object-type filtering
+   - ARC-1's where-used may be simpler — verify scope handling matches
+   - **Files to check**: `src/adt/codeintel.ts`
+
+5. **Service Binding Publish** (`sap/cli/rap.py`)
+   - `POST /sap/bc/adt/businessservices/bindings/{name}/publishjobs` endpoint
+   - ARC-1 reads SRVB but doesn't publish — important for RAP workflow completeness
+   - **Files to modify**: `src/adt/devtools.ts`, `src/handlers/intent.ts`
+
+6. **Inactive Objects List** (`sap/adt/activation.py`)
+   - `GET /sap/bc/adt/inactivectsobjects` — shows what needs activation
+   - Useful for LLMs to understand activation state before/after writes
+   - **Files to modify**: `src/adt/client.ts`, `src/handlers/intent.ts`
+
+7. **Transport Contents / Detail Levels** (`sap/adt/cts.py`)
+   - Recursive transport query shows objects in each task (E071 objects list)
+   - **Files to modify**: `src/adt/transport.ts`
+
+8. **Class Include Write Granularity** (`sap/adt/oo.py`)
+   - sapcli supports writing to specific class includes: `locals_def`, `locals_imp`, `test_classes`, `macros`
+   - Each has its own source URL: `/source/main`, `/includes/definitions`, `/includes/implementations`, `/includes/testclasses`
+   - **Files to check**: `src/adt/crud.ts` — verify ARC-1's write handles these include types
+
+### Low Priority — Nice-to-have / Future
+
+9. **Execute ABAP (IF_OO_ADT_CLASSRUN)** — Also in dassian-adt and vibing-steampunk. Needs safety gate design.
+
+10. **abapGit Checkout/Checkin Format** — Filesystem round-trip enables Git workflows. Could be useful for batch export/import.
+
+11. **gCTS Integration** — Full lifecycle management. Lower priority since abapGit is more common.
+
+12. **Function Module Auto-Group-Resolution** — UX improvement: search for FM name → resolve parent FUGR → fetch.
+
+### Testing Insights
+
+13. **XML Fixture Pattern** — sapcli's approach of separate `fixtures_*.py` files per module is similar to ARC-1's `tests/fixtures/xml/` but more systematic. Every ADT response has a corresponding fixture.
+
+14. **Connection Mock** — sapcli's `test/unit/mock.py` records all HTTP requests and returns pre-configured responses. Similar to ARC-1's `mock-fetch.ts` but more structured (Request/Response named tuples with helper methods).
+
+15. **System Tests** — `test/system/` contains shell scripts for live SAP integration testing. ARC-1 could adopt a similar approach for smoke tests.
+
+### Documentation Insights
+
+16. **Per-Command Documentation** — sapcli has `doc/commands/*.md` with one file per command group (28 files). ARC-1 could benefit from per-tool documentation beyond the CLAUDE.md reference.
+
+17. **AGENTS.md** — sapcli has an AGENTS.md for AI assistants. Pattern already adopted by ARC-1.
+
+### Error Handling Insights
+
+18. **Typed Error Hierarchy** — sapcli's `ADTError` parses SAP XML exception format and maps `type` IDs to specific Python exceptions (`ExceptionResourceAlreadyExists`, `ExceptionResourceNotFound`, etc.). ARC-1's `AdtApiError` could benefit from similar classification for better LLM hints.
+
+19. **Connection Error Friendliness** — `ADTConnectionError` provides human-friendly messages for Errno 5/111 (connection refused). ARC-1's `AdtNetworkError` could add similar hint text.
+
+---
+
+## Changelog & Relevance Tracker
+
+| Date | Change | Relevant? | Action for ARC-1 | Status |
+|------|--------|-----------|-------------------|--------|
+| 2026-04-11 | `c20d795` **Major refactor**: extracted HTTP/CSRF/auth into shared `sap/http/` module (`HTTPClient` class). Prep for pluggable auth (SSO). 763-line test file. | Medium | Watch for SSO/OAuth patterns. Architecture mirrors ARC-1's `src/adt/http.ts`. | Evaluated |
+| 2026-04-11 | `45b6228` CI fix: `fetch-depth: 0` for wheel version from git rev-list. Co-authored by Claude Sonnet 4.6. | No | — | — |
+| 2026-04-10 | `2ec4228` **New object type: Authorization Fields** (`authorizationfield` command). Read, where-used, activate. ADT endpoint: `/sap/bc/adt/authorizationfields/{name}`, XML namespace `http://www.sap.com/iam/auth`. | Medium | New ADT endpoint — could add to ARC-1's SAPRead for auth object analysis. | TODO |
+| 2026-04-11 | Issue #149 (OPEN): **Domain support** (DOMA) being added — create/delete disabled pending testing. | Low | ARC-1 already has DOMA read via `src/adt/client.ts`. Verify same endpoint used. | TODO |
+| 2026-04-09 | doc fixes | No | — | — |
+| 2026-04-07 | Windows install docs, GitHub CI updates | No | — | — |
+| 2026-03-31 | Added `abap find` command | Low | ARC-1 has SAPSearch | — |
+| 2026-03-28 | kubeconfig-style YAML config with CRUD subcommands | No | Different design (CLI vs MCP) | — |
+| 2026-03-23 | Function module auto-group-resolution | Low | Could adopt pattern | TODO |
+| 2018-2025 | Mature ADT client with 488+ commits | Yes | Study ADT endpoint patterns | Reference |
+
+_Last updated: 2026-04-11_

--- a/compare/README.md
+++ b/compare/README.md
@@ -18,6 +18,7 @@ This folder contains detailed analysis documents for each SAP ADT / MCP project 
 | 6 | [lemaiwo/btp-sap-odata-to-mcp-server](06-btp-odata-mcp.md) | OData-to-MCP Bridge | TypeScript | Moderate |
 | 7 | [DassianInc/dassian-adt](07-dassian-adt.md) | ADT MCP Server (abap-adt-api fork) | TypeScript | New/Active |
 | 8 | [Dassian ADT Gap Analysis](08-dassian-adt-feature-gap.md) | Feature gap deep-dive (from autoclosed PR) | — | Updated 2026-04-02 |
+| 9 | [jfilak/sapcli](09-sapcli.md) | Python CLI for ADT (CI/CD automation, oldest OSS ADT client) | Python | Very Active |
 | 9 | [SAP Joule for Developers (J4D)](J4D/01-joule-for-developers.md) | SAP's native AI copilot for ABAP — 12 capabilities mapped, skill coverage analysis | — | Updated 2026-04-04 |
 | 10 | [SAP ABAP MCP Server & ADT for VS Code](J4D/02-sap-abap-mcp-server-vscode.md) | SAP's official ABAP MCP server, Language Server, VS Code extension — strategic threat/opportunity analysis | — | Updated 2026-04-04 |
 | 11 | [ABAP File Formats (AFF) Opportunity](J4D/03-abap-file-formats-opportunity.md) | How SAP's open-source file format spec could enhance ARC-1 — 7 opportunities analyzed | — | Updated 2026-04-04 |

--- a/compare/fr0ster/commits.json
+++ b/compare/fr0ster/commits.json
@@ -1,15 +1,15 @@
 {
   "$schema": "Commit tracker for fr0ster/mcp-abap-adt — grouped by release, auto-triaged",
   "repo": "https://github.com/fr0ster/mcp-abap-adt",
-  "lastUpdated": "2026-04-08",
+  "lastUpdated": "2026-04-11",
   "lastCheckedSha": "783e596",
   "stats": {
     "totalCommits": 783,
     "trackedFrom": "v2.4.0 (2026-02-15)",
-    "totalTracked": 66,
-    "evaluated": 30,
+    "totalTracked": 67,
+    "evaluated": 33,
     "pending": 0,
-    "skipped": 36
+    "skipped": 34
   },
   "releases": [
     {
@@ -320,18 +320,40 @@
     },
     {
       "version": "v4.5.0-v4.5.2",
-      "date": "2026-03-26",
+      "date": "2026-03-26 to 2026-03-27",
+      "linkedInPost": "Oleksij Kyslytsja, 2026-03-28 — 'MCP ABAP ADT v4.5.0 — what's new'",
+      "releaseDeepDive": "evaluations/v4.5.0-release-deep-dive.md",
       "commits": [
+        {
+          "sha": "0cb3088",
+          "date": "2026-03-27",
+          "message": "chore: add husky + lint-staged for pre-commit Biome auto-fix",
+          "type": "chore",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "ARC-1 already has Biome pre-commit hook"
+        },
         {
           "sha": "3da3311",
           "date": "2026-03-26",
           "message": "feat: rewrite ListTransports to use AdtClient with Accept negotiation",
           "type": "feat",
           "status": "evaluated",
-          "priority": "medium",
-          "decision": "covered-by-415-retry",
-          "relevance": "Content-Type negotiation pattern — covered by 415 auto-retry implementation",
+          "priority": "low",
+          "decision": "no-action",
+          "relevance": "Content-Type negotiation for transports — ARC-1's global 415/406 retry in http.ts already covers this endpoint. Switched from raw HTTP to AdtClient abstraction, reducing 27 → 19 lines.",
           "evaluationFile": "evaluations/3da3311-accept-negotiation.md"
+        },
+        {
+          "sha": "b059736",
+          "date": "2026-03-26",
+          "message": "chore: update @mcp-abap-adt/adt-clients to 3.12.0 (415 Content-Type negotiation with auto-retry and caching)",
+          "type": "chore",
+          "status": "evaluated",
+          "priority": "low",
+          "decision": "no-action",
+          "relevance": "Core 415/406 auto-retry mechanism — ARC-1 already has equivalent functionality in http.ts. Only gap: fr0ster caches successful headers per endpoint; ARC-1 retries each time (P3 optimization).",
+          "evaluationFile": "evaluations/b059736-adt-clients-415-negotiation.md"
         },
         {
           "sha": "dce44ca",
@@ -349,9 +371,11 @@
           "date": "2026-03-26",
           "message": "fix: guarantee unlock via try-finally in all update handlers (#22)",
           "type": "fix",
-          "status": "skipped",
-          "priority": "skip",
-          "relevance": "ARC-1 already uses try-finally"
+          "status": "evaluated",
+          "priority": "low",
+          "decision": "no-action",
+          "relevance": "ARC-1 already uses try-finally via centralized safeUpdateSource() in crud.ts. fr0ster had the pattern duplicated in 9 handlers. ARC-1's approach is architecturally superior.",
+          "evaluationFile": "evaluations/32ab9d4-try-finally-unlock.md"
         },
         {
           "sha": "cfe67d2",
@@ -361,7 +385,7 @@
           "status": "evaluated",
           "priority": "low",
           "decision": "skip",
-          "relevance": "RAG tool descriptions — not relevant to intent-based architecture",
+          "relevance": "RAG tool descriptions — not relevant to intent-based architecture. Changed from type-list to action-verb format for embedding similarity. ARC-1's 11 tools don't need RAG discovery.",
           "evaluationFile": "evaluations/cfe67d2-rag-tool-descriptions.md"
         }
       ]

--- a/compare/fr0ster/commits.json
+++ b/compare/fr0ster/commits.json
@@ -1,17 +1,129 @@
 {
   "$schema": "Commit tracker for fr0ster/mcp-abap-adt — grouped by release, auto-triaged",
   "repo": "https://github.com/fr0ster/mcp-abap-adt",
-  "lastUpdated": "2026-04-11",
-  "lastCheckedSha": "783e596",
+  "lastUpdated": "2026-04-12",
+  "lastCheckedSha": "be56df1",
   "stats": {
-    "totalCommits": 783,
+    "totalCommits": 799,
     "trackedFrom": "v2.4.0 (2026-02-15)",
-    "totalTracked": 67,
-    "evaluated": 33,
+    "totalTracked": 76,
+    "evaluated": 39,
     "pending": 0,
-    "skipped": 34
+    "skipped": 37
   },
   "releases": [
+    {
+      "version": "v5.0.0-v5.0.1",
+      "date": "2026-04-11 to 2026-04-12",
+      "releaseDeepDive": "evaluations/v5.0.0-release-deep-dive.md",
+      "commits": [
+        {
+          "sha": "be56df1",
+          "date": "2026-04-12",
+          "message": "fix: remove duplicate compact feed wrappers that confused LLM tool selection",
+          "type": "fix",
+          "status": "evaluated",
+          "priority": "low",
+          "decision": "lesson-learned",
+          "relevance": "Validates ARC-1's intent-based approach. Duplicate tools at different abstraction levels confuse LLMs — fr0ster dropped 3 wrappers (292→289 tools). ARC-1's action routing avoids this by design.",
+          "evaluationFile": "evaluations/v5.0.0-release-deep-dive.md"
+        },
+        {
+          "sha": "6f32ef8",
+          "date": "2026-04-11",
+          "message": "chore: bump version to 5.0.0",
+          "type": "chore",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "Version bump"
+        },
+        {
+          "sha": "318b5d0",
+          "date": "2026-04-11",
+          "message": "feat: add RuntimeListFeeds handler for ADT feed reader",
+          "type": "feat",
+          "status": "evaluated",
+          "priority": "low",
+          "decision": "consider-future",
+          "relevance": "Unified ADT Atom feed reader with 5 feed types (descriptors, variants, dumps, system_messages, gateway_errors). ARC-1 already has dumps + traces. The individual feeds (SM02, gateway) are more useful than the meta-reader.",
+          "evaluationFile": "evaluations/v5.0.0-release-deep-dive.md"
+        },
+        {
+          "sha": "c0775a3",
+          "date": "2026-04-11",
+          "message": "feat: add RuntimeListSystemMessages handler for SM02 messages",
+          "type": "feat",
+          "status": "evaluated",
+          "priority": "medium",
+          "decision": "implement",
+          "relevance": "SM02 system messages — ARC-1 doesn't have this. Useful for AI agent situational awareness (maintenance windows, system announcements). Add as 'system_messages' action on SAPDiagnose. Effort: 0.5 day.",
+          "evaluationFile": "evaluations/v5.0.0-release-deep-dive.md"
+        },
+        {
+          "sha": "276f414",
+          "date": "2026-04-11",
+          "message": "feat: add RuntimeGetGatewayErrorLog handler for /IWFND/ERROR_LOG",
+          "type": "feat",
+          "status": "evaluated",
+          "priority": "medium",
+          "decision": "implement",
+          "relevance": "Gateway error log with detail view (source code + call stack). ARC-1 doesn't have this. Essential for OData/Gateway debugging. On-prem only. Add as 'gateway_errors' action on SAPDiagnose. Effort: 1 day.",
+          "evaluationFile": "evaluations/v5.0.0-release-deep-dive.md"
+        },
+        {
+          "sha": "e1540c3",
+          "date": "2026-04-11",
+          "message": "feat: register new runtime feed handlers in SystemHandlersGroup",
+          "type": "feat",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "Handler registration infra — not relevant to ARC-1"
+        },
+        {
+          "sha": "15d1290",
+          "date": "2026-04-11",
+          "message": "feat: add compact wrapper handlers for feeds, system messages, gateway errors",
+          "type": "feat",
+          "status": "evaluated",
+          "priority": "skip",
+          "decision": "skip",
+          "relevance": "Compact wrappers — removed in v5.0.1 due to LLM confusion. Validates ARC-1's approach."
+        },
+        {
+          "sha": "6b3b5d1",
+          "date": "2026-04-11",
+          "message": "refactor: migrate dump handlers to adt-clients 4.0.0 factory API",
+          "type": "refactor",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "Internal adt-clients API migration. ARC-1 uses own ADT client."
+        },
+        {
+          "sha": "ea79f0b",
+          "date": "2026-04-11",
+          "message": "refactor: migrate profiler handlers to adt-clients 4.0.0 factory API",
+          "type": "refactor",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "Internal adt-clients API migration. ARC-1 uses own ADT client."
+        }
+      ]
+    },
+    {
+      "version": "v4.9.0",
+      "date": "2026-04-09",
+      "commits": [
+        {
+          "sha": "unknown",
+          "date": "2026-04-09",
+          "message": "v4.9.0 release (details not fetched)",
+          "type": "chore",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "Release between v4.8.x and v5.0.0. No significant new features identified."
+        }
+      ]
+    },
     {
       "version": "v4.8.2-v4.8.7",
       "date": "2026-04-04 to 2026-04-08",

--- a/compare/fr0ster/evaluations/32ab9d4-try-finally-unlock.md
+++ b/compare/fr0ster/evaluations/32ab9d4-try-finally-unlock.md
@@ -1,0 +1,117 @@
+# Guaranteed Unlock via try-finally in All Update Handlers
+
+> **Priority**: None (ARC-1 already has this pattern)
+> **Source**: fr0ster commit 32ab9d4 (2026-03-26) — fixes issue #22
+> **ARC-1 component**: `src/adt/crud.ts` (lines 108-129), `src/handlers/intent.ts` (lines 1246-1257)
+
+## What fr0ster changed
+
+Refactored 9 update handlers from try-catch to try-finally for the lock/unlock lifecycle:
+
+**Affected handlers**: UpdateProgram, UpdateClass, UpdateInterface, UpdateView, UpdateTable, UpdateStructure, UpdateDomain, UpdateServiceDefinition, UpdateDataElement
+
+### The bug
+
+In the old pattern, unlock only happened in the catch block:
+
+```typescript
+const lock = await client.lock(objectUrl);
+try {
+  await client.updateSource(sourceUrl, source, lock.handle);
+  await client.checkRun(objectUrl);    // <-- if this throws...
+  await client.activate(objectUrl);     // <-- or this throws...
+} catch (error) {
+  await client.unlock(objectUrl, lock.handle);  // only unlock on error
+  throw error;
+}
+await client.unlock(objectUrl, lock.handle);    // unlock on success
+```
+
+**Problem**: If `checkRun()` or `activate()` threw an error that was caught elsewhere (e.g., a framework-level error handler), the unlock in the catch block might not execute, leaving the object permanently locked in SAP. Developers would need to manually unlock via SE03/SM12.
+
+### The fix
+
+```typescript
+const lock = await client.lock(objectUrl);
+try {
+  await client.updateSource(sourceUrl, source, lock.handle);
+} finally {
+  await client.unlock(objectUrl, lock.handle);
+}
+// Check + activate moved AFTER unlock
+await client.checkRun(objectUrl);
+await client.activate(objectUrl);
+```
+
+Key design changes:
+1. `finally` guarantees unlock regardless of error path
+2. Check/activate moved outside the lock scope (they don't need the lock)
+3. Simpler flow: only one unlock call instead of two
+
+### Why this matters for SAP
+
+Locked ABAP objects in SAP are a serious problem:
+- The lock is **system-wide** — no other developer or AI agent can edit that object
+- Locks persist across sessions — they don't auto-expire
+- Manual cleanup requires SE03 (Transport Organizer) or SM12 (Lock Entries) authorization
+- In BTP ABAP Environment, lock cleanup is even harder (no SE03/SM12 GUI)
+
+## ARC-1 comparison
+
+**ARC-1 has had try-finally unlock since the initial TypeScript implementation.**
+
+### Update path (`src/adt/crud.ts:108-129`)
+
+```typescript
+export async function safeUpdateSource(
+  http: AdtHttpClient, safety: SafetyConfig,
+  objectUrl: string, sourceUrl: string, source: string, transport?: string,
+): Promise<void> {
+  await http.withStatefulSession(async (session) => {
+    const lock = await lockObject(session, safety, objectUrl);
+    const effectiveTransport = transport ?? (lock.corrNr || undefined);
+    try {
+      await updateSource(session, safety, sourceUrl, source, lock.lockHandle, effectiveTransport);
+    } finally {
+      await unlockObject(session, objectUrl, lock.lockHandle);
+    }
+  });
+}
+```
+
+### Delete path (`src/handlers/intent.ts:1246-1257`)
+
+```typescript
+await client.http.withStatefulSession(async (session) => {
+  const lock = await lockObject(session, client.safety, objectUrl);
+  const effectiveTransport = transport ?? (lock.corrNr || undefined);
+  try {
+    await deleteObject(session, client.safety, objectUrl, lock.lockHandle, effectiveTransport);
+  } finally {
+    try {
+      await unlockObject(session, objectUrl, lock.lockHandle);
+    } catch {
+      // Object may already be deleted — unlock failure is expected
+    }
+  }
+});
+```
+
+### Design advantages of ARC-1's approach
+
+| Aspect | fr0ster (v4.5.0) | ARC-1 |
+|--------|------------------|-------|
+| Pattern | 9 duplicated try-finally blocks | 1 centralized `safeUpdateSource()` |
+| Session management | Connection reuse (implicit) | Explicit `withStatefulSession()` |
+| Transport resolution | Caller provides | Auto-extract from lock `corrNr` |
+| Safety checks | None (no safety system) | `checkOperation()` before lock |
+| Delete unlock | Standard try-finally | Nested try-catch (handles deleted objects) |
+
+ARC-1's centralized approach means:
+- One place to fix if the pattern needs updating
+- All write paths (update, create+write, edit_method, batch_create) share the same safe unlock
+- No risk of individual handlers forgetting the pattern
+
+## Decision
+
+**No action needed.** ARC-1's implementation is superior — centralized, session-aware, with safety checks and transport auto-resolution. The `crud.ts` file already references fr0ster's bug in its opening comment as a design lesson.

--- a/compare/fr0ster/evaluations/415-content-type-retry.md
+++ b/compare/fr0ster/evaluations/415-content-type-retry.md
@@ -1,8 +1,8 @@
 # 415 Content-Type Auto-Retry
 
-> **Priority**: High (Critical #3 in feature matrix)
-> **Source**: fr0ster issues #22, #23, #25 — commits 3da3311, 32ab9d4 (2026-03-26)
-> **Status**: Pending implementation in ARC-1
+> **Priority**: ~~High (Critical #3 in feature matrix)~~ **Resolved**
+> **Source**: fr0ster issues #22, #23, #25 — commits 3da3311, 32ab9d4, b059736 (2026-03-26)
+> **Status**: ✅ ARC-1 already has 406/415 auto-retry in `src/adt/http.ts:324-398`. See [v4.5.0 deep dive](v4.5.0-release-deep-dive.md).
 
 ## The problem
 
@@ -18,20 +18,19 @@ Examples from fr0ster issues:
 2. **Issue #23**: Rewrote `ListTransports` to use the ADT client with Accept negotiation instead of raw HTTP calls
 3. **Issue #22**: Added Content-Type auto-detection on checkruns + guaranteed unlock (the unlock part ARC-1 already has)
 
-## What ARC-1 needs
+## ARC-1 current state
 
-ARC-1 uses raw axios in `src/adt/http.ts`. Two options:
+**Already implemented.** ARC-1 has 406/415 auto-retry in `src/adt/http.ts:324-398` using undici/fetch (not axios):
 
-### Option A: Retry interceptor (recommended)
-Add an axios response interceptor that catches 415 errors, flips `Accept` between `application/xml` and `application/atom+xml`, and retries once.
+- **406 fallback**: `inferAcceptFromError()` extracts expected media type from SAP error body → try `application/xml` → try `*/*`
+- **415 fallback**: Switch Content-Type to `application/xml`
+- **One retry per request** (`negotiationRetried` guard prevents infinite loops)
+- **Audit logging** on both the failure and retry success
 
-### Option B: Per-endpoint Accept header map
-Maintain a map of ADT endpoints to their expected Accept headers. More precise but harder to maintain.
+### Remaining gap: Per-endpoint header caching
 
-**Recommendation**: Option A — simple, catches all cases, max 1 retry.
-
-**Effort estimate**: 0.5 day
+fr0ster's adt-clients 3.12.0 caches successful Content-Type per endpoint path. ARC-1 retries per-request. This is a P3 optimization — adds ~50-100ms on first call to each finicky endpoint per session.
 
 ## Decision
 
-**Implement Option A** — add 415 retry interceptor to `src/adt/http.ts`. Low effort, high robustness gain.
+**Resolved.** ARC-1's implementation is functionally equivalent. Per-endpoint caching is a nice-to-have (P3). See [v4.5.0 deep dive](v4.5.0-release-deep-dive.md) for full comparison.

--- a/compare/fr0ster/evaluations/b059736-adt-clients-415-negotiation.md
+++ b/compare/fr0ster/evaluations/b059736-adt-clients-415-negotiation.md
@@ -1,0 +1,113 @@
+# adt-clients 3.12.0: 415 Content-Type Negotiation with Auto-Retry
+
+> **Priority**: Low (ARC-1 already has equivalent functionality)
+> **Source**: fr0ster commit b059736 (2026-03-26) — updates @mcp-abap-adt/adt-clients to 3.12.0
+> **Related**: Issues #22, #23, #25; adt-clients commits in fr0ster/mcp-abap-adt-clients repo
+> **ARC-1 component**: `src/adt/http.ts` (lines 324-398)
+
+## What fr0ster did
+
+Updated the `@mcp-abap-adt/adt-clients` dependency to v3.12.0, which adds:
+
+1. **415 Content-Type auto-retry**: When SAP returns HTTP 415 (Unsupported Media Type), the library automatically retries with a corrected Content-Type header. This mirrors the existing 406 (Not Acceptable) retry for Accept headers.
+
+2. **Per-endpoint header caching**: After a successful retry, the correct Content-Type and Accept headers are cached per ADT endpoint path. Subsequent requests to the same endpoint use the cached headers, avoiding the retry round-trip.
+
+3. **Enabled by default**: `enableAcceptCorrection: true` is the default. Can be disabled with `enableAcceptCorrection: false` or `ADT_ACCEPT_CORRECTION=false`.
+
+### The problem this solves
+
+Different SAP system versions (S/4HANA Cloud, on-prem ECC, various patch levels) require different media types for the same ADT endpoint:
+
+- `/sap/bc/adt/cts/transportrequests` — some systems want `application/atom+xml`, others want `application/xml`
+- `/sap/bc/adt/checkruns` — Content-Type varies by system version
+- `/sap/bc/adt/programs/programs/.../source/main` — most accept `text/plain` but some require `application/xml`
+
+Hardcoding headers fails when connecting to heterogeneous SAP landscapes.
+
+### Implementation pattern (adt-clients 3.12.0)
+
+From the adt-clients v3.12.0 changelog:
+
+Two commits in the adt-clients repo:
+1. `feat: add Content-Type extraction for 415 negotiation` — parses SAP 415 error body to extract expected Content-Type
+2. `feat: handle 415 Unsupported Media Type with Content-Type retry and caching` — retry logic + per-endpoint cache
+
+The pattern:
+```
+Request → 415 → Extract expected Content-Type from error body → Retry with corrected header → Cache for endpoint
+Request → 406 → Extract expected Accept from error body → Retry with corrected header → Cache for endpoint
+```
+
+## ARC-1 current state
+
+ARC-1 already implements 406/415 auto-retry in `src/adt/http.ts:324-398`:
+
+```typescript
+// Handle 406/415 content negotiation failure — retry once with fallback headers
+if ((response.status === 406 || response.status === 415) && !negotiationRetried) {
+  negotiationRetried = true;
+  const fallbackHeaders = { ...headers };
+
+  if (response.status === 406) {
+    // 3-step fallback: infer from error body → application/xml → */*
+    const inferred = inferAcceptFromError(responseBody);
+    if (inferred && inferred !== fallbackHeaders.Accept) {
+      fallbackHeaders.Accept = inferred;
+    } else if (fallbackHeaders.Accept !== 'application/xml') {
+      fallbackHeaders.Accept = 'application/xml';
+    } else {
+      fallbackHeaders.Accept = '*/*';
+    }
+  } else {
+    // 415: try application/xml as Content-Type fallback
+    if (contentType && contentType !== 'application/xml') {
+      fallbackHeaders['Content-Type'] = 'application/xml';
+    }
+  }
+
+  // Retry with fallback headers (one retry max)
+  const retryResp = await this.doFetch(url, method, fallbackHeaders, body);
+  // ... audit logging ...
+  return retryResult;
+}
+```
+
+### Differences
+
+| Aspect | fr0ster (adt-clients 3.12.0) | ARC-1 (http.ts) |
+|--------|------------------------------|-----------------|
+| 406 retry | Yes | Yes |
+| 415 retry | Yes | Yes |
+| Error body parsing | Yes (extract expected type) | Yes (`inferAcceptFromError()`) |
+| Per-endpoint caching | Yes | No |
+| Retry limit | 1 per request | 1 per request |
+| Configurable | Yes (`enableAcceptCorrection`) | Always on |
+| Audit logging | Unknown | Yes (warn on failure, info on retry success) |
+
+### Gap: Per-endpoint caching
+
+The only thing ARC-1 lacks is per-endpoint header caching. In fr0ster's implementation, once a retry succeeds for a specific endpoint path, future requests immediately use the correct headers. In ARC-1, every first request to a finicky endpoint will trigger one failed request + one retry.
+
+**Impact**: ~50-100ms extra latency per unique endpoint path, per session. In practice this affects maybe 3-5 endpoints (transports, checkruns, some DDIC endpoints) and only on the first call to each.
+
+**Implementation sketch** (if ever needed):
+```typescript
+// Add to AdtHttpClient class
+private negotiatedHeaders = new Map<string, { accept?: string; contentType?: string }>();
+
+// In request method, before making request:
+const cached = this.negotiatedHeaders.get(path);
+if (cached?.accept && !headers.Accept) headers.Accept = cached.accept;
+if (cached?.contentType && !headers['Content-Type']) headers['Content-Type'] = cached.contentType;
+
+// After successful retry:
+this.negotiatedHeaders.set(path, {
+  accept: fallbackHeaders.Accept !== headers.Accept ? fallbackHeaders.Accept : undefined,
+  contentType: fallbackHeaders['Content-Type'] !== headers['Content-Type'] ? fallbackHeaders['Content-Type'] : undefined,
+});
+```
+
+## Decision
+
+**No action needed.** ARC-1's implementation is functionally equivalent and architecturally cleaner (centralized in http.ts vs spread across a separate library). Per-endpoint caching is a P3 optimization — add only if latency on heterogeneous SAP landscapes becomes a reported issue.

--- a/compare/fr0ster/evaluations/v4.5.0-release-deep-dive.md
+++ b/compare/fr0ster/evaluations/v4.5.0-release-deep-dive.md
@@ -1,0 +1,244 @@
+# fr0ster v4.5.0 Release Deep Dive
+
+> **Priority**: Mixed (features already implemented in ARC-1, one optimization opportunity)
+> **Source**: fr0ster v4.5.0-v4.5.2 (2026-03-26 to 2026-03-27) — 4 substantive commits + 3 chore commits
+> **LinkedIn post**: Oleksij Kyslytsja, 2026-03-28 — "MCP ABAP ADT v4.5.0 — what's new"
+> **Status**: Analyzed — ARC-1 already has all three features; one optimization opportunity identified
+
+## Release Summary
+
+The LinkedIn post highlights three features:
+1. **Guaranteed unlock on error** — try-catch → try-finally in 9 update handlers
+2. **Smarter Content-Type negotiation** — 406/415 auto-retry with per-endpoint caching
+3. **Better tool discovery for AI agents** — SearchObject description rewrite for RAG
+
+## Commit Timeline
+
+| SHA | Date | Message | Type |
+|-----|------|---------|------|
+| `cfe67d2` | 2026-03-26 10:22 | feat: rewrite SearchObject description for RAG discoverability | feat |
+| `32ab9d4` | 2026-03-26 13:23 | fix: guarantee unlock via try-finally in all update handlers | fix |
+| `dce44ca` | 2026-03-26 13:02 | fix: give SAP_AUTH_TYPE priority over SAP_JWT_TOKEN | fix |
+| `b059736` | 2026-03-26 16:22 | chore: update @mcp-abap-adt/adt-clients to 3.12.0 (415 auto-retry) | chore |
+| `3da3311` | 2026-03-26 18:52 | feat: rewrite ListTransports to use AdtClient with Accept negotiation | feat |
+| `0cb3088` | 2026-03-27 10:08 | chore: add husky + lint-staged for pre-commit Biome auto-fix | chore |
+
+Note: The LinkedIn post groups v4.4.1 through v4.5.2 as "v4.5.0". The version bumps were:
+- v4.4.1: `cfe67d2` (RAG description)
+- v4.4.2: `32ab9d4` (try-finally)
+- v4.5.0: `b059736` + `dce44ca` (adt-clients 3.12.0 + auth fix)
+- v4.5.1: `3da3311` (ListTransports rewrite)
+- v4.5.2: `0cb3088` (husky pre-commit)
+
+---
+
+## Feature 1: Guaranteed Unlock on Error
+
+### What fr0ster changed (commit `32ab9d4`)
+
+Refactored 9 update handlers from try-catch to try-finally for lock/unlock:
+
+**Before (vulnerable pattern):**
+```typescript
+// Lock acquired here — outside try block
+const lock = await client.lock(objectUrl);
+try {
+  await client.updateSource(sourceUrl, source, lock.handle);
+  // Check + activate after update
+  await client.checkRun(objectUrl);
+  await client.activate(objectUrl);
+} catch (error) {
+  // Unlock only on error — but if lock() itself throws in some
+  // intermediate state, or if error occurs between lock and try,
+  // the object stays locked permanently
+  await client.unlock(objectUrl, lock.handle);
+  throw error;
+}
+await client.unlock(objectUrl, lock.handle);
+```
+
+**After (safe pattern):**
+```typescript
+const lock = await client.lock(objectUrl);
+try {
+  await client.updateSource(sourceUrl, source, lock.handle);
+} finally {
+  await client.unlock(objectUrl, lock.handle);
+}
+// Check + activate moved after unlock
+await client.checkRun(objectUrl);
+await client.activate(objectUrl);
+```
+
+9 affected handlers: UpdateProgram, UpdateClass, UpdateInterface, UpdateView, UpdateTable, UpdateStructure, UpdateDomain, UpdateServiceDefinition, UpdateDataElement.
+
+### ARC-1 comparison
+
+**ARC-1 already has this pattern.** Implemented in `src/adt/crud.ts:112-129` via `safeUpdateSource()`:
+
+```typescript
+export async function safeUpdateSource(...): Promise<void> {
+  await http.withStatefulSession(async (session) => {
+    const lock = await lockObject(session, safety, objectUrl);
+    const effectiveTransport = transport ?? (lock.corrNr || undefined);
+    try {
+      await updateSource(session, safety, sourceUrl, source, lock.lockHandle, effectiveTransport);
+    } finally {
+      await unlockObject(session, objectUrl, lock.lockHandle);
+    }
+  });
+}
+```
+
+And the delete flow in `src/handlers/intent.ts:1246-1257`:
+
+```typescript
+await client.http.withStatefulSession(async (session) => {
+  const lock = await lockObject(session, client.safety, objectUrl);
+  const effectiveTransport = transport ?? (lock.corrNr || undefined);
+  try {
+    await deleteObject(session, client.safety, objectUrl, lock.lockHandle, effectiveTransport);
+  } finally {
+    try {
+      await unlockObject(session, objectUrl, lock.lockHandle);
+    } catch {
+      // Object may already be deleted — unlock failure is expected
+    }
+  }
+});
+```
+
+**Key differences:**
+- ARC-1 centralizes the lock/modify/unlock in `safeUpdateSource()` — one function used by all write paths
+- fr0ster had the pattern duplicated in 9 handlers, each needing individual fixes
+- ARC-1's `crud.ts` comments reference fr0ster's bug: "This was a hard-won lesson in the fr0ster codebase"
+- ARC-1's delete handler has a nested try-catch in finally (object may be deleted before unlock completes)
+
+**Verdict: No action needed.** ARC-1's centralized approach is superior to fr0ster's per-handler pattern.
+
+---
+
+## Feature 2: Smarter Content-Type Negotiation
+
+### What fr0ster changed
+
+Two layers of changes:
+
+**Layer 1: adt-clients library v3.12.0 (commit `b059736`)**
+
+The `@mcp-abap-adt/adt-clients` library added:
+- Automatic detection and retry on 415 (Unsupported Media Type) errors
+- Per-endpoint caching of successful Content-Type/Accept headers
+- `enableAcceptCorrection` setting (enabled by default)
+- Both 406 (Accept) and 415 (Content-Type) auto-retry work without configuration
+
+From the adt-clients v3.12.0 changelog:
+> "Addresses HTTP 415 (Unsupported Media Type) errors on on-premise ECC systems by implementing automatic detection and caching of the correct Content-Type per endpoint. This mirrors the existing Accept header negotiation mechanism for handling 406 errors."
+
+**Layer 2: ListTransports rewrite (commit `3da3311`, v4.5.1)**
+
+Rewrote `handleListTransports.ts` from raw HTTP calls to the ADT client abstraction:
+
+```typescript
+// Old: hardcoded Accept, manual URL construction
+const resp = await makeAdtRequestWithTimeout(connection, {
+  url: `/sap/bc/adt/cts/transportrequests?...`,
+  headers: { Accept: 'application/xml' },
+});
+
+// New: uses AdtClient with auto-negotiation
+const client = createAdtClient(connection, logger);
+const state = await client.getRequest().list({ user, status });
+const transports = parseTransportListXml(state.listResult?.data || '');
+```
+
+### ARC-1 comparison
+
+**ARC-1 already has 406/415 auto-retry** in `src/adt/http.ts:324-398`:
+
+- **406 fallback strategy**: `inferAcceptFromError()` extracts expected media type from SAP error body → try `application/xml` → try `*/*`
+- **415 fallback**: Switch Content-Type to `application/xml`
+- **One retry per request** (`negotiationRetried` guard)
+- **Audit logging** on both the failure and retry success
+
+**Key difference — per-endpoint caching:**
+
+fr0ster's adt-clients library caches successful Content-Type per endpoint path. Once a retry succeeds for `/sap/bc/adt/cts/transportrequests`, future calls use the correct header immediately without needing a retry.
+
+ARC-1 does **not** cache per-endpoint. Every request to a finicky endpoint will trigger one extra round-trip on first failure before succeeding.
+
+### Optimization opportunity
+
+**Per-endpoint Accept/Content-Type caching** could eliminate repeated retry round-trips. Implementation sketch:
+
+```typescript
+// In AdtHttpClient class
+private negotiatedHeaders = new Map<string, { accept?: string; contentType?: string }>();
+
+// After successful retry:
+this.negotiatedHeaders.set(path, {
+  accept: fallbackHeaders.Accept,
+  contentType: fallbackHeaders['Content-Type'],
+});
+
+// Before making request:
+const cached = this.negotiatedHeaders.get(path);
+if (cached?.accept) headers.Accept = cached.accept;
+if (cached?.contentType) headers['Content-Type'] = cached.contentType;
+```
+
+**Priority: Low.** The retry adds ~50-100ms per first-request-to-endpoint. In practice, most sessions hit each endpoint pattern only a few times, so the caching benefit is marginal. The current one-retry approach is correct and handles all SAP version differences.
+
+**Verdict: No action needed.** ARC-1's retry is functionally equivalent. Per-endpoint caching is a nice-to-have optimization (P3) that could be added if latency-sensitive deployments need it.
+
+---
+
+## Feature 3: Better Tool Discovery for AI Agents
+
+### What fr0ster changed (commit `cfe67d2`)
+
+Rewrote SearchObject tool description from type-list to action-verb format:
+
+**Before:**
+```
+[read-only] Search for ABAP objects by name pattern. Searches across all
+object types: packages (DEVC), classes (CLAS), interfaces (INTF), tables
+(TABL), structures, CDS views (DDLS), data elements (DTEL), domains (DOMA),
+programs (PROG), function groups (FUGR), function modules, service
+definitions (SRVD), service bindings (SRVB), behavior definitions (BDEF),
+metadata extensions (DDLX), and more.
+```
+
+**After:**
+```
+[read-only] Find, search, locate, or check if an ABAP repository object
+exists by name or wildcard pattern (e.g. 'ZOK*'). Use this tool to answer
+questions like 'is there a program named...', 'find all objects starting
+with...', 'does this class exist?', 'list objects matching...'.
+```
+
+The key insight: RAG-based tool selection (used by Copilot, VS Code, etc.) works on embedding similarity. When a user asks "is there a program named ZOK?" the old description matched `GetProgram/ReadProgram` higher than `SearchObject` because it listed types. The new description leads with action verbs that match user intent.
+
+### ARC-1 comparison
+
+**Not applicable.** ARC-1 uses 11 intent-based tools, not 287 individual tools. The LLM reads all 11 descriptions and routes by intent. No RAG/embedding selection needed.
+
+ARC-1's SAPSearch description is already action-oriented and environment-aware (`src/handlers/tools.ts:176-186`), with conditional source_code search mode.
+
+**Verdict: Skip.** Intent-based routing makes RAG optimization irrelevant for ARC-1.
+
+---
+
+## Summary: What's Useful for ARC-1
+
+| Feature | fr0ster Status | ARC-1 Status | Action |
+|---------|---------------|-------------|--------|
+| try-finally unlock | Fixed in v4.5.0 | Already implemented (crud.ts) | None |
+| 415/406 auto-retry | Added via adt-clients 3.12.0 | Already implemented (http.ts) | None |
+| Per-endpoint header caching | Added in adt-clients 3.12.0 | Not implemented | P3 optimization |
+| ListTransports Accept fix | Rewrote in v4.5.1 | Covered by global 415 retry | None |
+| RAG tool descriptions | Rewrote SearchObject | Not applicable (intent routing) | None |
+| Auth priority fix | SAP_AUTH_TYPE over JWT | Different auth model | None |
+| Husky pre-commit | Added in v4.5.2 | Already has Biome pre-commit | None |
+
+**Bottom line:** ARC-1 already has all three features fr0ster announced in v4.5.0. The only potential improvement is per-endpoint content-type caching, which is a P3 optimization with marginal latency benefit. ARC-1's centralized approach (one `safeUpdateSource()` function, global 415/406 retry in http.ts) is architecturally cleaner than fr0ster's per-handler pattern.

--- a/compare/fr0ster/evaluations/v5.0.0-release-deep-dive.md
+++ b/compare/fr0ster/evaluations/v5.0.0-release-deep-dive.md
@@ -1,0 +1,310 @@
+# fr0ster v5.0.0 Release Deep Dive — Runtime Feed Tools + adt-clients 4.0
+
+> **Priority**: Medium (new diagnostic capabilities ARC-1 lacks)
+> **Source**: fr0ster v5.0.0-v5.0.1 (2026-04-11) — 16 commits, 3 new tools, 1 breaking dependency change
+> **Status**: Analyzed — 2 features worth implementing, 1 architectural lesson learned
+
+## Release Summary
+
+v5.0.0 adds three new runtime analysis tools and migrates to a factory-based ADT client library:
+
+1. **RuntimeListFeeds** — Unified ADT Atom feed reader (8+ feed types)
+2. **RuntimeListSystemMessages** — SM02 system message reader
+3. **RuntimeGetGatewayErrorLog** — /IWFND/ERROR_LOG with detail view
+4. **adt-clients 4.0 factory API** — `getProfiler()`, `getDumps()`, `getFeeds()` domain objects
+
+v5.0.1 immediately followed to **remove compact wrapper duplicates** (HandlerFeedList, HandlerSystemMessageList, HandlerGatewayErrorList) that caused LLM tool selection confusion — reducing total tools from 292 to 289.
+
+## Commit Timeline
+
+| SHA | Date | Message | Type |
+|-----|------|---------|------|
+| `2c5cc71` | 2026-04-11 | chore: bump @mcp-abap-adt/adt-clients to ^4.0.0 | chore |
+| `ea79f0b` | 2026-04-11 | refactor: migrate profiler handlers to adt-clients 4.0.0 factory API | refactor |
+| `6b3b5d1` | 2026-04-11 | refactor: migrate dump handlers to adt-clients 4.0.0 factory API | refactor |
+| `318b5d0` | 2026-04-11 | feat: add RuntimeListFeeds handler for ADT feed reader | feat |
+| `c0775a3` | 2026-04-11 | feat: add RuntimeListSystemMessages handler for SM02 messages | feat |
+| `276f414` | 2026-04-11 | feat: add RuntimeGetGatewayErrorLog handler for /IWFND/ERROR_LOG | feat |
+| `e1540c3` | 2026-04-11 | feat: register new runtime feed handlers in SystemHandlersGroup | feat |
+| `15d1290` | 2026-04-11 | feat: add compact wrapper handlers for feeds, system messages, gateway errors | feat |
+| `91f925f` | 2026-04-11 | feat: register compact feed/sysmsg/gwerror handlers in CompactHandlersGroup | feat |
+| `1d8cc3a` | 2026-04-11 | test: add integration tests for new feed tools | test |
+| `af29895` | 2026-04-11 | test: fix feed handler tests — graceful skip for unsupported endpoints | test |
+| `71726b8` | 2026-04-11 | chore: update @mcp-abap-adt/adt-clients to 4.0.2 (fix XML entity expansion) | chore |
+| `bff732e` | 2026-04-11 | Merge PR #41: migrate to adt-clients 4.0.0 | merge |
+| `d295eaa` | 2026-04-11 | docs: regenerate tools documentation | docs |
+| `6f32ef8` | 2026-04-11 | chore: bump version to 5.0.0 | chore |
+| `be56df1` | 2026-04-12 | fix: remove duplicate compact feed wrappers (LLM confusion) | fix |
+
+---
+
+## Feature 1: RuntimeListFeeds — Unified ADT Feed Reader
+
+### What fr0ster built (commit `318b5d0`)
+
+A unified handler that reads ADT Atom feeds via 5 feed types:
+
+```typescript
+export const TOOL_DEFINITION = {
+  name: 'RuntimeListFeeds',
+  available_in: ['onprem', 'cloud'],
+  inputSchema: {
+    properties: {
+      feed_type: {
+        type: 'string',
+        enum: ['descriptors', 'variants', 'dumps', 'system_messages', 'gateway_errors'],
+        default: 'descriptors'
+      },
+      user: { type: 'string' },
+      max_results: { type: 'number' },
+      from: { type: 'string', description: 'YYYYMMDDHHMMSS' },
+      to: { type: 'string', description: 'YYYYMMDDHHMMSS' }
+    }
+  }
+}
+```
+
+Feed type routing:
+- `descriptors` → `feeds.list()` — Lists available feed descriptors on the system
+- `variants` → `feeds.variants()` — Lists feed variants (saved filter configurations)
+- `dumps` → `feeds.dumps(queryOptions)` — Runtime error dumps (same as ST22)
+- `system_messages` → `feeds.systemMessages(queryOptions)` — SM02 messages
+- `gateway_errors` → `feeds.gatewayErrors(queryOptions)` — /IWFND/ERROR_LOG
+
+### ARC-1 comparison
+
+ARC-1's SAPDiagnose already has `dumps` and `traces` actions that access the same underlying ADT Atom feed endpoints:
+- `/sap/bc/adt/runtime/dumps` — Atom feed (already implemented in `src/adt/diagnostics.ts:39-60`)
+- `/sap/bc/adt/runtime/traces/abaptraces` — Atom feed (already implemented in `src/adt/diagnostics.ts:95-103`)
+
+**What ARC-1 lacks:**
+- Feed descriptor listing (`descriptors` mode) — useful for discovery but not critical
+- Feed variant listing (`variants` mode) — saved filter configs, low value
+- System messages feed — see Feature 2 below
+- Gateway errors feed — see Feature 3 below
+
+### Assessment
+
+The unified feed approach is a **multi-tool design** (one tool for 5 feed types). ARC-1's intent-based approach would add these as additional actions to SAPDiagnose rather than creating a separate tool. The `descriptors` and `variants` modes are low-value meta-operations. The real value is in `system_messages` and `gateway_errors`, which get their own analysis below.
+
+**Priority: Low** for the unified feed reader itself. The individual feeds (SM02, gateway errors) are evaluated separately.
+
+---
+
+## Feature 2: RuntimeListSystemMessages (SM02)
+
+### What fr0ster built (commit `c0775a3`)
+
+Programmatic reader for SM02 system messages:
+
+```typescript
+// Parameters: user, max_results, from, to
+const runtimeClient = new AdtRuntimeClient(connection, logger);
+const feeds = runtimeClient.getFeeds();
+const messages = await feeds.systemMessages({
+  user: args?.user,
+  maxResults: args?.max_results,
+  from: args?.from,
+  to: args?.to,
+});
+// Returns: { success, count, messages[] }
+// Each message: { id, title, text, severity, validFrom, validTo, author }
+```
+
+Available on both on-prem and cloud.
+
+### ARC-1 comparison
+
+**ARC-1 does not have system message reading.** No references to SM02, system messages, or the system messages feed endpoint exist in the codebase.
+
+### Use cases
+
+1. **Pre-operation check**: AI agent can verify no maintenance window is scheduled before starting a long write operation
+2. **Error context**: When operations fail, the agent can check if there are system-wide announcements explaining the outage
+3. **Situation awareness**: "Is the system about to restart? Are there any warnings I should know about?"
+
+### Implementation for ARC-1
+
+Add a `system_messages` action to SAPDiagnose:
+
+```typescript
+// In src/adt/diagnostics.ts
+export async function listSystemMessages(
+  http: AdtHttpClient,
+  safety: SafetyConfig,
+  options?: { user?: string; maxResults?: number }
+): Promise<SystemMessage[]> {
+  checkOperation(safety, OperationType.Read, 'ListSystemMessages');
+  // Endpoint: likely /sap/bc/adt/feeds/systemmessages or similar Atom feed
+  const resp = await http.get('/sap/bc/adt/feeds/systemmessages', {
+    Accept: 'application/atom+xml;type=feed',
+  });
+  return parseSystemMessages(resp.body);
+}
+```
+
+In `src/handlers/intent.ts`, add to SAPDiagnose handler:
+```typescript
+case 'system_messages': {
+  const msgs = await listSystemMessages(client.http, client.safety, { user, maxResults });
+  return textResult(JSON.stringify(msgs, null, 2));
+}
+```
+
+**Priority: Medium.** Useful for AI agent situational awareness but not blocking any workflow.
+**Effort: 0.5 day** — straightforward Atom feed parsing (same pattern as dumps).
+**Caveat:** The exact ADT endpoint URL needs to be discovered (likely via `/sap/bc/adt/discovery` or by inspecting Eclipse ADT traffic). fr0ster's implementation goes through the adt-clients library so the endpoint is abstracted.
+
+---
+
+## Feature 3: RuntimeGetGatewayErrorLog (/IWFND/ERROR_LOG)
+
+### What fr0ster built (commit `276f414`)
+
+Gateway error log reader with two modes:
+
+```typescript
+// Available on on-prem only
+export const TOOL_DEFINITION = {
+  name: 'RuntimeGetGatewayErrorLog',
+  available_in: ['onprem'],
+  inputSchema: {
+    properties: {
+      error_url: { type: 'string', description: 'Feed URL for specific error detail' },
+      user: { type: 'string' },
+      max_results: { type: 'number' },
+      from: { type: 'string' },
+      to: { type: 'string' }
+    }
+  }
+}
+
+// List mode (default):
+const errors = await feeds.gatewayErrors({ user, maxResults, from, to });
+// Returns: { success, mode: 'list', count, errors[] }
+// Each error: { type, shortText, transactionId, dateTime, username }
+
+// Detail mode (when error_url provided):
+const detail = await feeds.gatewayErrorDetail(args.error_url);
+// Returns: { success, mode: 'detail', error: { serviceInfo, errorContext, sourceCode, callStack } }
+```
+
+### ARC-1 comparison
+
+**ARC-1 does not have gateway error log access.** No references to IWFND, gateway errors, or the gateway error log exist in the codebase.
+
+### Use cases
+
+1. **OData debugging**: When an AI agent publishes a service binding (SRVB) and the OData service fails, the gateway error log shows exactly what went wrong — including the specific source code line and call stack
+2. **Service binding troubleshooting**: After `SAPManage action=publish_service_binding`, if the published service doesn't work, gateway errors provide the diagnosis
+3. **Integration testing**: When testing OData endpoints, gateway errors show request/response details that aren't visible in the ADT response
+
+### Implementation for ARC-1
+
+Add a `gateway_errors` action to SAPDiagnose:
+
+```typescript
+// In src/adt/diagnostics.ts
+export async function listGatewayErrors(
+  http: AdtHttpClient,
+  safety: SafetyConfig,
+  options?: { user?: string; maxResults?: number }
+): Promise<GatewayError[]> {
+  checkOperation(safety, OperationType.Read, 'ListGatewayErrors');
+  // Endpoint: /sap/bc/adt/feeds/gwerrors or similar
+  const resp = await http.get('/sap/bc/adt/feedreader/feeds/...', {
+    Accept: 'application/atom+xml;type=feed',
+  });
+  return parseGatewayErrors(resp.body);
+}
+
+export async function getGatewayErrorDetail(
+  http: AdtHttpClient,
+  safety: SafetyConfig,
+  errorUrl: string
+): Promise<GatewayErrorDetail> {
+  checkOperation(safety, OperationType.Read, 'GetGatewayErrorDetail');
+  const resp = await http.get(errorUrl, {
+    Accept: 'application/atom+xml;type=entry',
+  });
+  return parseGatewayErrorDetail(resp.body);
+}
+```
+
+**Priority: Medium.** Very useful for OData development workflows. The detail view (source code + call stack) is high-value for debugging.
+**Effort: 1 day** — needs endpoint discovery + two-mode parsing (list + detail).
+**Caveat: On-prem only** — fr0ster marks this as `available_in: ['onprem']`. BTP ABAP Environment may not expose /IWFND/ERROR_LOG via ADT feeds. Need to verify.
+
+---
+
+## Feature 4: adt-clients 4.0 Factory API Migration
+
+### What fr0ster changed (commits `2c5cc71`, `ea79f0b`, `6b3b5d1`)
+
+Migrated from flat methods to factory-pattern domain objects:
+
+```typescript
+// Before (adt-clients 3.x):
+const client = new AdtRuntimeClient(connection, logger);
+const dumps = await client.listDumps(options);
+const trace = await client.getProfilerTrace(id);
+
+// After (adt-clients 4.0):
+const client = new AdtRuntimeClient(connection, logger);
+const dumps = await client.getDumps().list(options);
+const trace = await client.getProfiler().getTrace(id);
+const feeds = client.getFeeds();
+const messages = await feeds.systemMessages(options);
+```
+
+### ARC-1 comparison
+
+**Not applicable.** ARC-1 uses its own ADT client (`src/adt/client.ts`, `src/adt/diagnostics.ts`) with direct HTTP calls via undici/fetch. There's no external adt-clients dependency to migrate.
+
+ARC-1's architecture (flat functions with explicit HTTP and safety parameters) is simpler than fr0ster's factory pattern but achieves the same result. No action needed.
+
+---
+
+## Feature 5: Compact Wrapper Removal (v5.0.1 lesson)
+
+### What happened (commit `be56df1`)
+
+fr0ster added compact wrappers (HandlerFeedList, HandlerSystemMessageList, HandlerGatewayErrorList) in v5.0.0, then immediately removed them in v5.0.1 because they **duplicated the system-level tools** and caused "LLM tool selection confusion."
+
+Tool count dropped from 292 to 289.
+
+### Lesson for ARC-1
+
+**This validates ARC-1's intent-based architecture.** With 287+ tools, LLMs struggle to pick the right one when duplicates exist at different abstraction levels. ARC-1's 11 intent-based tools + action routing avoids this entirely.
+
+The right approach for ARC-1: add `system_messages` and `gateway_errors` as new actions on SAPDiagnose — not as separate tools.
+
+---
+
+## Summary: What's Useful for ARC-1
+
+| Feature | fr0ster Status | ARC-1 Status | Action | Priority |
+|---------|---------------|-------------|--------|----------|
+| RuntimeListFeeds (unified reader) | v5.0.0 | Partial (dumps + traces via SAPDiagnose) | Consider adding `feeds` action for discovery | Low |
+| RuntimeListSystemMessages (SM02) | v5.0.0 | Not implemented | **Add `system_messages` action to SAPDiagnose** | Medium |
+| RuntimeGetGatewayErrorLog | v5.0.0 (on-prem only) | Not implemented | **Add `gateway_errors` action to SAPDiagnose** | Medium |
+| adt-clients 4.0 factory API | v5.0.0 | Not applicable (own client) | None | N/A |
+| Compact wrapper removal | v5.0.1 | Not applicable | Validates intent-based approach | N/A |
+| XML entity expansion fix | v5.0.1 (adt-clients 4.0.2) | Check fast-xml-parser config | Verify `processEntities` setting | Low |
+
+### Implementation roadmap for ARC-1
+
+**Phase 1 (0.5 day):** Add `system_messages` action to SAPDiagnose
+- New function in `src/adt/diagnostics.ts`
+- New case in SAPDiagnose handler in `src/handlers/intent.ts`
+- New types in `src/adt/types.ts`
+- Endpoint discovery needed (inspect Eclipse ADT traffic or use `/sap/bc/adt/discovery`)
+
+**Phase 2 (1 day):** Add `gateway_errors` action to SAPDiagnose
+- Two-mode handler: list (with filters) + detail (with source code + call stack)
+- On-prem only (add feature detection guard)
+- High value for OData/RAP development workflows
+
+**Phase 3 (optional, 0.5 day):** Add `feeds` action for feed descriptor discovery
+- Lists available feeds on the system
+- Low value but helps with system capability introspection

--- a/compare/fr0ster/overview.md
+++ b/compare/fr0ster/overview.md
@@ -2,7 +2,7 @@
 
 > Tracking commits and issues from [fr0ster/mcp-abap-adt](https://github.com/fr0ster/mcp-abap-adt) for features worth adopting in ARC-1.
 
-_Last updated: 2026-04-08_
+_Last updated: 2026-04-11_
 
 ## Approach
 
@@ -19,11 +19,11 @@ _Last updated: 2026-04-08_
 | Metric | Commits | Issues |
 |--------|---------|--------|
 | Total | 783 | 40 |
-| Tracked | 66 | 40 |
-| Evaluated | 30 | 40 |
+| Tracked | 67 | 40 |
+| Evaluated | 33 | 40 |
 | Pending evaluation | 0 | 0 |
-| Skipped (not relevant) | 36 | 25 |
-| Evaluation files | 17 | 10 |
+| Skipped (not relevant) | 34 | 25 |
+| Evaluation files | 20 | 10 |
 
 ## Priority Summary
 
@@ -32,7 +32,7 @@ _Last updated: 2026-04-08_
 | Source | ID | Description | ARC-1 Matrix Ref |
 |--------|----|-------------|-------------------|
 | commit | TLS cluster (5 commits) | HTTPS/TLS for HTTP Streamable transport | Critical #5 |
-| issue | #22, #23, #25 | 415 Content-Type auto-retry / Accept negotiation | Critical #3 |
+| ~~issue~~ | ~~#22, #23, #25~~ | ~~415 Content-Type auto-retry / Accept negotiation~~ | ~~Critical #3~~ ✅ ARC-1 already has 406/415 retry |
 | issue | #26 | TLS/HTTPS implementation reference | Critical #5 |
 
 ### Medium Priority (evaluate for adoption)

--- a/compare/fr0ster/overview.md
+++ b/compare/fr0ster/overview.md
@@ -2,7 +2,7 @@
 
 > Tracking commits and issues from [fr0ster/mcp-abap-adt](https://github.com/fr0ster/mcp-abap-adt) for features worth adopting in ARC-1.
 
-_Last updated: 2026-04-11_
+_Last updated: 2026-04-12_
 
 ## Approach
 
@@ -18,12 +18,12 @@ _Last updated: 2026-04-11_
 
 | Metric | Commits | Issues |
 |--------|---------|--------|
-| Total | 783 | 40 |
-| Tracked | 67 | 40 |
-| Evaluated | 33 | 40 |
+| Total | 799 | 40 |
+| Tracked | 76 | 40 |
+| Evaluated | 39 | 40 |
 | Pending evaluation | 0 | 0 |
-| Skipped (not relevant) | 34 | 25 |
-| Evaluation files | 20 | 10 |
+| Skipped (not relevant) | 37 | 25 |
+| Evaluation files | 22 | 10 |
 
 ## Priority Summary
 
@@ -39,6 +39,8 @@ _Last updated: 2026-04-11_
 
 | Source | ID | Description | ARC-1 Matrix Ref |
 |--------|----|-------------|-------------------|
+| commit | c0775a3 | SM02 system messages reader (RuntimeListSystemMessages) | New SAPDiagnose action |
+| commit | 276f414 | Gateway error log with detail view (RuntimeGetGatewayErrorLog) | New SAPDiagnose action |
 | commit | 459f961 | Dump lookup by datetime+user, structured dump list | Enhance SAPDiagnose |
 | commit | e5628dc | Read handlers returning source + metadata together | UX improvement |
 | commit | 9ef5843 | Create vs Update separation (breaking change) | SAPWrite design |

--- a/compare/vibing-steampunk/commits.json
+++ b/compare/vibing-steampunk/commits.json
@@ -1,17 +1,151 @@
 {
   "$schema": "Commit tracker for oisee/vibing-steampunk — grouped by release, auto-triaged",
   "repo": "https://github.com/oisee/vibing-steampunk",
-  "lastUpdated": "2026-04-08",
-  "lastCheckedSha": "11c2253",
+  "lastUpdated": "2026-04-12",
+  "lastCheckedSha": "e62c7d5",
   "stats": {
-    "totalCommits": 470,
+    "totalCommits": 495,
     "trackedFrom": "v2.22.0 (2026-02-01)",
-    "totalTracked": 82,
-    "evaluated": 82,
+    "totalTracked": 95,
+    "evaluated": 90,
     "pending": 0,
-    "skipped": 55
+    "skipped": 60
   },
   "releases": [
+    {
+      "version": "post-v2.39.0 (Apr 9-12 sprint)",
+      "date": "2026-04-09 to 2026-04-12",
+      "commits": [
+        {
+          "sha": "e62c7d5",
+          "date": "2026-04-12",
+          "message": "feat: add SAML SSO authentication for S/4HANA Public Cloud (#97)",
+          "type": "feat",
+          "status": "evaluated",
+          "priority": "low",
+          "decision": "defer",
+          "relevance": "SAML SSO auth (programmatic + browser) for S/4HANA Public Cloud with IAS. ARC-1 uses BTP OAuth / Destination Service instead. Low priority unless SAML-only customers appear. Credential-cmd pattern is independently interesting.",
+          "evaluationFile": "evaluations/e62c7d5-saml-sso-auth.md"
+        },
+        {
+          "sha": "d96c38e",
+          "date": "2026-04-12",
+          "message": "feat: detect HANA database from S4CORE component in GetSystemInfo (#100)",
+          "type": "feat",
+          "status": "evaluated",
+          "priority": "low",
+          "decision": "consider-future",
+          "relevance": "HANA detection fallback via S4CORE component. ARC-1 GetSystemInfo could benefit if database type detection is needed."
+        },
+        {
+          "sha": "0713d75",
+          "date": "2026-04-12",
+          "message": "fix: enforce SAP_ALLOWED_PACKAGES on existing-object mutations (#101)",
+          "type": "fix",
+          "status": "evaluated",
+          "priority": "critical",
+          "decision": "implement",
+          "relevance": "CRITICAL: ARC-1 has the SAME BUG. checkPackage() only called on create, not on update/delete/edit_method. Package allowlist can be bypassed for mutations to existing objects. Must fix immediately.",
+          "evaluationFile": "evaluations/0713d75-package-safety-mutations.md"
+        },
+        {
+          "sha": "a66bcd5",
+          "date": "2026-04-10",
+          "message": "fix: correct releaseState bug and update tests for C0-C4 API structure",
+          "type": "fix",
+          "status": "evaluated",
+          "priority": "medium",
+          "decision": "verify",
+          "relevance": "API release state was reading from uninitialized variable instead of actual C1.Status.State. ARC-1 should verify its getApiReleaseState extracts correctly.",
+          "evaluationFile": "evaluations/a66bcd5-release-state-bugfix.md"
+        },
+        {
+          "sha": "880aa68",
+          "date": "2026-04-09",
+          "message": "feat: default mode changed to hyperfocused",
+          "type": "feat",
+          "status": "evaluated",
+          "priority": "low",
+          "decision": "market-signal",
+          "relevance": "vibing-steampunk now defaults to hyperfocused (1 tool) instead of focused (100 tools). Market signal: single-tool mode is winning. Validates ARC-1's intent-based approach."
+        },
+        {
+          "sha": "fc99eb3",
+          "date": "2026-04-09",
+          "message": "feat: add tr-boundaries, cr-boundaries, cr-history commands",
+          "type": "feat",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "CLI-only transport/CR boundary analysis. Queries E070A, R3TR, LIMU tables. Not MCP tools — CLI commands for analysis reports."
+        },
+        {
+          "sha": "5049e0e",
+          "date": "2026-04-09",
+          "message": "fix: batch SAP IN-clause queries to 5 items (255-char limit)",
+          "type": "fix",
+          "status": "evaluated",
+          "priority": "low",
+          "decision": "verify",
+          "relevance": "SAP has 255-char limit on WHERE clauses in free SQL. Queries with many items need batching. ARC-1 should verify RunQuery handles long IN clauses gracefully."
+        },
+        {
+          "sha": "b0e37c6",
+          "date": "2026-04-09",
+          "message": "feat: two-pass package resolution (TADIR + TFDIR fallback)",
+          "type": "feat",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "CLI-only package resolution for function modules via TFDIR. Not an MCP tool."
+        },
+        {
+          "sha": "8a478aa",
+          "date": "2026-04-09",
+          "message": "fix: RELEASE-State in runAPISurface (andreasmuenster)",
+          "type": "fix",
+          "status": "evaluated",
+          "priority": "medium",
+          "decision": "verify",
+          "relevance": "Related to a66bcd5 — same API release state fix from community contributor. Verify ARC-1 implementation."
+        },
+        {
+          "sha": "8565769",
+          "date": "2026-04-09",
+          "message": "feat: CO_TRANSPORTED edge kind for co-change signals",
+          "type": "feat",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "Graph analysis edge type — CLI-only boundary analysis."
+        },
+        {
+          "sha": "91b49f1",
+          "date": "2026-04-08",
+          "message": "feat: graph export formats (DOT, PlantUML, GraphML)",
+          "type": "feat",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "CLI-only graph export. Not MCP tools."
+        },
+        {
+          "sha": "8a60b62",
+          "date": "2026-04-08",
+          "message": "feat: Mermaid graph output with package subgraphs",
+          "type": "feat",
+          "status": "skipped",
+          "priority": "skip",
+          "relevance": "CLI-only graph export."
+        },
+        {
+          "sha": "7c8dfbc",
+          "date": "2026-04-08",
+          "message": "feat: cache config support in .vsp.json and env vars",
+          "type": "feat",
+          "status": "evaluated",
+          "priority": "low",
+          "decision": "no-action",
+          "relevance": "Cache configuration via config file. ARC-1 already has cache config via env vars and CLI flags."
+        }
+      ]
+    },
     {
       "version": "v2.38.1-v2.39.0+ (boundary analysis sprint)",
       "date": "2026-04-07 to 2026-04-08",

--- a/compare/vibing-steampunk/evaluations/0713d75-package-safety-mutations.md
+++ b/compare/vibing-steampunk/evaluations/0713d75-package-safety-mutations.md
@@ -1,0 +1,113 @@
+# Package Safety Enforcement on Existing-Object Mutations
+
+> **Priority**: **CRITICAL** — ARC-1 has the same bug
+> **Source**: vibing-steampunk commit 0713d75, PR #101 (2026-04-12)
+> **ARC-1 component**: `src/handlers/intent.ts` (update/delete/edit_method handlers), `src/adt/safety.ts`
+> **Status**: Bug confirmed in ARC-1 — `checkPackage()` only called on create, not on update/delete/edit_method
+
+## The Bug (vibing-steampunk)
+
+`SAP_ALLOWED_PACKAGES` was only enforced on object creation flows. Existing-object mutations (EditSource, WriteProgram, WriteClass, UpdateSource, DeleteObject, RenameObject) bypassed the package restriction entirely.
+
+This meant: if `SAP_ALLOWED_PACKAGES=$TMP`, a user could still modify or delete objects in `ZSAP_CORE` or any other restricted package.
+
+## vibing-steampunk's Fix
+
+Introduced a unified `checkMutation` gate that:
+1. Resolves the object's package via `SearchObject` (extracts package from search metadata)
+2. Validates package against the allowlist before any mutation
+3. Covers: UpdateSource, WriteProgram, WriteClass, WriteSource, DeleteObject, RenameObject, CreateTestInclude, UpdateClassInclude, WriteMessageClassTexts, WriteDataElementLabels, UI5 mutations
+
+Key functions added:
+- `checkObjectPackageSafety()` — resolves package + validates against allowlist
+- `getObjectPackage()` — extracts package from search results
+- `normalizeObjectURLForPackageCheck()` — strips `/source/main`, `/includes/` suffixes
+- Precedence: explicit Package param > resolve via ObjectURL > fail closed
+
+## ARC-1 Status: SAME BUG EXISTS
+
+**`checkPackage()` is only called in two places** in `src/handlers/intent.ts`:
+
+1. **Line 1175** — `create` action: `checkPackage(client.safety, pkg)` ✅
+2. **Line 1272** — `batch_create` action: `checkPackage(client.safety, pkg)` ✅
+
+**Not called in these mutation handlers:**
+
+| Handler | Line | Package Check | Status |
+|---------|------|--------------|--------|
+| `update` | 1163-1172 | ❌ None | **VULNERABLE** |
+| `edit_method` | 1213-1244 | ❌ None | **VULNERABLE** |
+| `delete` | 1245-1262 | ❌ None | **VULNERABLE** |
+
+### Proof of concept
+
+If `SAP_ALLOWED_PACKAGES=Z*` (only custom Z* objects allowed):
+
+- ✅ `SAPWrite(action=create, package=ZSAP)` → Blocked by `checkPackage()`
+- ❌ `SAPWrite(action=update, name=CL_IN_RESTRICTED_PKG)` → **Succeeds** (no check)
+- ❌ `SAPWrite(action=delete, name=CL_IN_RESTRICTED_PKG)` → **Succeeds** (no check)
+- ❌ `SAPWrite(action=edit_method, name=CL_IN_RESTRICTED_PKG)` → **Succeeds** (no check)
+
+## Recommended Fix for ARC-1
+
+### Option A: Resolve package before mutation (recommended)
+
+Before each mutation, resolve the object's package and validate:
+
+```typescript
+// Add helper to resolve package for an existing object
+async function resolveAndCheckPackage(
+  client: AdtClient,
+  type: string,
+  name: string,
+): Promise<void> {
+  if (client.safety.allowedPackages.length === 0) return; // no restrictions configured
+  
+  // Use search to find the object's package
+  const results = await client.searchObject(name);
+  const match = results.find(r => r.name.toUpperCase() === name.toUpperCase());
+  if (!match?.packageName) {
+    throw new AdtSafetyError(
+      `Cannot determine package for ${type} ${name} — mutation blocked by safety policy`
+    );
+  }
+  checkPackage(client.safety, match.packageName);
+}
+
+// In update handler:
+case 'update': {
+  await resolveAndCheckPackage(client, type, name);  // NEW
+  // ... existing update logic ...
+}
+
+// In edit_method handler:
+case 'edit_method': {
+  await resolveAndCheckPackage(client, type, name);  // NEW
+  // ... existing edit_method logic ...
+}
+
+// In delete handler:
+case 'delete': {
+  await resolveAndCheckPackage(client, type, name);  // NEW
+  // ... existing delete logic ...
+}
+```
+
+### Option B: Check package in CRUD layer
+
+Add package check to `safeUpdateSource()` and `deleteObject()` in `crud.ts`. This is more centralized but requires passing the safety config's allowedPackages and a package resolver to the CRUD layer.
+
+**Recommendation: Option A** — keeps the check in the handler layer where we already have access to the client and search capabilities.
+
+### Edge cases to handle
+
+1. **Object not found in search**: Fail closed (block the mutation)
+2. **Object has no package**: Fail closed
+3. **No allowedPackages configured**: Skip check (no restrictions)
+4. **Performance**: The search call adds ~100-200ms per mutation. Could cache package mapping.
+
+## Decision
+
+**IMPLEMENT IMMEDIATELY.** This is a safety system bypass — the exact scenario `SAP_ALLOWED_PACKAGES` is designed to prevent. vibing-steampunk's fix is the reference implementation.
+
+**Effort**: 0.5 day (implement + test)

--- a/compare/vibing-steampunk/evaluations/a66bcd5-release-state-bugfix.md
+++ b/compare/vibing-steampunk/evaluations/a66bcd5-release-state-bugfix.md
@@ -1,0 +1,37 @@
+# API Release State Bug Fix (C0-C4 Structure)
+
+> **Priority**: Medium — verify ARC-1's API release state implementation
+> **Source**: vibing-steampunk commit a66bcd5 (2026-04-10), PR #95 fix
+> **ARC-1 component**: `src/adt/client.ts` (getApiReleaseState)
+
+## The Bug
+
+vibing-steampunk's `runAPISurface()` had a bug where `releaseState` was read from an uninitialized variable instead of the actual data structure:
+
+```go
+// WRONG: releaseState was empty string, never populated
+releaseState = strings.ToUpper(strings.TrimSpace(releaseState))
+
+// FIXED: read from actual C1 status structure
+releaseState = strings.ToUpper(strings.TrimSpace(state.C1.Status.State))
+```
+
+The test updates also changed from old `apiState` XML schema to new `apiRelease` structure with `c1Release` and `status` elements, validating against `/sap/bc/adt/apireleases/` endpoint.
+
+## ARC-1 comparison
+
+ARC-1 implemented API release state in PR #77 (`src/adt/client.ts`). The implementation should be verified to ensure:
+
+1. The release state is correctly extracted from the XML response
+2. The C0-C4 classification is properly parsed
+3. The `/sap/bc/adt/apireleases/` endpoint format matches expectations
+
+### Verification steps
+
+1. Check `src/adt/client.ts` for `getApiReleaseState` — ensure it reads the state from the correct XML element
+2. Check `src/adt/xml-parser.ts` — ensure the API release state parser handles the `c1Release.status.state` path
+3. Run integration tests against a live system to verify C0/C1/C2/C3/C4 states are returned correctly
+
+## Decision
+
+**Verify** — review ARC-1's API release state implementation against this bug pattern. Low effort (code review), could prevent a similar extraction bug.

--- a/compare/vibing-steampunk/evaluations/e62c7d5-saml-sso-auth.md
+++ b/compare/vibing-steampunk/evaluations/e62c7d5-saml-sso-auth.md
@@ -1,0 +1,61 @@
+# SAML SSO Authentication for S/4HANA Public Cloud
+
+> **Priority**: Low (ARC-1 has different auth model for cloud — BTP OAuth)
+> **Source**: vibing-steampunk commit e62c7d5, PR #97 (2026-04-12) by blicksten
+> **ARC-1 component**: `src/adt/oauth.ts`, `src/server/http.ts`
+
+## What vibing-steampunk added
+
+Three authentication enhancements:
+
+1. **`--saml-auth`**: Programmatic SAML SSO without browser. Implements full SAP→IAS→SAP SAML flow. Doesn't support MFA.
+2. **`--browser-auth` improvements**: Better cookie filtering, 500ms polling, verbose SAML redirect logging for browser-based SAML/IAS flows with MFA support.
+3. **`--credential-cmd`**: External credential provider (git-credential-helper pattern). Commands return JSON `{"username":"...","password":"..."}`.
+
+Security hardening:
+- HTTPS→HTTP downgrade prevention (5 enforcement points)
+- Host validation prevents credential exfiltration
+- Credential zeroing after use
+- No shell execution in credential commands (argv-based)
+- 10-hop redirect/form chain limit
+- Auto re-authentication on 401 with stampede protection
+
+### Configuration
+
+```bash
+# Programmatic SAML (headless)
+vsp --saml-auth --saml-user user@company.com --saml-password '***' \
+    --url https://your-system.s4hana.cloud.sap
+
+# Browser-based SAML (with MFA)
+vsp --browser-auth --url https://your-system.s4hana.cloud.sap
+
+# External credential provider
+vsp --saml-auth --credential-cmd 'my-credential-helper get SAP' \
+    --url https://your-system.s4hana.cloud.sap
+```
+
+## ARC-1 comparison
+
+ARC-1 connects to S/4HANA Public Cloud differently:
+- **BTP ABAP Environment**: OAuth 2.0 browser login via `src/adt/oauth.ts`
+- **BTP Destination Service**: Service key + destination configuration
+- **Principal Propagation**: Per-user JWT → BTP Destination → SAP session
+
+ARC-1 doesn't need SAML for BTP because it uses OAuth 2.0 / service keys. However, for **on-prem S/4HANA systems behind IAS/SAML** (without BTP Destination Service), SAML auth could be relevant.
+
+### Use case gap
+
+If a customer has:
+- S/4HANA on-prem
+- IAS (Identity Authentication Service) as IdP
+- Basic Auth disabled
+- No BTP Destination Service available
+
+Then ARC-1 can't connect. vibing-steampunk's SAML auth handles this scenario.
+
+## Decision
+
+**Low priority / defer.** ARC-1's target deployment is BTP-native (Destination Service + Cloud Connector). Customers without BTP access can use Basic Auth. SAML-only deployments are an edge case. If demand appears, study vibing-steampunk's implementation as reference.
+
+The `--credential-cmd` pattern is independently interesting for credential rotation — could be considered for ARC-1's API key management.

--- a/compare/vibing-steampunk/overview.md
+++ b/compare/vibing-steampunk/overview.md
@@ -2,7 +2,7 @@
 
 > Tracking commits and issues from [oisee/vibing-steampunk](https://github.com/oisee/vibing-steampunk) (ARC-1's upstream) for features and bug fixes worth adopting.
 
-_Last updated: 2026-04-08_
+_Last updated: 2026-04-12_
 
 ## Approach
 
@@ -16,12 +16,12 @@ _Last updated: 2026-04-08_
 
 | Metric | Commits | Issues |
 |--------|---------|--------|
-| Total | 470 | 42 |
-| Tracked | 82 | 42 |
-| Evaluated | 82 | 42 |
+| Total | 495 | 42 |
+| Tracked | 95 | 42 |
+| Evaluated | 90 | 42 |
 | Pending evaluation | 0 | 0 |
-| Skipped (not relevant) | 55 | 22 |
-| Evaluation files | 28 | 9 |
+| Skipped (not relevant) | 60 | 22 |
+| Evaluation files | 31 | 9 |
 
 ## Priority Summary
 
@@ -29,8 +29,9 @@ _Last updated: 2026-04-08_
 
 | Source | ID | Description | ARC-1 Matrix Ref |
 |--------|----|-------------|-------------------|
+| commit | **0713d75** | **CRITICAL: Package safety bypass on mutations — ARC-1 has same bug** | **Safety system bypass** |
 | commit | 7270ad7 | API release state for S/4HANA Clean Core | New — critical for BTP/cloud |
-| issue | #9 | Transport 406 Accept header (same class as fr0ster 415) | Critical #3 |
+| ~~issue~~ | ~~#9~~ | ~~Transport 406 Accept header (same class as fr0ster 415)~~ | ~~Critical #3~~ ✅ ARC-1 has 415/406 retry |
 
 ### Medium Priority (evaluate/verify)
 
@@ -57,6 +58,9 @@ _Last updated: 2026-04-08_
 | commit | 7fbfbba | ignore_warnings for EditSource | Consider for edit_method |
 | commit | ba83e22 + 558a300 | Package deps + call graph analysis | Medium #31 in matrix |
 | commit | 0756e94 | ABAP parser + deps as MCP tools | Consider for SAPContext |
+| commit | a66bcd5 | API release state bug fix (C0-C4 structure) | Verify getApiReleaseState |
+| commit | e62c7d5 | SAML SSO for S/4HANA Public Cloud | Low — defer unless SAML-only demand |
+| commit | 880aa68 | Default mode → hyperfocused (market signal) | Validates intent-based approach |
 | issue | #91, #88 | 423 lock handle errors (recurring) | Verify crud.ts |
 | issue | #78 | 423 lock handle on ECC 6.0 | Verify crud.ts |
 | issue | #40 | i18n/translation tools | Closed by commit 566f1f7 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,7 +42,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | # | ID | Feature | Priority | Effort | Category |
 |---|-----|---------|----------|--------|----------|
 | ~~1~~ | ~~FEAT-02~~ | ~~API Release Status / Clean Core~~ | ~~P0~~ | ~~S~~ | ~~Completed 2026-04-10~~ |
-| 2 | FEAT-07 | TLS/HTTPS for HTTP Streamable | P0 | S | Features |
+| 2 | FEAT-07 | TLS/HTTPS for HTTP Streamable | P3 | S | Features |
 | 3 | FEAT-08 | Content-Type 415/406 Auto-Retry | P0 | XS | Features |
 | 4 | FEAT-14 | 401 Session Timeout Auto-Retry | P0 | XS | Features |
 | 5 | FEAT-15 | Namespace URL Encoding Audit | P1 | XS | Features |
@@ -139,8 +139,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 1. ~~**FEAT-02** API Release Status / Clean Core (S)~~ — **completed 2026-04-10**
 2. **FEAT-08** Content-Type 415/406 Auto-Retry (XS) — both fr0ster and VSP hit this
 3. **FEAT-14** 401 Session Timeout Auto-Retry (XS) — centralized gateway idles between requests
-4. **FEAT-07** TLS/HTTPS for HTTP Streamable (S) — enterprise deployments without reverse proxy
-5. **FEAT-15** Namespace URL Encoding Audit (XS) — silent failures for namespaced objects
+4. **FEAT-15** Namespace URL Encoding Audit (XS) — silent failures for namespaced objects
 
 ### Phase A.5: Proactive Compatibility (P0)
 6. **FEAT-38** ADT Service Discovery / MIME Negotiation (S) — probe `/sap/bc/adt/discovery` once at startup to learn supported MIME types per endpoint; eliminates 415/406 retries entirely. sapcli has had this since 2018. Supersedes reactive FEAT-08 approach.
@@ -195,8 +194,9 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 36. **FEAT-34** i18n Translation Management (M) — VSP added 7 translation tools
 
 ### Phase F: Future / Niche (P3)
-37. **FEAT-05** Code Refactoring (L) — rename, extract method, change package
-38. **FEAT-29** P3 Backlog — see [FEAT-29 table](#feat-29-p3-backlog-future--niche) for SSE, debugger, execute ABAP, call graph, UI5/BSP, RFC, embeddable server, lock registry, language attributes
+37. **FEAT-07** TLS/HTTPS for HTTP Streamable (S) — most deployments use reverse proxy (BTP gorouter, nginx, K8s Ingress) for TLS termination; in-app TLS is edge case
+38. **FEAT-05** Code Refactoring (L) — rename, extract method, change package
+39. **FEAT-29** P3 Backlog — see [FEAT-29 table](#feat-29-p3-backlog-future--niche) for SSE, debugger, execute ABAP, call graph, UI5/BSP, RFC, embeddable server, lock registry, language attributes
 
 ---
 
@@ -223,10 +223,10 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 ### FEAT-07: TLS/HTTPS for HTTP Streamable Transport
 | Field | Value |
 |-------|-------|
-| **Priority** | P0 |
+| **Priority** | P3 (downgraded from P0, 2026-04-11) |
 | **Effort** | S (1-2 days) |
 | **Risk** | Low |
-| **Usefulness** | High — required for production enterprise deployments without reverse proxy |
+| **Usefulness** | Low — most deployments use reverse proxy for TLS termination |
 | **Status** | Not started |
 | **Source** | [fr0ster tracker: TLS evaluation](../compare/fr0ster/evaluations/tls-https-support.md) |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # ARC-1 Roadmap
 
-**Last Updated:** 2026-04-10
+**Last Updated:** 2026-04-11
 **Project:** ARC-1 (ABAP Relay Connector) — MCP Server for SAP ABAP Systems
 **Repository:** https://github.com/marianfoo/arc-1
 
@@ -77,9 +77,16 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | 34 | FEAT-36 | Type Information (SAPNavigate) | P2 | S | Features |
 | 35 | OPS-02 | Health Check Enhancements | P2 | XS | Ops |
 | 36 | DOC-03 | SAP Community Blog Post | P2 | S | Docs |
-| 37 | FEAT-05 | Code Refactoring (Rename, Extract) | P3 | L | Features |
-| 38 | FEAT-29 | P3 Backlog (14 items) | P3 | various | Features |
-| 39 | OPS-03 | Multi-System Routing | P3 | L | Ops |
+| 37 | FEAT-37 | DCL (Access Control) Read/Write | P1 | S | Features |
+| 38 | FEAT-38 | ADT Service Discovery (MIME Negotiation) | P0 | S | Features |
+| 39 | FEAT-39 | Transport Enhancements (delete, reassign, types) | P2 | S | Features |
+| 40 | FEAT-40 | FLP Launchpad Management (OData) | P1 | M | Features |
+| 41 | FEAT-41 | ABAP Unit Test Coverage (statement-level) | P2 | S | Features |
+| 42 | FEAT-42 | ATC Output Formats (JUnit4, checkstyle, codeclimate) | P2 | XS | Features |
+| 43 | FEAT-43 | DDIC Auth & Misc Read (Authorization Fields, Feature Toggles) | P2 | S | Features |
+| 44 | FEAT-05 | Code Refactoring (Rename, Extract) | P3 | L | Features |
+| 45 | FEAT-29 | P3 Backlog (14 items) | P3 | various | Features |
+| 46 | OPS-03 | Multi-System Routing | P3 | L | Ops |
 
 ---
 
@@ -135,14 +142,19 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 4. **FEAT-07** TLS/HTTPS for HTTP Streamable (S) — enterprise deployments without reverse proxy
 5. **FEAT-15** Namespace URL Encoding Audit (XS) — silent failures for namespaced objects
 
+### Phase A.5: Proactive Compatibility (P0)
+6. **FEAT-38** ADT Service Discovery / MIME Negotiation (S) — probe `/sap/bc/adt/discovery` once at startup to learn supported MIME types per endpoint; eliminates 415/406 retries entirely. sapcli has had this since 2018. Supersedes reactive FEAT-08 approach.
+
 ### Phase B: Core Value Features (P1)
-6. **FEAT-17** Type Auto-Mappings for SAPWrite (XS) — eliminate LLM type code confusion
-7. **FEAT-12** Fix Proposals / Auto-Fix (S) — safer than LLM-guessed fixes
-8. **FEAT-16** Error Intelligence (S) — actionable hints for SAP errors (subsumes SEC-03)
-9. **FEAT-13** DDIC Domain/Data Element Write (S) — complete data modeling workflow
-10. **FEAT-18** Function Group Bulk Fetch (S) — token/round-trip savings
-11. **DOC-01** Copilot Studio Setup Guide (S) — critical for enterprise adoption
-12. **DOC-02** Basis Admin Security Guide (S) — admin audience needs clear guidance
+7. **FEAT-37** DCL (Access Control) Read/Write (S) — missing CDS access control objects; sapcli, VSP have this. Critical for RAP development workflow.
+8. **FEAT-40** FLP Launchpad Management (M) — OData-based Fiori Launchpad customization (catalogs, groups, tiles). sapcli has full implementation via `/sap/opu/odata/UI2/PAGE_BUILDER_CUST`. High value for enterprise Fiori rollout automation.
+9. **FEAT-17** Type Auto-Mappings for SAPWrite (XS) — eliminate LLM type code confusion
+10. **FEAT-12** Fix Proposals / Auto-Fix (S) — safer than LLM-guessed fixes
+11. **FEAT-16** Error Intelligence (S) — actionable hints for SAP errors (subsumes SEC-03)
+12. **FEAT-13** DDIC Domain/Data Element Write (S) — complete data modeling workflow
+13. **FEAT-18** Function Group Bulk Fetch (S) — token/round-trip savings
+14. **DOC-01** Copilot Studio Setup Guide (S) — critical for enterprise adoption
+15. **DOC-02** Basis Admin Security Guide (S) — admin audience needs clear guidance
 
 ### Phase C: ADT Feature Parity (P2) — Quick Wins
 13. **FEAT-32** Table Pagination / Offset (XS) — VSP has this, practical improvement
@@ -154,11 +166,15 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 19. **OPS-02** Health Check Enhancements (XS) — `/health/deep` with SAP connectivity check
 
 ### Phase D: ADT Feature Parity (P2) — Larger Items
-20. **FEAT-09** SQL Trace Monitoring (S) — completes diagnostics story
-21. **SEC-05** Rate Limiting (S) — prevent runaway AI loops
-22. **FEAT-20** Source Version / Revision History (S) — version comparison, rollback (VSP + abap-adt-api have it)
-23. **FEAT-31** Code Coverage from Unit Tests (S) — VSP has this (Apr 4)
-24. **FEAT-33** CDS Impact Analysis (S) — VSP has this (Apr 4)
+20. **FEAT-39** Transport Enhancements (S) — delete, reassign owner, transport type selection (K/W/T/S/R), recursive release. sapcli has full CTS lifecycle.
+21. **FEAT-41** ABAP Unit Test Coverage (S) — statement-level coverage via `/runtime/traces/coverage/measurements/{id}` with paginated follow-up. sapcli + AWS Accelerator have this.
+22. **FEAT-42** ATC Output Formats (XS) — JUnit4, checkstyle, codeclimate formatters for CI/CD integration. sapcli has these.
+23. **FEAT-43** DDIC Auth & Misc Read (S) — Authorization Fields (`/authorizationfields`), Feature Toggles, Enhancement Implementations. sapcli added auth fields Apr 2026.
+24. **FEAT-09** SQL Trace Monitoring (S) — completes diagnostics story
+25. **SEC-05** Rate Limiting (S) — prevent runaway AI loops
+26. **FEAT-20** Source Version / Revision History (S) — version comparison, rollback (VSP + abap-adt-api have it)
+27. **FEAT-31** Code Coverage from Unit Tests (S) — VSP has this (Apr 4). See also FEAT-41 for sapcli's approach.
+28. **FEAT-33** CDS Impact Analysis (S) — VSP has this (Apr 4)
 25. **FEAT-24** CompareSource / Diff (S) — code review workflows
 26. **FEAT-26** MCP Client Config Snippets (S) — onboarding UX
 27. **FEAT-25** CDS Unit Tests (S) — CDS test-driven development
@@ -248,6 +264,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 - Retry with `Accept: application/xml` -> `Accept: */*` (or vice versa)
 - Retry with `Content-Type: application/xml` -> `text/plain` for transport endpoints
 - Max 1 retry, log the fallback
+- **See also FEAT-38** (ADT Service Discovery) for proactive MIME negotiation instead of reactive retry
 
 ---
 
@@ -894,6 +911,171 @@ SAP_RATE_LIMIT_BURST=10  # burst allowance
 **Why:** SAP Community visibility drives adoption.
 
 **Why not:** Marketing, not a feature. Better timing is after P1 + most P2 features are stable — ship the product first, then evangelize. One blog post in a sea of SAP Community content may not move the needle for adoption.
+
+---
+
+### FEAT-37: DCL (Access Control) Read/Write
+| Field | Value |
+|-------|-------|
+| **Priority** | P1 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low |
+| **Usefulness** | High — completes RAP development workflow |
+| **Status** | Not started |
+| **Source** | [sapcli comparison](../compare/09-sapcli.md) |
+
+**What:** Add read and write support for CDS access control objects (DCL). sapcli uses the ADT basepath `/dcl/sources`. DCL objects are a mandatory part of RAP development — every CDS entity needs an access control to restrict data access.
+
+**Current gap:** ARC-1 supports DDLS, DDLX, BDEF, SRVD, SRVB for RAP but is missing DCL, which breaks the RAP object creation workflow.
+
+**Implementation:**
+- Add `getDcl(name)` to `src/adt/client.ts` using `/sap/bc/adt/acm/dcl/sources/{name}/source/main`
+- Add DCL to `objectBasePath()` and `sourceUrlForType()` in `src/adt/crud.ts`
+- Add `buildCreateXml()` support for DCL in `src/adt/crud.ts`
+- Add DCL to `SAPREAD_TYPES_ONPREM`, `SAPREAD_TYPES_BTP`, `SAPWRITE_TYPES_ONPREM`, `SAPWRITE_TYPES_BTP` in `src/handlers/tools.ts`
+- Add unit tests with XML fixtures
+
+---
+
+### FEAT-38: ADT Service Discovery (MIME Negotiation)
+| Field | Value |
+|-------|-------|
+| **Priority** | P0 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low |
+| **Usefulness** | Very High — eliminates 415/406 content-type errors proactively |
+| **Status** | Not started |
+| **Source** | [sapcli comparison](../compare/09-sapcli.md), sapcli `sap/adt/discovery.py` |
+
+**What:** Call `GET /sap/bc/adt/discovery` at startup to learn which MIME type versions each ADT endpoint supports. Cache the accepted Content-Type/Accept values per endpoint. Use correct headers from the start instead of guessing and retrying on 415/406.
+
+**Why:** sapcli has done this since 2018 — it's the standard ADT pattern. ARC-1 currently uses reactive retry logic (FEAT-08) which adds latency and doesn't cover all edge cases. The discovery document tells you exactly what each endpoint accepts, eliminating guesswork.
+
+**Why this is better than FEAT-08 alone:** FEAT-08 retries after failure (1 extra round-trip per mismatch). FEAT-38 probes once at startup and gets it right the first time for all subsequent requests. Combined approach: discovery at startup + FEAT-08 retry as fallback.
+
+**Implementation:**
+- Add `fetchDiscovery()` to `src/adt/http.ts` — parses `/sap/bc/adt/discovery` XML into a `Map<endpointPath, { accept: string[], contentType: string[] }>`
+- Call during `AdtHttpClient` initialization (alongside CSRF fetch, which already hits `/sap/bc/adt/core/discovery`)
+- Store in `AdtHttpClient` instance; cache in SQLite if caching enabled
+- Before each request, look up endpoint in discovery map; use correct MIME types
+- Fallback to current behavior if discovery fails or endpoint not in map
+- Add to `src/adt/features.ts` as a feature probe
+
+---
+
+### FEAT-39: Transport Enhancements
+| Field | Value |
+|-------|-------|
+| **Priority** | P2 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low |
+| **Usefulness** | Medium — completes CTS lifecycle for LLM workflows |
+| **Status** | Not started |
+| **Source** | [sapcli comparison](../compare/09-sapcli.md) |
+
+**What:** Extend SAPTransport with: delete transport/task, reassign owner, transport type selection (Workbench/K, Customizing/W, Transport-of-Copies/T, Development-Correction/S, Repair/R), recursive release (release tasks first, then request), and transport contents listing (E071 objects). Subsumes FEAT-19.
+
+**Current state:** ARC-1 supports list, get, create (Workbench only), release. sapcli has full CTS lifecycle including delete, reassign, 5 transport types, recursive release, and `-rrr` detail levels showing objects.
+
+**Implementation:**
+- Add `deleteTransport()` to `src/adt/transport.ts` — `DELETE /sap/bc/adt/cts/transportrequests/{id}`
+- Add `reassignTransport()` — modify owner attribute
+- Add `transportType` parameter to `createTransport()` — currently hardcoded `tm:type="K"`
+- Add `recursive` flag to `releaseTransport()` — release child tasks before parent
+- Enhance `getTransport()` response parsing to include task objects (E071 entries)
+- Add new actions to SAPTransport handler in `src/handlers/intent.ts`
+- Safety check: transport operations gated by `enableTransports` config
+
+---
+
+### FEAT-40: FLP Launchpad Management (OData)
+| Field | Value |
+|-------|-------|
+| **Priority** | P1 |
+| **Effort** | M (3-5 days) |
+| **Risk** | Medium — OData API, different from ADT REST |
+| **Usefulness** | Very High — enterprise Fiori rollout automation |
+| **Status** | Not started |
+| **Source** | [sapcli comparison](../compare/09-sapcli.md), sapcli `sap/cli/flp.py` + `sap/odata/` |
+
+**What:** Manage Fiori Launchpad configuration: catalogs, groups, target mappings, and tile assignments. Uses OData service `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` (on-prem) or equivalent BTP API.
+
+**Why:** Fiori Launchpad configuration is a major pain point in SAP projects. Automating catalog/group/tile setup via LLM saves hours of manual work per role. This is the kind of high-value enterprise automation that differentiates ARC-1 from developer-only tools.
+
+**Implementation:**
+- New `src/adt/flp.ts` module — OData client for PAGE_BUILDER_CUST
+- Operations: list catalogs, list groups, list target mappings, create/assign tiles, create catalog/group entries
+- New `SAPManage` action: `flp_catalog_list`, `flp_group_list`, `flp_assign_tile`, etc.
+- Alternatively: new FLP-specific tool if operations are complex enough
+- Safety: gated by write permissions; read operations always allowed
+- Consider pyodata-style OData parsing or use existing `src/adt/ui5-repository.ts` pattern
+
+---
+
+### FEAT-41: ABAP Unit Test Coverage (Statement-Level)
+| Field | Value |
+|-------|-------|
+| **Priority** | P2 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low |
+| **Usefulness** | High — enables test-driven ABAP development |
+| **Status** | Not started |
+| **Source** | [sapcli comparison](../compare/09-sapcli.md), sapcli `sap/adt/aunit.py` |
+
+**What:** Fetch statement-level code coverage after running ABAP Unit tests. Uses `POST /sap/bc/adt/runtime/traces/coverage/measurements/{id}` with paginated `rel=next` follow-up for large result sets.
+
+**Why:** Coverage data tells the LLM which lines are untested, enabling targeted test generation. sapcli and AWS Accelerator both have this. Currently ARC-1 runs tests but returns only pass/fail — no coverage metrics.
+
+**Concern:** Coverage for a 500-line class generates 500+ lines of output. May need summarization (e.g., "85% covered, 12 uncovered lines: 45-48, 102-105, 200-204") rather than raw line-by-line data.
+
+**Implementation:**
+- Add `enableCoverage` parameter to `runUnitTests()` in `src/adt/devtools.ts`
+- Post coverage measurement request, parse response with pagination
+- Return summary + uncovered line ranges (not raw per-line data, to avoid context bloat)
+- Integrate into SAPDiagnose or SAPRead `run_tests` action
+
+---
+
+### FEAT-42: ATC Output Formats
+| Field | Value |
+|-------|-------|
+| **Priority** | P2 |
+| **Effort** | XS (< 1 day) |
+| **Risk** | Low |
+| **Usefulness** | Medium — CI/CD integration |
+| **Status** | Not started |
+| **Source** | [sapcli comparison](../compare/09-sapcli.md) |
+
+**What:** Format ATC check results as JUnit4 XML, checkstyle XML, or codeclimate JSON. Currently ARC-1 returns raw ATC results.
+
+**Why:** Standard output formats enable integration with CI/CD pipelines (GitHub Actions, Jenkins, GitLab CI) and code quality dashboards.
+
+**Implementation:**
+- Add `format` parameter to ATC handler in `src/handlers/intent.ts` (`raw`, `junit4`, `checkstyle`, `codeclimate`)
+- Formatter functions in new `src/adt/atc-formatters.ts`
+- Default to current format for LLM consumption; optional structured formats for CI/CD
+
+---
+
+### FEAT-43: DDIC Auth & Misc Read (Authorization Fields, Feature Toggles)
+| Field | Value |
+|-------|-------|
+| **Priority** | P2 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low |
+| **Usefulness** | Medium — niche but useful for authorization analysis |
+| **Status** | Not started |
+| **Source** | [sapcli comparison](../compare/09-sapcli.md), sapcli commit `2ec4228` (Apr 2026) |
+
+**What:** Add read support for Authorization Fields (`/sap/bc/adt/authorizationfields/{name}`, XML namespace `http://www.sap.com/iam/auth`), Feature Toggles (`/sap/bc/adt/sfw/featuretoggles`), and Enhancement Implementations (BAdI). sapcli recently added Authorization Fields (Apr 2026) and has had Feature Toggles since 2023.
+
+**Why:** Authorization analysis is important for security audits. Feature toggles are used in SAP's switch framework for conditional features.
+
+**Implementation:**
+- Add `getAuthorizationField(name)` to `src/adt/client.ts`
+- Add `getFeatureToggle(name)` to `src/adt/client.ts`
+- Add both types to SAPRead handler
+- XML parsing in `src/adt/xml-parser.ts` for the `auth:auth` namespace
 
 ---
 


### PR DESCRIPTION
Research the actual code changes in fr0ster/mcp-abap-adt v4.5.0
(LinkedIn post by Oleksij Kyslytsja) and evaluate relevance to ARC-1.

Key findings:
- Guaranteed unlock (try-finally): ARC-1 already has this via centralized
  safeUpdateSource() in crud.ts — superior to fr0ster's 9-handler fix
- 415/406 Content-Type auto-retry: ARC-1 already has this in http.ts with
  inferAcceptFromError() fallback. Only gap: per-endpoint header caching (P3)
- RAG tool descriptions: Not applicable to ARC-1's intent-based routing

New files:
- v4.5.0-release-deep-dive.md: Comprehensive analysis of all 6 commits
- 32ab9d4-try-finally-unlock.md: Lock safety pattern comparison
- b059736-adt-clients-415-negotiation.md: Content negotiation implementation

Updated: overview.md, commits.json, 05-fr0ster-mcp-abap-adt.md,
00-feature-matrix.md, 415-content-type-retry.md

https://claude.ai/code/session_01V5VSPhi1VLC99XkYoDHSyi