### PR TITLE
fix: enforce allowedPackages on all SAPWrite operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ handleToolCall (handlers/intent.ts)
   ├─ 1. Scope check: TOOL_SCOPES[toolName] vs authInfo.scopes (only when authInfo present)
   ├─ 2. Zod validation: getToolSchema(toolName) → safeParse(args) (rejects invalid input with LLM-friendly errors)
   ├─ 3. Route to handler: handleSAPRead(), handleSAPWrite(), etc.
-  ├─ 4. Package check: checkPackage(safety, packageName) (for SAPWrite create)
+  ├─ 4. Package check: checkPackage(safety, packageName) (for all SAPWrite actions: create, update, delete, edit_method)
   │
   ▼
 ADT Client Method (adt/client.ts, crud.ts, devtools.ts, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ npm run dev
 | `SAP_BLOCK_FREE_SQL` / `--block-free-sql` | Block RunQuery execution (default: false) |
 | `SAP_ALLOWED_OPS` / `--allowed-ops` | Whitelist operation types (e.g., "RSQ") |
 | `SAP_DISALLOWED_OPS` / `--disallowed-ops` | Blacklist operation types (e.g., "CDUA") |
-| `SAP_ALLOWED_PACKAGES` / `--allowed-packages` | Restrict to packages (default: `$TMP`; supports wildcards: "Z*") |
+| `SAP_ALLOWED_PACKAGES` / `--allowed-packages` | Restrict write operations to packages (default: `$TMP`; supports wildcards: "Z*"). Reads are not restricted by package. |
 | `SAP_ENABLE_TRANSPORTS` / `--enable-transports` | Enable CTS transport management (default: false) |
 | `ARC1_API_KEY` / `--api-key` | API key for MCP endpoint auth (Bearer token) |
 | `ARC1_API_KEYS` / `--api-keys` | Multiple API keys with profiles (`key1:viewer,key2:developer`) |
@@ -227,7 +227,7 @@ handleToolCall (handlers/intent.ts)
   ├─ 1. Scope check: TOOL_SCOPES[toolName] vs authInfo.scopes (only when authInfo present)
   ├─ 2. Zod validation: getToolSchema(toolName) → safeParse(args) (rejects invalid input with LLM-friendly errors)
   ├─ 3. Route to handler: handleSAPRead(), handleSAPWrite(), etc.
-  ├─ 4. Package check: checkPackage(safety, packageName) (for SAPWrite create)
+  ├─ 4. Package check: checkPackage(safety, packageName) (for all SAPWrite actions: create, update, delete, edit_method)
   │
   ▼
 ADT Client Method (adt/client.ts, crud.ts, devtools.ts, etc.)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Built for organizations that need AI-assisted SAP development with guardrails. I
 
 - **Read-only mode** — block all writes with a single flag (`--read-only`)
 - **Operation allowlists/denylists** — control exactly which operation types (read, write, search, query, activate, transport) are permitted
-- **Package restrictions** — limit AI access to specific packages with wildcards (`--allowed-packages "Z*,$TMP"`)
+- **Package restrictions** — limit AI write operations (create, update, delete) to specific packages with wildcards (`--allowed-packages "Z*,$TMP"`). Read operations are not restricted by package — use SAP's native authorization for read-level access control
 - **Data access control** — block table data preview (`--block-data`) or free-form SQL (`--block-free-sql`)
 - **Transport safety** — require transport assignments, restrict to specific transports, or make transports read-only. Update/delete operations auto-use the lock correction number when no explicit transport is provided
 - **Safety profiles** — preconfigured roles like `--profile viewer`, `developer-data`, or `developer-sql`

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -96,7 +96,7 @@ All connection and safety flags are available:
 # Read-only mode
 arc1 --read-only
 
-# Restrict packages
+# Restrict write operations to specific packages (reads are not restricted by package)
 arc1 --allowed-packages "ZPROD*,$TMP"
 
 # Block free-form SQL

--- a/docs/security-guide.md
+++ b/docs/security-guide.md
@@ -101,7 +101,7 @@ For full setup instructions, see [API Key Setup](api-key-setup.md).
 | `--read-only` | `true` for production systems | Prevents any write operations through ARC-1 |
 | `--block-free-sql` | `true` for sensitive systems | Blocks arbitrary SQL queries against the database |
 | `--block-data` | `true` unless table preview is required | Prevents named table content preview |
-| `--allowed-packages` | `Z*,Y*,$TMP` | Restricts operations to custom code packages (defaults to `$TMP` if not set) |
+| `--allowed-packages` | `Z*,Y*,$TMP` | Restricts write operations (create, update, delete) to custom code packages (defaults to `$TMP` if not set). Read operations are not restricted by package. |
 | `--pp-strict` | `true` when PP is enabled | Rejects requests without user identity (no fallback to shared account) |
 | `--enable-transports` | `false` unless needed | Transport management is opt-in |
 

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -466,4 +466,16 @@ export class AdtClient {
     );
     return resp.body;
   }
