### PR TITLE
docs: create plans

### DIFF
--- a/docs/plans/feat-13-ddic-domain-dataelement-write.md
+++ b/docs/plans/feat-13-ddic-domain-dataelement-write.md
@@ -1,0 +1,218 @@
+# Plan: FEAT-13 DDIC Domain/Data Element Write
+
+## Overview
+
+Add create, update, and delete support for DDIC Domains (DOMA) and Data Elements (DTEL) to the SAPWrite tool. Currently ARC-1 can read these objects but cannot write them, blocking full AI-assisted data modeling workflows (e.g., "create domain ZSTATUS with values A=Active, I=Inactive, then create a data element referencing it").
+
+The ADT API for DOMA/DTEL write was validated against the A4H test system. Key findings:
+
+1. **Create** uses POST to the collection URL (`/sap/bc/adt/ddic/domains`, `/sap/bc/adt/ddic/dataelements`) with type-specific v2 content types — NOT `application/xml` like other object types.
+2. **Update** uses the standard lock/PUT/unlock flow with stateful sessions (already supported by `http.withStatefulSession()`).
+3. **Delete** uses the standard lock/DELETE/unlock flow.
+4. **Content types**: Only v2 is supported (`application/vnd.sap.adt.domains.v2+xml`, `application/vnd.sap.adt.dataelements.v2+xml`). v1 returns 406.
+5. **Data element XML is strictly ordered** — every field from `typeKind` through `deactivateBIDIFiltering` must be present.
+6. **Domain fixed values** work via nested `<doma:fixValues>` elements in the create/update XML.
+
+Design approach: DOMA/DTEL writes differ from source-based objects (PROG, CLAS, etc.) because they have no `/source/main` endpoint — the entire object is defined by structured XML properties. This requires a new "metadata write" pattern: create sends the full XML body, update sends a PUT with the full XML body (not source text). This is fundamentally different from the existing create-then-write-source pattern.
+
+## Context
+
+### Current State
+
+- DOMA/DTEL **read** is fully implemented: `client.getDomain()`, `client.getDataElement()`, XML parsing, type definitions
+- DOMA/DTEL are in `SAPREAD_TYPES` but NOT in `SAPWRITE_TYPES`
+- `buildCreateXml()` has no cases for DOMA/DTEL
+- The existing `create` action in SAPWrite creates an object shell then writes source — this pattern doesn't work for DOMA/DTEL which have no source endpoint
+- `safeUpdateSource()` writes text/plain to `/source/main` — DOMA/DTEL updates need XML PUT to the object URL itself
+
+### Target State
+
+- SAPWrite supports `create`, `update`, `delete` for DOMA and DTEL
+- Domain creates accept: dataType, length, decimals, outputLength, conversionExit, signExists, lowercase, fixedValues, valueTable
+- Data element creates accept: typeKind (domain or predefinedAbapType), typeName/domainName, dataType, length, decimals, labels (short/medium/long/heading), searchHelp, searchHelpParameter, setGetParameter, changeDocument
+- Updates use lock/PUT/unlock with the full XML body
+- Deletes follow existing lock/DELETE/unlock pattern (already works, just needs type routing)
+- `batch_create` also supports DOMA/DTEL for end-to-end data modeling in one call
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/crud.ts` | CRUD operations: lock/update/delete/create patterns |
+| `src/adt/client.ts` | ADT client facade — getDomain(), getDataElement() at lines 300-311 |
+| `src/adt/types.ts` | DomainInfo (line 240), DataElementInfo (line 256) — existing read types |
+| `src/adt/xml-parser.ts` | parseDomainMetadata() (line 354), parseDataElementMetadata() (line 405) |
+| `src/handlers/intent.ts` | handleSAPWrite() (line 1142), buildCreateXml() (line 954), objectBasePath() (line 1074) |
+| `src/handlers/schemas.ts` | SAPWRITE_TYPES arrays (line 121-122), SAPWriteSchema (line 138) |
+| `src/handlers/tools.ts` | SAPWRITE_TYPES arrays (line 101-102), tool descriptions (line 104) |
+| `src/handlers/hyperfocused.ts` | Hyperfocused mode — may need DOMA/DTEL write references |
+| `src/adt/safety.ts` | checkOperation(), checkPackage() — already covers Create/Update/Delete |
+| `tests/unit/handlers/intent.test.ts` | SAPWrite handler tests |
+| `tests/unit/adt/crud.test.ts` | CRUD operation unit tests |
+| `tests/fixtures/xml/domain-metadata.xml` | Domain XML fixture (BUKRS) |
+| `tests/fixtures/xml/dataelement-metadata.xml` | Data element XML fixture (BUKRS) |
+
+### Design Principles
+
+1. **Metadata-write pattern, not source-write**: DOMA/DTEL have no `/source/main`. Creates send the full XML body; updates PUT the full XML body to the object URL. This is a new pattern distinct from source-based objects.
+2. **Type-specific content types are mandatory**: `application/vnd.sap.adt.domains.v2+xml` and `application/vnd.sap.adt.dataelements.v2+xml`. Generic `application/xml` returns 415.
+3. **Reuse existing CRUD primitives**: `lockObject()`, `unlockObject()`, `deleteObject()`, `createObject()` from `src/adt/crud.ts` all work for DOMA/DTEL — only the content type and body differ.
+4. **New `updateObject()` function**: Needed for metadata PUT (existing `updateSource()` writes text/plain). Add a parallel function that PUTs XML to the object URL.
+5. **Strict XML element ordering for data elements**: All fields must be present in exact order. Use a builder function that always emits every field.
+6. **Sensible defaults**: Omitted properties get safe defaults (empty strings, false booleans, "000000" for lengths). The LLM only needs to specify what matters.
+7. **Consistent safety**: All writes go through existing `checkOperation()` and `checkPackage()` gates. No new safety surface needed.
+
+## Development Approach
+
+- Test-first: add XML fixtures for create/update responses, then implement builders, then wire handlers
+- Each task ends with `npm test` passing
+- Integration tests validate against the A4H system
+- The new `updateObject()` function in crud.ts is the key primitive — it enables the lock/PUT-XML/unlock pattern for metadata objects
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add CRUD primitives for metadata objects
+
+**Files:**
+- Modify: `src/adt/crud.ts`
+- Modify: `tests/unit/adt/crud.test.ts`
+
+Add a new `updateObject()` function to `src/adt/crud.ts` that PUTs an XML body to an object URL with a custom content type. This parallels the existing `updateSource()` (line 68) but writes structured XML instead of text/plain to the object URL instead of `/source/main`.
+
+Also add a `safeUpdateObject()` convenience function (paralleling `safeUpdateSource()` at line 112) that wraps the lock/updateObject/unlock pattern with `withStatefulSession()`.
+
+- [ ] Add `updateObject(http, safety, objectUrl, body, lockHandle, contentType, transport?)` function to `src/adt/crud.ts`. It should call `checkOperation(safety, OperationType.Update, 'UpdateObject')`, then `http.put()` with the given content type (not text/plain). URL construction: append `?lockHandle=...` and optionally `&corrNr=...` — same pattern as `updateSource()` at line 78-85.
+- [ ] Add `safeUpdateObject(http, safety, objectUrl, body, contentType, transport?)` that wraps lock/updateObject/unlock in `withStatefulSession()` with try-finally. Follow the exact pattern of `safeUpdateSource()` at line 112-129, including `lock.corrNr` auto-propagation.
+- [ ] Update the `createObject()` function signature — it already accepts `contentType` parameter (line 56), so no change needed there. Just verify it works with the v2 content types.
+- [ ] Add unit tests (~6 tests): updateObject happy path, updateObject with transport, safeUpdateObject happy path with lock/unlock, safeUpdateObject corrNr auto-propagation, safeUpdateObject unlock-on-error, updateObject safety block. Mock pattern: `vi.mock('undici', ...)` with `mockResponse()` from `tests/helpers/mock-fetch.ts`.
+- [ ] Run `npm test` — all tests must pass
+
+### Task 2: Add XML builders for DOMA/DTEL create and update
+
+**Files:**
+- Modify: `src/handlers/intent.ts` (the `buildCreateXml()` function at line 954)
+- Create: `src/adt/ddic-xml.ts` (new file for DDIC XML builder functions)
+- Create: `tests/unit/adt/ddic-xml.test.ts`
+- Create: `tests/fixtures/xml/domain-create-response.xml`
+- Create: `tests/fixtures/xml/dataelement-create-response.xml`
+
+DOMA/DTEL creation XML is significantly more complex than other object types (which are just a root element with name/description/package). Domains need `<doma:content>` with type information, output information, and optional value information. Data elements need `<dtel:definition>` with ALL fields in strict order.
+
+- [ ] Create `src/adt/ddic-xml.ts` with two builder functions:
+  - `buildDomainXml(params: DomainCreateParams): string` — builds the full domain XML with `<doma:domain>` root element, namespace declarations (`xmlns:doma="http://www.sap.com/dictionary/domain"`, `xmlns:adtcore="http://www.sap.com/adt/core"`), `<adtcore:packageRef>`, and `<doma:content>` containing typeInformation, outputInformation, and valueInformation (with optional fixValues). Parameters: `{ name, description, package, dataType, length, decimals?, outputLength?, conversionExit?, signExists?, lowercase?, fixedValues?: Array<{low, high?, description}>, valueTable? }`.
+  - `buildDataElementXml(params: DataElementCreateParams): string` — builds the full data element XML with `<blue:wbobj>` root (namespace `xmlns:blue="http://www.sap.com/wbobj/dictionary/dtel"`), `<adtcore:packageRef>`, and `<dtel:dataElement>` with ALL fields in strict order: typeKind, typeName, dataType, dataTypeLength, dataTypeDecimals, shortFieldLabel, shortFieldLength, shortFieldMaxLength, mediumFieldLabel, mediumFieldLength, mediumFieldMaxLength, longFieldLabel, longFieldLength, longFieldMaxLength, headingFieldLabel, headingFieldLength, headingFieldMaxLength, searchHelp, searchHelpParameter, setGetParameter, defaultComponentName, deactivateInputHistory, changeDocument, leftToRightDirection, deactivateBIDIFiltering. Parameters: `{ name, description, package, typeKind, typeName?, domainName?, dataType?, length?, decimals?, shortLabel?, mediumLabel?, longLabel?, headingLabel?, searchHelp?, searchHelpParameter?, setGetParameter?, defaultComponentName?, changeDocument? }`.
+  - Both functions must use `escapeXml()` for all user-provided values (import from `intent.ts` or duplicate the 5-line helper).
+  - Length/decimal values must be zero-padded to 6 digits (e.g., `"4"` → `"000004"`) to match SAP's format. Label length fields should default to their maxLength values.
+- [ ] Export `DomainCreateParams` and `DataElementCreateParams` interfaces from `src/adt/ddic-xml.ts`.
+- [ ] Add `buildCreateXml()` cases for DOMA and DTEL in `src/handlers/intent.ts` (line 954). These should delegate to the new builder functions in `ddic-xml.ts`. The DOMA case uses `adtcore:type="DOMA/DD"`, DTEL uses `adtcore:type="DTEL/DE"`. Note: `buildCreateXml()` currently takes `(type, name, pkg, description)` — for DOMA/DTEL we need additional properties. Add an optional 5th parameter `properties?: Record<string, unknown>` to pass through domain/data element specific fields.
+- [ ] Add XML fixtures: `tests/fixtures/xml/domain-create-response.xml` (based on actual SAP response from test — domain with `adtcore:version="inactive"`), `tests/fixtures/xml/dataelement-create-response.xml`.
+- [ ] Add unit tests (~10 tests) in `tests/unit/adt/ddic-xml.test.ts`: buildDomainXml basic, buildDomainXml with fixed values, buildDomainXml with value table, buildDomainXml zero-padding, buildDataElementXml with domain reference, buildDataElementXml with predefined type, buildDataElementXml strict field ordering, buildDataElementXml with all optional fields, buildDataElementXml defaults for omitted fields, XML escaping of special characters.
+- [ ] Run `npm test` — all tests must pass
+
+### Task 3: Wire DOMA/DTEL into SAPWrite handler
+
+**Files:**
+- Modify: `src/handlers/intent.ts` (handleSAPWrite at line 1142)
+- Modify: `src/handlers/schemas.ts` (SAPWRITE_TYPES at line 121-122, SAPWriteSchema at line 138)
+- Modify: `src/handlers/tools.ts` (SAPWRITE_TYPES at line 101-102, descriptions at line 104)
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+Wire the new DOMA/DTEL write capability into the SAPWrite handler. This is the most complex task because DOMA/DTEL writes follow a different flow than source-based objects.
+
+- [ ] Add `'DOMA'` and `'DTEL'` to `SAPWRITE_TYPES_ONPREM` and `SAPWRITE_TYPES_BTP` in both `src/handlers/schemas.ts` (line 121-122) and `src/handlers/tools.ts` (line 101-102).
+- [ ] Add DOMA/DTEL-specific properties to the Zod schema in `src/handlers/schemas.ts`. Add optional fields to `SAPWriteSchema` (line 138): `dataType: z.string().optional()`, `length: z.coerce.number().optional()`, `decimals: z.coerce.number().optional()`, `outputLength: z.coerce.number().optional()`, `conversionExit: z.string().optional()`, `signExists: z.coerce.boolean().optional()`, `lowercase: z.coerce.boolean().optional()`, `fixedValues: z.array(z.object({low: z.string(), high: z.string().optional(), description: z.string().optional()})).optional()`, `valueTable: z.string().optional()`, `typeKind: z.enum(['domain', 'predefinedAbapType']).optional()`, `typeName: z.string().optional()`, `shortLabel: z.string().optional()`, `mediumLabel: z.string().optional()`, `longLabel: z.string().optional()`, `headingLabel: z.string().optional()`, `searchHelp: z.string().optional()`, `searchHelpParameter: z.string().optional()`, `setGetParameter: z.string().optional()`, `defaultComponentName: z.string().optional()`, `changeDocument: z.coerce.boolean().optional()`. Do the same for `SAPWriteSchemaBtp`. Also add these to the batch object schemas.
+- [ ] Update the `create` case in `handleSAPWrite()` (line 1182) to detect DOMA/DTEL and use a different flow:
+  - For DOMA: call `buildDomainXml()` with the DDIC properties from args, then `createObject()` with content type `application/vnd.sap.adt.domains.v2+xml; charset=utf-8`. The create URL is `/sap/bc/adt/ddic/domains` (the collection URL from `objectBasePath('DOMA')`). Do NOT attempt to write source after create (DOMA has no source).
+  - For DTEL: call `buildDataElementXml()` with properties from args, then `createObject()` with content type `application/vnd.sap.adt.dataelements.v2+xml; charset=utf-8`. Create URL: `/sap/bc/adt/ddic/dataelements`. No source write.
+  - Return a success message with the created object details.
+- [ ] Update the `update` case in `handleSAPWrite()` (line 1171) to detect DOMA/DTEL and use `safeUpdateObject()` instead of `safeUpdateSource()`. For update, the LLM sends the full property set (same fields as create). Build the XML body, then PUT it to the object URL with the v2 content type. This replaces the entire object definition.
+- [ ] Update the `delete` case — no changes needed. The existing lock/DELETE/unlock flow already works for DOMA/DTEL (verified on test system). `objectUrlForType()` already returns the correct URL for DOMA/DTEL (line 1102-1105).
+- [ ] Update the `batch_create` case (line 1274) to handle DOMA/DTEL objects: use the metadata-write flow (no source step, no lint step) and the correct content type.
+- [ ] Update SAPWrite tool descriptions in `src/handlers/tools.ts` (lines 104-114) to mention DOMA and DTEL support with property descriptions.
+- [ ] Add unit tests (~12 tests): create DOMA with basic properties, create DOMA with fixed values, create DTEL with domain reference, create DTEL with predefined type, update DOMA (mock lock/PUT/unlock), update DTEL, delete DOMA, delete DTEL, batch_create with DOMA+DTEL, DOMA create with package check, DTEL create in read-only mode (blocked), Zod schema validation for DOMA/DTEL properties.
+- [ ] Run `npm test` — all tests must pass
+
+### Task 4: Add integration tests
+
+**Files:**
+- Modify: `tests/integration/crud.lifecycle.integration.test.ts`
+- Modify: `tests/integration/crud-harness.ts` (if new helpers needed)
+
+Add integration tests that exercise the full DOMA/DTEL CRUD lifecycle against the real SAP system. These tests require `TEST_SAP_URL` to be set.
+
+- [ ] Add a `describe('DOMA CRUD lifecycle')` block in `tests/integration/crud.lifecycle.integration.test.ts`:
+  - Generate unique name using `generateUniqueName('ZARC1_TDOM')` from `crud-harness.ts`
+  - Create a domain with `CHAR` type, length 1, two fixed values (A=Active, I=Inactive)
+  - Read back and verify: dataType, length, fixedValues match
+  - Update: change length to 2, add a third fixed value
+  - Read back and verify updates applied
+  - Delete the domain
+  - Read back — expect 404
+  - Use `try/finally` for cleanup (delete in finally block, `// best-effort-cleanup` tag)
+- [ ] Add a `describe('DTEL CRUD lifecycle')` block:
+  - Generate unique name using `generateUniqueName('ZARC1_TDEL')`
+  - Create a data element with `typeKind: 'predefinedAbapType'`, `dataType: 'CHAR'`, length 10, labels (short/medium/long/heading)
+  - Read back and verify: typeKind, dataType, length, labels match
+  - Update: change labels
+  - Read back and verify updates
+  - Delete the data element
+  - Read back — expect 404
+  - Cleanup via `try/finally`
+- [ ] Add a `describe('DOMA+DTEL dependency lifecycle')` block:
+  - Create a domain, then create a data element referencing it (`typeKind: 'domain'`, `typeName: domainName`)
+  - Read the data element back, verify it references the domain
+  - Delete data element first, then domain (reverse dependency order)
+  - Cleanup via `try/finally`
+- [ ] Use `requireOrSkip(ctx, testUrl, SkipReason.NO_CREDENTIALS)` for credential checks. Use `expectSapFailureClass()` for expected errors.
+- [ ] Run `npm run test:integration` (if SAP credentials available) or verify tests compile with `npm run typecheck`
+
+### Task 5: Add E2E tests
+
+**Files:**
+- Modify: `tests/e2e/fixtures.ts`
+- Create: `tests/e2e/ddic-write.e2e.test.ts`
+
+Add E2E tests that exercise DOMA/DTEL write through the full MCP JSON-RPC stack.
+
+- [ ] Add a new E2E test file `tests/e2e/ddic-write.e2e.test.ts` with tests for:
+  - SAPWrite create DOMA — call via MCP `callTool('SAPWrite', {action: 'create', type: 'DOMA', name: uniqueName, package: '$TMP', dataType: 'CHAR', length: 1, fixedValues: [{low: 'X', description: 'Test'}]})`. Use `expectToolSuccess()`. Clean up in `finally` with delete.
+  - SAPWrite create DTEL — call via MCP with domain-based and predefined type variants.
+  - SAPWrite update DOMA — create, then update with new properties, read back to verify.
+  - SAPWrite delete DOMA/DTEL — create then delete, verify 404 on re-read.
+  - SAPWrite batch_create with DOMA+DTEL — create domain then data element referencing it in one batch call.
+- [ ] Use `connectClient()` and helpers from `tests/e2e/helpers.ts`. Use `generateUniqueName()` for collision-safe names. All transient objects cleaned up in `finally` blocks.
+- [ ] Run `npm run test:e2e` (if MCP server running) or verify with `npm run typecheck`
+
+### Task 6: Update documentation and roadmap
+
+**Files:**
+- Modify: `docs/tools.md`
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+- Modify: `README.md` (if feature list needs updating)
+- Modify: `.claude/commands/implement-feature.md` (if it references SAPWrite capabilities)
+
+- [ ] Update `docs/tools.md` SAPWrite section: add DOMA and DTEL to the supported types list, document the DDIC-specific parameters (dataType, length, fixedValues, typeKind, labels, etc.), add example calls for creating a domain with fixed values and creating a data element referencing a domain.
+- [ ] Update `docs/roadmap.md`: change FEAT-13 status from "Not started" to "Done", add completion date.
+- [ ] Update `compare/00-feature-matrix.md`: change Domain write and Data element write from ❌ to ✅, refresh "Last Updated" date.
+- [ ] Update `CLAUDE.md`:
+  - Add `src/adt/ddic-xml.ts` to the codebase structure tree under `src/adt/`
+  - Add row to "Key Files for Common Tasks" table: "Add DDIC domain/data element write" → `src/adt/ddic-xml.ts`, `src/adt/crud.ts`, `src/handlers/intent.ts`
+  - Update config table if any new config options were added
+  - Update SAPWrite types list in any example or reference
+- [ ] Check `.claude/commands/implement-feature.md` and other skills for references to SAPWrite supported types that need DOMA/DTEL added.
+- [ ] Run `npm test` — all tests still pass after doc changes
+
+### Task 7: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Verify DOMA/DTEL appear in SAPWrite tool schema (check JSON schema output)
+- [ ] Verify existing SAPRead for DOMA/DTEL still works (no regressions)
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/flp-launchpad-management.md
+++ b/docs/plans/flp-launchpad-management.md
@@ -1,0 +1,348 @@
+# FLP Launchpad Management (FEAT-40)
+
+## Overview
+
+This plan adds Fiori Launchpad (FLP) management capabilities to ARC-1, enabling LLM-driven automation of catalog, group, tile, and target mapping configuration via the SAP OData service `/sap/opu/odata/UI2/PAGE_BUILDER_CUST`.
+
+sapcli has a full FLP implementation (`sap/flp/service.py`, `sap/flp/builder.py`) using three OData entity sets: `Catalogs`, `Pages` (groups), and `PageChipInstances` (tiles and target mappings). ARC-1 will expose equivalent read and write operations through `SAPManage` actions.
+
+**Test system verification (A4H, SAP_BASIS 758, verified 2026-04-12):**
+- The OData service `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` is **fully active** (HTTP 200). `$metadata` returns the complete EDM schema.
+- **Entity sets confirmed:** `Catalogs` (112 entries), `Pages` (41 entries), `PageChipInstances`, `Chips`, `Bags`, `Properties`, `ChipBags`, `ChipProperties`, `ChipInstanceBags`, `ChipInstanceProperties`, `PageSets`. Also 2 FunctionImports: `CloneCatalog`, `ClonePageChipInstance`.
+- **Supported formats:** `atom json xlsx` (per `sap:supported-formats` in metadata).
+- **CRUD verified:** POST to `Catalogs` returns HTTP 201 with the created entity. DELETE returns HTTP 204 (no content). CSRF token fetching works via the OData service root.
+- **Catalog entity properties:** `id`, `type`, `domainId`, `remoteType`, `title`, `systemAlias`, `remoteId`, `isReadOnly`, `originalLanguage`, `scope`, `baseUrl`, `chipCount`, `outdated`. Key: `id`. Navigation: `CatalogPage`, `Chips`.
+- **Page entity properties:** `id`, `title`, `catalogId`, `layout`, `originalLanguage`, `isCatalogPage`, `chipInstanceCount`, `isPersLocked`, `isReadOnly`, `scope`, `updated`, `outdated`. Key: `id`. Navigation: `Catalog`, `allCatalogs`, `PageChipInstances`, `Bags`.
+- **PageChipInstance properties:** `pageId` + `instanceId` (composite key), `chipId`, `title`, `configuration`, `layoutData`, `remoteCatalogId`, `referencePageId`, `referenceChipInstanceId`, `isReadOnly`, `scope`, `updated`, `outdated`. Navigation: `Chip`, `ReferenceChip`, `RemoteCatalog`, `ReferenceChipInstance`, `ChipInstanceBags`.
+- **Create catalog response:** `POST /Catalogs { domainId: "ZARC1_TEST_CAT", title: "ARC1 Test Catalog", type: "CATALOG_PAGE" }` → `201 Created` with `id: "X-SAP-UI2-CATALOGPAGE:ZARC1_TEST_CAT"`, `scope: "CUSTOMIZING"`, `chipCount: "0000"`. The SAP system prefixes `domainId` with `X-SAP-UI2-CATALOGPAGE:` to generate the `id`.
+- **Performance:** Unfiltered queries on large entity sets (112 catalogs) timeout after 30s without `$top`/`$select`. Always use `$top` and `$select` for listing operations.
+- **Known issue:** `PageChipInstances` with `$filter=pageId eq 'X-SAP-UI2-CATALOGPAGE:{id}'` triggers `ASSERTION_FAILED` for some catalog IDs (e.g., `/UI2/TEST_CHIP_CATALOG_1`, `SAP_BASIS_BCG_UI_WDR_UI_ELEMENTS`). Unfiltered `$top=N` queries work fine. The implementation should handle this error gracefully.
+- **Double-serialized JSON confirmed:** A real `PageChipInstance` configuration value: `{"tileConfiguration":"{\"semantic_object\":\"DataAgingObjectGroup\",\"semantic_action\":\"manageDAGrpT\",\"display_title_text\":\"Manage Data Aging Groups\",\"url\":\"/sap/bc/ui5_ui5/sap/bas_daggrp_man\",...}"}` — the `tileConfiguration` value is itself a JSON string that must be parsed a second time.
+
+**Design decision — SAPManage vs new tool:** FLP operations are added as new `SAPManage` actions rather than a separate tool. This keeps the tool count at 11 (design principle #3) and matches the management/admin nature of FLP configuration. Read operations (`flp_list_catalogs`, `flp_list_groups`) use `OperationType.Read`; write operations (`flp_create_catalog`, `flp_create_tile`, etc.) use `OperationType.Workflow`.
+
+## Context
+
+### Current State
+
+- ARC-1 has one existing OData client: `src/adt/ui5-repository.ts` (51 lines) querying `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` with JSON format, `Accept: application/json` header, and OData V2 `d`-property response parsing.
+- `SAPManage` currently has 3 actions: `features`, `probe`, `cache_stats` (lines 1975-2051 in `intent.ts`).
+- Feature detection in `src/adt/features.ts` probes 7 endpoints. No FLP probe exists.
+- sapcli's FLP implementation uses 3 entity sets on `PAGE_BUILDER_CUST`:
+  - `Catalogs` — business catalog CRUD (type `CATALOG_PAGE`). Test system has 112 catalogs including `/UI2/CATALOG_ALL`, `/UI2/FLPD_CATALOG`, and SAP_BASIS catalogs.
+  - `Pages` — groups/spaces CRUD (catalogId `/UI2/FLPD_CATALOG`). Test system has 41 pages including groups like `SAP_BASIS_BCG_UI_WDR_UI_ELEMENTS`.
+  - `PageChipInstances` — tiles, target mappings, tile-to-group assignments. Composite key: `(pageId, instanceId)`.
+- Tile configuration uses double-serialized JSON: the `configuration` field is a JSON string containing a `tileConfiguration` key whose value is also a JSON string. Verified on test system with real target mapping instances.
+- Key chip IDs: `X-SAP-UI2-CHIP:/UI2/STATIC_APPLAUNCHER` (tile), `X-SAP-UI2-CHIP:/UI2/ACTION` (target mapping). Both confirmed present on test system.
+- The OData service also exposes 2 FunctionImports: `CloneCatalog(sourceId, targetId, title)` and `ClonePageChipInstance(sourcePageId, sourceChipInstanceId, targetPageId)` — useful for future extensions but out of scope for initial implementation.
+- **Performance consideration:** The OData service is slow on large entity sets (30s+ for 112 catalogs without `$select`). All list operations must use `$top` (with configurable limit) and `$select` to avoid timeouts.
+
+### Target State
+
+- New module `src/adt/flp.ts` with OData client functions for FLP management.
+- 6 new `SAPManage` actions: `flp_list_catalogs`, `flp_list_groups`, `flp_create_catalog`, `flp_create_group`, `flp_create_tile`, `flp_add_tile_to_group`.
+- Feature detection for FLP availability via `PAGE_BUILDER_CUST` probe.
+- Unit tests for all OData parsing and handler routing.
+- Integration tests for live FLP queries.
+- Updated authorization documentation with FLP-specific SAP authorization objects (S_SERVICE, S_PB_CHIP, /UI2/CHIP).
+- Updated Cloud Connector documentation with required resource paths for `/sap/opu/odata/UI2/PAGE_BUILDER_CUST`.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/flp.ts` | **New** — OData client for PAGE_BUILDER_CUST (catalogs, groups, tiles) |
+| `src/adt/ui5-repository.ts` | Existing OData pattern to follow |
+| `src/adt/types.ts` | Add FLP type interfaces |
+| `src/adt/features.ts` | Add `flp` feature probe |
+| `src/adt/config.ts` | Add `flp` to FeatureConfig |
+| `src/handlers/intent.ts` | Add FLP actions to `handleSAPManage()` |
+| `src/handlers/tools.ts` | Update SAPManage action enum and descriptions |
+| `src/handlers/schemas.ts` | Update SAPManage Zod schema with FLP actions and params |
+| `tests/unit/adt/flp.test.ts` | **New** — Unit tests for FLP OData client |
+| `tests/unit/handlers/intent.test.ts` | Add FLP SAPManage action tests |
+
+### Design Principles
+
+1. **Follow existing OData pattern** — `ui5-repository.ts` is the template: `$format=json`, `Accept: application/json`, OData V2 `d`-property parsing, `checkOperation()` at entry point.
+2. **HTTP client reuse** — FLP OData uses the same `AdtHttpClient` as ADT. CSRF tokens, cookies, auth headers are all inherited. No new HTTP infrastructure needed.
+3. **Read-safe by default** — List operations use `OperationType.Read` (always allowed). Create/modify operations use `OperationType.Workflow` (blocked by `readOnly`).
+4. **Progressive implementation** — Start with read operations (list catalogs, list groups), then add write operations (create catalog, create tile, add tile to group). Reads are useful standalone for auditing existing FLP configuration.
+5. **Double-serialized JSON handling** — Tile configuration uses nested JSON strings (sapcli pattern). Parse on read, serialize on write. Expose clean JSON to the LLM, handle serialization internally.
+6. **Feature-gated** — Add FLP to the feature probe system. When PAGE_BUILDER_CUST is not active (404), FLP actions return a clear error message instead of a cryptic HTTP error.
+7. **Performance-aware queries** — Always use `$top` and `$select` for OData list queries. The test system (112 catalogs) shows that unfiltered queries without `$select` timeout after 30s. Default `$top=500` is a reasonable upper bound.
+8. **Graceful error handling for ASSERTION_FAILED** — Some `PageChipInstances` filter queries trigger SAP backend assertion errors for specific catalog page IDs. The implementation must catch these and return empty results with a warning, not throw.
+
+## Development Approach
+
+Unit tests mock `AdtHttpClient` using the same `mockHttp()` factory as `tests/unit/adt/ui5-repository.test.ts` (lines 7-16). OData JSON responses use helper functions wrapping `{ d: { results: [...] } }` for collections and `{ d: { ... } }` for single entities. Test data should use real field values from the A4H test system (e.g., `id: "/UI2/CATALOG_ALL"`, `chipId: "X-SAP-UI2-CHIP:/UI2/ACTION"`).
+
+Integration tests run against the live SAP system when `TEST_SAP_URL` is set. The A4H test system has the PAGE_BUILDER_CUST service fully active with 112 catalogs and 41 pages. CRUD integration tests are slow (~60-90s per create/delete operation) and must use `try/finally` for cleanup.
+
+**Important for the `mockHttp()` factory:** The mock must include a `delete` method (not present in the `ui5-repository.test.ts` mock since UI5 repo only reads). Add `delete: vi.fn().mockResolvedValue({ statusCode: 204, headers: {}, body: '' })` to match the real SAP DELETE response (HTTP 204, no body).
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add FLP type definitions and OData client (read operations)
+
+**Files:**
+- Modify: `src/adt/types.ts`
+- Create: `src/adt/flp.ts`
+
+This task creates the core FLP OData client module with read operations. It follows the same pattern as `src/adt/ui5-repository.ts`: import `AdtHttpClient`, `SafetyConfig`, `checkOperation`, use `$format=json`, parse OData V2 `d.results` responses.
+
+- [ ] In `src/adt/types.ts`, add these interfaces at the end of the file (after `BspDeployInfo` at line ~318). These match the OData `$metadata` entity types verified on the A4H test system:
+  ```typescript
+  /** FLP catalog from PAGE_BUILDER_CUST OData (entity: Catalog) */
+  export interface FlpCatalog {
+    id: string;           // e.g. "X-SAP-UI2-CATALOGPAGE:ZARC1_TEST_CAT" (auto-generated key)
+    domainId: string;     // e.g. "ZARC1_TEST_CAT" (user-provided ID)
+    title: string;        // e.g. "ARC1 Test Catalog"
+    type: string;         // e.g. "CATALOG_PAGE" or "" (empty for system catalogs)
+    scope: string;        // e.g. "CUSTOMIZING" (set automatically on create)
+    chipCount: string;    // e.g. "0000" (4-char counter)
+  }
+  /** FLP group (page) from PAGE_BUILDER_CUST OData (entity: Page) */
+  export interface FlpGroup {
+    id: string;           // e.g. "SAP_BASIS_BCG_UI_WDR_UI_ELEMENTS"
+    title: string;        // e.g. "Web Dynpro ABAP - UI Elements"
+    catalogId: string;    // always "/UI2/FLPD_CATALOG" for groups
+    layout: string;       // JSON string with order array, or empty
+  }
+  /** FLP tile/target mapping instance from PAGE_BUILDER_CUST OData (entity: PageChipInstance) */
+  export interface FlpTileInstance {
+    instanceId: string;   // e.g. "00O2TO3741QLWH4GV74AHMWQE"
+    chipId: string;       // e.g. "X-SAP-UI2-CHIP:/UI2/STATIC_APPLAUNCHER" or "X-SAP-UI2-CHIP:/UI2/ACTION"
+    pageId: string;       // e.g. "X-SAP-UI2-CATALOGPAGE:SAP_BASIS_TCR_T"
+    title: string;        // display title (often empty — title is in configuration)
+    configuration: Record<string, unknown> | null; // parsed double-serialized JSON
+  }
+  ```
+- [ ] Create `src/adt/flp.ts` with service path constant: `export const FLP_SERVICE_PATH = '/sap/opu/odata/UI2/PAGE_BUILDER_CUST';`
+- [ ] Add `listCatalogs(http, safety)` function: `GET ${FLP_SERVICE_PATH}/Catalogs?$format=json&$top=500&$select=id,domainId,title,type,scope,chipCount` with `Accept: application/json`. The `$top=500` and `$select` are critical — the test system has 112 catalogs and unfiltered queries without `$select` timeout after 30s. Parse `data.d.results` array, map to `FlpCatalog[]`. Use `checkOperation(safety, OperationType.Read, 'ListFlpCatalogs')`. Handle 404 gracefully (return empty array). Expected response shape: `{"d":{"results":[{"id":"/UI2/CATALOG_ALL","domainId":"/UI2/CATALOG_ALL","title":"Catalog with all Chips","type":"","scope":"","chipCount":"..."}]}}`.
+- [ ] Add `listGroups(http, safety)` function: `GET ${FLP_SERVICE_PATH}/Pages?$format=json&$top=500&$select=id,title,catalogId,layout&$filter=catalogId eq '/UI2/FLPD_CATALOG'` — filters to only FLP groups (not system pages). Parse to `FlpGroup[]`. Expected response: groups like `{"id":"SAP_BASIS_BCG_UI_WDR_UI_ELEMENTS","title":"Web Dynpro ABAP - UI Elements","catalogId":"/UI2/FLPD_CATALOG","layout":"{...}"}`.
+- [ ] Add `listTiles(http, safety, catalogId)` function: `GET ${FLP_SERVICE_PATH}/PageChipInstances?$format=json&$top=500&$select=pageId,instanceId,chipId,title,configuration&$filter=pageId eq 'X-SAP-UI2-CATALOGPAGE:${encodeURIComponent(catalogId)}'`. **Important:** some catalog page IDs cause `ASSERTION_FAILED` errors on the SAP backend (verified on test system). Catch this error and return an empty array with a warning message instead of throwing. Parse `configuration` field: it's a JSON string containing `tileConfiguration` which is also a JSON string. Parse both levels and return clean `FlpTileInstance[]`.
+- [ ] Add a helper function `parseTileConfiguration(configStr: string): Record<string, unknown> | null` that safely handles the double-JSON parsing, returning `null` if parsing fails.
+- [ ] Run `npm test` — all existing tests must pass
+
+### Task 2: Add unit tests for FLP OData client (read operations)
+
+**Files:**
+- Create: `tests/unit/adt/flp.test.ts`
+
+Add unit tests for the FLP OData client created in Task 1. Follow the test pattern from `tests/unit/adt/ui5-repository.test.ts`: mock `AdtHttpClient` with `vi.fn()`, create OData JSON helpers, assert URL construction and response parsing.
+
+- [ ] Create `tests/unit/adt/flp.test.ts` with a `mockHttp()` factory function identical to the one in `ui5-repository.test.ts` (lines 7-16)
+- [ ] Add OData helpers: `odataCollection(results)` → `JSON.stringify({ d: { results } })` and `odataSingle(entity)` → `JSON.stringify({ d: entity })`
+- [ ] Add test: `listCatalogs returns parsed catalogs` — mock response with the real OData shape: `{"d":{"results":[{"id":"/UI2/CATALOG_ALL","domainId":"/UI2/CATALOG_ALL","title":"Catalog with all Chips","type":"","scope":"","chipCount":"0042"},{"id":"X-SAP-UI2-CATALOGPAGE:ZARC1_TEST_CAT","domainId":"ZARC1_TEST_CAT","title":"ARC1 Test Catalog","type":"CATALOG_PAGE","scope":"CUSTOMIZING","chipCount":"0000"}]}}`. Assert correct URL contains `/Catalogs?$format=json&$top=500&$select=`, assert returned array has 2 entries with correct field mapping.
+- [ ] Add test: `listCatalogs returns empty array on 404` — mock 404 AdtApiError, assert returns `[]`
+- [ ] Add test: `listCatalogs sends Accept: application/json header` — assert `http.get` called with header `Accept: application/json`
+- [ ] Add test: `listGroups filters by catalogId` — assert URL contains `$filter=catalogId%20eq%20'/UI2/FLPD_CATALOG'` (URL-encoded space)
+- [ ] Add test: `listTiles parses double-serialized configuration` — use real response shape from test system: `configuration` is `'{"tileConfiguration":"{\\"semantic_object\\":\\"DataAgingObjectGroup\\",\\"semantic_action\\":\\"manageDAGrpT\\",\\"display_title_text\\":\\"Manage Data Aging Groups\\"}"}'`. Assert the returned tile has `configuration.semantic_object === 'DataAgingObjectGroup'` and `configuration.display_title_text === 'Manage Data Aging Groups'`.
+- [ ] Add test: `listTiles handles malformed configuration gracefully` — mock response with `configuration: "C1"` (real value found on test system for tic-tac-toe gadget). Assert `configuration` is `null`.
+- [ ] Add test: `listTiles handles ASSERTION_FAILED error gracefully` — mock `http.get` throwing `AdtApiError` with status 500 and body containing `ASSERTION_FAILED`. Assert returns empty array (not throw), since this is a known SAP backend issue for some catalog page IDs.
+- [ ] Add test: `listCatalogs throws on safety check when Read is blocked` — use `{ disallowedOps: 'R' }` safety config
+- [ ] Run `npm test` — all tests pass (~9 new tests)
+
+### Task 3: Add FLP write operations to OData client
+
+**Files:**
+- Modify: `src/adt/flp.ts`
+
+Add create operations following sapcli's `sap/flp/service.py` patterns. Write operations use `POST` with JSON payload and require CSRF tokens (handled automatically by `AdtHttpClient`).
+
+- [ ] Add `createCatalog(http, safety, domainId, title)` function: `POST ${FLP_SERVICE_PATH}/Catalogs` with JSON body `{ domainId, title, type: 'CATALOG_PAGE' }`, Content-Type `application/json`, Accept `application/json`. Use `checkOperation(safety, OperationType.Workflow, 'CreateFlpCatalog')`. Return the created catalog entity. **Verified on test system:** Returns HTTP 201 with full entity including auto-generated `id: "X-SAP-UI2-CATALOGPAGE:${domainId}"`, `scope: "CUSTOMIZING"`, `chipCount: "0000"`. The `domainId` is the user-provided ID; SAP generates the prefixed `id`. **Performance note:** This operation takes ~30-60s on the test system — the HTTP client timeout may need consideration.
+- [ ] Add `createGroup(http, safety, id, title)` function: `POST ${FLP_SERVICE_PATH}/Pages` with JSON body `{ id, title, catalogId: '/UI2/FLPD_CATALOG', layout: '' }`. Use `checkOperation(safety, OperationType.Workflow, 'CreateFlpGroup')`.
+- [ ] Add `createTile(http, safety, catalogId, tile)` function: `POST ${FLP_SERVICE_PATH}/PageChipInstances` with JSON body matching sapcli's pattern: `chipId: 'X-SAP-UI2-CHIP:/UI2/STATIC_APPLAUNCHER'`, `pageId: 'X-SAP-UI2-CATALOGPAGE:${catalogId}'`, `scope: 'CUSTOMIZING'`, `configuration` field as double-serialized JSON string. Accept a `tile` parameter with: `{ id, title, icon, semanticObject, semanticAction, url?, subtitle?, info? }`. Return the created instance (including `instanceId`).
+- [ ] Add `addTileToGroup(http, safety, groupId, catalogId, tileInstanceId)` function: `POST ${FLP_SERVICE_PATH}/PageChipInstances` with body `{ chipId: 'X-SAP-UI2-PAGE:X-SAP-UI2-CATALOGPAGE:${catalogId}:${tileInstanceId}', pageId: groupId }`. Use `checkOperation(safety, OperationType.Workflow, 'AddFlpTileToGroup')`.
+- [ ] Add `deleteCatalog(http, safety, catalogId)` function: `DELETE ${FLP_SERVICE_PATH}/Catalogs('${encodeURIComponent(catalogId)}')`. The `catalogId` parameter is the full OData key (e.g., `X-SAP-UI2-CATALOGPAGE:ZARC1_TEST_CAT`). Use `checkOperation(safety, OperationType.Workflow, 'DeleteFlpCatalog')`. **Verified on test system:** Returns HTTP 204 (no content) on success. No response body.
+- [ ] Run `npm test` — all existing tests must pass
+
+### Task 4: Add unit tests for FLP write operations
+
+**Files:**
+- Modify: `tests/unit/adt/flp.test.ts`
+
+Add tests for write operations. Write operations use `http.post()` and `http.delete()`. Assert request body, headers, and CSRF flow.
+
+- [ ] Add test: `createCatalog sends correct OData POST` — assert URL is `${FLP_SERVICE_PATH}/Catalogs`, body is JSON with `{ domainId: 'ZARC1_TEST', title: 'Test', type: 'CATALOG_PAGE' }`, Content-Type is `application/json`. Mock response should return 201 with entity including auto-generated `id: 'X-SAP-UI2-CATALOGPAGE:ZARC1_TEST'` (matching real SAP behavior).
+- [ ] Add test: `createCatalog uses Workflow operation type` — use safety config with `disallowedOps: 'W'`, assert throws `blocked by safety`
+- [ ] Add test: `createTile serializes double-JSON configuration` — call `createTile()` with tile data, assert the body sent to `http.post()` has `configuration` as a JSON string containing `tileConfiguration` as a nested JSON string
+- [ ] Add test: `createTile uses correct chipId and pageId` — assert body has `chipId: 'X-SAP-UI2-CHIP:/UI2/STATIC_APPLAUNCHER'` and `pageId: 'X-SAP-UI2-CATALOGPAGE:MY_CATALOG'`
+- [ ] Add test: `addTileToGroup constructs composite chipId` — assert body `chipId` matches `'X-SAP-UI2-PAGE:X-SAP-UI2-CATALOGPAGE:CATALOG:TILE123'`
+- [ ] Add test: `deleteCatalog sends DELETE with encoded key` — call `deleteCatalog(http, safety, 'X-SAP-UI2-CATALOGPAGE:ZARC1_TEST')`. Assert `http.delete` called with URL containing `Catalogs('X-SAP-UI2-CATALOGPAGE%3AZARC1_TEST')` (colon encoded). Mock 204 response (no body, matching real SAP behavior).
+- [ ] Add test: `createGroup sends correct payload` — assert body has `catalogId: '/UI2/FLPD_CATALOG'` and `layout: ''`
+- [ ] Run `npm test` — all tests pass (~7 new tests)
+
+### Task 5: Add FLP feature probe
+
+**Files:**
+- Modify: `src/adt/features.ts`
+- Modify: `src/adt/types.ts`
+- Modify: `src/adt/config.ts`
+
+Add FLP as a probed feature so that FLP availability is detected at startup.
+
+- [ ] In `src/adt/features.ts`, add a new probe to the `PROBES` array (after the `ui5repo` entry at line 40): `{ id: 'flp', endpoint: '/sap/opu/odata/UI2/PAGE_BUILDER_CUST/', description: 'FLP customization (PAGE_BUILDER_CUST)' }`. Note the trailing slash — the OData service root responds with HTTP 200 on the test system (A4H). The probe uses HEAD, which should also return 200.
+- [ ] In `src/adt/types.ts`, add `flp: FeatureStatus;` to the `ResolvedFeatures` interface (after `ui5repo` at line ~46)
+- [ ] In `src/adt/config.ts`, find the `FeatureConfig` interface and add `flp: FeatureMode;`. Find the `defaultFeatureConfig()` function and add `flp: 'auto'` to defaults.
+- [ ] In `src/adt/features.ts`, add `flp: config.flp` to the `modeMap` record in `probeFeatures()` (line ~81)
+- [ ] In `src/adt/features.ts`, add `flp: 'FLP customization (PAGE_BUILDER_CUST)'` to the `descriptions` record in `resolveWithoutProbing()` (line ~336)
+- [ ] In `src/handlers/intent.ts`, add `featureConfig.flp = config.featureFlp as 'auto' | 'on' | 'off';` in the probe action handler (after line ~2022), and add `featureFlp` field to `ServerConfig` if needed (check `src/server/types.ts`)
+- [ ] Run `npm test` — all existing tests must pass. Some feature probe tests in `tests/unit/adt/features.test.ts` may need updating to account for the new `flp` feature.
+
+### Task 6: Wire FLP actions into SAPManage handler
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/tools.ts`
+
+Connect the FLP OData client to the SAPManage tool by adding new action cases.
+
+- [ ] In `src/handlers/schemas.ts` (line 250), update the SAPManage schema enum to include FLP actions:
+  ```typescript
+  action: z.enum(['features', 'probe', 'cache_stats', 'flp_list_catalogs', 'flp_list_groups', 'flp_list_tiles', 'flp_create_catalog', 'flp_create_group', 'flp_create_tile', 'flp_add_tile_to_group']),
+  ```
+  Also add optional FLP-specific parameters to the schema: `catalogId: z.string().optional()`, `groupId: z.string().optional()`, `title: z.string().optional()`, `domainId: z.string().optional()`, `tileInstanceId: z.string().optional()`, and a `tile` object schema for create_tile: `tile: z.object({ id: z.string(), title: z.string(), icon: z.string().optional(), semanticObject: z.string(), semanticAction: z.string(), url: z.string().optional(), subtitle: z.string().optional(), info: z.string().optional() }).optional()`
+- [ ] In `src/handlers/tools.ts`, update the SAPManage action enum at line 637 to include all FLP actions. Update the description strings `SAPMANAGE_DESC_ONPREM` (line 199) and `SAPMANAGE_DESC_BTP` (line 211) to document FLP actions:
+  ```
+  - "flp_list_catalogs": List FLP business catalogs
+  - "flp_list_groups": List FLP groups
+  - "flp_list_tiles": List tiles in a catalog (requires catalogId)
+  - "flp_create_catalog": Create a business catalog (requires domainId, title)
+  - "flp_create_group": Create a group (requires groupId, title)
+  - "flp_create_tile": Create a tile in a catalog (requires catalogId, tile object)
+  - "flp_add_tile_to_group": Add a tile to a group (requires groupId, catalogId, tileInstanceId)
+  ```
+  Also add parameter descriptions to the `inputSchema.properties` object for `catalogId`, `groupId`, `title`, `domainId`, `tileInstanceId`, and `tile`.
+- [ ] In `src/handlers/intent.ts`, add FLP action cases to the `handleSAPManage()` switch statement (before the `default:` case at line 2048). Import the FLP functions from `../adt/flp.js`. For each action:
+  - `flp_list_catalogs`: call `listCatalogs(client.http, client.safety)`, return `textResult(JSON.stringify(result, null, 2))`
+  - `flp_list_groups`: call `listGroups(client.http, client.safety)`
+  - `flp_list_tiles`: extract `catalogId` from args, require it, call `listTiles(client.http, client.safety, catalogId)`
+  - `flp_create_catalog`: extract `domainId`, `title` from args, call `createCatalog(...)`
+  - `flp_create_group`: extract args, call `createGroup(...)`
+  - `flp_create_tile`: extract `catalogId` and `tile` from args, call `createTile(...)`
+  - `flp_add_tile_to_group`: extract `groupId`, `catalogId`, `tileInstanceId` from args, call `addTileToGroup(...)`
+- [ ] For write actions, check FLP feature availability from `cachedFeatures` before executing. If `cachedFeatures?.flp?.available === false`, return a helpful error: `"FLP customization service (PAGE_BUILDER_CUST) is not available on this system. Check ICF service activation in SICF."`
+- [ ] Run `npm test` — all tests pass
+
+### Task 7: Add unit tests for SAPManage FLP action routing
+
+**Files:**
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+Add tests for FLP action routing in the SAPManage handler. Follow existing patterns in the file for SAPManage tests.
+
+- [ ] Add a `describe('SAPManage FLP actions', ...)` block
+- [ ] Add test: `flp_list_catalogs returns catalog list` — mock the ADT client's `http.get` to return an OData catalog response, call `handleToolCall` with `SAPManage` + `action: 'flp_list_catalogs'`. Assert the result contains parsed catalog JSON.
+- [ ] Add test: `flp_list_tiles requires catalogId` — call with `action: 'flp_list_tiles'` without `catalogId`. Assert error result.
+- [ ] Add test: `flp_create_catalog blocked in readOnly mode` — set `readOnly: true` in safety config, assert write operation is blocked
+- [ ] Add test: `flp_create_tile serializes configuration correctly` — verify the POST body contains double-serialized JSON
+- [ ] Add test: `unknown FLP action returns error` — call with `action: 'flp_unknown'`, assert error result listing available actions
+- [ ] Run `npm test` — all tests pass (~5 new tests)
+
+### Task 8: Add integration tests for FLP OData
+
+**Files:**
+- Modify: `tests/integration/adt.integration.test.ts`
+
+Add integration tests that probe the real SAP system for FLP service availability and attempt read operations.
+
+- [ ] Add a `describe('FLP (PAGE_BUILDER_CUST)', ...)` block in the integration test file
+- [ ] Add test: `probes FLP service availability` — call `http.get('/sap/opu/odata/UI2/PAGE_BUILDER_CUST/')` with `Accept: application/json`. Expected: HTTP 200 on A4H test system (service is confirmed active). Use `requireOrSkip(ctx, serviceAvailable, SkipReason.BACKEND_UNSUPPORTED)` if the service returns 404.
+- [ ] Add test: `lists catalogs` — call `listCatalogs()`, assert result is an array with length > 0 (A4H has 112 catalogs). Verify at least one catalog has `id` and `domainId` fields. Use `requireOrSkip` for service availability.
+- [ ] Add test: `lists groups` — call `listGroups()`, assert result is an array. On A4H, expect groups filtered by `catalogId eq '/UI2/FLPD_CATALOG'` (41 pages total, but not all are FLP groups).
+- [ ] Add test: `CRUD lifecycle — create and delete catalog` — create catalog with `domainId: 'ZARC1_INTTEST_' + Date.now()`, assert returned entity has `id` starting with `X-SAP-UI2-CATALOGPAGE:`. Then delete by the returned `id`, assert no error. Use `try/finally` for cleanup (delete in finally). This test is slow (~60-90s) due to SAP backend processing.
+- [ ] Wrap FLP tests in a conditional block: skip the entire describe if the FLP service probe returns 404. Use `requireOrSkip(ctx, serviceAvailable, SkipReason.BACKEND_UNSUPPORTED)`.
+- [ ] Run `npm run test:integration` — tests pass (confirmed: PAGE_BUILDER_CUST is active on A4H test system)
+
+### Task 9: Update documentation (roadmap, feature matrix, tools, CLAUDE.md)
+
+**Files:**
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `docs/tools.md`
+- Modify: `CLAUDE.md`
+
+Update project artifacts to reflect FLP feature completion.
+
+- [ ] In `docs/roadmap.md`: update FEAT-40 status from "Not started" to "Completed", add completion date. Move to the "Completed" table. Strike through in the prioritized execution order.
+- [ ] In `compare/00-feature-matrix.md`: update the FLP/OData row to show ✅ for ARC-1
+- [ ] In `docs/tools.md`: add FLP actions to the SAPManage tool reference section (currently at lines 474-521). Document each action, required parameters, and example responses.
+- [ ] In `CLAUDE.md`: update the "Key Files for Common Tasks" table to add a row for FLP: `Add FLP operation | src/adt/flp.ts, src/handlers/intent.ts, src/handlers/tools.ts, src/handlers/schemas.ts`. Update the codebase structure tree to include `src/adt/flp.ts`. Add `flp` to the FeatureConfig reference if the config table lists feature flags.
+- [ ] Run `npm run lint` — no lint errors in modified docs
+
+### Task 10: Update authorization & Cloud Connector documentation for FLP OData route
+
+**Files:**
+- Modify: `docs/authorization.md`
+- Modify: `docs/setup-guide.md` (or `docs/sap-trial-setup.md` if more appropriate)
+- Modify: `docs/principal-propagation-setup.md`
+- Modify: `docs/security-guide.md`
+
+The FLP feature uses a non-ADT OData endpoint (`/sap/opu/odata/UI2/PAGE_BUILDER_CUST`) that requires separate SAP authorization objects and explicit Cloud Connector resource whitelisting. Without these, FLP operations will fail with 403 (authorization) or connection errors (CC not routing the path).
+
+**SAP Authorization (verified via SAP Help Portal — [Authorizations for UI Services](https://help.sap.com/docs/ABAP_PLATFORM_NEW/9765143c554c4ec3951fb17ff80d8989/86fa207d3edd4ed987e66b547d1b3025.html)):**
+
+The PAGE_BUILDER_CUST OData service requires these SAP authorization objects beyond the standard ADT objects (S_ADT_RES, S_DEVELOP):
+
+| Auth Object | Field | Value | Purpose |
+|-------------|-------|-------|---------|
+| **S_SERVICE** | SRV_NAME | (hashed — see USOBHASH table) | OData service access for `/UI2/PAGE_BUILDER_CUST` |
+| | SRV_TYPE | HT | Hash type |
+| **S_PB_CHIP** | ACTIVITY | All (admin) or 03+16 (read-only) | Page builder access — required for catalog/tile operations |
+| | CHIP_NAME | (none or X-SAP-UI2*) | |
+| **/UI2/CHIP** | ACTIVITY | All (admin) or 03+16 (read-only) | Chip access — required for tile creation |
+| | /UI2/CHIP | X-SAP-UI2* | |
+| **S_DEVELOP** | OBJTYPE | IWSG | OData service group registration |
+| **S_TRANSPRT** | (standard) | | Required if FLP customizations are transported |
+
+SAP provides example roles: `SAP_FLP_ADMIN` (full admin — includes PAGE_BUILDER_CUST + CONF + PERS) and `SAP_FLP_USER` (end-user — only PAGE_BUILDER_PERS + INTEROP + LAUNCHPAD).
+
+- [ ] In `docs/authorization.md`, add FLP-specific authorization objects to the "Key SAP Authorization Objects" table (after `S_SQL_VIEW` at line ~249):
+  ```
+  | **S_SERVICE** | OData service start authorization (hashed SRV_NAME) | SAPManage (FLP actions) |
+  | **S_PB_CHIP** | Page builder chip access | SAPManage (FLP actions) |
+  | **/UI2/CHIP** | UI2 chip access | SAPManage (FLP actions) |
+  ```
+- [ ] In `docs/authorization.md`, add a new "Recommended SAP Roles" entry for FLP:
+  ```
+  | **ZMCP_FLP** | S_SERVICE (PAGE_BUILDER_CUST), S_PB_CHIP, /UI2/CHIP, S_DEVELOP (OBJTYPE=IWSG) | FLP launchpad management via SAPManage |
+  ```
+  Also add a note: "Alternatively, assign SAP standard role `SAP_FLP_ADMIN` which includes all required authorizations for FLP customization."
+- [ ] In `docs/authorization.md`, add a note in the "POST Needed for Read Operations" warning box that FLP list operations also use HTTP GET (not POST), but the OData service still requires S_SERVICE authorization.
+- [ ] In `docs/authorization.md`, add an "ICF Service Activation" subsection after the authorization objects table explaining that the PAGE_BUILDER_CUST OData service must be activated via transaction `/IWFND/MAINT_SERVICE` (see [SAP Help: Activate OData Services for FLP](https://help.sap.com/docs/FIORI_IMPLEMENTATION_740/bc700aa28d5c468c84969c3b33773710/b7383953fcabff4fe10000000a44176d.html)). List the required services: `/UI2/PAGE_BUILDER_CUST` (activated as `ZPAGE_BUILDER_CUST` in customer namespace). Verification: `curl -s -o /dev/null -w "%{http_code}" "$SAP_URL/sap/opu/odata/UI2/PAGE_BUILDER_CUST/"` should return 200.
+
+**Cloud Connector Resource Whitelisting:**
+
+The `sap-trial-setup.md` uses a permissive `/` wildcard for all paths. Production deployments with restrictive CC resource rules need to explicitly whitelist the FLP OData path. SAP's own documentation ([Expose Service Paths on SAP Cloud Connector](https://help.sap.com/docs/SAP_COPILOT/c7d829d2dff24c458f88fe7671e3ae8e/c50ef094c74440bebc95b1e6ed4a8df6.html)) lists `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` as a required whitelist path.
+
+- [ ] In `docs/principal-propagation-setup.md`, add a "Required Cloud Connector Resource Paths" section after the system mapping step (Step 2, line ~74). Document the minimum CC resource paths for ARC-1:
+  ```
+  | URL Path | Access Policy | Purpose |
+  |----------|--------------|---------|
+  | `/sap/bc/adt` | Path and all sub-paths | ADT API (all ARC-1 read/write operations) |
+  | `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` | Path and all sub-paths | FLP launchpad management (SAPManage FLP actions) |
+  | `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` | Path and all sub-paths | UI5 ABAP Repository (BSP deploy info) |
+  ```
+  Note: the trial setup guide uses `/` (all paths) which implicitly includes these. Production deployments should use explicit path whitelisting for defense-in-depth.
+- [ ] In `docs/security-guide.md`, add a note in the BTP-specific security section mentioning that FLP management operations require additional CC resource paths beyond `/sap/bc/adt` if restrictive path whitelisting is used.
+- [ ] In `docs/setup-guide.md` (if it exists) or `docs/sap-trial-setup.md`, add a note in the "Adding Resources" section (line ~558) that the `/` wildcard includes FLP OData paths, but production deployments should use explicit paths. List `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` as needed for FLP management.
+- [ ] Run `npm run lint` — no lint errors in modified docs
+
+### Task 11: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Verify FLP feature probe is included in `SAPManage probe` output (check feature list)
+- [ ] Verify `SAPManage flp_list_catalogs` is routed correctly (check handler switch)
+- [ ] Verify SAPManage tool description includes FLP actions (check tools.ts)
+- [ ] Verify `docs/authorization.md` includes FLP-specific auth objects (S_SERVICE, S_PB_CHIP, /UI2/CHIP)
+- [ ] Verify `docs/principal-propagation-setup.md` includes CC resource path for `/sap/opu/odata/UI2/PAGE_BUILDER_CUST`
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/http-resilience-and-namespace-audit.md
+++ b/docs/plans/http-resilience-and-namespace-audit.md
@@ -1,0 +1,183 @@
+# HTTP Resilience & Namespace Encoding Audit (FEAT-08, FEAT-14, FEAT-15)
+
+## Overview
+
+This plan addresses three P0/P1 roadmap items that harden ARC-1's HTTP resilience and URL safety:
+
+1. **FEAT-08 (Content-Type 415/406 Auto-Retry)** — Already fully implemented in `src/adt/http.ts:325-398` with 13 unit tests. The roadmap and feature matrix need updating to reflect completion.
+
+2. **FEAT-14 (401 Session Timeout Auto-Retry)** — Not yet implemented. SAP sessions expire after 15-30 minutes of idle time. When ARC-1 runs as a centralized gateway, idle gaps between user requests cause 401 responses that bubble up as errors mid-conversation. The fix: on 401, reset session state (cookies + CSRF token), re-authenticate, and retry the original request once. This follows the same pattern as the existing 403 CSRF retry and DB connection retry.
+
+3. **FEAT-15 (Namespace URL Encoding Audit)** — Code audit confirms `encodeURIComponent()` is consistently applied across all 35+ call sites in `client.ts`, `crud.ts`, `codeintel.ts`, `devtools.ts`, and `transport.ts`. Existing unit tests (`client.test.ts:370-389`, `crud.test.ts:104-114`, `devtools.test.ts:277-285`, `intent.test.ts:607-629`) verify namespaced objects encode correctly. However, `devtools.ts` interpolates object URLs/names into XML attributes without `escapeXmlAttr()` — inconsistent with `codeintel.ts` which does escape. This is a defense-in-depth fix (object URLs from `objectUrlForType()` are pre-encoded, but raw names in `activateBatch()` and `publishBody()` are not escaped).
+
+## Context
+
+### Current State
+
+**401 handling (FEAT-14):**
+- `src/adt/http.ts` handles 403 (CSRF retry, lines 294-322), 406/415 (content negotiation retry, lines 325-398), and DB connection errors (session reset + retry, lines 238-292).
+- 401 is NOT retried — it throws `AdtApiError` immediately via `handleResponse()` at line 442-444 (`if (status >= 400) { throw new AdtApiError(body.slice(0, 500), status, path, body); }`).
+- `src/adt/errors.ts` has `isSessionExpired` (for HTTP 400 + session timeout body) and `isUnauthorized` (for 401) properties on `AdtApiError`, but neither triggers retry.
+- For Basic Auth (on-premise): credentials are stored in `AdtHttpConfig` and sent on every request via `applyAuthHeader()` (line 584-588). A 401 after successful initial auth indicates session cookie staleness — clearing cookies and retrying with same credentials re-establishes the session.
+- For Bearer tokens (BTP ABAP): `bearerTokenProvider()` is called per-request (line 188-191) and handles token caching/refresh internally (`src/adt/oauth.ts`). A 401 means the cached token expired — calling the provider again triggers refresh.
+- Guard pattern exists: `dbRetryInProgress` flag (line 98) prevents infinite DB retry loops. Same pattern needed for 401.
+- **Live SAP test system verification (A4H, SAP_BASIS 758):** Sending a request with an invalid/expired session cookie (no auth header) returns HTTP 401 with headers: `www-authenticate: Basic realm="SAP NetWeaver Application Server [A4H/001]"`, `set-cookie: sap-usercontext=sap-client=001; path=/`. The response body is HTML (9321 bytes). This confirms the retry pattern: on 401, clear stale session cookies, re-apply Basic Auth (or refresh Bearer token), and retry.
+
+**Namespace encoding (FEAT-15):**
+- URL path encoding: 35+ `encodeURIComponent()` calls across `client.ts`, `crud.ts`, `codeintel.ts`, `devtools.ts`, `transport.ts`. All consistent.
+- XML attribute encoding: `codeintel.ts` uses `escapeXmlAttr()` (lines 14-19, 143, 189, 194). `transport.ts` uses `escapeXml()` (lines 68, 118-119). `devtools.ts` does NOT escape — lines 25, 45, 73, 130, 193, 226 interpolate URLs/names directly into XML.
+- Risk: Object names from `objectUrlForType()` are pre-encoded (safe), but `activateBatch()` receives `o.name` (raw) and `publishBody()` receives `name` (raw) — if a name contains `"`, `<`, or `&`, the XML breaks.
+
+### Target State
+
+- 401 responses trigger one automatic retry after session reset (cookies + CSRF cleared, credentials re-sent).
+- `devtools.ts` uses `escapeXmlAttr()` for all XML attribute interpolation, consistent with `codeintel.ts`.
+- FEAT-08 marked completed in roadmap and feature matrix.
+- FEAT-14 and FEAT-15 marked completed in roadmap and feature matrix.
+- All existing tests continue to pass; new tests cover 401 retry and XML escaping.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/http.ts` | Core HTTP transport — add 401 retry logic (main change) |
+| `src/adt/errors.ts` | Error types — already has `isUnauthorized` property |
+| `src/adt/devtools.ts` | Syntax check, activate, publish, ATC — add XML attribute escaping |
+| `src/adt/codeintel.ts` | Reference for `escapeXmlAttr()` pattern (already correct) |
+| `tests/unit/adt/http.test.ts` | HTTP client tests — add 401 retry tests |
+| `tests/unit/adt/devtools.test.ts` | DevTools tests — add XML escaping tests |
+| `docs/roadmap.md` | Update FEAT-08, FEAT-14, FEAT-15 status |
+| `compare/00-feature-matrix.md` | Update P0/P1 gap lists |
+
+### Design Principles
+
+1. **One retry, always guarded** — 401 retry uses the same `flag + try/finally` pattern as DB connection retry. Never infinite loops.
+2. **Session reset before retry** — Clear cookies + CSRF token so SAP's ICM assigns a fresh work process. This is the proven pattern from DB connection retry.
+3. **No retry inside stateful sessions** — When `sessionType === 'stateful'`, a 401 means the stateful session is gone. Retrying would create a new session but lose the lock. Still retry (the meaningful error like "lock not held" is more useful than "401 Unauthorized"), but log a warning.
+4. **Bearer token refresh on 401** — Call `bearerTokenProvider()` again before retry. The provider handles token lifecycle internally.
+5. **Defense-in-depth XML escaping** — Even though current object URLs are pre-encoded, escape all XML attribute interpolation to prevent future regressions.
+6. **Minimal scope** — FEAT-08 is already done, FEAT-15 is a small hardening fix. FEAT-14 is the main implementation work.
+
+## Development Approach
+
+The implementation follows the existing retry patterns in `src/adt/http.ts`. The 401 retry block should be structurally identical to the DB connection retry (lines 238-292) — same guard flag pattern, same `resetSession()` + cookie rebuild + `doFetch()` retry sequence, same audit logging. Tests use the established `vi.mock('undici')` + `mockResponse()` pattern from `tests/helpers/mock-fetch.ts`. Changes are isolated to the HTTP transport layer (FEAT-14) and XML body construction (FEAT-15).
+
+**Live SAP verification:** The A4H test system (SAP_BASIS 758) confirms that: (1) a request with an expired/invalid session cookie and no Basic Auth header returns HTTP 401 with `www-authenticate: Basic realm="SAP NetWeaver Application Server [A4H/001]"`; (2) re-sending the same request with valid Basic Auth credentials succeeds (HTTP 200) and establishes a new session via `Set-Cookie: SAP_SESSIONID_A4H_001=...`.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add 401 session timeout auto-retry to HTTP client
+
+**Files:**
+- Modify: `src/adt/http.ts`
+
+Add automatic retry on 401 responses in the `request()` method of `AdtHttpClient`. This follows the same pattern as the existing 403 CSRF retry (lines 294-322) and DB connection retry (lines 238-292).
+
+- [ ] Add a `private authRetryInProgress = false` guard field to `AdtHttpClient` (line ~98, next to `dbRetryInProgress`)
+- [ ] In the `request()` method, after the 406/415 content negotiation block (after line 398) and before the CSRF token store (line 401), add a 401 retry block. The block must handle both Basic Auth (on-premise) and Bearer token (BTP) auth modes. Reference: the `request()` method builds auth at lines 186-191 (`applyAuthHeader()` for Basic, `bearerTokenProvider()` for Bearer). The retry block:
+  - Check: `response.status === 401 && !this.authRetryInProgress`
+  - Set `authRetryInProgress = true` in try, reset in finally
+  - Log an audit warning: `"401 session expired — resetting session and retrying"` (use `logger.emitAudit()` matching the DB retry pattern at lines 241-250)
+  - Call `this.resetSession()` (line 546-549) to clear cookies + CSRF token
+  - Re-apply auth: call `this.applyAuthHeader(headers)` (line 584-588, re-applies Basic Auth from stored `config.username`/`config.password`). If `this.config.bearerTokenProvider` exists, call it to get a fresh token: `const token = await this.config.bearerTokenProvider(); headers.Authorization = 'Bearer ' + token;`
+  - Re-fetch CSRF token for modifying requests: `if (isModifyingMethod(method)) { await this.fetchCsrfToken(); headers['X-CSRF-Token'] = this.csrfToken; }`
+  - Rebuild cookie header from fresh jar (same pattern as DB retry, lines 262-270): iterate `this.cookieJar`, join as `k=v`, set `headers.Cookie` or `delete headers.Cookie` if empty
+  - Execute retry: `const retryResp = await this.doFetch(url, method, headers, body)`
+  - Store cookies from retry via `this.storeCookies(retryResp)`, then `const retryBody = await retryResp.text()`, then `this.handleResponse(retryResp.status, retryResp.headers, retryBody, path)`
+  - Log audit info on success: `"401 session retry succeeded"`
+  - Return the retry result
+- [ ] Ensure the 401 retry block is placed BEFORE the existing 403 CSRF retry block (line 294), since a 401 supersedes CSRF issues. Move the ordering so that in the `request()` method the checks flow: DB connection error → 401 session retry → 403 CSRF retry → 406/415 negotiation retry → normal response handling
+- [ ] Run `npm test` — all existing tests must pass (the new code path is not exercised yet)
+
+### Task 2: Add unit tests for 401 session timeout auto-retry
+
+**Files:**
+- Modify: `tests/unit/adt/http.test.ts`
+
+Add tests for the 401 retry logic in `AdtHttpClient`. Follow the existing test patterns in the same file (see "406/415 content negotiation retry" describe block at line 584 for structure).
+
+- [ ] Add a new `describe('401 session timeout auto-retry', ...)` block after the existing "406/415 content negotiation retry" block (after line ~750)
+- [ ] Add test: `retries GET on 401 after session reset` — mock first fetch → 401 (with response headers `www-authenticate: Basic realm="SAP..."`, `set-cookie: sap-usercontext=sap-client=001`), second fetch → 200 success. For a GET, no CSRF re-fetch is needed (only modifying methods need CSRF). Assert 2 fetch calls (original + retry), assert retry succeeds with status 200. Note: the 401 response from SAP includes `set-cookie` headers — the retry must send fresh cookies from `resetSession()`, not the stale ones.
+- [ ] Add test: `retries POST on 401 with fresh CSRF token` — mock CSRF fetch (HEAD to `/sap/bc/adt/core/discovery`) → 200 with `x-csrf-token: TOKEN1`, POST → 401, then on retry: CSRF re-fetch → 200 with `x-csrf-token: TOKEN2`, retry POST → 200. Assert CSRF token is refreshed, assert retry POST sends `X-CSRF-Token: TOKEN2` header.
+- [ ] Add test: `does not retry on 401 when already retrying (guard)` — mock first fetch → 401, retry also → 401. Assert only 2 fetches (original + one retry), assert throws `AdtApiError` with `statusCode: 401`. The `authRetryInProgress` guard prevents infinite recursion.
+- [ ] Add test: `does not retry non-401 errors` — mock fetch → 500. Assert only 1 fetch, assert throws `AdtApiError`
+- [ ] Add test: `clears cookies on 401 retry` — mock CSRF fetch → 200 with `Set-Cookie: SAP_SESSIONID_A4H_001=SESSION1`, GET → 401 with `Set-Cookie: sap-usercontext=sap-client=001`, retry GET → 200. Assert retry request Cookie header does NOT contain `SAP_SESSIONID_A4H_001=SESSION1` (the old session cookie was cleared by `resetSession()`).
+- [ ] Add test: `refreshes bearer token on 401 retry` — create client with `bearerTokenProvider` mock: `vi.fn().mockResolvedValueOnce('token1').mockResolvedValueOnce('token2')`. Mock GET → 401, retry → 200. Assert retry has `Authorization: Bearer token2`. This covers the BTP ABAP scenario where OAuth tokens expire.
+- [ ] Add test: `401 retry guard is per-request not per-instance` — two sequential requests that both get 401 on first try. Assert both retry successfully (guard resets between requests via `finally { this.authRetryInProgress = false }`).
+- [ ] Run `npm test` — all tests pass (~8 new tests)
+
+### Task 3: Add XML attribute escaping to devtools.ts
+
+**Files:**
+- Modify: `src/adt/devtools.ts`
+
+`devtools.ts` interpolates object URLs and names into XML attribute values without escaping, unlike `codeintel.ts` which uses `escapeXmlAttr()`. Add consistent escaping for defense-in-depth.
+
+- [ ] Add an `escapeXmlAttr()` function to `devtools.ts` (or import a shared one). Use the same implementation as `codeintel.ts:14-19`: replace `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;`, `'` → `&apos;`
+- [ ] In `syntaxCheck()` (line 25): the template literal `adtcore:uri="${objectUrl}"` — change to `adtcore:uri="${escapeXmlAttr(objectUrl)}"`. The objectUrl comes from `objectUrlForType()` and is pre-encoded via `encodeURIComponent`, but escaping is defense-in-depth.
+- [ ] In `activate()` (line 45): change `adtcore:uri="${objectUrl}"` to `adtcore:uri="${escapeXmlAttr(objectUrl)}"`
+- [ ] In `activateBatch()` (line 73): this is the **highest-risk** site — `o.name` is a raw object name (not URL-encoded), and `o.url` is a raw URL. The `.map()` call: `adtcore:uri="${o.url}" adtcore:name="${o.name}"` — change to `adtcore:uri="${escapeXmlAttr(o.url)}" adtcore:name="${escapeXmlAttr(o.name)}"`. A name like `ZCL_"TEST"` would break the XML attribute quoting without escaping.
+- [ ] In `publishBody()` (line 130): `adtcore:name="${name}"` — change to `adtcore:name="${escapeXmlAttr(name)}"`. The `name` parameter is a raw service binding name passed directly from the handler.
+- [ ] In `runUnitTests()` (line 193): change `adtcore:uri="${objectUrl}"` to `adtcore:uri="${escapeXmlAttr(objectUrl)}"`
+- [ ] In `runAtcCheck()` (line 226): change `adtcore:uri="${objectUrl}"` to `adtcore:uri="${escapeXmlAttr(objectUrl)}"`
+- [ ] Run `npm test` — all existing tests must pass (escaping is transparent for normal inputs)
+
+### Task 4: Add unit tests for XML attribute escaping in devtools
+
+**Files:**
+- Modify: `tests/unit/adt/devtools.test.ts`
+
+Add tests verifying that `escapeXmlAttr()` is applied in devtools XML body construction. The test file uses `vi.mock('undici')` + `mockResponse()` pattern.
+
+- [ ] Add test: `syntaxCheck escapes special chars in object URL` — call `syntaxCheck()` with an objectUrl containing `&` (e.g., `/sap/bc/adt/oo/classes/CL_TEST&FOO`). Assert the fetch body contains `&amp;` not raw `&`
+- [ ] Add test: `activate escapes special chars in object URL` — same pattern for `activate()`
+- [ ] Add test: `activateBatch escapes special chars in name and URL` — call `activateBatch()` with an object whose name contains `"` (e.g., `ZCL_"TEST"`). Assert the fetch body contains `&quot;` not raw `"`
+- [ ] Add test: `publishServiceBinding escapes name in XML body` — call `publishServiceBinding()` with a name containing `<` (e.g., `ZSRV<TEST`). Assert the fetch body contains `&lt;` not raw `<`
+- [ ] Run `npm test` — all tests pass (~4 new tests)
+
+### Task 5: Extract shared `escapeXmlAttr` utility to avoid duplication
+
+**Files:**
+- Modify: `src/adt/codeintel.ts`
+- Modify: `src/adt/devtools.ts`
+- Modify: `src/adt/transport.ts`
+
+After Task 3 adds a local `escapeXmlAttr()` to `devtools.ts`, three files have their own copy of XML escaping logic (`codeintel.ts:14-19`, `transport.ts:118-120`, `devtools.ts`). Extract to a shared location.
+
+- [ ] Add an `escapeXmlAttr()` export to `src/adt/xml-parser.ts` (which already exists and is the shared XML utility). The function: `export function escapeXmlAttr(s: string): string { return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;'); }`
+- [ ] Update `src/adt/codeintel.ts`: remove the local `escapeXmlAttr` function (lines 14-19), add `import { escapeXmlAttr } from './xml-parser.js'`
+- [ ] Update `src/adt/devtools.ts`: remove the local `escapeXmlAttr` function (added in Task 3), add `import { escapeXmlAttr } from './xml-parser.js'`
+- [ ] Update `src/adt/transport.ts`: rename local `escapeXml` (line 118) usage to use the shared `escapeXmlAttr` import. The `escapeXml` function in transport.ts lacks `'` → `&apos;` replacement — the shared version is more complete. Remove the local `escapeXml` function and import `escapeXmlAttr` from `./xml-parser.js`
+- [ ] Add a unit test in `tests/unit/adt/xml-parser.test.ts`: test `escapeXmlAttr` handles `&`, `<`, `>`, `"`, `'` and passes through normal strings unchanged
+- [ ] Run `npm test` — all tests pass
+
+### Task 6: Update documentation, roadmap, and feature matrix
+
+**Files:**
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+
+Update project artifacts to reflect FEAT-08 (already done), FEAT-14, and FEAT-15 completion.
+
+- [ ] In `docs/roadmap.md` overview table (lines 43-48): strike through FEAT-08, FEAT-14, FEAT-15 rows and add "Completed" date, following the FEAT-02 pattern on line 43
+- [ ] In `docs/roadmap.md` Phase A section (lines 138-142): strike through the three items and add completion notes
+- [ ] In `docs/roadmap.md` FEAT-08 detail section (line 246-267): update Status from "Not started" to "Completed" and add implementation note explaining it was already implemented in the transport write compatibility work
+- [ ] In `docs/roadmap.md` FEAT-14 detail section (line 271-286): update Status to "Completed" and add implementation note
+- [ ] In `docs/roadmap.md` FEAT-15 detail section (line 289-304): update Status to "Completed" and add implementation note about the audit confirming `encodeURIComponent` consistency + XML attribute escaping hardening
+- [ ] In `compare/00-feature-matrix.md` P0 section (line ~281-284): strike through "401 session timeout auto-retry" and mark as implemented
+- [ ] In `compare/00-feature-matrix.md` P1 section (line ~289): remove "namespace encoding audit" from the gap list (or strike through)
+- [ ] Move FEAT-08, FEAT-14, FEAT-15 entries to the "Completed" overview table in `docs/roadmap.md` (lines 92-130), with appropriate dates
+- [ ] Run `npm run lint` — no lint errors in modified docs
+
+### Task 7: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Verify 401 retry is exercised by checking test output for the new describe block
+- [ ] Verify XML escaping tests pass by checking test output for the new devtools tests
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/transport-enhancements.md
+++ b/docs/plans/transport-enhancements.md
@@ -8,7 +8,15 @@ Extend `SAPTransport` with the full CTS lifecycle: delete transport/task, reassi
 - `DELETE /sap/bc/adt/cts/transportrequests/{id}` → HTTP 200 (idempotent; 400 if already released)
 - Create with types K, W, T all return HTTP 201 (S and R need further testing — may require specific CTS config)
 - Change owner via `POST /{id}` with `tm:useraction="changeowner"` → HTTP 200
-- Transport contents (E071 objects): **NOT included** in GET response on trial system — the `addobject` mechanism requires proper CTS layer config. However, the `getTransport()` response XML already has the structure for `<tm:task>` nodes, and task objects would appear as nested `<tm:abapobject>` elements when the system records them. For now, we enhance parsing to capture whatever the system returns, and note that transport contents depend on CTS configuration.
+- Transport contents (E071 objects): **NOT included** in GET response on trial system — the `addobject` mechanism requires proper CTS layer config. However, the `getTransport()` response XML already has the structure for `<tm:task>` nodes, and task objects would appear as nested `<tm:abap_object>` elements when the system records them. For now, we enhance parsing to capture whatever the system returns, and note that transport contents depend on CTS configuration.
+
+**Reference implementation: [sapcli](https://github.com/jfilak/sapcli)** (`sap/adt/cts.py`) — trusted reference for CTS ADT operations. Key patterns adopted:
+- XML element for objects is `tm:abap_object` (with underscore), attributes: `tm:pgmid`, `tm:type`, `tm:name`, `tm:wbtype`, `tm:obj_desc`/`tm:obj_info`, `tm:lock_status`, `tm:position`
+- All three operations (delete, reassign, release) support `recursive` — release children first, skip already-released (status `R`)
+- Release response should be parsed for success/failure report (`ReleaseResponseHandler` in sapcli)
+- List transports sends dual Accept: `transportorganizertree.v1+xml, transportorganizer.v1+xml`
+- sapcli uses `PUT` for reassign with `tm:targetuser` attribute on root element; our A4H test showed `PUT` returns 400 but `POST` with nested `<tm:request tm:owner="...">` works — we use POST (likely SAP version difference, both are valid)
+- Create payload includes `tm:useraction="newrequest"` and a nested `<tm:task tm:owner="{owner}"/>` — we omit these as SAP accepts the simpler form
 
 **Bugs found during testing:**
 - `getTransport()` uses `CTS_ACCEPT_TREE` but should use `CTS_CONTENT_TYPE_ORGANIZER` — works via 406/415 retry fallback but wastes a round-trip
@@ -31,7 +39,7 @@ Current code:
 
 ### Target State
 
-SAPTransport supports 7 actions: `list`, `get`, `create`, `release`, `delete`, `reassign`, `release_recursive`. Create accepts a `type` parameter (K/W/T). Get response includes task objects when available.
+SAPTransport supports 7 actions: `list`, `get`, `create`, `release`, `delete`, `reassign`, `release_recursive`. Create accepts a `type` parameter (K/W/T). Delete and reassign also support a `recursive` flag (matching sapcli). Get response includes task objects when available.
 
 ### Key Files
 
@@ -52,9 +60,10 @@ SAPTransport supports 7 actions: `list`, `get`, `create`, `release`, `delete`, `
 
 1. **All new actions gated by `checkTransport()`** — delete and reassign are write operations (`isWrite: true`), matching create/release behavior.
 2. **Transport type limited to K/W/T** — Development-Correction (S) and Repair (R) require specific CTS config that most systems lack. Start with the 3 types confirmed working on the test system.
-3. **Recursive release is a new action, not a flag** — `release_recursive` as a distinct action prevents accidental recursive release when the LLM only intends single release.
-4. **Transport contents parsing is best-effort** — The GET response includes task objects only when the system records them. Parse whatever is available, don't fail if missing.
+3. **Recursive release is a new action, not a flag** — `release_recursive` as a distinct action prevents accidental recursive release when the LLM only intends single release. Delete and reassign accept a `recursive` boolean parameter (matching sapcli pattern).
+4. **Transport contents parsing is best-effort** — The GET response includes task objects only when the system records them. Parse whatever is available, don't fail if missing. Object attributes follow sapcli's `WorkbenchABAPObject` model: `pgmid`, `type`, `name`, `wbtype`, `description`, `locked`, `position`.
 5. **Fix Accept header bugs opportunistically** — `getTransport()` and `releaseTransport()` should use `CTS_CONTENT_TYPE_ORGANIZER`, not `CTS_ACCEPT_TREE`.
+6. **Follow sapcli patterns** — sapcli (`sap/adt/cts.py`) is the trusted reference implementation. Follow its XML structures, attribute names, and recursive operation patterns.
 
 ## Development Approach
 
@@ -74,18 +83,22 @@ Tasks are ordered: types first, then core transport functions, then handler wiri
 
 Add types for transport objects and fix the Accept header bugs found during SAP system testing.
 
-- [ ] In `src/adt/types.ts`, add `TransportObject` interface after the `TransportTask` interface (line ~110):
+- [ ] In `src/adt/types.ts`, add `TransportObject` interface after the `TransportTask` interface (line ~110). Follow sapcli's `WorkbenchABAPObject` model from `sap/adt/cts.py`:
   ```typescript
   export interface TransportObject {
-    pgmid: string;       // e.g., "R3TR", "LIMU"
-    object: string;      // e.g., "PROG", "CLAS", "METH"
-    objectName: string;  // e.g., "ZTEST_PROGRAM"
+    pgmid: string;       // e.g., "R3TR", "LIMU" — from tm:pgmid
+    type: string;        // e.g., "PROG", "CLAS", "TABD" — from tm:type
+    name: string;        // e.g., "ZTEST_PROGRAM" — from tm:name
+    wbtype: string;      // 2-letter workbench type code — from tm:wbtype
+    description: string; // object description — from tm:obj_desc or tm:obj_info
+    locked: boolean;     // lock status — from tm:lock_status ('X' = locked)
+    position: string;    // 6-digit zero-padded position — from tm:position
   }
   ```
 - [ ] In `src/adt/types.ts`, add `objects: TransportObject[]` to the `TransportTask` interface (line ~105-110)
 - [ ] In `src/adt/transport.ts`, fix `getTransport()` (line 50): change `Accept: CTS_ACCEPT_TREE` to `Accept: CTS_CONTENT_TYPE_ORGANIZER` — the single-transport endpoint requires the organizer media type, not the tree variant
 - [ ] In `src/adt/transport.ts`, fix `releaseTransport()` (line 89): change `Accept: CTS_ACCEPT_TREE` to `Accept: CTS_CONTENT_TYPE_ORGANIZER` — same issue
-- [ ] In `src/adt/transport.ts`, update `parseTransportList()` (line ~100-116) to extract `<tm:abapobject>` nodes from within each `<tm:task>` element, mapping attributes `@_pgmid`, `@_object`, `@_name` to `TransportObject[]`. Use `findDeepNodes(task, 'abapobject')` for extraction.
+- [ ] In `src/adt/transport.ts`, update `parseTransportList()` (line ~100-116) to extract `<tm:abap_object>` nodes (note: underscore in element name, per sapcli's SAX handler) from within each `<tm:task>` element. Map attributes: `@_pgmid` → `pgmid`, `@_type` → `type`, `@_name` → `name`, `@_wbtype` → `wbtype` (default `''`), `@_obj_desc` or `@_obj_info` → `description` (default `''`), `@_lock_status` → `locked` (`'X'` = true), `@_position` → `position` (default `'000000'`). Use `findDeepNodes(task, 'abap_object')` for extraction.
 - [ ] Run `npm test` — all tests must pass (some transport unit tests may need Accept header assertions updated)
 
 ### Task 2: Add deleteTransport, reassignTransport, and enhance createTransport
@@ -95,15 +108,15 @@ Add types for transport objects and fix the Accept header bugs found during SAP 
 
 Add the three new transport operations to the ADT layer.
 
-- [ ] Add `deleteTransport(http, safety, transportId)` function. SAP endpoint: `DELETE /sap/bc/adt/cts/transportrequests/{id}`. Use `checkTransport(safety, transportId, 'DeleteTransport', true)` — it's a write operation. The endpoint is idempotent (returns 200 even for non-existent transports) but returns 400 for already-released transports.
-- [ ] Add `reassignTransport(http, safety, transportId, newOwner)` function. SAP endpoint: `POST /sap/bc/adt/cts/transportrequests/{id}` with body:
+- [ ] Add `deleteTransport(http, safety, transportId, recursive?)` function. SAP endpoint: `DELETE /sap/bc/adt/cts/transportrequests/{id}`. Use `checkTransport(safety, transportId, 'DeleteTransport', true)` — it's a write operation. The endpoint is idempotent (returns 200 even for non-existent transports) but returns 400 for already-released transports. When `recursive=true`, first fetch the transport via `getTransport()`, then delete all unreleased tasks (status !== 'R') before deleting the parent — matching sapcli's `_delete_children()` pattern.
+- [ ] Add `reassignTransport(http, safety, transportId, newOwner, recursive?)` function. SAP endpoint: `POST /sap/bc/adt/cts/transportrequests/{id}` with body:
   ```xml
   <?xml version="1.0" encoding="UTF-8"?>
   <tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:useraction="changeowner">
     <tm:request tm:number="{id}" tm:owner="{newOwner}"/>
   </tm:root>
   ```
-  Use `CTS_CONTENT_TYPE_ORGANIZER` for both Content-Type and Accept. Use `checkTransport(safety, transportId, 'ReassignTransport', true)`.
+  Use `CTS_CONTENT_TYPE_ORGANIZER` for both Content-Type and Accept. Use `checkTransport(safety, transportId, 'ReassignTransport', true)`. When `recursive=true`, first reassign all unreleased tasks before the parent — matching sapcli's `_reassign_children()` pattern. Note: sapcli uses `PUT` with `tm:targetuser` on root, but our A4H testing confirmed `POST` with nested `<tm:request tm:owner>` works; `PUT` returned 400. Use POST.
 - [ ] Enhance `createTransport()` (line ~58-79) to accept an optional `transportType` parameter (default `'K'`). Replace the hardcoded `tm:type="K"` on line 68 with `tm:type="${escapeXml(transportType)}"`. Valid values are `'K'` (Workbench), `'W'` (Customizing), `'T'` (Transport of Copies).
 - [ ] Run `npm test` — all tests must pass
 
@@ -131,14 +144,16 @@ Connect the new transport functions to the MCP tool interface.
   - Add `'delete'`, `'reassign'`, `'release_recursive'` to the `action` enum
   - Add `type: z.enum(['K', 'W', 'T']).optional()` for transport type selection on create
   - Add `owner: z.string().optional()` for reassign target
+  - Add `recursive: z.boolean().optional()` for recursive delete/reassign (matches sapcli's `--recursive` flag)
 - [ ] In `src/handlers/tools.ts` (line ~647-663), update the SAPTransport tool definition:
   - Extend the `action` enum: `['list', 'get', 'create', 'release', 'delete', 'reassign', 'release_recursive']`
   - Add `type` property: `{ type: 'string', enum: ['K', 'W', 'T'], description: 'Transport type for create: K=Workbench (default), W=Customizing, T=Transport of Copies' }`
   - Add `owner` property: `{ type: 'string', description: 'New owner (for reassign)' }`
+  - Add `recursive` property: `{ type: 'boolean', description: 'Apply recursively to tasks (for delete/reassign). release_recursive always recurses.' }`
   - Update the tool description string (both `SAPTRANSPORT_DESC_ONPREM` and `SAPTRANSPORT_DESC_BTP`) to mention new actions
 - [ ] In `src/handlers/intent.ts` (line ~1806-1841), add cases to the `handleSAPTransport()` switch:
-  - `case 'delete'`: require `id`, call `deleteTransport()`, return success message
-  - `case 'reassign'`: require `id` and `owner`, call `reassignTransport()`, return success message
+  - `case 'delete'`: require `id`, pass `recursive` boolean, call `deleteTransport()`, return success message
+  - `case 'reassign'`: require `id` and `owner`, pass `recursive` boolean, call `reassignTransport()`, return success message
   - `case 'release_recursive'`: require `id`, call `releaseTransportRecursive()`, return JSON of released IDs
   - For `case 'create'`: pass `args.type` (cast to string, default `'K'`) as the new `transportType` parameter
   - Update the default error message to list all 7 supported actions
@@ -152,18 +167,22 @@ Connect the new transport functions to the MCP tool interface.
 
 Add comprehensive unit tests for the new transport operations. The existing test file has 28 tests following patterns with `vi.fn()` mock HTTP clients and `enabledSafety` config.
 
-- [ ] Add tests for `deleteTransport()` (~5 tests):
+- [ ] Add tests for `deleteTransport()` (~7 tests):
   - Blocked when transports not enabled
   - Blocked when transport read-only
   - Sends DELETE to correct URL with encoded transport ID
   - Succeeds on HTTP 200
   - Verify it passes correct headers
-- [ ] Add tests for `reassignTransport()` (~5 tests):
+  - Recursive: deletes unreleased tasks before parent (verify call order — tasks first, then parent)
+  - Recursive: skips already-released tasks (status 'R')
+- [ ] Add tests for `reassignTransport()` (~7 tests):
   - Blocked when transports not enabled
   - Blocked when transport read-only
   - Sends POST with correct XML body containing `tm:useraction="changeowner"` and new owner
   - Escapes special characters in owner name
   - Uses correct CTS_CONTENT_TYPE_ORGANIZER media type
+  - Recursive: reassigns unreleased tasks before parent
+  - Recursive: skips already-released tasks (status 'R')
 - [ ] Add tests for `createTransport()` with transport type (~3 tests):
   - Default type is 'K' when not specified (existing behavior preserved)
   - Type 'W' included in XML body as `tm:type="W"`
@@ -176,9 +195,10 @@ Add comprehensive unit tests for the new transport operations. The existing test
 - [ ] Add tests for Accept header fixes (~2 tests):
   - `getTransport()` sends `CTS_CONTENT_TYPE_ORGANIZER` Accept header (was `CTS_ACCEPT_TREE`)
   - `releaseTransport()` sends `CTS_CONTENT_TYPE_ORGANIZER` Accept header (was `CTS_ACCEPT_TREE`)
-- [ ] Add tests for transport object parsing (~2 tests):
-  - Tasks with `<tm:abapobject>` elements parsed into `objects` array
+- [ ] Add tests for transport object parsing (~3 tests):
+  - Tasks with `<tm:abap_object>` elements (underscore in name, per sapcli) parsed into `objects` array with all fields: pgmid, type, name, wbtype, description, locked, position
   - Tasks without objects return empty `objects` array
+  - Object with `tm:lock_status="X"` parses as `locked: true`, missing/empty parses as `locked: false`
 - [ ] Run `npm test` — all tests must pass
 
 ### Task 6: Unit tests for handler routing

--- a/docs/plans/transport-enhancements.md
+++ b/docs/plans/transport-enhancements.md
@@ -1,0 +1,267 @@
+# Transport Enhancements (FEAT-19 + FEAT-39)
+
+## Overview
+
+Extend `SAPTransport` with the full CTS lifecycle: delete transport/task, reassign owner, transport type selection (K/W/T/S/R), recursive release, and transport contents listing. This subsumes FEAT-19 (transport contents) into the broader FEAT-39 (transport enhancements).
+
+**SAP test system validation** confirmed all planned endpoints work on A4H:
+- `DELETE /sap/bc/adt/cts/transportrequests/{id}` → HTTP 200 (idempotent; 400 if already released)
+- Create with types K, W, T all return HTTP 201 (S and R need further testing — may require specific CTS config)
+- Change owner via `POST /{id}` with `tm:useraction="changeowner"` → HTTP 200
+- Transport contents (E071 objects): **NOT included** in GET response on trial system — the `addobject` mechanism requires proper CTS layer config. However, the `getTransport()` response XML already has the structure for `<tm:task>` nodes, and task objects would appear as nested `<tm:abapobject>` elements when the system records them. For now, we enhance parsing to capture whatever the system returns, and note that transport contents depend on CTS configuration.
+
+**Bugs found during testing:**
+- `getTransport()` uses `CTS_ACCEPT_TREE` but should use `CTS_CONTENT_TYPE_ORGANIZER` — works via 406/415 retry fallback but wastes a round-trip
+- `releaseTransport()` same issue — uses `CTS_ACCEPT_TREE` instead of `CTS_CONTENT_TYPE_ORGANIZER`
+
+These bugs will be fixed as part of this plan.
+
+## Context
+
+### Current State
+
+ARC-1 supports 4 transport actions: `list`, `get`, `create` (Workbench/K only), `release`. sapcli has full CTS lifecycle including delete, reassign, 5 transport types, recursive release, and `-rrr` detail levels showing objects.
+
+Current code:
+- `src/adt/transport.ts` — 4 functions: `listTransports`, `getTransport`, `createTransport`, `releaseTransport`
+- `src/handlers/intent.ts:1806-1841` — `handleSAPTransport()` switch on 4 actions
+- `src/handlers/schemas.ts:216-221` — Zod schema with `action: z.enum(['list', 'get', 'create', 'release'])`
+- `src/handlers/tools.ts:647-663` — Tool definition with 4 enum values
+- `src/adt/safety.ts:172-193` — `checkTransport()` with `enableTransports`, `transportReadOnly`, `allowedTransports`
+
+### Target State
+
+SAPTransport supports 7 actions: `list`, `get`, `create`, `release`, `delete`, `reassign`, `release_recursive`. Create accepts a `type` parameter (K/W/T). Get response includes task objects when available.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/transport.ts` | Core transport ADT operations — add `deleteTransport()`, `reassignTransport()`, enhance `createTransport()`, `releaseTransport()`, fix Accept headers |
+| `src/adt/types.ts` | Transport types — add `TransportObject` interface, extend `TransportTask` with `objects` field |
+| `src/handlers/intent.ts` | Tool handler — add `delete`, `reassign`, `release_recursive` cases |
+| `src/handlers/schemas.ts` | Zod validation — extend `SAPTransportSchema` with new actions and params |
+| `src/handlers/tools.ts` | Tool definition — add new actions, `type`, `owner` params |
+| `src/adt/safety.ts` | Safety — `deleteTransport` and `reassignTransport` are write ops |
+| `tests/unit/adt/transport.test.ts` | Unit tests for transport functions |
+| `tests/unit/handlers/intent.test.ts` | Unit tests for handler routing |
+| `tests/integration/transport.integration.test.ts` | Integration tests against live SAP |
+| `tests/e2e/saptransport.e2e.test.ts` | E2E tests via MCP client |
+
+### Design Principles
+
+1. **All new actions gated by `checkTransport()`** — delete and reassign are write operations (`isWrite: true`), matching create/release behavior.
+2. **Transport type limited to K/W/T** — Development-Correction (S) and Repair (R) require specific CTS config that most systems lack. Start with the 3 types confirmed working on the test system.
+3. **Recursive release is a new action, not a flag** — `release_recursive` as a distinct action prevents accidental recursive release when the LLM only intends single release.
+4. **Transport contents parsing is best-effort** — The GET response includes task objects only when the system records them. Parse whatever is available, don't fail if missing.
+5. **Fix Accept header bugs opportunistically** — `getTransport()` and `releaseTransport()` should use `CTS_CONTENT_TYPE_ORGANIZER`, not `CTS_ACCEPT_TREE`.
+
+## Development Approach
+
+Tasks are ordered: types first, then core transport functions, then handler wiring, then tests, then docs. Each task is self-contained with full context for autonomous execution.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Extend transport types and fix Accept headers
+
+**Files:**
+- Modify: `src/adt/types.ts`
+- Modify: `src/adt/transport.ts`
+
+Add types for transport objects and fix the Accept header bugs found during SAP system testing.
+
+- [ ] In `src/adt/types.ts`, add `TransportObject` interface after the `TransportTask` interface (line ~110):
+  ```typescript
+  export interface TransportObject {
+    pgmid: string;       // e.g., "R3TR", "LIMU"
+    object: string;      // e.g., "PROG", "CLAS", "METH"
+    objectName: string;  // e.g., "ZTEST_PROGRAM"
+  }
+  ```
+- [ ] In `src/adt/types.ts`, add `objects: TransportObject[]` to the `TransportTask` interface (line ~105-110)
+- [ ] In `src/adt/transport.ts`, fix `getTransport()` (line 50): change `Accept: CTS_ACCEPT_TREE` to `Accept: CTS_CONTENT_TYPE_ORGANIZER` — the single-transport endpoint requires the organizer media type, not the tree variant
+- [ ] In `src/adt/transport.ts`, fix `releaseTransport()` (line 89): change `Accept: CTS_ACCEPT_TREE` to `Accept: CTS_CONTENT_TYPE_ORGANIZER` — same issue
+- [ ] In `src/adt/transport.ts`, update `parseTransportList()` (line ~100-116) to extract `<tm:abapobject>` nodes from within each `<tm:task>` element, mapping attributes `@_pgmid`, `@_object`, `@_name` to `TransportObject[]`. Use `findDeepNodes(task, 'abapobject')` for extraction.
+- [ ] Run `npm test` — all tests must pass (some transport unit tests may need Accept header assertions updated)
+
+### Task 2: Add deleteTransport, reassignTransport, and enhance createTransport
+
+**Files:**
+- Modify: `src/adt/transport.ts`
+
+Add the three new transport operations to the ADT layer.
+
+- [ ] Add `deleteTransport(http, safety, transportId)` function. SAP endpoint: `DELETE /sap/bc/adt/cts/transportrequests/{id}`. Use `checkTransport(safety, transportId, 'DeleteTransport', true)` — it's a write operation. The endpoint is idempotent (returns 200 even for non-existent transports) but returns 400 for already-released transports.
+- [ ] Add `reassignTransport(http, safety, transportId, newOwner)` function. SAP endpoint: `POST /sap/bc/adt/cts/transportrequests/{id}` with body:
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:useraction="changeowner">
+    <tm:request tm:number="{id}" tm:owner="{newOwner}"/>
+  </tm:root>
+  ```
+  Use `CTS_CONTENT_TYPE_ORGANIZER` for both Content-Type and Accept. Use `checkTransport(safety, transportId, 'ReassignTransport', true)`.
+- [ ] Enhance `createTransport()` (line ~58-79) to accept an optional `transportType` parameter (default `'K'`). Replace the hardcoded `tm:type="K"` on line 68 with `tm:type="${escapeXml(transportType)}"`. Valid values are `'K'` (Workbench), `'W'` (Customizing), `'T'` (Transport of Copies).
+- [ ] Run `npm test` — all tests must pass
+
+### Task 3: Add recursive release
+
+**Files:**
+- Modify: `src/adt/transport.ts`
+
+Add a function that releases all unreleased tasks of a transport before releasing the transport itself. This is the equivalent of sapcli's recursive release behavior.
+
+- [ ] Add `releaseTransportRecursive(http, safety, transportId)` function. First call `getTransport()` to fetch the transport and its tasks. Then iterate over tasks where `status !== 'R'` (not yet released) and call `releaseTransport()` for each task ID. Finally call `releaseTransport()` on the parent transport ID. Use `checkTransport(safety, transportId, 'ReleaseTransportRecursive', true)`.
+- [ ] Return a summary object: `{ released: string[] }` listing all IDs that were released (tasks + request), in order.
+- [ ] Run `npm test` — all tests must pass
+
+### Task 4: Wire new actions into handler, schema, and tool definition
+
+**Files:**
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/tools.ts`
+- Modify: `src/handlers/intent.ts`
+
+Connect the new transport functions to the MCP tool interface.
+
+- [ ] In `src/handlers/schemas.ts` (line ~216-221), extend `SAPTransportSchema`:
+  - Add `'delete'`, `'reassign'`, `'release_recursive'` to the `action` enum
+  - Add `type: z.enum(['K', 'W', 'T']).optional()` for transport type selection on create
+  - Add `owner: z.string().optional()` for reassign target
+- [ ] In `src/handlers/tools.ts` (line ~647-663), update the SAPTransport tool definition:
+  - Extend the `action` enum: `['list', 'get', 'create', 'release', 'delete', 'reassign', 'release_recursive']`
+  - Add `type` property: `{ type: 'string', enum: ['K', 'W', 'T'], description: 'Transport type for create: K=Workbench (default), W=Customizing, T=Transport of Copies' }`
+  - Add `owner` property: `{ type: 'string', description: 'New owner (for reassign)' }`
+  - Update the tool description string (both `SAPTRANSPORT_DESC_ONPREM` and `SAPTRANSPORT_DESC_BTP`) to mention new actions
+- [ ] In `src/handlers/intent.ts` (line ~1806-1841), add cases to the `handleSAPTransport()` switch:
+  - `case 'delete'`: require `id`, call `deleteTransport()`, return success message
+  - `case 'reassign'`: require `id` and `owner`, call `reassignTransport()`, return success message
+  - `case 'release_recursive'`: require `id`, call `releaseTransportRecursive()`, return JSON of released IDs
+  - For `case 'create'`: pass `args.type` (cast to string, default `'K'`) as the new `transportType` parameter
+  - Update the default error message to list all 7 supported actions
+- [ ] Import the new functions (`deleteTransport`, `reassignTransport`, `releaseTransportRecursive`) in `intent.ts`
+- [ ] Run `npm test` — all tests must pass
+
+### Task 5: Unit tests for new transport functions
+
+**Files:**
+- Modify: `tests/unit/adt/transport.test.ts`
+
+Add comprehensive unit tests for the new transport operations. The existing test file has 28 tests following patterns with `vi.fn()` mock HTTP clients and `enabledSafety` config.
+
+- [ ] Add tests for `deleteTransport()` (~5 tests):
+  - Blocked when transports not enabled
+  - Blocked when transport read-only
+  - Sends DELETE to correct URL with encoded transport ID
+  - Succeeds on HTTP 200
+  - Verify it passes correct headers
+- [ ] Add tests for `reassignTransport()` (~5 tests):
+  - Blocked when transports not enabled
+  - Blocked when transport read-only
+  - Sends POST with correct XML body containing `tm:useraction="changeowner"` and new owner
+  - Escapes special characters in owner name
+  - Uses correct CTS_CONTENT_TYPE_ORGANIZER media type
+- [ ] Add tests for `createTransport()` with transport type (~3 tests):
+  - Default type is 'K' when not specified (existing behavior preserved)
+  - Type 'W' included in XML body as `tm:type="W"`
+  - Type 'T' included in XML body as `tm:type="T"`
+- [ ] Add tests for `releaseTransportRecursive()` (~4 tests):
+  - Blocked when transports not enabled
+  - Releases unreleased tasks before parent (verify call order via mock)
+  - Skips already-released tasks (status 'R')
+  - Returns list of all released IDs in order
+- [ ] Add tests for Accept header fixes (~2 tests):
+  - `getTransport()` sends `CTS_CONTENT_TYPE_ORGANIZER` Accept header (was `CTS_ACCEPT_TREE`)
+  - `releaseTransport()` sends `CTS_CONTENT_TYPE_ORGANIZER` Accept header (was `CTS_ACCEPT_TREE`)
+- [ ] Add tests for transport object parsing (~2 tests):
+  - Tasks with `<tm:abapobject>` elements parsed into `objects` array
+  - Tasks without objects return empty `objects` array
+- [ ] Run `npm test` — all tests must pass
+
+### Task 6: Unit tests for handler routing
+
+**Files:**
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+Add handler-level tests for the new SAPTransport actions. Follow existing patterns in the file — search for "SAPTransport" to find the existing test block.
+
+- [ ] Add test for `delete` action: verifies `deleteTransport()` called with correct transport ID
+- [ ] Add test for `delete` without ID: returns error result
+- [ ] Add test for `reassign` action: verifies `reassignTransport()` called with ID and owner
+- [ ] Add test for `reassign` without owner: returns error result
+- [ ] Add test for `release_recursive` action: verifies `releaseTransportRecursive()` called
+- [ ] Add test for `create` with `type: 'W'`: verifies type passed through to `createTransport()`
+- [ ] Add test for `create` without type: defaults to `'K'`
+- [ ] Run `npm test` — all tests must pass
+
+### Task 7: Integration tests
+
+**Files:**
+- Modify: `tests/integration/transport.integration.test.ts`
+
+Add integration tests for the new transport operations. The existing file creates transports in the test SAP system and validates responses. Tests require `TEST_SAP_URL` env vars and use `getTestClient()` factory with `enableTransports: true`.
+
+- [ ] Add integration test for delete: create a transport, then delete it, then verify `getTransport()` returns null
+- [ ] Add integration test for create with type 'W': create a Customizing transport, verify it has type 'W', then clean up (delete)
+- [ ] Add integration test for create with type 'T': create a Transport of Copies, verify type 'T', then clean up
+- [ ] Add integration test for reassign: create a transport, reassign to same user (safe — we know the user exists), verify owner is updated via `getTransport()`, clean up
+- [ ] Add integration test for recursive release: create a transport, call `releaseTransportRecursive()`, verify transport status is 'R'. Note: on A4H trial, tasks may not exist on fresh transports, so recursive release should still work (just releases the request)
+- [ ] Use `try/finally` for cleanup (delete transports). Tag cleanup catches with `// best-effort-cleanup`
+- [ ] Run `npm run test:integration` if SAP credentials are available, otherwise just run `npm test`
+
+### Task 8: E2E tests
+
+**Files:**
+- Modify: `tests/e2e/saptransport.e2e.test.ts`
+
+Add E2E tests for the new transport actions via MCP client. The existing file uses `connectClient()`, `callTool()`, `expectToolSuccess()` from `tests/e2e/helpers.ts`.
+
+- [ ] Add E2E test for `delete`: create transport, then call SAPTransport with `action: 'delete'`, verify success message
+- [ ] Add E2E test for `create` with `type: 'W'`: create Customizing transport, verify success, clean up with delete
+- [ ] Add E2E test for `reassign`: create transport, reassign to same user, verify success
+- [ ] Add E2E test for `release_recursive`: create transport, call with `action: 'release_recursive'`, verify released IDs in response
+- [ ] Add E2E test for unknown action error message: verify it now lists all 7 actions
+- [ ] Use `try/finally` with best-effort cleanup (delete transports). Tag catches with `// best-effort-cleanup`
+- [ ] Run `npm test` — all tests must pass (E2E tests require running server)
+
+### Task 9: Documentation updates
+
+**Files:**
+- Modify: `docs/tools.md`
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+
+Update all affected documentation artifacts.
+
+- [ ] In `docs/tools.md`, update the SAPTransport section:
+  - Add `delete`, `reassign`, `release_recursive` to the action enum
+  - Add `type` parameter (K/W/T) for create
+  - Add `owner` parameter for reassign
+  - Update examples to show new actions
+- [ ] In `docs/roadmap.md`:
+  - Update FEAT-19 status to "Completed" (subsumed by FEAT-39 implementation)
+  - Update FEAT-39 status to "Completed"
+  - Add note about which transport types are supported and which are deferred (S, R)
+- [ ] In `compare/00-feature-matrix.md`, section "9. Transport / CTS" (line ~151-162):
+  - Update "Transport contents" row: change ARC-1 from `❌` to `⚠️ (parsed when available)`
+  - Update "Transport assign" row: change ARC-1 from `❌` to `✅`
+  - Add row for "Delete transport": ARC-1 `✅`, fill other columns based on existing data
+  - Add row for "Transport types" showing ARC-1 `⚠️ (K/W/T)` vs sapcli `✅ (5 types: K/W/T/S/R)`
+  - Add row for "Recursive release": ARC-1 `✅` vs sapcli `✅ (recursive)`
+  - Update "Last updated" date
+- [ ] In `CLAUDE.md`:
+  - No structural changes needed — the config table already has `SAP_ENABLE_TRANSPORTS`, and the Key Files table already references `src/adt/transport.ts` and `src/handlers/intent.ts`
+- [ ] Run `npm run lint` — no errors
+
+### Task 10: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Verify the new actions appear in the tool schema when `enableTransports=true` by inspecting `src/handlers/tools.ts`
+- [ ] Verify safety gates: `deleteTransport` and `reassignTransport` are blocked by `transportReadOnly` and `!enableTransports`
+- [ ] Move this plan to `docs/plans/completed/`


### PR DESCRIPTION
## Summary

- Adds implementation plan for FEAT-13: DDIC Domain/Data Element Write support in SAPWrite
- ADT API endpoints validated against A4H test system (create/update/delete all confirmed working)
- 7-task plan covering CRUD primitives, XML builders, handler wiring, integration/E2E tests, and docs

### Key findings from SAP test validation

- Only v2 content types supported (`application/vnd.sap.adt.domains.v2+xml`, `application/vnd.sap.adt.dataelements.v2+xml`)
- Data element XML requires **all fields in strict order** — omitting any returns 400
- Create uses POST to collection URL without `_action=CREATE` param
- Standard lock/PUT/unlock works for updates; stateful sessions mandatory
- Domain fixed values work as nested XML elements

## Test plan

- [ ] Review plan structure matches ralphex format (Task headers, checkboxes only in tasks, validation commands)
- [ ] Verify plan is executable: `ralphex docs/plans/feat-13-ddic-domain-dataelement-write.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)