### PR TITLE
feat: transport pre-flight check for non-$TMP package writes

### DIFF
--- a/docs/mcp-usage.md
+++ b/docs/mcp-usage.md
@@ -75,7 +75,9 @@ flowchart TD
     RTYPE -->|Find objects| SS[SAPSearch]
     RTYPE -->|System info| SR3[SAPRead type=SYSTEM]
 
-    READ -->|Write| SW[SAPWrite]
+    READ -->|Write| WTYPE{Local or transportable package?}
+    WTYPE -->|Local $TMP| SW[SAPWrite]
+    WTYPE -->|Transportable| ST[SAPTransport check → SAPWrite with transport]
     READ -->|Activate| SA[SAPActivate]
     READ -->|Navigate| SN[SAPNavigate]
     READ -->|Diagnose| SD[SAPDiagnose]
@@ -114,7 +116,9 @@ flowchart TD
 
 | Task | Tool | Parameters |
 |------|------|------------|
-| Create new object | `SAPWrite` | `action=create, type=PROG, name=ZTEST, source=...` |
+| Create new object (local) | `SAPWrite` | `action=create, type=PROG, name=ZTEST, source=...` |
+| Create in transport package | `SAPWrite` | `action=create, type=PROG, name=ZTEST, source=..., package=ZDEV, transport=A4HK900123` |
+| Check transport requirement | `SAPTransport` | `action=check, type=CLAS, name=ZCL_TEST, package=ZDEV` |
 | Update existing | `SAPWrite` | `action=update, type=CLAS, name=ZCL_TEST, source=...` |
 | Delete object | `SAPWrite` | `action=delete, type=PROG, name=ZTEST` |
 | Activate | `SAPActivate` | `name=ZCL_TEST, type=CLAS` |
@@ -161,7 +165,37 @@ Step 1: SAPRead(type="MESSAGES", name="ZRAY_00")
         → Returns JSON with all messages
 ```
 
-### 4. Investigate Runtime Errors
+### 4. Create Objects in Transportable Packages
+
+When creating objects in non-`$TMP` packages, a transport number is required. ARC-1 detects this automatically and returns guidance, but the optimal workflow is:
+
+```
+Step 1: SAPTransport(action="check", type="CLAS", name="ZCL_ORDER", package="ZDEV")
+        → Returns whether a transport is needed, existing transports, any locked transport
+
+Step 2: (if transport needed) SAPTransport(action="list")
+        → Returns modifiable transports for the current user
+        OR
+        SAPTransport(action="create", description="Create ZCL_ORDER class")
+        → Creates a new transport and returns the transport ID
+
+Step 3: SAPWrite(action="create", type="CLAS", name="ZCL_ORDER", source="...", package="ZDEV", transport="A4HK900123")
+        → Creates the object in the transportable package with the transport number
+```
+
+**Shortcut:** If you skip the check step, ARC-1's pre-flight check will detect the missing transport and return an actionable error with existing transports listed — you can then pick one and retry.
+
+**Batch creation:** The same flow applies to `batch_create`. Provide the `transport` parameter at the top level — all objects in the batch use the same transport.
+
+```
+SAPWrite(action="batch_create", package="ZDEV", transport="A4HK900123", objects=[
+  {type:"DDLS", name:"ZI_TRAVEL", source:"..."},
+  {type:"BDEF", name:"ZI_TRAVEL", source:"..."},
+  {type:"CLAS", name:"ZBP_I_TRAVEL", source:"..."}
+])
+```
+
+### 5. Investigate Runtime Errors
 
 ```
 Step 1: SAPDiagnose(action="dumps", user="DEVELOPER")
@@ -182,6 +216,13 @@ Step 2: SAPDiagnose(action="dump_detail", name="<dump_id>")
 | `"DESC" is not allowed` | Used SQL `DESC` | Use `DESCENDING` instead |
 | `"ASC" is not allowed` | Used SQL `ASC` | Use `ASCENDING` instead |
 | `LIMIT not recognized` | Used SQL `LIMIT` | Use `maxRows` parameter |