+
+  /**
+   * Resolve the ABAP package of an existing object by fetching its metadata.
+   * Returns the package name (e.g., "$TMP", "ZPACKAGE") or empty string if not found.
+   * Used by SAPWrite to enforce allowedPackages on update/delete/edit_method.
+   */
+  async resolveObjectPackage(objectUrl: string): Promise<string> {
+    checkOperation(this.safety, OperationType.Read, 'ResolveObjectPackage');
+    const resp = await this.http.get(objectUrl);
+    const match = resp.body.match(/adtcore:packageRef[^>]*adtcore:name="([^"]*)"/);
+    return match?.[1] ?? '';
+  }
 }

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -1159,8 +1159,17 @@ async function handleSAPWrite(
   const objectUrl = objectUrlForType(type, name);
   const srcUrl = sourceUrlForType(type, name);
 
+  // Helper: enforce allowedPackages for existing objects (update/delete/edit_method).
+  // Only fetches metadata when package restrictions are configured — no extra HTTP call otherwise.
+  async function enforcePackageForExistingObject(): Promise<void> {
+    if (client.safety.allowedPackages.length === 0) return;
+    const pkg = await client.resolveObjectPackage(objectUrl);
+    if (pkg) checkPackage(client.safety, pkg);
+  }
+
   switch (action) {
     case 'update': {
+      await enforcePackageForExistingObject();
       // Pre-write lint validation
       const lintWarnings = runPreWriteLint(source, type, name, config);
       if (lintWarnings.blocked) return lintWarnings.result!;
@@ -1215,6 +1224,7 @@ async function handleSAPWrite(
       if (!method) return errorResult('"method" is required for edit_method action.');
       if (!source) return errorResult('"source" (new method body) is required for edit_method action.');
       if (type !== 'CLAS') return errorResult('edit_method is only supported for type=CLAS.');
+      await enforcePackageForExistingObject();
 
       // Fetch current full source (use cache if available)
       const currentSource = cachingLayer
@@ -1243,6 +1253,7 @@ async function handleSAPWrite(
       return lintWarnings.warnings ? textResult(`${msg}\n\n${lintWarnings.warnings}`) : textResult(msg);
     }
     case 'delete': {
+      await enforcePackageForExistingObject();
       // Lock, delete, unlock pattern — auto-propagate lock corrNr if no explicit transport
       await client.http.withStatefulSession(async (session) => {
         const lock = await lockObject(session, client.safety, objectUrl);

--- a/tests/unit/adt/client.test.ts
+++ b/tests/unit/adt/client.test.ts
@@ -756,4 +756,40 @@ describe('AdtClient', () => {
       expect(apps).toEqual([]);
     });
   });
+
+  describe('resolveObjectPackage', () => {
+    it('extracts package name from ADT metadata XML', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          '<class:abapClass xmlns:adtcore="http://www.sap.com/adt/core" adtcore:name="ZCL_TEST"><adtcore:packageRef adtcore:uri="/sap/bc/adt/packages/%24tmp" adtcore:type="DEVC/K" adtcore:name="$TMP" adtcore:description="Local Objects"/></class:abapClass>',
+        ),
+      );
+      const client = createClient();
+      const pkg = await client.resolveObjectPackage('/sap/bc/adt/oo/classes/ZCL_TEST');
+      expect(pkg).toBe('$TMP');
+    });
+
+    it('returns empty string when no packageRef in response', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<some:element/>'));
+      const client = createClient();
+      const pkg = await client.resolveObjectPackage('/sap/bc/adt/programs/programs/ZTEST');
+      expect(pkg).toBe('');
+    });
+
+    it('extracts package from minimal packageRef element', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          '<prog:program xmlns:adtcore="http://www.sap.com/adt/core"><adtcore:packageRef adtcore:name="ZPACKAGE"/></prog:program>',
+        ),
+      );
+      const client = createClient();
+      const pkg = await client.resolveObjectPackage('/sap/bc/adt/programs/programs/ZTEST');
+      expect(pkg).toBe('ZPACKAGE');
+    });
+  });
 });

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -1225,6 +1225,123 @@ ENDCLASS.`;
       // Should not be blocked by package check (may fail at HTTP level, but that's OK)
       expect(result.content[0]?.text).not.toContain('blocked by safety');
     });
+
+    it('rejects update when object is in a non-allowed package', async () => {
+      // Mock: first call = resolveObjectPackage (GET object URL → XML with packageRef),
+      // subsequent calls = normal CSRF/lock/update/unlock flow
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          '<class:abapClass xmlns:adtcore="http://www.sap.com/adt/core" adtcore:name="ZCL_TEST"><adtcore:packageRef adtcore:name="ZFORBIDDEN"/></class:abapClass>',
+          { 'x-csrf-token': 'T' },
+        ),
+      );
+      const restrictedClient = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'admin',
+        password: 'secret',
+        safety: { ...unrestrictedSafetyConfig(), allowedPackages: ['$TMP'] },
+      });
+      const result = await handleToolCall(restrictedClient, DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'update',
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        source: 'CLASS zcl_test DEFINITION PUBLIC. ENDCLASS. CLASS zcl_test IMPLEMENTATION. ENDCLASS.',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('ZFORBIDDEN');
+      expect(result.content[0]?.text).toContain('blocked');
+    });
+
+    it('rejects delete when object is in a non-allowed package', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          '<program:abapProgram xmlns:adtcore="http://www.sap.com/adt/core"><adtcore:packageRef adtcore:name="SAP_BASIS"/></program:abapProgram>',
+          { 'x-csrf-token': 'T' },
+        ),
+      );
+      const restrictedClient = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'admin',
+        password: 'secret',
+        safety: { ...unrestrictedSafetyConfig(), allowedPackages: ['Z*', '$TMP'] },
+      });
+      const result = await handleToolCall(restrictedClient, DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'delete',
+        type: 'PROG',
+        name: 'SAPL_STANDARD',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('SAP_BASIS');
+      expect(result.content[0]?.text).toContain('blocked');
+    });
+
+    it('rejects edit_method when class is in a non-allowed package', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          '<class:abapClass xmlns:adtcore="http://www.sap.com/adt/core"><adtcore:packageRef adtcore:name="ZFORBIDDEN"/></class:abapClass>',
+          { 'x-csrf-token': 'T' },
+        ),
+      );
+      const restrictedClient = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'admin',
+        password: 'secret',
+        safety: { ...unrestrictedSafetyConfig(), allowedPackages: ['$TMP'] },
+      });
+      const result = await handleToolCall(restrictedClient, DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'edit_method',
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        method: 'do_something',
+        source: 'METHOD do_something. ENDMETHOD.',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('ZFORBIDDEN');
+      expect(result.content[0]?.text).toContain('blocked');
+    });
+
+    it('allows update when object is in an allowed package', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          '<class:abapClass xmlns:adtcore="http://www.sap.com/adt/core"><adtcore:packageRef adtcore:name="$TMP"/></class:abapClass>',
+          { 'x-csrf-token': 'T' },
+        ),
+      );
+      const restrictedClient = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'admin',
+        password: 'secret',
+        safety: { ...unrestrictedSafetyConfig(), allowedPackages: ['$TMP'] },
+      });
+      const result = await handleToolCall(restrictedClient, DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'update',
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        source: 'CLASS zcl_test DEFINITION PUBLIC. ENDCLASS. CLASS zcl_test IMPLEMENTATION. ENDCLASS.',
+      });
+      expect(result.content[0]?.text).not.toContain('blocked by safety');
+    });
+
+    it('skips package resolution when allowedPackages is empty (unrestricted)', async () => {
+      // With no package restrictions, resolveObjectPackage should NOT be called
+      const client = createClient(); // unrestricted safety
+      const result = await handleToolCall(client, DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'update',
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        source: 'CLASS zcl_test DEFINITION PUBLIC. ENDCLASS. CLASS zcl_test IMPLEMENTATION. ENDCLASS.',
+      });
+      // unrestricted config has empty allowedPackages → skip resolveObjectPackage
+      expect(result.content[0]?.text).not.toContain('blocked by safety');
+    });
   });
 
   // ─── SAPWrite Pre-Write Lint Gate ───────────────────────────────


### PR DESCRIPTION
## Summary

- **Security fix**: `checkPackage()` was only enforced on `create` and `batch_create` — `update`, `delete`, and `edit_method` could bypass `--allowed-packages` restrictions entirely
- Added `resolveObjectPackage()` to ADT client that fetches object metadata and extracts the package from `adtcore:packageRef`. Only called when `allowedPackages` is configured (no extra HTTP call when unrestricted)
- Updated docs (README, CLAUDE.md, AGENTS.md, security-guide, cli-guide) to clarify that `--allowed-packages` restricts **write operations only**, not reads — read-level access control is delegated to SAP native authorization

## Test plan

- [x] 3 new unit tests for `resolveObjectPackage()` (XML extraction, missing packageRef, minimal format)
- [x] 5 new handler tests: rejects update/delete/edit_method on forbidden packages, allows update on allowed package, skips resolution when unrestricted
- [x] All 1375 existing tests pass
- [x] Lint and typecheck clean
- [ ] Integration test on live SAP system: verify update/delete blocked for objects in non-allowed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)