### PR TITLE
fix: feature probe only treats 404 as unavailable, not all HTTP errors

### DIFF
--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -19,6 +19,7 @@
 
 import { Version } from '@abaplint/core';
 import type { FeatureConfig, FeatureMode } from './config.js';
+import { AdtApiError } from './errors.js';
 import type { AdtHttpClient } from './http.js';
 import type { AuthProbeResult, FeatureStatus, ResolvedFeatures, SystemType } from './types.js';
 import { parseInstalledComponents } from './xml-parser.js';
@@ -94,12 +95,18 @@ export async function probeFeatures(
     Promise.all(
       probesToRun.map(async (probe) => {
         try {
-          // HEAD is lightweight — just checks if the endpoint exists (2xx/3xx = available).
-          // GET on collection endpoints like /ddic/ddl/sources can return 4xx/5xx even when
-          // the feature is available, because they expect a specific object name or parameters.
-          const response = await client.head(probe.endpoint);
-          return { id: probe.id, available: response.statusCode < 400 };
-        } catch {
+          // GET on collection endpoints may return 4xx/5xx when the feature is available
+          // (e.g. /ddic/ddl/sources returns 400 without an object name, transport returns 200).
+          // handleResponse() throws AdtApiError for all status >= 400, so we catch here:
+          // - 404 = ICF service not activated / endpoint doesn't exist → unavailable
+          // - any other HTTP error (400, 403, 405, 500) = endpoint exists → available
+          // - network-level error (no AdtApiError) → unavailable
+          await client.get(probe.endpoint);
+          return { id: probe.id, available: true };
+        } catch (err) {
+          if (err instanceof AdtApiError && err.statusCode !== 404) {
+            return { id: probe.id, available: true };
+          }
           return { id: probe.id, available: false };
         }
       }),


### PR DESCRIPTION
## Summary

PR #94 switched probes from `GET` to `HEAD`, but that introduced a new bug: `HEAD` on the transport endpoint (`/sap/bc/adt/cts/transportrequests`) returns **400**, so transport was showing as unavailable even when it works fine.

The real root cause is that `handleResponse()` throws `AdtApiError` for **all** status ≥ 400. The catch block returned `available: false` for every exception, including 400/403/405/500 which mean the endpoint exists but just needs parameters or auth.

**Correct logic:**
- `GET` the collection endpoint
- Success → available
- `AdtApiError` with status **404** → unavailable (ICF service not activated)
- `AdtApiError` with any other status (400, 403, 405, 500) → **available** (endpoint exists)
- Network error (not `AdtApiError`) → unavailable

Verified against real A4H ABAP 7.58:

| Feature | HTTP status | Result |
|---------|-------------|--------|
| **rap** | 400 (needs object name) | ✅ available: true |
| **transport** | 200 | ✅ available: true |
| **ui5repo** | 403 (auth) | ✅ available: true |
| **flp** | 200 | ✅ available: true |
| hana | 404 (ICF not activated) | ✅ available: false |
| abapGit | 404 (not installed) | ✅ available: false |

## Test plan

- [x] `npm test` — 1526 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)