+
+### SAPWrite Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Package requires transport | Non-`$TMP` package, no transport provided | Use `SAPTransport(action="list")` or `SAPTransport(action="create")` to get a transport ID, then pass it via `transport` parameter |
+| Package not in allowed list | Package not in `--allowed-packages` | Admin must add the package to the allow list |
 
 ### SAPRead Errors
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -192,7 +192,14 @@ SAPWrite(action="create", type="DTEL", name="ZSTATUS", package="$TMP",
   shortLabel="Status", mediumLabel="Order Status")
 ```
 
-**Transport behavior:** For `update` and `delete` actions on transportable packages, ARC-1 automatically reuses the correction number from the SAP object lock when no explicit `transport` is provided. This means writes to transportable objects often succeed without manually specifying a transport. For `create` and `batch_create`, an explicit transport may still be required depending on the target package and system configuration.
+**Transport behavior:**
+
+- **`update` and `delete`**: ARC-1 automatically reuses the correction number from the SAP object lock when no explicit `transport` is provided. This means writes to transportable objects often succeed without manually specifying a transport.
+- **`create` and `batch_create`**: ARC-1 performs a **transport pre-flight check** for non-`$TMP` packages when no transport is provided. This calls the SAP transport checks endpoint to determine whether a transport number is required:
+  - If the object is already locked in a transport, ARC-1 auto-uses that transport.
+  - If the package is local (e.g., `$TMP`), no transport is needed — creation proceeds.
+  - If a transport IS required but none was provided, ARC-1 returns an actionable error message listing existing transports and guiding the caller to use `SAPTransport(action="list")` or `SAPTransport(action="create")` first.
+  - If the pre-flight check fails (older system, permissions), ARC-1 proceeds and lets SAP handle the error.
 
 **Note:** Not available by default (read-only mode). Enable with `--read-only=false` or `--profile developer`. When enabled, write access is restricted to package `$TMP` (local objects). To write to other packages, configure `--allowed-packages` (e.g., `"Z*,$TMP"`).
 
@@ -284,26 +291,53 @@ SAPQuery(sql="SELECT * FROM mara WHERE matnr LIKE 'Z%'", maxRows=50)
 
 ## SAPTransport
 
-Manage CTS transport requests (SE09/SE10 equivalent): list, get details, create (K/W/T types), release, delete, reassign owner, and recursive release.
+Manage CTS transport requests (SE09/SE10 equivalent): list, get details, create (K/W/T types), release, delete, reassign owner, recursive release, and check transport requirements.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | string | Yes | `list`, `get`, `create`, `release`, `delete`, `reassign`, or `release_recursive` |
+| `action` | string | Yes | `list`, `get`, `create`, `release`, `delete`, `reassign`, `release_recursive`, or `check` |
 | `id` | string | No | Transport request ID, e.g. `A4HK900123` (for get/release/delete/reassign/release_recursive) |
 | `description` | string | No | Transport description text (required for create) |
+| `name` | string | No | Object name (for check action, e.g. `ZCL_ORDER`) |
+| `package` | string | No | Package name (for check action, e.g. `ZDEV`) |
 | `user` | string | No | SAP username to filter by (for list). Defaults to the current SAP user. Use `*` to list all users. |
 | `status` | string | No | Transport status filter (for list). `D`=modifiable (default), `R`=released, `*`=all statuses. |
-| `type` | string | No | Transport type for create: `K` (Workbench, default), `W` (Customizing), `T` (Transport of Copies) |
+| `type` | string | No | For create: transport type `K` (Workbench, default), `W` (Customizing), `T` (Transport of Copies). For check: object type (`PROG`, `CLAS`, `DDLS`, etc.) |
 | `owner` | string | No | New owner SAP username (required for reassign) |
 | `recursive` | boolean | No | Apply recursively to child tasks (for delete/reassign). `release_recursive` always recurses. |
+
+**Actions:**
+
+- **`list`** — List transport requests. Defaults to current user, modifiable (status D), all types (Workbench, Customizing, Transport of Copies).
+- **`get`** — Get transport details including tasks and objects.
+- **`create`** — Create a new transport request. Requires `description`. Optional `type` (K/W/T).
+- **`release`** — Release a single transport or task.
+- **`delete`** — Delete a transport. Use `recursive=true` to delete tasks first.
+- **`reassign`** — Change transport owner. Requires `owner`. Use `recursive=true` for tasks too.
+- **`release_recursive`** — Release all unreleased tasks first, then the transport itself.
+- **`check`** — Check if a transport number is required for creating an object in a specific package. Requires `type`, `name`, and `package`. Returns whether transport recording is required, whether the package is local, existing transports, and any locked transport. **Does NOT require `--enable-transports`** — this is a read-only pre-flight check.
+
+**Check action output:**
+```json
+{
+  "package": "ZDEV",
+  "transportRequired": true,
+  "isLocal": false,
+  "deliveryUnit": "HOME",
+  "existingTransports": [
+    { "id": "A4HK900123", "description": "My transport", "owner": "DEVELOPER" }
+  ],
+  "summary": "Package \"ZDEV\" requires a transport for object creation."
+}
+```
 
 **List defaults:** Without parameters, `list` returns modifiable transports (status D) for the current SAP user, across all transport types (Workbench, Customizing, Transport of Copies). Query params follow sapcli's `workbench_params()` pattern (`requestType=KWT`, `requestStatus`).
 
 **Protocol compatibility:** ARC-1 uses endpoint-specific CTS media types and includes a one-retry content negotiation fallback (406/415) for SAP version variance.
 
-**Note:** Only available when `--enable-transports` is set.
+**Note:** Most actions require `--enable-transports`. The `check` action works without it (read-only).
 
 ---
 

--- a/src/adt/transport.ts
+++ b/src/adt/transport.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AdtHttpClient } from './http.js';
-import { checkTransport, type SafetyConfig } from './safety.js';
+import { checkOperation, checkTransport, OperationType, type SafetyConfig } from './safety.js';
 import type { TransportObject, TransportRequest, TransportTask } from './types.js';
 import { escapeXmlAttr, findDeepNodes, parseXml } from './xml-parser.js';
 
@@ -203,6 +203,131 @@ async function reassignSingle(http: AdtHttpClient, transportId: string, newOwner
     CTS_CONTENT_TYPE_ORGANIZER,
     { Accept: CTS_CONTENT_TYPE_ORGANIZER },
   );
+}
+
+// ─── Transport Info (pre-flight check) ──────────────────────────────
+
+/** Transport requirement info returned by the CTS transport checks endpoint */
+export interface TransportInfo {
+  /** Whether transport recording is required ('X' = required, '' = not needed) */
+  recording: boolean;
+  /** Whether the package is a local package (no transport needed) */
+  isLocal: boolean;
+  /** Delivery unit: 'LOCAL' for local packages, transport layer name otherwise */
+  deliveryUnit: string;
+  /** Package name */
+  devclass: string;
+  /** Available existing transports the object could be added to */
+  existingTransports: Array<{ id: string; description: string; owner: string }>;
+  /** If the object is already locked in a transport */
+  lockedTransport?: string;
+}
+
+/**
+ * Check transport requirements for an object URL and package.
+ *
+ * Calls POST /sap/bc/adt/cts/transportchecks to determine whether a
+ * transport number is needed for object creation/modification. This is the
+ * same endpoint used by ADT Eclipse and abap-adt-api's `transportInfo()`.
+ *
+ * @param objectUrl - ADT object URL (e.g., `/sap/bc/adt/oo/classes/zcl_foo`)
+ * @param devclass - Package name (e.g., `$TMP`, `Z_RAP_VB_1`)
+ * @param operation - `I` for insert/create, empty string for modify (default: `I`)
+ */
+export async function getTransportInfo(
+  http: AdtHttpClient,
+  safety: SafetyConfig,
+  objectUrl: string,
+  devclass: string,
+  operation = 'I',
+): Promise<TransportInfo> {
+  // Transport info is a read operation — doesn't require enableTransports
+  checkOperation(safety, OperationType.Read, 'TransportInfo');
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+    <DATA>
+      <DEVCLASS>${escapeXmlAttr(devclass)}</DEVCLASS>
+      <URI>${escapeXmlAttr(objectUrl)}</URI>
+      <OPERATION>${escapeXmlAttr(operation)}</OPERATION>
+    </DATA>
+  </asx:values>
+</asx:abap>`;
+
+  const resp = await http.post(
+    '/sap/bc/adt/cts/transportchecks',
+    body,
+    'application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.transport.service.checkData',
+    { Accept: 'application/vnd.sap.as+xml' },
+  );
+
+  return parseTransportInfo(resp.body);
+}
+
+/** Parse transport check response XML */
+function parseTransportInfo(xml: string): TransportInfo {
+  const parsed = parseXml(xml);
+
+  // Extract flat fields from DATA element
+  const recording = String(findDeepValue(parsed, 'RECORDING') ?? '') === 'X';
+  const isLocal = String(findDeepValue(parsed, 'DLVUNIT') ?? '') === 'LOCAL';
+  const deliveryUnit = String(findDeepValue(parsed, 'DLVUNIT') ?? '');
+  const devclass = String(findDeepValue(parsed, 'DEVCLASS') ?? '');
+
+  // Extract locked transport from LOCKS/HEADER
+  const locks = findDeepNodes(parsed, 'LOCKS');
+  let lockedTransport: string | undefined;
+  if (locks.length > 0) {
+    const headers = findDeepNodes(locks[0], 'HEADER');
+    if (headers.length > 0) {
+      const trkorr = String((headers[0] as Record<string, unknown>).TRKORR ?? '');
+      if (trkorr) lockedTransport = trkorr;
+    }
+  }
+
+  // Extract available transports
+  const transportNodes = findDeepNodes(parsed, 'TRANSPORTS');
+  const existingTransports: TransportInfo['existingTransports'] = [];
+  if (transportNodes.length > 0) {
+    // TRANSPORTS contains an array of transport header elements
+    const headers = findDeepNodes(transportNodes[0], 'headers');
+    for (const h of headers) {
+      const rec = h as Record<string, unknown>;
+      const id = String(rec.TRKORR ?? '');
+      const description = String(rec.AS4TEXT ?? '');
+      const owner = String(rec.AS4USER ?? '');
+      if (id) existingTransports.push({ id, description, owner });
+    }
+  }
+
+  return {
+    recording,
+    isLocal,
+    deliveryUnit,
+    devclass,
+    existingTransports,
+    ...(lockedTransport ? { lockedTransport } : {}),
+  };
+}
+
+/** Deep value finder for flat XML structures */
+function findDeepValue(obj: unknown, key: string): unknown {
+  if (!obj || typeof obj !== 'object') return undefined;
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      const found = findDeepValue(item, key);
+      if (found !== undefined) return found;
+    }
+    return undefined;
+  }
+  const record = obj as Record<string, unknown>;
+  if (key in record) return record[key];
+  for (const val of Object.values(record)) {
+    const found = findDeepValue(val, key);
+    if (found !== undefined) return found;
+  }
+  return undefined;
 }
 
 // ─── Parsers ────────────────────────────────────────────────────────

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -71,6 +71,7 @@ import {
   createTransport,
   deleteTransport,
   getTransport,
+  getTransportInfo,
   listTransports,
   reassignTransport,
   releaseTransport,
@@ -1435,6 +1436,42 @@ async function handleSAPWrite(
       checkPackage(client.safety, pkg);
       const description = String(args.description ?? name);
 
+      // Pre-flight: check transport requirements for non-$TMP packages when no transport provided.
+      // SAP requires a transport number for objects in transportable packages.
+      // Instead of letting SAP return a cryptic error, we detect this early and return
+      // an actionable error message guiding the LLM to use SAPTransport first.
+      let effectiveTransport = transport;
+      if (!transport && pkg.toUpperCase() !== '$TMP') {
+        try {
+          const transportInfo = await getTransportInfo(client.http, client.safety, objectUrl, pkg, 'I');
+          if (transportInfo.lockedTransport) {
+            // Object is already locked in a transport — use it automatically
+            effectiveTransport = transportInfo.lockedTransport;
+          } else if (!transportInfo.isLocal && transportInfo.recording) {
+            // Transport IS required but none provided — return guidance
+            const existingList =
+              transportInfo.existingTransports.length > 0
+                ? `\n\nExisting transports for this package:\n${transportInfo.existingTransports
+                    .slice(0, 10)
+                    .map((t) => `  - ${t.id}: ${t.description} (${t.owner})`)
+                    .join('\n')}`
+                : '';
+            return errorResult(
+              `Package "${pkg}" requires a transport number for object creation, but none was provided.\n\n` +
+                `To fix this, either:\n` +
+                `1. Use SAPTransport(action="list") to find an existing modifiable transport\n` +
+                `2. Use SAPTransport(action="create", description="...") to create a new one\n` +
+                `3. Then retry SAPWrite(action="create", ..., transport="<transport_id>")` +
+                existingList,
+            );
+          }
+          // isLocal=true or recording=false → no transport needed, proceed without one
+        } catch {
+          // If transportInfo check fails (older system, permissions, etc.), proceed without it.
+          // SAP will return its own error if a transport is actually needed.
+        }
+      }
+
       // AFF header validation (if schema available for this type)
       const affResult = validateAffHeader(type, { description, originalLanguage: 'en' });
       if (!affResult.valid) {
@@ -1455,7 +1492,7 @@ async function handleSAPWrite(
       // 'application/*' — the wildcard lets the SAP server resolve the correct
       // handler (matching how ADT Eclipse and abap-adt-api send requests).
       const contentType = isDdicMetadataType(type) ? ddicContentTypeForType(type) : 'application/*';
-      const result = await createObject(client.http, client.safety, createUrl, body, contentType, transport);
+      const result = await createObject(client.http, client.safety, createUrl, body, contentType, effectiveTransport);
 
       if (isDdicMetadataType(type)) {
         // SAP's DTEL POST ignores labels, searchHelp, etc. — they require a follow-up PUT.
@@ -1465,9 +1502,9 @@ async function handleSAPWrite(
           const ct = ddicContentTypeForType(type);
           await client.http.withStatefulSession(async (session) => {
             const lock = await lockObject(session, client.safety, objectUrl);
-            const effectiveTransport = transport ?? (lock.corrNr || undefined);
+            const lockTransport = effectiveTransport ?? (lock.corrNr || undefined);
             try {
-              await updateObject(session, client.safety, objectUrl, body, lock.lockHandle, ct, effectiveTransport);
+              await updateObject(session, client.safety, objectUrl, body, lock.lockHandle, ct, lockTransport);
             } finally {
               await unlockObject(session, objectUrl, lock.lockHandle);
             }
@@ -1487,7 +1524,7 @@ async function handleSAPWrite(
           );
         }
 
-        await safeUpdateSource(client.http, client.safety, objectUrl, srcUrl, source, transport);
+        await safeUpdateSource(client.http, client.safety, objectUrl, srcUrl, source, effectiveTransport);
         cachingLayer?.invalidate(type, name);
         const msg = `Created ${type} ${name} in package ${pkg} and wrote source code.`;
         return lintWarnings.warnings ? textResult(`${msg}\n\n${lintWarnings.warnings}`) : textResult(msg);
@@ -1558,6 +1595,38 @@ async function handleSAPWrite(
       // Check package is allowed before starting any creates
       checkPackage(client.safety, pkg);
 
+      // Pre-flight transport check for batch_create (same logic as single create)
+      let batchTransport = transport;
+      if (!transport && pkg.toUpperCase() !== '$TMP') {
+        try {
+          // Use first object's URL for the transport check
+          const firstObj = objects[0];
+          const firstUrl = objectUrlForType(String(firstObj.type ?? ''), String(firstObj.name ?? ''));
+          const transportInfo = await getTransportInfo(client.http, client.safety, firstUrl, pkg, 'I');
+          if (transportInfo.lockedTransport) {
+            batchTransport = transportInfo.lockedTransport;
+          } else if (!transportInfo.isLocal && transportInfo.recording) {
+            const existingList =
+              transportInfo.existingTransports.length > 0
+                ? `\n\nExisting transports for this package:\n${transportInfo.existingTransports
+                    .slice(0, 10)
+                    .map((t) => `  - ${t.id}: ${t.description} (${t.owner})`)
+                    .join('\n')}`
+                : '';
+            return errorResult(
+              `Package "${pkg}" requires a transport number for object creation, but none was provided.\n\n` +
+                `To fix this, either:\n` +
+                `1. Use SAPTransport(action="list") to find an existing modifiable transport\n` +
+                `2. Use SAPTransport(action="create", description="...") to create a new one\n` +
+                `3. Then retry SAPWrite(action="batch_create", ..., transport="<transport_id>")` +
+                existingList,
+            );
+          }
+        } catch {
+          // If transportInfo check fails, proceed — SAP will return its own error if needed.
+        }
+      }
+
       const results: Array<{ type: string; name: string; status: 'success' | 'failed'; error?: string }> = [];
 
       for (const obj of objects) {
@@ -1601,23 +1670,15 @@ async function handleSAPWrite(
           const objDdicProps = getDdicWriteProperties(obj);
           const body = buildCreateXml(objType, objName, pkg, objDescription, objDdicProps);
           const contentType = metadataObject ? ddicContentTypeForType(objType) : 'application/*';
-          await createObject(client.http, client.safety, createUrl, body, contentType, transport);
+          await createObject(client.http, client.safety, createUrl, body, contentType, batchTransport);
 
           // Step 1b: DTEL POST ignores labels — follow up with PUT on main session
           if (objType === 'DTEL' && dtelNeedsPostCreateUpdate(objDdicProps)) {
             await client.http.withStatefulSession(async (session) => {
               const lock = await lockObject(session, client.safety, objUrl);
-              const effectiveTransport = transport ?? (lock.corrNr || undefined);
+              const lockTransport = batchTransport ?? (lock.corrNr || undefined);
               try {
-                await updateObject(
-                  session,
-                  client.safety,
-                  objUrl,
-                  body,
-                  lock.lockHandle,
-                  contentType,
-                  effectiveTransport,
-                );
+                await updateObject(session, client.safety, objUrl, body, lock.lockHandle, contentType, lockTransport);
               } finally {
                 await unlockObject(session, objUrl, lock.lockHandle);
               }
@@ -1627,7 +1688,7 @@ async function handleSAPWrite(
           // Step 2: Write source if provided
           if (!metadataObject && objSource) {
             const srcUrl = sourceUrlForType(objType, objName);
-            await safeUpdateSource(client.http, client.safety, objUrl, srcUrl, objSource, transport);
+            await safeUpdateSource(client.http, client.safety, objUrl, srcUrl, objSource, batchTransport);
           }
 
           // Step 3: Activate the object
@@ -2194,9 +2255,43 @@ async function handleSAPTransport(client: AdtClient, args: Record<string, unknow
       const result = await releaseTransportRecursive(client.http, client.safety, id);
       return textResult(JSON.stringify(result, null, 2));
     }
+    case 'check': {
+      // Check transport requirements for an object/package combination.
+      // Does NOT require enableTransports — this is a read-only check.
+      const objectType = String(args.type ?? '');
+      const objectName = String(args.name ?? '');
+      const pkg = String(args.package ?? '');
+      if (!objectType || !objectName) return errorResult('"type" and "name" are required for "check" action.');
+      if (!pkg) return errorResult('"package" is required for "check" action.');
+
+      const objectUrl = objectUrlForType(objectType, objectName);
+      const info = await getTransportInfo(client.http, client.safety, objectUrl, pkg, 'I');
+
+      const summary = info.isLocal
+        ? `Package "${pkg}" is local — no transport required.`
+        : info.recording
+          ? `Package "${pkg}" requires a transport for object creation.`
+          : `Package "${pkg}" does not require transport recording.`;
+
+      return textResult(
+        JSON.stringify(
+          {
+            package: pkg,
+            transportRequired: !info.isLocal && info.recording,
+            isLocal: info.isLocal,
+            deliveryUnit: info.deliveryUnit,
+            existingTransports: info.existingTransports,
+            ...(info.lockedTransport ? { lockedTransport: info.lockedTransport } : {}),
+            summary,
+          },
+          null,
+          2,
+        ),
+      );
+    }
     default:
       return errorResult(
-        `Unknown SAPTransport action: ${action}. Supported: list, get, create, release, delete, reassign, release_recursive`,
+        `Unknown SAPTransport action: ${action}. Supported: list, get, create, release, delete, reassign, release_recursive, check`,
       );
   }
 }

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -319,12 +319,14 @@ export const SAPDiagnoseSchema = z.object({
 // ─── SAPTransport ───────────────────────────────────────────────────
 
 export const SAPTransportSchema = z.object({
-  action: z.enum(['list', 'get', 'create', 'release', 'delete', 'reassign', 'release_recursive']),
+  action: z.enum(['list', 'get', 'create', 'release', 'delete', 'reassign', 'release_recursive', 'check']),
   id: z.string().optional(),
   description: z.string().optional(),
+  name: z.string().optional(),
+  package: z.string().optional(),
   user: z.string().optional(),
   status: z.string().optional(),
-  type: z.enum(['K', 'W', 'T']).optional(),
+  type: z.string().optional(),
   owner: z.string().optional(),
   recursive: z.boolean().optional(),
 });

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -195,14 +195,16 @@ const SAPTRANSPORT_DESC_ONPREM =
   'Manage CTS transport requests (SE09/SE10 equivalent). ' +
   'Actions: list (defaults to current user, modifiable transports — both Workbench and Customizing), ' +
   'get (details with tasks and objects), create (K=Workbench, W=Customizing, T=Transport of Copies), ' +
-  'release, delete, reassign (change owner), release_recursive (release tasks first, then parent). ' +
+  'release, delete, reassign (change owner), release_recursive (release tasks first, then parent), ' +
+  'check (check if a package requires a transport — provide type, name, package). ' +
   'Transport IDs look like A4HK900123. Status: D=modifiable, R=released.';
 
 const SAPTRANSPORT_DESC_BTP =
   'Manage transport requests (BTP ABAP Environment, SE09/SE10 equivalent). ' +
   'Actions: list (defaults to current user, modifiable transports — both Workbench and Customizing), ' +
   'get (details with tasks and objects), create (K=Workbench, W=Customizing, T=Transport of Copies), ' +
-  'release, delete, reassign (change owner), release_recursive (release tasks first, then parent). ' +
+  'release, delete, reassign (change owner), release_recursive (release tasks first, then parent), ' +
+  'check (check if a package requires a transport — provide type, name, package). ' +
   'On BTP, transport release triggers a gCTS push to the software component Git repository. ' +
   'Import into target systems is done via the Manage Software Components app or Cloud Transport Management Service (cTMS), not via this tool.';
 
@@ -412,8 +414,15 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
             description:
               'Object description for create action (defaults to name if omitted). Max 60 chars for most types.',
           },
-          package: { type: 'string', description: 'Package for new objects (default $TMP)' },
-          transport: { type: 'string', description: 'Transport request number (for transportable packages)' },
+          package: {
+            type: 'string',
+            description: 'Package for new objects (default $TMP). Non-$TMP packages require a transport number.',
+          },
+          transport: {
+            type: 'string',
+            description:
+              'Transport request number. Required for non-$TMP packages. Use SAPTransport(action="list") to find or SAPTransport(action="create") to create one.',
+          },
           dataType: { type: 'string', description: 'DOMA/DTEL: ABAP data type (e.g., CHAR, NUMC, DEC)' },
           length: { type: 'number', description: 'DOMA/DTEL: data type length' },
           decimals: { type: 'number', description: 'DOMA/DTEL: decimal places' },
@@ -808,7 +817,7 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
         properties: {
           action: {
             type: 'string',
-            enum: ['list', 'get', 'create', 'release', 'delete', 'reassign', 'release_recursive'],
+            enum: ['list', 'get', 'create', 'release', 'delete', 'reassign', 'release_recursive', 'check'],
             description:
               'list: show transports (defaults to current user, modifiable only). ' +
               'get: fetch transport details including tasks and objects. ' +
@@ -816,7 +825,8 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
               'release: release a single transport or task. ' +
               'delete: delete a transport (use recursive=true to delete tasks first). ' +
               'reassign: change transport owner (use recursive=true for tasks too). ' +
-              'release_recursive: release all unreleased tasks first, then the transport itself.',
+              'release_recursive: release all unreleased tasks first, then the transport itself. ' +
+              'check: check if a transport is needed for a package/object (requires type, name, package).',
           },
           id: {
             type: 'string',
@@ -824,6 +834,8 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
               'Transport request ID, e.g. A4HK900123 (required for get/release/delete/reassign/release_recursive)',
           },
           description: { type: 'string', description: 'Transport description text (required for create)' },
+          name: { type: 'string', description: 'Object name (for check action)' },
+          package: { type: 'string', description: 'Package name (for check action)' },
           user: {
             type: 'string',
             description:
@@ -835,8 +847,8 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
           },
           type: {
             type: 'string',
-            enum: ['K', 'W', 'T'],
-            description: 'Transport type for create: K=Workbench (default), W=Customizing, T=Transport of Copies',
+            description:
+              'For create: transport type K=Workbench (default), W=Customizing, T=Transport of Copies. For check: object type (PROG, CLAS, DDLS, etc.)',
           },
           owner: { type: 'string', description: 'New owner SAP username (required for reassign)' },
           recursive: {

--- a/tests/unit/adt/transport.test.ts
+++ b/tests/unit/adt/transport.test.ts
@@ -9,6 +9,7 @@ import {
   createTransport,
   deleteTransport,
   getTransport,
+  getTransportInfo,
   listTransports,
   reassignTransport,
   releaseTransport,
@@ -632,6 +633,183 @@ describe('Transport Management', () => {
       expect(CTS_ACCEPT_TREE).toBe('application/vnd.sap.adt.transportorganizertree.v1+xml');
       expect(CTS_CONTENT_TYPE_ORGANIZER).toBe('application/vnd.sap.adt.transportorganizer.v1+xml');
       expect(CTS_NAMESPACE_TM).toBe('http://www.sap.com/cts/adt/tm');
+    });
+  });
+
+  // ─── getTransportInfo ─────────────────────────────────────────────
+
+  describe('getTransportInfo', () => {
+    it('posts to /sap/bc/adt/cts/transportchecks endpoint', async () => {
+      const xml = `<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+        <asx:values><DATA>
+          <RECORDING/>
+          <DLVUNIT>LOCAL</DLVUNIT>
+          <DEVCLASS>$TMP</DEVCLASS>
+        </DATA></asx:values>
+      </asx:abap>`;
+      const http = mockHttp(xml);
+      await getTransportInfo(http, unrestrictedSafetyConfig(), '/sap/bc/adt/oo/classes/zcl_test', '$TMP');
+      const url = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+      expect(url).toBe('/sap/bc/adt/cts/transportchecks');
+    });
+
+    it('sends correct content type and accept headers', async () => {
+      const xml = `<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA>
+        <RECORDING/>
+        <DLVUNIT>LOCAL</DLVUNIT>
+        <DEVCLASS>$TMP</DEVCLASS>
+      </DATA></asx:values></asx:abap>`;
+      const http = mockHttp(xml);
+      await getTransportInfo(http, unrestrictedSafetyConfig(), '/sap/bc/adt/oo/classes/zcl_test', '$TMP');
+      const calls = (http.post as ReturnType<typeof vi.fn>).mock.calls[0];
+      const contentType = calls?.[2] as string;
+      expect(contentType).toContain('application/vnd.sap.as+xml');
+      expect(contentType).toContain('dataname=com.sap.adt.transport.service.checkData');
+    });
+
+    it('includes object URI and devclass in request body', async () => {
+      const xml = `<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA>
+        <RECORDING/>
+        <DLVUNIT>LOCAL</DLVUNIT>
+        <DEVCLASS>$TMP</DEVCLASS>
+      </DATA></asx:values></asx:abap>`;
+      const http = mockHttp(xml);
+      await getTransportInfo(http, unrestrictedSafetyConfig(), '/sap/bc/adt/oo/classes/zcl_test', 'Z_MY_PKG');
+      const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
+      expect(body).toContain('<URI>/sap/bc/adt/oo/classes/zcl_test</URI>');
+      expect(body).toContain('<DEVCLASS>Z_MY_PKG</DEVCLASS>');
+      expect(body).toContain('<OPERATION>I</OPERATION>');
+    });
+
+    it('parses local package response (no transport needed)', async () => {
+      const xml = `<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+        <asx:values><DATA>
+          <PGMID>R3TR</PGMID>
+          <OBJECT>CLAS</OBJECT>
+          <OBJECTNAME>ZCL_TEST</OBJECTNAME>
+          <DEVCLASS>$TMP</DEVCLASS>
+          <DLVUNIT>LOCAL</DLVUNIT>
+          <RECORDING/>
+          <KORRFLAG/>
+        </DATA></asx:values>
+      </asx:abap>`;
+      const http = mockHttp(xml);
+      const info = await getTransportInfo(http, unrestrictedSafetyConfig(), '/sap/bc/adt/oo/classes/zcl_test', '$TMP');
+      expect(info.isLocal).toBe(true);
+      expect(info.recording).toBe(false);
+      expect(info.deliveryUnit).toBe('LOCAL');
+      expect(info.devclass).toBe('$TMP');
+      expect(info.existingTransports).toEqual([]);
+      expect(info.lockedTransport).toBeUndefined();
+    });
+
+    it('parses transportable package response (transport required)', async () => {
+      const xml = `<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+        <asx:values><DATA>
+          <PGMID>R3TR</PGMID>
+          <OBJECT>DDLS</OBJECT>
+          <OBJECTNAME>ZI_TRAVEL</OBJECTNAME>
+          <DEVCLASS>Z_RAP_VB_1</DEVCLASS>
+          <DLVUNIT>SAP</DLVUNIT>
+          <RECORDING>X</RECORDING>
+          <KORRFLAG>X</KORRFLAG>
+          <TRANSPORTS>
+            <headers>
+              <TRKORR>A4HK900502</TRKORR>
+              <AS4TEXT>RAP development</AS4TEXT>
+              <AS4USER>DEVELOPER</AS4USER>
+            </headers>
+            <headers>
+              <TRKORR>A4HK900503</TRKORR>
+              <AS4TEXT>CDS views</AS4TEXT>
+              <AS4USER>DEVELOPER</AS4USER>
+            </headers>
+          </TRANSPORTS>
+        </DATA></asx:values>
+      </asx:abap>`;
+      const http = mockHttp(xml);
+      const info = await getTransportInfo(
+        http,
+        unrestrictedSafetyConfig(),
+        '/sap/bc/adt/ddic/ddl/sources/zi_travel',
+        'Z_RAP_VB_1',
+      );
+      expect(info.isLocal).toBe(false);
+      expect(info.recording).toBe(true);
+      expect(info.deliveryUnit).toBe('SAP');
+      expect(info.devclass).toBe('Z_RAP_VB_1');
+      expect(info.existingTransports).toHaveLength(2);
+      expect(info.existingTransports[0]).toEqual({
+        id: 'A4HK900502',
+        description: 'RAP development',
+        owner: 'DEVELOPER',
+      });
+    });
+
+    it('parses locked transport from response', async () => {
+      const xml = `<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+        <asx:values><DATA>
+          <DEVCLASS>Z_MY_PKG</DEVCLASS>
+          <DLVUNIT>SAP</DLVUNIT>
+          <RECORDING>X</RECORDING>
+          <LOCKS>
+            <HEADER>
+              <TRKORR>A4HK900999</TRKORR>
+              <AS4TEXT>Locked transport</AS4TEXT>
+            </HEADER>
+          </LOCKS>
+        </DATA></asx:values>
+      </asx:abap>`;
+      const http = mockHttp(xml);
+      const info = await getTransportInfo(
+        http,
+        unrestrictedSafetyConfig(),
+        '/sap/bc/adt/oo/classes/zcl_test',
+        'Z_MY_PKG',
+      );
+      expect(info.lockedTransport).toBe('A4HK900999');
+    });
+
+    it('does not require enableTransports flag (read-only check)', async () => {
+      const xml = `<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA>
+        <RECORDING/>
+        <DLVUNIT>LOCAL</DLVUNIT>
+        <DEVCLASS>$TMP</DEVCLASS>
+      </DATA></asx:values></asx:abap>`;
+      const http = mockHttp(xml);
+      const safety = { ...unrestrictedSafetyConfig(), enableTransports: false };
+      // Should NOT throw — transportInfo is a read operation
+      const info = await getTransportInfo(http, safety, '/sap/bc/adt/oo/classes/zcl_test', '$TMP');
+      expect(info.isLocal).toBe(true);
+    });
+
+    it('defaults operation to I (insert)', async () => {
+      const xml = `<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA>
+        <RECORDING/>
+        <DLVUNIT>LOCAL</DLVUNIT>
+        <DEVCLASS>$TMP</DEVCLASS>
+      </DATA></asx:values></asx:abap>`;
+      const http = mockHttp(xml);
+      await getTransportInfo(http, unrestrictedSafetyConfig(), '/sap/bc/adt/oo/classes/zcl_test', '$TMP');
+      const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
+      expect(body).toContain('<OPERATION>I</OPERATION>');
+    });
+
+    it('handles empty transport list', async () => {
+      const xml = `<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA>
+        <DEVCLASS>Z_MY_PKG</DEVCLASS>
+        <DLVUNIT>SAP</DLVUNIT>
+        <RECORDING>X</RECORDING>
+      </DATA></asx:values></asx:abap>`;
+      const http = mockHttp(xml);
+      const info = await getTransportInfo(
+        http,
+        unrestrictedSafetyConfig(),
+        '/sap/bc/adt/oo/classes/zcl_test',
+        'Z_MY_PKG',
+      );
+      expect(info.existingTransports).toEqual([]);
+      expect(info.recording).toBe(true);
     });
   });
 });

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -4096,6 +4096,184 @@ ENDCLASS.`;
     });
   });
 
+  // ─── SAPWrite transport pre-flight check ───────────────────────────
+
+  describe('SAPWrite transport pre-flight check', () => {
+    const transportInfoResponse = (recording: boolean, isLocal: boolean, transports: string[] = []) => {
+      const transportEntries = transports
+        .map((t) => `<headers><TRKORR>${t}</TRKORR><AS4TEXT>Transport ${t}</AS4TEXT><AS4USER>DEV</AS4USER></headers>`)
+        .join('');
+      return `<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA>
+        <RECORDING>${recording ? 'X' : ''}</RECORDING>
+        <DLVUNIT>${isLocal ? 'LOCAL' : 'SAP'}</DLVUNIT>
+        <DEVCLASS>Z_MY_PKG</DEVCLASS>
+        ${transports.length > 0 ? `<TRANSPORTS>${transportEntries}</TRANSPORTS>` : ''}
+      </DATA></asx:values></asx:abap>`;
+    };
+
+    it('returns guidance error when creating in transportable package without transport', async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      mockFetch.mockImplementation((url: string, opts: any) => {
+        calls.push({ url: String(url), method: opts?.method ?? 'GET' });
+        if (String(url).includes('/cts/transportchecks')) {
+          return Promise.resolve(
+            mockResponse(200, transportInfoResponse(true, false, ['A4HK900502']), { 'x-csrf-token': 'T' }),
+          );
+        }
+        return Promise.resolve(mockResponse(200, '<xml/>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'create',
+        type: 'PROG',
+        name: 'ZTEST',
+        package: 'Z_MY_PKG',
+        source: 'REPORT ztest.',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('requires a transport number');
+      expect(result.content[0]?.text).toContain('SAPTransport');
+      expect(result.content[0]?.text).toContain('A4HK900502');
+    });
+
+    it('proceeds without transport for $TMP packages (no transportInfo call)', async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      mockFetch.mockImplementation((url: string, opts: any) => {
+        calls.push({ url: String(url), method: opts?.method ?? 'GET' });
+        return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'create',
+        type: 'PROG',
+        name: 'ZTEST',
+        package: '$TMP',
+        source: 'REPORT ztest.',
+      });
+
+      expect(result.isError).toBeUndefined();
+      // No call to transportchecks for $TMP
+      expect(calls.some((c) => c.url.includes('/cts/transportchecks'))).toBe(false);
+    });
+
+    it('proceeds when transport is explicitly provided (no transportInfo call)', async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      mockFetch.mockImplementation((url: string, opts: any) => {
+        calls.push({ url: String(url), method: opts?.method ?? 'GET' });
+        return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'create',
+        type: 'PROG',
+        name: 'ZTEST',
+        package: 'Z_MY_PKG',
+        transport: 'A4HK900502',
+        source: 'REPORT ztest.',
+      });
+
+      expect(result.isError).toBeUndefined();
+      // No call to transportchecks when transport is explicitly provided
+      expect(calls.some((c) => c.url.includes('/cts/transportchecks'))).toBe(false);
+    });
+
+    it('auto-uses locked transport from transportInfo response', async () => {
+      const lockedResponse = `<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA>
+        <RECORDING>X</RECORDING>
+        <DLVUNIT>SAP</DLVUNIT>
+        <DEVCLASS>Z_MY_PKG</DEVCLASS>
+        <LOCKS><HEADER><TRKORR>A4HK900999</TRKORR></HEADER></LOCKS>
+      </DATA></asx:values></asx:abap>`;
+      const calls: Array<{ url: string; method: string }> = [];
+      mockFetch.mockImplementation((url: string, opts: any) => {
+        calls.push({ url: String(url), method: opts?.method ?? 'GET' });
+        if (String(url).includes('/cts/transportchecks')) {
+          return Promise.resolve(mockResponse(200, lockedResponse, { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'create',
+        type: 'PROG',
+        name: 'ZTEST',
+        package: 'Z_MY_PKG',
+        source: 'REPORT ztest.',
+      });
+
+      expect(result.isError).toBeUndefined();
+      // Create call should include the locked transport as corrNr
+      const createCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/programs/programs'));
+      expect(createCall?.url).toContain('corrNr=A4HK900999');
+    });
+
+    it('proceeds if transportInfo check fails (graceful fallback)', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url).includes('/cts/transportchecks')) {
+          return Promise.resolve(mockResponse(500, 'Internal Error', { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'create',
+        type: 'PROG',
+        name: 'ZTEST',
+        package: 'Z_MY_PKG',
+        source: 'REPORT ztest.',
+      });
+
+      // Should proceed without blocking — SAP will return its own error if needed
+      // (may still fail later for other reasons, but transport check itself should not block)
+      expect(result.content[0]?.text).not.toContain('requires a transport number');
+    });
+
+    it('returns guidance error for batch_create in transportable package without transport', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url).includes('/cts/transportchecks')) {
+          return Promise.resolve(
+            mockResponse(200, transportInfoResponse(true, false, ['A4HK900502']), { 'x-csrf-token': 'T' }),
+          );
+        }
+        return Promise.resolve(mockResponse(200, '<xml/>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'batch_create',
+        package: 'Z_MY_PKG',
+        objects: [
+          { type: 'DDLS', name: 'ZI_TRAVEL', source: '@EndUserText.label: "Travel"\ndefine view entity ZI_TRAVEL ...' },
+        ],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('requires a transport number');
+      expect(result.content[0]?.text).toContain('SAPTransport');
+    });
+
+    it('proceeds for local package response even if DLVUNIT is not LOCAL', async () => {
+      // Some packages might not require recording even if not strictly "LOCAL"
+      mockFetch.mockImplementation((url: string) => {
+        if (String(url).includes('/cts/transportchecks')) {
+          return Promise.resolve(mockResponse(200, transportInfoResponse(false, false), { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'create',
+        type: 'PROG',
+        name: 'ZTEST',
+        package: 'Z_MY_PKG',
+        source: 'REPORT ztest.',
+      });
+
+      // recording=false → no transport needed, proceed
+      expect(result.content[0]?.text).not.toContain('requires a transport number');
+    });
+  });
+
   // ─── SAPTransport handler routing ─────────────────────────────────
 
   describe('SAPTransport handler routing', () => {


### PR DESCRIPTION
## Summary
- **Transport pre-flight check**: When creating objects in transportable packages (non-`$TMP`) without a transport number, ARC-1 now calls `POST /sap/bc/adt/cts/transportchecks` to detect whether a transport is required. Returns an actionable error with existing transports and step-by-step guidance to use `SAPTransport` first.
- **Auto-use locked transport**: If the transport check reveals the object is already locked in a transport, that transport is used automatically — no user action needed.
- **New `SAPTransport(action="check")`**: Explicit action to check transport requirements for a given package/object combination, returns JSON with `transportRequired`, `existingTransports`, and `lockedTransport`.
- **Graceful fallback**: If the transport check endpoint fails (older system, permissions), proceeds without blocking — SAP will return its own error if a transport is truly needed.

## Context
When an LLM tries to create DDLS/BDEF/SRVD objects in transportable packages like `Z_RAP_VB_1`, SAP requires a transport number. Previously, the LLM would get a cryptic SAP error. Now it gets a clear message like:

```
Package "Z_RAP_VB_1" requires a transport number for object creation, but none was provided.

To fix this, either:
1. Use SAPTransport(action="list") to find an existing modifiable transport
2. Use SAPTransport(action="create", description="...") to create a new one
3. Then retry SAPWrite(action="create", ..., transport="<transport_id>")

Existing transports for this package:
  - A4HK900502: RAP development (DEVELOPER)
```

## Files changed
| File | Change |
|------|--------|
| `src/adt/transport.ts` | Add `getTransportInfo()` and `TransportInfo` type |
| `src/handlers/intent.ts` | Pre-flight transport check in create/batch_create flows |
| `src/handlers/schemas.ts` | Add `check` action and `name`/`package` fields to SAPTransport schema |
| `src/handlers/tools.ts` | Update tool descriptions for transport requirements |
| `tests/unit/adt/transport.test.ts` | 9 new tests for `getTransportInfo()` |
| `tests/unit/handlers/intent.test.ts` | 7 new tests for transport pre-flight logic |

## Test plan
- [x] All 1531 unit tests pass
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npx biome check`)
- [x] TypeScript type check passes (`npm run typecheck`)
- [ ] Integration test on SAP A4H system (transport list verified via MCP)
- [ ] Test DDLS creation in `Z_RAP_VB_1` with transport number end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)