### PR TITLE
fix: align ADT API patterns with reference abap-adt-api implementation

### DIFF
--- a/src/adt/crud.ts
+++ b/src/adt/crud.ts
@@ -31,7 +31,9 @@ export async function lockObject(
   }
 
   const resp = await http.post(`${objectUrl}?_action=LOCK&accessMode=${accessMode}`, undefined, undefined, {
-    Accept: 'application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.lock.result',
+    // Dual Accept: vendor-specific type for structured lock result parsing,
+    // plus wildcard fallback for SAP versions that don't support the vendor type.
+    Accept: 'application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.lock.result, application/*;q=0.8',
   });
 
   // Parse lock response (asx:abap format) — simple regex extraction
@@ -53,7 +55,7 @@ export async function createObject(
   safety: SafetyConfig,
   objectUrl: string,
   body: string,
-  contentType = 'application/xml',
+  contentType = 'application/*',
   transport?: string,
 ): Promise<string> {
   checkOperation(safety, OperationType.Create, 'CreateObject');

--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -62,10 +62,12 @@ export async function activate(
   <adtcore:objectReference adtcore:uri="${escapeXmlAttr(objectUrl)}"/>
 </adtcore:objectReferences>`;
 
+  // Use application/* wildcard for Content-Type — matches how ADT Eclipse
+  // and abap-adt-api send activation requests. More resilient across SAP versions.
   const resp = await http.post(
     `/sap/bc/adt/activation?method=activate&preauditRequested=${preaudit}`,
     body,
-    'application/xml',
+    'application/*',
     { Accept: 'application/xml' },
   );
 
@@ -103,7 +105,7 @@ ${refs}
   const resp = await http.post(
     `/sap/bc/adt/activation?method=activate&preauditRequested=${preaudit}`,
     body,
-    'application/xml',
+    'application/*',
     { Accept: 'application/xml' },
   );
 

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -421,12 +421,18 @@ export class AdtHttpClient {
           }
           // If Accept is already */* and no inferred type, no useful fallback — skip retry
         } else {
-          // 415: Server rejected our Content-Type — try application/xml fallback
-          if (contentType && contentType !== 'application/xml') {
+          // 415: Server rejected our Content-Type — try fallbacks:
+          // 1. Specific type → application/xml (common for vendor-type mismatches)
+          // 2. application/xml → application/* (DDL-based endpoints reject the literal
+          //    type but accept the wildcard, matching how ADT Eclipse sends requests)
+          if (contentType && contentType !== 'application/xml' && contentType !== 'application/*') {
             fallbackHeaders['Content-Type'] = 'application/xml';
             headersChanged = true;
+          } else if (contentType === 'application/xml') {
+            fallbackHeaders['Content-Type'] = 'application/*';
+            headersChanged = true;
           }
-          // If Content-Type is already application/xml or absent, no useful fallback — skip retry
+          // If Content-Type is already application/* or absent, no useful fallback — skip retry
         }
 
         if (headersChanged) {

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -1014,7 +1014,10 @@ function ddicContentTypeForType(type: string): string {
     case 'DTEL':
       return DATAELEMENT_V2_CONTENT_TYPE;
     default:
-      return 'application/xml';
+      // Wildcard lets the SAP server resolve the correct handler.
+      // Sending 'application/xml' causes 415 on DDL-based endpoints
+      // (DDLS, BDEF, SRVD, DDLX) whose resource classes reject that literal type.
+      return 'application/*';
   }
 }
 
@@ -1206,19 +1209,20 @@ export function buildCreateXml(
 </bdef:behaviorDefinition>`;
     case 'SRVD':
       return `<?xml version="1.0" encoding="UTF-8"?>
-<srvd:srvdSource xmlns:srvd="http://www.sap.com/adt/ddic/srvd/sources"
+<srvd:srvdSource xmlns:srvd="http://www.sap.com/adt/ddic/srvdsources"
                  xmlns:adtcore="http://www.sap.com/adt/core"
                  adtcore:description="${escapeXml(description)}"
                  adtcore:name="${escapeXml(name)}"
                  adtcore:type="SRVD/SRV"
                  adtcore:masterLanguage="EN"
                  adtcore:masterSystem="H00"
-                 adtcore:responsible="DEVELOPER">
+                 adtcore:responsible="DEVELOPER"
+                 srvd:srvdSourceType="S">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </srvd:srvdSource>`;
     case 'DDLX':
       return `<?xml version="1.0" encoding="UTF-8"?>
-<ddlx:ddlxSource xmlns:ddlx="http://www.sap.com/adt/ddic/ddlx/sources"
+<ddlx:ddlxSource xmlns:ddlx="http://www.sap.com/adt/ddic/ddlxsources"
                  xmlns:adtcore="http://www.sap.com/adt/core"
                  adtcore:description="${escapeXml(description)}"
                  adtcore:name="${escapeXml(name)}"
@@ -1447,7 +1451,10 @@ async function handleSAPWrite(
 
       // Step 1: Create the object (metadata only)
       const createUrl = objectUrl.replace(/\/[^/]+$/, ''); // parent collection URL
-      const contentType = isDdicMetadataType(type) ? ddicContentTypeForType(type) : 'application/xml';
+      // DOMA/DTEL require vendor-specific v2 content types; all other types use
+      // 'application/*' — the wildcard lets the SAP server resolve the correct
+      // handler (matching how ADT Eclipse and abap-adt-api send requests).
+      const contentType = isDdicMetadataType(type) ? ddicContentTypeForType(type) : 'application/*';
       const result = await createObject(client.http, client.safety, createUrl, body, contentType, transport);
 
       if (isDdicMetadataType(type)) {
@@ -1593,7 +1600,7 @@ async function handleSAPWrite(
           const createUrl = objUrl.replace(/\/[^/]+$/, '');
           const objDdicProps = getDdicWriteProperties(obj);
           const body = buildCreateXml(objType, objName, pkg, objDescription, objDdicProps);
-          const contentType = metadataObject ? ddicContentTypeForType(objType) : 'application/xml';
+          const contentType = metadataObject ? ddicContentTypeForType(objType) : 'application/*';
           await createObject(client.http, client.safety, createUrl, body, contentType, transport);
 
           // Step 1b: DTEL POST ignores labels — follow up with PUT on main session

--- a/tests/unit/adt/devtools.test.ts
+++ b/tests/unit/adt/devtools.test.ts
@@ -214,7 +214,7 @@ describe('DevTools', () => {
       expect(http.post).toHaveBeenCalledWith(
         '/sap/bc/adt/activation?method=activate&preauditRequested=true',
         expect.stringContaining('objectReference'),
-        'application/xml',
+        'application/*',
         expect.objectContaining({ Accept: 'application/xml' }),
       );
     });
@@ -225,7 +225,7 @@ describe('DevTools', () => {
       expect(http.post).toHaveBeenCalledWith(
         '/sap/bc/adt/activation?method=activate&preauditRequested=false',
         expect.stringContaining('objectReference'),
-        'application/xml',
+        'application/*',
         expect.objectContaining({ Accept: 'application/xml' }),
       );
     });
@@ -344,7 +344,7 @@ describe('DevTools', () => {
       expect(http.post).toHaveBeenCalledWith(
         '/sap/bc/adt/activation?method=activate&preauditRequested=true',
         expect.any(String),
-        'application/xml',
+        'application/*',
         expect.objectContaining({ Accept: 'application/xml' }),
       );
     });
@@ -360,7 +360,7 @@ describe('DevTools', () => {
       expect(http.post).toHaveBeenCalledWith(
         '/sap/bc/adt/activation?method=activate&preauditRequested=false',
         expect.any(String),
-        'application/xml',
+        'application/*',
         expect.objectContaining({ Accept: 'application/xml' }),
       );
     });

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -735,14 +735,33 @@ describe('AdtHttpClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(4);
     });
 
-    it('415 skips retry when Content-Type is already application/xml', async () => {
+    it('415 retries with application/* when Content-Type is application/xml', async () => {
       // CSRF fetch
       mockFetch.mockResolvedValueOnce(mockResponse(200, '', { 'x-csrf-token': 'T' }));
-      // POST with application/xml → 415 (no useful fallback, should throw without retry)
+      // POST with application/xml → 415
+      mockFetch.mockResolvedValueOnce(mockResponse(415, 'Unsupported'));
+      // Retry with application/* → 200
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'created'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      const resp = await client.post('/path', '<d/>', 'application/xml');
+
+      expect(resp.statusCode).toBe(200);
+      // CSRF fetch + initial POST + retry POST
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      // Verify retry used application/* content type
+      const retryCall = mockFetch.mock.calls[2];
+      expect(retryCall[1].headers['Content-Type']).toBe('application/*');
+    });
+
+    it('415 skips retry when Content-Type is already application/*', async () => {
+      // CSRF fetch
+      mockFetch.mockResolvedValueOnce(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      // POST with application/* → 415 (no useful fallback, should throw without retry)
       mockFetch.mockResolvedValueOnce(mockResponse(415, 'Unsupported'));
 
       const client = new AdtHttpClient(getDefaultConfig());
-      await expect(client.post('/path', '<d/>', 'application/xml')).rejects.toThrow();
+      await expect(client.post('/path', '<d/>', 'application/*')).rejects.toThrow();
 
       // CSRF fetch + one POST — no retry
       expect(mockFetch).toHaveBeenCalledTimes(2);

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -3925,17 +3925,18 @@ ENDCLASS.`;
     it('returns correct XML for SRVD', () => {
       const xml = buildCreateXml('SRVD', 'ZSD_TRAVEL', 'ZPACKAGE', 'Travel Service Def');
       expect(xml).toContain('<srvd:srvdSource');
-      expect(xml).toContain('xmlns:srvd="http://www.sap.com/adt/ddic/srvd/sources"');
+      expect(xml).toContain('xmlns:srvd="http://www.sap.com/adt/ddic/srvdsources"');
       expect(xml).toContain('adtcore:type="SRVD/SRV"');
       expect(xml).toContain('adtcore:name="ZSD_TRAVEL"');
       expect(xml).toContain('adtcore:description="Travel Service Def"');
+      expect(xml).toContain('srvd:srvdSourceType="S"');
       expect(xml).toContain('<adtcore:packageRef adtcore:name="ZPACKAGE"/>');
     });
 
     it('returns correct XML for DDLX', () => {
       const xml = buildCreateXml('DDLX', 'ZC_TRAVEL', 'ZPACKAGE', 'Travel Metadata Ext');
       expect(xml).toContain('<ddlx:ddlxSource');
-      expect(xml).toContain('xmlns:ddlx="http://www.sap.com/adt/ddic/ddlx/sources"');
+      expect(xml).toContain('xmlns:ddlx="http://www.sap.com/adt/ddic/ddlxsources"');
       expect(xml).toContain('adtcore:type="DDLX/EX"');
       expect(xml).toContain('adtcore:name="ZC_TRAVEL"');
       expect(xml).toContain('adtcore:description="Travel Metadata Ext"');


### PR DESCRIPTION
## Summary

Cross-referenced the [abap-adt-api](https://github.com/marcellourbani/abap-adt-api) library (the reference ADT REST client by Marcello Urbani) to align ARC-1's HTTP patterns with the battle-tested implementation.

### Content-Type improvements
- **Object creation**: Use `application/*` wildcard for POST (was `application/xml`) — SAP DDL-based endpoints reject the literal type with HTTP 415
- **Activation**: Use `application/*` for activation POST (was `application/xml`) — more resilient across SAP versions
- **Default parameter**: Update `createObject()` function default to `application/*`
- **415 fallback chain**: Extended to `specific → xml → wildcard` (was `specific → xml`)

### XML namespace fixes (matching abap-adt-api type registry)
- **SRVD**: `http://www.sap.com/adt/ddic/srvdsources` (was `srvd/sources` — extra slash)
- **DDLX**: `http://www.sap.com/adt/ddic/ddlxsources` (was `ddlx/sources` — extra slash)
- DDLS namespace was already correct (`ddlsources`)
- Add `srvd:srvdSourceType="S"` attribute to SRVD creation XML

### Lock resilience
- Add `application/*;q=0.8` fallback to lock Accept header for SAP version compatibility

## Test plan

- [x] 1515 unit tests pass
- [x] Typecheck clean
- [x] Lint clean
- [ ] E2E: verify DDLS/SRVD/DDLX creation works against SAP test system