### PR TITLE
docs: RAP object creation gap analysis, roadmap items & implementation plans

### DIFF
--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -120,6 +120,11 @@ _Last updated: 2026-04-13 (fr0ster v5.0.8: 14 activation tools, 303 total)_
 | AFF schema validation (pre-create) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
 | Type auto-mappings (CLAS→CLAS/OC) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ | ✅ (ADTObjectType) |
 | Create test class | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ | ✅ (class write test_classes) |
+| Table write (TABL) | ❌ (FEAT-44) | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ | ✅ |
+| Package create (DEVC) | ❌ (FEAT-45) | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ | ✅ |
+| Service binding create (SRVB) | ❌ (FEAT-46) | ❌ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ | ✅ |
+| Message class write (MSAG) | ❌ (FEAT-47) | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ✅ |
+| DCL write (DCLS) | ❌ (FEAT-37) | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ✅ |
 
 ## 7. Code Intelligence
 

--- a/docs/plans/feat-44-tabl-create.md
+++ b/docs/plans/feat-44-tabl-create.md
@@ -1,0 +1,167 @@
+# Plan: FEAT-44 TABL (Database Table) Create/Update/Delete
+
+## Overview
+
+Add create, update, and delete support for DDIC database tables (TABL) to the SAPWrite tool. Tables are a prerequisite for CDS-based RAP development — root views reference persistent tables, and draft tables are required for managed BOs with draft. Two real-world RAP projects ([Xexer/abap_rap_blog](https://github.com/Xexer/abap_rap_blog) with 8 tables, [SAP-samples/cloud-abap-rap](https://github.com/SAP-samples/cloud-abap-rap) with 15 tables) cannot be created end-to-end without TABL write support.
+
+**Critical design decision:** TABL is a **source-based** type, not a metadata-based type like DOMA/DTEL. Research from abap-adt-api (gold standard) confirms that table creation uses a `blue:blueSource` XML shell (like BDEF), and field definitions are written via `/source/main` as CDS-style source text. This means TABL follows the same create-then-write-source pattern as DDLS/BDEF/SRVD, NOT the XML-metadata pattern of DOMA/DTEL.
+
+Key findings from abap-adt-api and sapcli:
+- **XML shell:** `<blue:blueSource>` root element with `adtcore:type="TABL/DT"`, namespace `http://www.sap.com/wbobj/blue`
+- **Content-type for creation:** `application/*` (same as DDLS/BDEF — the wildcard lets SAP resolve)
+- **Source URL:** `/sap/bc/adt/ddic/tables/{name}/source/main` (already used by ARC-1's `getTable()`)
+- **Source format:** CDS-like definition text (`@EndUserText.label : 'description'\ndefine table ztable {\n  key client : abap.clnt;\n  ...}`)
+- **Activation required:** Yes, standard activation after create
+
+## Context
+
+### Current State
+
+- TABL **read** is fully implemented: `client.getTable(name)` reads source from `/sap/bc/adt/ddic/tables/{name}/source/main`
+- `objectBasePath('TABL')` already returns `/sap/bc/adt/ddic/tables/` (intent.ts line ~1507)
+- `SAPREAD_TYPES` includes TABL for both on-prem and BTP
+- `SAPWRITE_TYPES` does NOT include TABL
+- `buildCreateXml()` has no TABL case — falls through to generic objectReferences (which would fail)
+- `isDdicMetadataType()` returns false for TABL (correct — TABL is source-based)
+- The existing BDEF case in `buildCreateXml()` (line ~1370) uses `blue:blueSource` — TABL uses the same XML root element
+
+### Target State
+
+- SAPWrite supports `create`, `update`, `delete` for TABL
+- `batch_create` also supports TABL (critical for RAP stack creation: tables → CDS views → BDEF → SRVD)
+- TABL creation: POST shell XML to `/sap/bc/adt/ddic/tables/`, then PUT source to `/source/main`
+- TABL update: standard lock → PUT source → unlock (same as DDLS/BDEF)
+- TABL delete: standard lock → DELETE → unlock
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/handlers/intent.ts` | `handleSAPWrite()` (line ~1551), `buildCreateXml()` (line ~1302), `objectBasePath()` (line ~1483), `isDdicMetadataType()` (line ~1042), `needsVendorContentType()` (line ~1047) |
+| `src/handlers/tools.ts` | `SAPWRITE_TYPES_ONPREM` / `SAPWRITE_TYPES_BTP` (line ~103-104), tool descriptions (line ~106-118) |
+| `src/handlers/schemas.ts` | Zod `SAPWRITE_TYPES_ONPREM` / `SAPWRITE_TYPES_BTP` (line ~123-136), batch object schemas |
+| `src/adt/client.ts` | `getTable(name)` at line ~281 — reads via `/source/main` |
+| `src/adt/crud.ts` | `createObject()`, `safeUpdateSource()`, delete flow — all reusable |
+| `src/adt/ddic-xml.ts` | Existing DOMA/DTEL builders — reference for XML builder pattern |
+| `tests/unit/handlers/intent.test.ts` | SAPWrite handler tests |
+| `tests/unit/adt/ddic-xml.test.ts` | DDIC XML builder tests — reference for test pattern |
+| `tests/e2e/rap-write.e2e.test.ts` | RAP write lifecycle E2E tests — add TABL lifecycle here |
+
+### Design Principles
+
+1. **Source-based, not metadata-based**: TABL uses `/source/main` like DDLS/BDEF/SRVD. Do NOT add TABL to `isDdicMetadataType()`. The create flow is: POST shell XML → write source via PUT → activate.
+2. **Reuse BDEF's blue:blueSource pattern**: The XML shell for TABL creation is nearly identical to BDEF — same root element, same namespace, only `adtcore:type` differs (`TABL/DT` vs `BDEF/BDO`).
+3. **No new CRUD primitives needed**: `createObject()`, `safeUpdateSource()`, and the delete flow in intent.ts all work as-is for TABL.
+4. **BTP compatibility**: TABL is supported on BTP ABAP Environment (for custom tables). Add to both on-prem and BTP write type arrays.
+5. **Content-type**: Use `application/*` for creation (matching abap-adt-api's approach), not a vendor-specific type. Do NOT add TABL to `needsVendorContentType()`.
+
+## Development Approach
+
+- Follow the BDEF pattern exactly since TABL uses the same XML root element
+- The main changes are: add TABL to type arrays, add TABL case to `buildCreateXml()`, update descriptions
+- Test with XML snapshot assertions on the builder, plus E2E lifecycle on the test system
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add TABL to write type arrays and buildCreateXml
+
+**Files:**
+- Modify: `src/handlers/tools.ts`
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+- Modify: `tests/unit/adt/ddic-xml.test.ts`
+
+Add TABL as a writable type and implement the creation XML builder. TABL uses the same `blue:blueSource` XML shell as BDEF (line ~1370 in intent.ts), with `adtcore:type="TABL/DT"` instead of `BDEF/BDO`.
+
+- [ ] Add `'TABL'` to `SAPWRITE_TYPES_ONPREM` array in `src/handlers/tools.ts` (line ~103) — insert after `'SRVD'` to keep alphabetical grouping with other DDIC types
+- [ ] Add `'TABL'` to `SAPWRITE_TYPES_BTP` array in `src/handlers/tools.ts` (line ~104)
+- [ ] Update `SAPWRITE_DESC_ONPREM` (line ~106) and `SAPWRITE_DESC_BTP` (line ~113) to mention TABL in the supported types list
+- [ ] Add `'TABL'` to `SAPWRITE_TYPES_ONPREM` array in `src/handlers/schemas.ts` (line ~123)
+- [ ] Add `'TABL'` to `SAPWRITE_TYPES_BTP` array in `src/handlers/schemas.ts` (line ~136)
+- [ ] Add `'TABL'` to the batch object schema type enums in `src/handlers/schemas.ts` (both `batchObjectSchemaOnprem` at line ~144 and `batchObjectSchemaBtp` at line ~172)
+- [ ] Add a `case 'TABL':` to `buildCreateXml()` in `src/handlers/intent.ts` (line ~1302). The XML is identical to the BDEF case (line ~1370) except `adtcore:type="TABL/DT"`. Use:
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue"
+                   xmlns:adtcore="http://www.sap.com/adt/core"
+                   adtcore:description="${escapeXml(description)}"
+                   adtcore:name="${escapeXml(name)}"
+                   adtcore:type="TABL/DT"
+                   adtcore:masterLanguage="EN"
+                   adtcore:masterSystem="H00"
+                   adtcore:responsible="DEVELOPER">
+    <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+  </blue:blueSource>
+  ```
+- [ ] Verify that TABL does NOT need to be added to `isDdicMetadataType()` (line ~1042) — TABL is source-based, not metadata-based. The existing `case 'create':` handler (line ~1611) will correctly follow the source-write path (step 2: write source if provided).
+- [ ] Verify that TABL does NOT need to be added to `needsVendorContentType()` (line ~1047) — TABL uses `application/*` like DDLS/SRVD.
+- [ ] Add unit tests (~5 tests) in `tests/unit/handlers/intent.test.ts`:
+  - `buildCreateXml('TABL', ...)` produces correct XML with `blue:blueSource` root and `TABL/DT` type
+  - SAPWrite create with type=TABL calls createObject + safeUpdateSource (not safeUpdateObject)
+  - SAPWrite update with type=TABL calls safeUpdateSource (source-based, not metadata)
+  - SAPWrite delete with type=TABL follows lock/delete/unlock
+  - SAPWrite batch_create with TABL processes source correctly
+- [ ] Run `npm test` — all tests must pass
+
+### Task 2: Update tool descriptions and JSON Schema
+
+**Files:**
+- Modify: `src/handlers/tools.ts`
+- Modify: `docs/tools.md`
+
+Update the SAPWrite tool description and JSON Schema input properties to document TABL support, and update the tools reference doc.
+
+- [ ] In `src/handlers/tools.ts`, update the SAPWrite `inputSchema.properties.type.description` to mention TABL alongside other supported types
+- [ ] In `src/handlers/tools.ts`, update the `objects` array item description to mention TABL can be included in batch_create for RAP stack creation
+- [ ] In `docs/tools.md`, add TABL to the SAPWrite supported types table. Add an example showing TABL creation with source:
+  ```
+  SAPWrite(action="create", type="TABL", name="ZTRAVEL", package="$TMP",
+    source="@EndUserText.label : 'Travel'\ndefine table ztravel {\n  key client : abap.clnt;\n  key travel_id : abap.numc(8);\n  description : abap.char(256);\n}")
+  ```
+- [ ] In `docs/tools.md`, update the batch_create example to show a TABL → DDLS → BDEF → SRVD sequence
+- [ ] Run `npm test` — all tests must pass
+
+### Task 3: Add E2E test for TABL lifecycle
+
+**Files:**
+- Modify: `tests/e2e/rap-write.e2e.test.ts`
+
+Add a TABL create → read → update → activate → delete lifecycle test to the RAP write E2E suite. This test exercises the full MCP JSON-RPC stack.
+
+- [ ] Add a new test case to `tests/e2e/rap-write.e2e.test.ts`: `'SAPWrite create TABL, read, update, activate, delete'`. Use `uniqueName('ZTABL_')` for a collision-safe name. The test should:
+  1. Create a table with `SAPWrite(action="create", type="TABL", name=..., package="$TMP", source="@EndUserText.label : '...'\ndefine table ... { key client : abap.clnt; key id : abap.numc(8); }")`
+  2. Read it back with `SAPRead(type="TABL", name=...)` and verify source contains the field definitions
+  3. Activate with `SAPActivate(name=..., type="TABL")`
+  4. Update source with `SAPWrite(action="update", type="TABL", name=..., source=...)` adding a new field
+  5. Delete with `SAPWrite(action="delete", type="TABL", name=...)`
+  6. Use `try/finally` with `bestEffortDelete()` for cleanup
+- [ ] The test should use `requireOrSkip(ctx, rapAvailable, 'RAP/CDS not available on test system')` since TABL creation on the test system may require CDS support
+- [ ] Run `npm test` — all tests must pass (E2E tests only run with `npm run test:e2e`)
+
+### Task 4: Update documentation and roadmap
+
+**Files:**
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+
+Update all documentation artifacts to reflect TABL write support.
+
+- [ ] In `docs/roadmap.md`, update FEAT-44 status from "Not started" to "Completed"
+- [ ] In `compare/00-feature-matrix.md`, update the "Table write (TABL)" row: change `❌ (FEAT-44)` to `✅`
+- [ ] In `CLAUDE.md`, update the `SAPWRITE_TYPES` references in Code Patterns or any mention of supported write types to include TABL
+- [ ] Run `npm test` — all tests must pass
+
+### Task 5: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Verify `buildCreateXml('TABL', 'ZTEST', '$TMP', 'Test')` produces valid XML with `blue:blueSource` root and `TABL/DT` type
+- [ ] Verify that SAPWrite create with type=TABL follows the source-write path (NOT the DDIC metadata path)
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/feat-45-devc-create.md
+++ b/docs/plans/feat-45-devc-create.md
@@ -1,0 +1,209 @@
+# Plan: FEAT-45 DEVC (Package) Create
+
+## Overview
+
+Add package creation to ARC-1 via the SAPManage tool. Packages (DEVC) are the container for all ABAP development objects — without package creation, LLMs cannot set up greenfield projects or organize objects into proper packages. Six of eight competitors support package creation.
+
+**Key design decision: SAPManage, not SAPWrite.** Packages are infrastructure/administrative objects, not source code objects. They don't have source code, don't need activation, and their creation XML is fundamentally different from all SAPWrite types. Following ARC-1's intent-based design:
+- SAPWrite = source code and DDIC metadata objects (PROG, CLAS, DDLS, DOMA, DTEL, TABL, etc.)
+- SAPManage = infrastructure operations (features, probe, cache, FLP, and now packages)
+
+Research from abap-adt-api (gold standard):
+- **Endpoint:** `POST /sap/bc/adt/packages`
+- **Content-type:** `application/*`
+- **XML root:** `<pak:package>` with namespace `http://www.sap.com/adt/packages`
+- **ADT type:** `DEVC/K`
+- **Required fields:** name, description, superPackage, softwareComponent, transportLayer, packageType
+- **No activation needed** — packages are active on creation
+- **Transport:** Non-local packages require a transport number (`?corrNr=...`)
+
+## Context
+
+### Current State
+
+- Package **read** is implemented: `client.getPackageContents()` lists objects via `/sap/bc/adt/repository/nodestructure`
+- `SAPRead type=DEVC` returns package contents as JSON
+- `objectBasePath('DEVC')` is NOT currently mapped (unlike TABL, SRVB which are)
+- No create/delete support for packages
+- `checkPackage()` in safety.ts validates the *target* package for writes — for DEVC creation, we should validate the *parent* (superPackage), not the new package name itself
+
+### Target State
+
+- `SAPManage action=create_package` creates a new package with specified properties
+- `SAPManage action=delete_package` deletes an existing package
+- Required parameters: name, description; optional: superPackage, packageType, softwareComponent, transportLayer, transport
+- Sensible defaults: packageType=development, superPackage derived from name prefix or empty
+- Safety: package creation is gated by `checkOperation(safety, OperationType.Create, 'CreatePackage')` — blocked by `readOnly`
+- Transport pre-flight: same pattern as SAPWrite create for non-$TMP packages
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/handlers/intent.ts` | `handleSAPManage()` — add `create_package` and `delete_package` actions |
+| `src/handlers/tools.ts` | SAPManage tool definition — add actions and parameters to JSON Schema |
+| `src/handlers/schemas.ts` | `SAPManageSchema` (line ~371) — add `create_package`/`delete_package` to action enum and new fields |
+| `src/adt/crud.ts` | `createObject()` — reusable for package POST; lock/delete flow for deletion |
+| `src/adt/safety.ts` | `checkOperation()`, `checkPackage()` — safety gates |
+| `src/adt/client.ts` | `getPackageContents()` at line ~369 — existing read; add package metadata read if needed |
+| `tests/unit/handlers/intent.test.ts` | SAPManage handler tests |
+| `tests/e2e/rap-write.e2e.test.ts` | E2E tests — add package lifecycle test |
+
+### Design Principles
+
+1. **SAPManage is the right home**: Packages are infrastructure, not source code. FLP operations (catalogs, groups, tiles) are already in SAPManage — packages follow the same pattern.
+2. **Reuse existing CRUD primitives**: `createObject()` from `src/adt/crud.ts` works for the POST. Delete uses the standard lock/DELETE/unlock flow.
+3. **Dedicated XML builder**: Package XML is complex (superPackage, softwareComponent, transportLayer, packageType) — use a dedicated builder function, similar to `buildDomainXml()` in `ddic-xml.ts`.
+4. **Safety enforcement**: Use `checkOperation(safety, OperationType.Create, 'CreatePackage')` for creation. For package allowlist checking, validate the *superPackage* (parent), not the new package name — you can't restrict creating children of $TMP if $TMP is in the allowlist.
+5. **Transport handling**: Reuse the existing transport pre-flight pattern from SAPWrite create (intent.ts line ~1616-1650).
+6. **No activation**: Packages are immediately active after creation — no SAPActivate step needed.
+
+## Development Approach
+
+- Add a dedicated package XML builder function in a new section of `src/adt/ddic-xml.ts` (or a new `src/adt/package-xml.ts` if cleaner)
+- Wire into SAPManage handler with new actions
+- Test with unit tests for XML builder and handler routing, plus E2E lifecycle
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add package XML builder
+
+**Files:**
+- Modify: `src/adt/ddic-xml.ts`
+- Modify: `tests/unit/adt/ddic-xml.test.ts`
+
+Add a `buildPackageXml()` function to `src/adt/ddic-xml.ts` that constructs the DEVC creation XML. The XML follows the abap-adt-api pattern with `pak:package` root element.
+
+- [ ] Add a `PackageCreateParams` interface to `src/adt/ddic-xml.ts`:
+  ```typescript
+  export interface PackageCreateParams {
+    name: string;
+    description: string;
+    superPackage?: string;       // parent package (default: empty)
+    softwareComponent?: string;  // e.g., "LOCAL" or "HOME"
+    transportLayer?: string;     // e.g., "HOME" or system-specific
+    packageType?: 'development' | 'structure' | 'main';  // default: 'development'
+  }
+  ```
+- [ ] Add `buildPackageXml(params: PackageCreateParams): string` function. Based on abap-adt-api research, the XML format is:
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <pak:package xmlns:pak="http://www.sap.com/adt/packages"
+    xmlns:adtcore="http://www.sap.com/adt/core"
+    adtcore:description="..."
+    adtcore:name="ZPACKAGE"
+    adtcore:type="DEVC/K"
+    adtcore:version="active"
+    adtcore:responsible="DEVELOPER">
+    <adtcore:packageRef adtcore:name="ZPACKAGE"/>
+    <pak:attributes pak:packageType="development"/>
+    <pak:superPackage adtcore:name="PARENT_PACKAGE"/>
+    <pak:applicationComponent/>
+    <pak:transport>
+      <pak:softwareComponent pak:name="LOCAL"/>
+      <pak:transportLayer pak:name=""/>
+    </pak:transport>
+    <pak:translation/>
+    <pak:useAccesses/>
+    <pak:packageInterfaces/>
+    <pak:subPackages/>
+  </pak:package>
+  ```
+  All user-provided values must be XML-escaped via the existing `escapeXml()` function.
+- [ ] Add unit tests (~6 tests) in `tests/unit/adt/ddic-xml.test.ts`:
+  - `buildPackageXml` basic with name and description
+  - `buildPackageXml` with superPackage specified
+  - `buildPackageXml` with softwareComponent and transportLayer
+  - `buildPackageXml` with packageType='structure'
+  - `buildPackageXml` defaults (packageType=development, empty superPackage)
+  - `buildPackageXml` XML escaping of special characters in description
+- [ ] Run `npm test` — all tests must pass
+
+### Task 2: Wire package create/delete into SAPManage handler
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `src/handlers/tools.ts`
+- Modify: `src/handlers/schemas.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+Add `create_package` and `delete_package` actions to SAPManage. The create action uses the XML builder from Task 1 and POSTs to `/sap/bc/adt/packages`. The delete action uses the standard lock/DELETE/unlock flow.
+
+- [ ] In `src/handlers/schemas.ts`, add `'create_package'` and `'delete_package'` to the `SAPManageSchema` action enum (line ~372). Add new optional fields to the schema:
+  - `name: z.string().optional()` (if not already present)
+  - `description: z.string().optional()` (if not already present — check; it's not in current SAPManageSchema)
+  - `superPackage: z.string().optional()`
+  - `softwareComponent: z.string().optional()`
+  - `transportLayer: z.string().optional()`
+  - `packageType: z.enum(['development', 'structure', 'main']).optional()`
+  - `transport: z.string().optional()`
+  Note: some fields like `name` and `description` may not exist yet in SAPManageSchema — add them if missing.
+- [ ] In `src/handlers/tools.ts`, update the SAPManage tool definition:
+  - Add `'create_package'` and `'delete_package'` to the action enum in `inputSchema.properties.action.enum`
+  - Add new properties to `inputSchema.properties`: `name`, `description` (if not present), `superPackage`, `softwareComponent`, `transportLayer`, `packageType`, `transport`
+  - Update the SAPManage description string to mention package management
+- [ ] In `src/handlers/intent.ts`, find the `handleSAPManage()` function and add cases for `create_package` and `delete_package`:
+  - **create_package**: Extract params (name, description, superPackage, softwareComponent, transportLayer, packageType, transport). Call `checkOperation(safety, OperationType.Create, 'CreatePackage')`. Build XML via `buildPackageXml()`. POST to `/sap/bc/adt/packages` via `createObject()` from crud.ts. Add transport pre-flight check (same pattern as SAPWrite create at intent.ts line ~1616-1650, using `/sap/bc/adt/packages/${name}` as the object URL for transport info). Return success message.
+  - **delete_package**: Extract name and transport. Call `checkOperation(safety, OperationType.Delete, 'DeletePackage')`. Use lock/delete/unlock flow via `client.http.withStatefulSession()` (same pattern as SAPWrite delete at intent.ts line ~1749-1766) against `/sap/bc/adt/packages/${name}`.
+- [ ] Add unit tests (~8 tests) in `tests/unit/handlers/intent.test.ts`:
+  - SAPManage create_package happy path — calls createObject with correct URL and XML body
+  - SAPManage create_package with transport — appends corrNr query parameter
+  - SAPManage create_package without name — returns error
+  - SAPManage create_package blocked by readOnly — returns AdtSafetyError
+  - SAPManage delete_package happy path — calls lock/delete/unlock
+  - SAPManage delete_package blocked by readOnly — returns AdtSafetyError
+  - SAPManage create_package transport pre-flight — returns guidance when transport required but not provided
+  - SAPManage create_package with all optional fields — XML contains superPackage, softwareComponent, etc.
+- [ ] Run `npm test` — all tests must pass
+
+### Task 3: Add E2E test for package lifecycle
+
+**Files:**
+- Modify: `tests/e2e/rap-write.e2e.test.ts`
+
+Add a package create → verify → delete lifecycle test to the E2E suite. Packages don't need activation, so the lifecycle is simpler.
+
+- [ ] Add a new test case: `'SAPManage create_package, verify, delete'`. Use `uniqueName('ZARC1T_')` for a collision-safe name (packages max 30 chars). The test should:
+  1. Create a package with `SAPManage(action="create_package", name=..., description="ARC-1 E2E test package")` in `$TMP` (no transport needed)
+  2. Read contents with `SAPRead(type="DEVC", name=...)` — verify it returns (possibly empty) contents
+  3. Delete with `SAPManage(action="delete_package", name=...)`
+  4. Use `try/finally` for cleanup — best-effort delete in finally block
+- [ ] The test does NOT need rapAvailable check — packages are a basic ABAP feature available on all systems
+- [ ] Run `npm test` — all tests must pass (E2E tests only run with `npm run test:e2e`)
+
+### Task 4: Update documentation and roadmap
+
+**Files:**
+- Modify: `docs/tools.md`
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+
+Update all documentation artifacts to reflect package creation support.
+
+- [ ] In `docs/tools.md`, add `create_package` and `delete_package` to the SAPManage section. Document parameters (name, description, superPackage, softwareComponent, transportLayer, packageType, transport). Add examples:
+  ```
+  SAPManage(action="create_package", name="ZRAP_TRAVEL", description="RAP Travel Demo")
+  SAPManage(action="create_package", name="ZRAP_TRAVEL", description="RAP Travel Demo",
+    superPackage="ZRAP", softwareComponent="HOME", transportLayer="HOME",
+    packageType="development", transport="K900123")
+  SAPManage(action="delete_package", name="ZRAP_TRAVEL")
+  ```
+- [ ] In `docs/roadmap.md`, update FEAT-45 status from "Not started" to "Completed"
+- [ ] In `compare/00-feature-matrix.md`, update the "Package create (DEVC)" row: change `❌ (FEAT-45)` to `✅`
+- [ ] In `CLAUDE.md`, update the Key Files table to mention package creation under "Add new write operation" or add a new row for package operations pointing to `src/handlers/intent.ts` (handleSAPManage), `src/adt/ddic-xml.ts` (buildPackageXml)
+- [ ] Run `npm test` — all tests must pass
+
+### Task 5: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Verify `buildPackageXml({ name: 'ZTEST', description: 'Test' })` produces valid XML with `pak:package` root and `DEVC/K` type
+- [ ] Verify SAPManage create_package is blocked by `readOnly=true`
+- [ ] Verify SAPManage create_package handles transport pre-flight for non-$TMP packages
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/feat-46-srvb-create.md
+++ b/docs/plans/feat-46-srvb-create.md
@@ -1,0 +1,226 @@
+# Plan: FEAT-46 SRVB (Service Binding) Create
+
+## Overview
+
+Add SRVB (Service Binding) creation to the SAPWrite tool. ARC-1 already reads service bindings (`SAPRead type=SRVB`) and can publish/unpublish them via `SAPActivate action=publish_srvb/unpublish_srvb`, but cannot create the binding object itself. This is the last missing piece for a fully automated RAP stack lifecycle: TABL → DDLS → BDEF → SRVD → CLAS → **SRVB** → publish.
+
+Research from abap-adt-api (gold standard):
+- **Endpoint:** `POST /sap/bc/adt/businessservices/bindings`
+- **Content-type:** `application/*`
+- **XML root:** `<srvb:serviceBinding>` with namespace `http://www.sap.com/adt/ddic/ServiceBindings`
+- **ADT type:** `SRVB/SVB`
+- **Required fields:** name, description, service definition reference, binding type (ODATA), category (0=Web API, 1=UI)
+- **Source-based:** SRVB is NOT a source-based type — it has no `/source/main` endpoint. It's a metadata-structured object like DOMA/DTEL, but with a unique XML structure for binding configuration
+- **Activation required:** Yes, standard activation after creation. Then publish via `publish_srvb` to make OData service available
+
+**Design consideration:** SRVB read already uses a vendor content type (`application/vnd.sap.adt.businessservices.servicebinding.v2+xml`) for the Accept header. For creation, abap-adt-api uses `application/*` which works. The creation XML includes the service definition reference and binding properties.
+
+## Context
+
+### Current State
+
+- SRVB **read** is implemented: `client.getSrvb(name)` at line ~272 in client.ts reads via `/sap/bc/adt/businessservices/bindings/{name}` with vendor Accept header
+- `SAPRead type=SRVB` returns structured JSON: OData version, binding type, publish status, service definition ref
+- `objectBasePath('SRVB')` already returns `/sap/bc/adt/businessservices/bindings/` (intent.ts line ~1505)
+- `SAPActivate action=publish_srvb` and `unpublish_srvb` already work via `devtools.ts` (line ~158, ~177)
+- SRVB is NOT in `SAPWRITE_TYPES` — cannot be created
+- `buildCreateXml()` has no SRVB case
+- SRVB creation XML is more complex than source-based types — it needs nested `<srvb:services>` and `<srvb:binding>` elements
+
+### Target State
+
+- SAPWrite supports `create`, `update`, `delete` for SRVB
+- `batch_create` also supports SRVB (final piece in RAP stack sequence)
+- SRVB creation requires: name, description, service definition name, optional binding type/category
+- After creation + activation, guide the LLM to use `SAPActivate action=publish_srvb` to publish
+- SRVB is treated as a metadata type (no `/source/main`) — update uses XML PUT, not source PUT
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/handlers/intent.ts` | `handleSAPWrite()` (line ~1551), `buildCreateXml()` (line ~1302), `objectBasePath()` (line ~1483), `isDdicMetadataType()` (line ~1042), `needsVendorContentType()` (line ~1047), `vendorContentTypeForType()` (line ~1070) |
+| `src/handlers/tools.ts` | `SAPWRITE_TYPES_ONPREM/BTP` (line ~103-104), tool descriptions |
+| `src/handlers/schemas.ts` | `SAPWRITE_TYPES` Zod enums (line ~123-136), SAPWriteSchema |
+| `src/adt/client.ts` | `getSrvb()` at line ~272 — existing read with vendor content type |
+| `src/adt/crud.ts` | `createObject()`, `safeUpdateObject()`, delete flow |
+| `src/adt/devtools.ts` | `publishServiceBinding()` at line ~158, `unpublishServiceBinding()` at line ~177 |
+| `src/adt/ddic-xml.ts` | Existing XML builders — add SRVB builder here |
+| `tests/unit/handlers/intent.test.ts` | SAPWrite handler tests |
+| `tests/unit/adt/ddic-xml.test.ts` | XML builder tests |
+| `tests/e2e/rap-write.e2e.test.ts` | RAP write lifecycle E2E tests |
+
+### Design Principles
+
+1. **Metadata-type pattern, but distinct from DOMA/DTEL**: SRVB has no `/source/main` — updates are full XML PUT like DOMA/DTEL. But the XML structure is completely different (nested services/binding elements vs. DDIC content).
+2. **Add to isDdicMetadataType or introduce isSrvbType**: The existing `isDdicMetadataType()` check gates whether the update flow uses `safeUpdateObject()` (XML PUT) or `safeUpdateSource()` (text PUT). SRVB needs the XML PUT path. Rather than adding SRVB to `isDdicMetadataType()` (which is semantically wrong — SRVB isn't DDIC), rename the function to `isMetadataWriteType()` or add a separate check.
+3. **New SRVB-specific parameters**: SRVB creation needs `serviceDefinition` (the SRVD name to bind to), `bindingType` (default: "ODATA"), and `category` (0=Web API, 1=UI, default: "0"). These are new SAPWrite parameters, distinct from the DOMA/DTEL fields.
+4. **Content-type**: Use `application/*` for creation POST (matching abap-adt-api). For update PUT, use `application/vnd.sap.adt.businessservices.servicebinding.v2+xml` (the vendor type already used by getSrvb for reading).
+5. **Post-create guidance**: After successful creation, include a hint in the response: "Use SAPActivate to activate, then SAPActivate(action='publish_srvb') to publish the OData service."
+
+## Development Approach
+
+- Add SRVB XML builder with service definition reference and binding configuration
+- Wire into SAPWrite as a metadata-write type (XML PUT for updates, no source/main)
+- Refactor `isDdicMetadataType()` to `isMetadataWriteType()` covering DOMA, DTEL, and SRVB
+- Test with XML builder unit tests plus E2E lifecycle
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add SRVB XML builder and new parameters
+
+**Files:**
+- Modify: `src/adt/ddic-xml.ts`
+- Modify: `tests/unit/adt/ddic-xml.test.ts`
+
+Add a `buildServiceBindingXml()` function to construct the SRVB creation XML. Based on abap-adt-api research, the XML needs nested service and binding elements.
+
+- [ ] Add a `ServiceBindingCreateParams` interface to `src/adt/ddic-xml.ts`:
+  ```typescript
+  export interface ServiceBindingCreateParams {
+    name: string;
+    description: string;
+    package: string;
+    serviceDefinition: string;   // SRVD name to bind to
+    bindingType?: string;        // default: 'ODATA'
+    category?: '0' | '1';       // '0' = Web API, '1' = UI; default: '0'
+    version?: string;            // service version, default: '0001'
+  }
+  ```
+- [ ] Add `buildServiceBindingXml(params: ServiceBindingCreateParams): string` function. Based on abap-adt-api research, the XML format is:
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <srvb:serviceBinding xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings"
+    xmlns:adtcore="http://www.sap.com/adt/core"
+    adtcore:description="..."
+    adtcore:name="ZSB_TRAVEL_O4"
+    adtcore:type="SRVB/SVB"
+    adtcore:language="EN"
+    adtcore:masterLanguage="EN"
+    adtcore:responsible="DEVELOPER">
+    <adtcore:packageRef adtcore:name="$TMP"/>
+    <srvb:services srvb:name="ZSB_TRAVEL_O4">
+      <srvb:content srvb:version="0001">
+        <srvb:serviceDefinition adtcore:name="ZSD_TRAVEL"/>
+      </srvb:content>
+    </srvb:services>
+    <srvb:binding srvb:category="0" srvb:type="ODATA" srvb:version="V2">
+      <srvb:implementation adtcore:name=""/>
+    </srvb:binding>
+  </srvb:serviceBinding>
+  ```
+  Notes: `srvb:services srvb:name` matches the binding name. `srvb:version` in content is the service version ("0001"). `srvb:version` in binding element is the OData protocol version ("V2" even for V4 — this is what abap-adt-api sends). All values XML-escaped.
+- [ ] Add unit tests (~5 tests) in `tests/unit/adt/ddic-xml.test.ts`:
+  - `buildServiceBindingXml` basic — correct root element and SRVB/SVB type
+  - `buildServiceBindingXml` with service definition reference in nested elements
+  - `buildServiceBindingXml` default category=0 and bindingType=ODATA
+  - `buildServiceBindingXml` with category=1 (UI binding)
+  - `buildServiceBindingXml` XML escaping of special characters
+- [ ] Run `npm test` — all tests must pass
+
+### Task 2: Wire SRVB into SAPWrite type arrays and handler
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `src/handlers/tools.ts`
+- Modify: `src/handlers/schemas.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+Add SRVB as a writable type. SRVB uses the metadata-write pattern (no `/source/main`), so it needs to be routed through the XML PUT path for updates.
+
+- [ ] Add `'SRVB'` to `SAPWRITE_TYPES_ONPREM` in `src/handlers/tools.ts` (line ~103)
+- [ ] Add `'SRVB'` to `SAPWRITE_TYPES_BTP` in `src/handlers/tools.ts` (line ~104)
+- [ ] Update `SAPWRITE_DESC_ONPREM` and `SAPWRITE_DESC_BTP` to mention SRVB
+- [ ] Add `'SRVB'` to `SAPWRITE_TYPES_ONPREM` and `SAPWRITE_TYPES_BTP` in `src/handlers/schemas.ts` (both main schemas and batch object schemas)
+- [ ] Add SRVB-specific fields to `SAPWriteSchema` in `src/handlers/schemas.ts`: `serviceDefinition: z.string().optional()`, `bindingType: z.string().optional()`, `category: z.enum(['0', '1']).optional()`
+- [ ] Add SRVB-specific properties to the SAPWrite JSON Schema in `src/handlers/tools.ts`:
+  - `serviceDefinition: { type: 'string', description: 'SRVB: service definition name (SRVD) to bind to' }`
+  - `bindingType: { type: 'string', description: 'SRVB: binding type (default: ODATA)' }`
+  - `category: { type: 'string', enum: ['0', '1'], description: 'SRVB: 0=Web API, 1=UI (default: 0)' }`
+- [ ] In `src/handlers/intent.ts`, refactor `isDdicMetadataType()` (line ~1042) to cover SRVB. Options:
+  - Rename to `isMetadataWriteType()` and add SRVB: `return type === 'DOMA' || type === 'DTEL' || type === 'SRVB';`
+  - Or keep `isDdicMetadataType()` for DOMA/DTEL and add a separate check for SRVB in the update/create paths
+  - The key requirement: SRVB updates must use `safeUpdateObject()` (XML PUT), not `safeUpdateSource()` (text PUT)
+- [ ] Add `'SRVB'` to `needsVendorContentType()` (line ~1047) — SRVB needs a vendor content type for updates
+- [ ] Add SRVB case to `vendorContentTypeForType()` (line ~1070): return `'application/vnd.sap.adt.businessservices.servicebinding.v2+xml; charset=utf-8'`
+- [ ] Add a `case 'SRVB':` to `buildCreateXml()` (line ~1302). This should extract SRVB-specific properties from the `properties` parameter and delegate to `buildServiceBindingXml()` from `ddic-xml.ts`. Extract properties: `serviceDefinition` (required for SRVB create — return error if missing), `bindingType`, `category`, `version`.
+- [ ] In the `case 'create':` handler (line ~1611): after the `isDdicMetadataType()` / `isMetadataWriteType()` check, SRVB should follow the metadata path (return immediately after createObject, no source write). Add a post-create hint in the success message: "Use SAPActivate to activate, then SAPActivate(action='publish_srvb', name='...') to publish."
+- [ ] Add `getDdicWriteProperties()` extraction for SRVB-specific fields (or add a separate `getSrvbWriteProperties()` function) to pass serviceDefinition, bindingType, category through to buildCreateXml
+- [ ] Add unit tests (~8 tests) in `tests/unit/handlers/intent.test.ts`:
+  - SAPWrite create type=SRVB produces correct XML with service binding root
+  - SAPWrite create type=SRVB without serviceDefinition returns error
+  - SAPWrite create type=SRVB follows metadata-write path (no safeUpdateSource)
+  - SAPWrite update type=SRVB uses safeUpdateObject (XML PUT, not source PUT)
+  - SAPWrite delete type=SRVB follows lock/delete/unlock
+  - SAPWrite batch_create with SRVB — processes correctly after SRVD in sequence
+  - SAPWrite create type=SRVB includes post-create publish hint
+  - SAPWrite create type=SRVB blocked by readOnly
+- [ ] Run `npm test` — all tests must pass
+
+### Task 3: Add E2E test for SRVB lifecycle
+
+**Files:**
+- Modify: `tests/e2e/rap-write.e2e.test.ts`
+
+Add a SRVB create → activate → publish → unpublish → delete lifecycle test. This builds on the existing RAP write E2E suite which already tests DDLS + BDEF + SRVD.
+
+- [ ] Add a new test case: `'SAPWrite create SRVB, activate, publish, unpublish, delete'`. Use `uniqueName('ZSB_ARC_')` for the binding name and create a matching SRVD first. The test should:
+  1. Create a DDLS: `SAPWrite(action="create", type="DDLS", name=ddlsName, ...)` with a simple CDS view
+  2. Create a BDEF: `SAPWrite(action="create", type="BDEF", name=ddlsName, ...)` with basic managed behavior
+  3. Create a SRVD: `SAPWrite(action="create", type="SRVD", name=srvdName, ...)` referencing the DDLS
+  4. Activate all: DDLS, BDEF, SRVD in order
+  5. Create a SRVB: `SAPWrite(action="create", type="SRVB", name=srvbName, serviceDefinition=srvdName, category="0")`
+  6. Activate the SRVB: `SAPActivate(name=srvbName, type="SRVB")`
+  7. Read: `SAPRead(type="SRVB", name=srvbName)` — verify JSON contains service definition reference
+  8. Publish: `SAPActivate(action="publish_srvb", name=srvbName)`
+  9. Unpublish: `SAPActivate(action="unpublish_srvb", name=srvbName)`
+  10. Delete: SRVB, SRVD, BDEF, DDLS in reverse order
+  11. Use `try/finally` with best-effort cleanup
+- [ ] The test should use `requireOrSkip(ctx, rapAvailable, 'RAP/CDS not available on test system')` since SRVB requires RAP
+- [ ] Run `npm test` — all tests must pass (E2E tests only run with `npm run test:e2e`)
+
+### Task 4: Update documentation and roadmap
+
+**Files:**
+- Modify: `docs/tools.md`
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+
+Update all documentation artifacts to reflect SRVB write support.
+
+- [ ] In `docs/tools.md`, add SRVB to the SAPWrite supported types table. Document the new parameters (serviceDefinition, bindingType, category). Add examples:
+  ```
+  SAPWrite(action="create", type="SRVB", name="ZSB_TRAVEL_O4", package="$TMP",
+    serviceDefinition="ZSD_TRAVEL", category="0")
+  ```
+  Update the batch_create example to include SRVB as the final step:
+  ```
+  SAPWrite(action="batch_create", package="$TMP", objects=[
+    {type:"TABL", name:"ZTRAVEL", source:"..."},
+    {type:"DDLS", name:"ZI_TRAVEL", source:"..."},
+    {type:"BDEF", name:"ZI_TRAVEL", source:"..."},
+    {type:"SRVD", name:"ZSD_TRAVEL", source:"..."},
+    {type:"CLAS", name:"ZBP_I_TRAVEL", source:"..."},
+    {type:"SRVB", name:"ZSB_TRAVEL_O4", serviceDefinition:"ZSD_TRAVEL", category:"0"}
+  ])
+  ```
+- [ ] In `docs/roadmap.md`, update FEAT-46 status from "Not started" to "Completed"
+- [ ] In `compare/00-feature-matrix.md`, update the "Service binding create (SRVB)" row: change `❌ (FEAT-46)` to `✅`
+- [ ] In `CLAUDE.md`, update relevant sections to mention SRVB is now writable
+- [ ] Run `npm test` — all tests must pass
+
+### Task 5: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Verify `buildServiceBindingXml(...)` produces valid XML with `srvb:serviceBinding` root and `SRVB/SVB` type
+- [ ] Verify SAPWrite create with type=SRVB follows the metadata-write path (not source-write)
+- [ ] Verify SAPWrite update with type=SRVB uses `safeUpdateObject()` with vendor content type
+- [ ] Verify batch_create with SRVB works in a RAP stack sequence (DDLS → BDEF → SRVD → SRVB)
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/feat-47-msag-read-write.md
+++ b/docs/plans/feat-47-msag-read-write.md
@@ -1,0 +1,214 @@
+# Plan: FEAT-47 MSAG (Message Class) Read/Write
+
+## Overview
+
+Add message class (MSAG) creation and structured read support to ARC-1. Message classes are used in RAP for structured error messages in exception classes (e.g., `RAISE EXCEPTION TYPE zcx_travel USING MESSAGE` referencing a message class). Without MSAG write, LLMs must use hardcoded text in RAISEs instead of proper message classes, which is bad practice in ABAP.
+
+**Current state:** ARC-1 already reads message class texts via `SAPRead type=MESSAGES` using `getMessages()` (reads from `/sap/bc/adt/msg/messages/{name}`), but returns raw XML. It cannot create message classes, and the read output is not structured.
+
+Research from abap-adt-api (gold standard):
+- **Creation endpoint:** `POST /sap/bc/adt/messageclass`
+- **Content-type:** `application/*`
+- **XML root:** `<mc:messageClass>` with namespace `http://www.sap.com/adt/MessageClass`
+- **ADT type:** `MSAG/N`
+- **Creation is container-only:** POST creates the empty message class; individual messages (T100 entries with number + short text) are added via a separate mechanism — either via source-like PUT or via individual message endpoints
+- **No activation needed:** Message classes are immediately active after creation (like packages)
+
+**Key design insight:** MSAG creation via abap-adt-api uses the generic `createBodySimple()` — the simplest possible creation XML (same shape as PROG/CLAS). The complexity is in managing individual messages AFTER creation. From sapcli research: individual messages are managed via `/sap/bc/adt/messageclass/{name}/messages/{number}`. ARC-1 can support individual message editing via the SAPWrite update action.
+
+## Context
+
+### Current State
+
+- `SAPRead type=MESSAGES` reads message class texts via `client.getMessages(name)` at line ~423 in client.ts
+- `getMessages()` reads from `/sap/bc/adt/msg/messages/{name}` — returns raw XML body (not parsed)
+- `objectBasePath()` does NOT have a MSAG mapping
+- MSAG is not in `SAPWRITE_TYPES`
+- `buildCreateXml()` has no MSAG case
+- The current `/sap/bc/adt/msg/messages/` endpoint is for listing messages — the object endpoint for CRUD is `/sap/bc/adt/messageclass/`
+
+### Target State
+
+- SAPWrite `create` for type=MSAG creates an empty message class container
+- SAPWrite `update` for type=MSAG writes individual messages via source-based update
+- SAPWrite `delete` for type=MSAG deletes the message class
+- `SAPRead type=MESSAGES` enhanced to return structured JSON (message number, type, short text) instead of raw XML
+- `batch_create` supports MSAG (create message class before exception classes that reference it)
+- MSAG treated as a source-based type — individual messages are written as source text to `/sap/bc/adt/messageclass/{name}/source/main` (to be confirmed via testing; if not available, use the metadata approach)
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/handlers/intent.ts` | `handleSAPWrite()` (line ~1551), `buildCreateXml()` (line ~1302), `objectBasePath()` (line ~1483), SAPRead MESSAGES case (line ~792) |
+| `src/handlers/tools.ts` | `SAPWRITE_TYPES_ONPREM/BTP` (line ~103-104), tool descriptions |
+| `src/handlers/schemas.ts` | `SAPWRITE_TYPES` Zod enums (line ~123-136) |
+| `src/adt/client.ts` | `getMessages()` at line ~423 — current raw XML read |
+| `src/adt/xml-parser.ts` | XML parsing functions — add message class parser |
+| `src/adt/types.ts` | Type definitions — add MessageClassInfo interface |
+| `src/adt/crud.ts` | `createObject()`, `safeUpdateSource()`, delete flow |
+| `src/adt/ddic-xml.ts` | XML builders — add MSAG builder |
+| `tests/unit/handlers/intent.test.ts` | SAPWrite handler tests |
+| `tests/unit/adt/ddic-xml.test.ts` | XML builder tests |
+| `tests/unit/adt/xml-parser.test.ts` | XML parser tests — add message class parsing |
+
+### Design Principles
+
+1. **Simple creation XML**: MSAG creation uses the same simple pattern as PROG/CLAS — just a root element with name/description/package. No complex nested elements for creation.
+2. **Source-based for message content**: After container creation, individual messages are written via the standard source mechanism (lock → PUT source → unlock). The "source" for a message class is the message entries.
+3. **Structured read**: Parse the current raw XML response from `getMessages()` into a structured JSON format with message number, type (E/W/I/S/A), and short text.
+4. **objectBasePath mapping**: Add `MSAG → '/sap/bc/adt/messageclass/'` — this is the CRUD endpoint. The existing `/sap/bc/adt/msg/messages/` is a different read-only endpoint for message text listing.
+5. **No activation**: Message classes are immediately active — no SAPActivate step needed.
+6. **Both on-prem and BTP**: Message classes are available on both platforms.
+
+## Development Approach
+
+- Start with the structured read enhancement (parse existing XML)
+- Add creation XML builder (simple — same pattern as PROG)
+- Wire into SAPWrite with proper objectBasePath
+- Test with unit tests for XML builder/parser, plus integration test for lifecycle
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add MSAG to objectBasePath and buildCreateXml
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `src/adt/ddic-xml.ts`
+- Modify: `tests/unit/adt/ddic-xml.test.ts`
+
+Add the MSAG creation XML builder and URL mapping. MSAG creation uses a simple XML shell (like PROG/CLAS) with `mc:messageClass` root element.
+
+- [ ] Add `case 'MSAG':` to `objectBasePath()` in `src/handlers/intent.ts` (line ~1483): return `'/sap/bc/adt/messageclass/'`
+- [ ] Add a `case 'MSAG':` to `buildCreateXml()` in `src/handlers/intent.ts` (line ~1302). The XML follows the simple creation pattern:
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <mc:messageClass xmlns:mc="http://www.sap.com/adt/MessageClass"
+                   xmlns:adtcore="http://www.sap.com/adt/core"
+                   adtcore:description="${escapeXml(description)}"
+                   adtcore:name="${escapeXml(name)}"
+                   adtcore:type="MSAG/N"
+                   adtcore:language="EN"
+                   adtcore:masterLanguage="EN"
+                   adtcore:responsible="DEVELOPER">
+    <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+  </mc:messageClass>
+  ```
+  Note: MSAG includes `adtcore:language="EN"` and does NOT have `adtcore:masterSystem="H00"` — matching the abap-adt-api pattern.
+- [ ] Add unit tests (~3 tests) in `tests/unit/adt/ddic-xml.test.ts`:
+  - `buildCreateXml('MSAG', ...)` produces correct XML with `mc:messageClass` root and `MSAG/N` type
+  - XML includes `adtcore:language="EN"` and `adtcore:masterLanguage="EN"`
+  - XML escaping of special characters in name and description
+- [ ] Run `npm test` — all tests must pass
+
+### Task 2: Wire MSAG into SAPWrite type arrays and handler
+
+**Files:**
+- Modify: `src/handlers/tools.ts`
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+Add MSAG as a writable type in SAPWrite. MSAG follows the source-based pattern — after container creation, messages are written as source text.
+
+- [ ] Add `'MSAG'` to `SAPWRITE_TYPES_ONPREM` in `src/handlers/tools.ts` (line ~103)
+- [ ] Add `'MSAG'` to `SAPWRITE_TYPES_BTP` in `src/handlers/tools.ts` (line ~104) — message classes are available on BTP
+- [ ] Update `SAPWRITE_DESC_ONPREM` and `SAPWRITE_DESC_BTP` to mention MSAG
+- [ ] Add `'MSAG'` to `SAPWRITE_TYPES_ONPREM` and `SAPWRITE_TYPES_BTP` in `src/handlers/schemas.ts` (both main schemas and batch object schemas)
+- [ ] Verify MSAG does NOT need to be added to `isDdicMetadataType()` — MSAG is source-based (messages are written via `/source/main` or similar source endpoint). The standard create → write source flow should work.
+- [ ] Verify MSAG does NOT need to be added to `needsVendorContentType()` — MSAG uses `application/*` for creation (per abap-adt-api)
+- [ ] Add unit tests (~6 tests) in `tests/unit/handlers/intent.test.ts`:
+  - SAPWrite create type=MSAG calls createObject with correct URL (`/sap/bc/adt/messageclass/`)
+  - SAPWrite create type=MSAG produces correct XML body
+  - SAPWrite create type=MSAG with source writes messages after creation
+  - SAPWrite update type=MSAG calls safeUpdateSource
+  - SAPWrite delete type=MSAG follows lock/delete/unlock
+  - SAPWrite create type=MSAG blocked by readOnly
+- [ ] Run `npm test` — all tests must pass
+
+### Task 3: Enhance SAPRead MESSAGES to return structured data
+
+**Files:**
+- Modify: `src/adt/xml-parser.ts`
+- Modify: `src/adt/types.ts`
+- Modify: `src/adt/client.ts`
+- Modify: `src/handlers/intent.ts`
+- Create: `tests/fixtures/xml/message-class.xml`
+- Modify: `tests/unit/adt/xml-parser.test.ts`
+
+Enhance the existing `SAPRead type=MESSAGES` to return structured JSON instead of raw XML. Parse message entries into a clean format with message number, type, and text.
+
+- [ ] Add a `MessageClassInfo` interface to `src/adt/types.ts`:
+  ```typescript
+  export interface MessageClassInfo {
+    name: string;
+    description: string;
+    messages: Array<{
+      number: string;    // e.g., "001", "002"
+      type: string;      // E=Error, W=Warning, I=Info, S=Success, A=Abort
+      shortText: string; // Message short text
+    }>;
+  }
+  ```
+- [ ] Add a `parseMessageClass(xml: string): MessageClassInfo` function to `src/adt/xml-parser.ts`. The function should parse the ADT XML response from `/sap/bc/adt/msg/messages/{name}` and extract message entries. The XML structure from ADT typically wraps messages in a collection — parse all message elements and extract number, type, and text attributes.
+- [ ] Create a test fixture `tests/fixtures/xml/message-class.xml` with a sample ADT message class XML response. This should include a message class with 2-3 messages of different types (E, I, S).
+- [ ] Update `client.getMessages()` in `src/adt/client.ts` (line ~423): change return type from `Promise<string>` to `Promise<string>` (keep returning raw for now — the structured parsing happens in the handler for backwards compatibility). Or better: add a new `getMessageClassInfo(name: string): Promise<MessageClassInfo>` method that reads from `/sap/bc/adt/messageclass/{name}` and returns parsed data.
+- [ ] In `src/handlers/intent.ts`, update the `case 'MESSAGES':` handler (line ~792) to return structured JSON when possible. Try calling `getMessageClassInfo()` first; if the endpoint isn't available, fall back to the current raw `getMessages()` response.
+- [ ] Add unit tests (~4 tests) in `tests/unit/adt/xml-parser.test.ts`:
+  - `parseMessageClass` returns name and description
+  - `parseMessageClass` extracts all message entries with number, type, text
+  - `parseMessageClass` handles empty message class (no messages)
+  - `parseMessageClass` handles XML with special characters in message text
+- [ ] Run `npm test` — all tests must pass
+
+### Task 4: Add integration test for MSAG lifecycle
+
+**Files:**
+- Modify: `tests/e2e/rap-write.e2e.test.ts`
+
+Add a message class create → read → delete lifecycle test.
+
+- [ ] Add a new test case: `'SAPWrite create MSAG, read, delete'`. Use `uniqueName('ZARC1_')` for a collision-safe name (message class names max 20 chars, so use a short prefix). The test should:
+  1. Create: `SAPWrite(action="create", type="MSAG", name=..., package="$TMP", description="ARC-1 test message class")`
+  2. Read: `SAPRead(type="MESSAGES", name=...)` — verify it returns data about the message class
+  3. Delete: `SAPWrite(action="delete", type="MSAG", name=...)`
+  4. Use `try/finally` with best-effort delete for cleanup
+- [ ] The test does NOT need rapAvailable check — message classes are a basic ABAP feature
+- [ ] Run `npm test` — all tests must pass (E2E tests only run with `npm run test:e2e`)
+
+### Task 5: Update documentation and roadmap
+
+**Files:**
+- Modify: `docs/tools.md`
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+
+Update all documentation artifacts to reflect MSAG write support.
+
+- [ ] In `docs/tools.md`, add MSAG to the SAPWrite supported types table. Document MSAG creation and note that messages can be written as source text. Add examples:
+  ```
+  SAPWrite(action="create", type="MSAG", name="ZCM_TRAVEL", package="$TMP",
+    description="Travel application messages")
+  SAPWrite(action="delete", type="MSAG", name="ZCM_TRAVEL")
+  ```
+- [ ] In `docs/tools.md`, update the SAPRead MESSAGES description to note it now returns structured JSON with message number, type, and text
+- [ ] In `docs/roadmap.md`, update FEAT-47 status from "Not started" to "Completed"
+- [ ] In `compare/00-feature-matrix.md`, update the "Message class write (MSAG)" row: change `❌ (FEAT-47)` to `✅`
+- [ ] In `CLAUDE.md`, update relevant sections to mention MSAG is now writable
+- [ ] Run `npm test` — all tests must pass
+
+### Task 6: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Verify `buildCreateXml('MSAG', 'ZTEST_MSG', '$TMP', 'Test messages')` produces valid XML with `mc:messageClass` root and `MSAG/N` type
+- [ ] Verify `objectBasePath('MSAG')` returns `/sap/bc/adt/messageclass/`
+- [ ] Verify SAPWrite create with type=MSAG follows the source-based path (container creation + optional source write)
+- [ ] Verify SAPRead type=MESSAGES returns structured JSON with message entries
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,9 +84,13 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | 41 | FEAT-41 | ABAP Unit Test Coverage (statement-level) | P2 | S | Features |
 | 42 | FEAT-42 | ATC Output Formats (JUnit4, checkstyle, codeclimate) | P2 | XS | Features |
 | 43 | FEAT-43 | DDIC Auth & Misc Read (Authorization Fields, Feature Toggles) | P2 | S | Features |
-| 44 | FEAT-05 | Code Refactoring (Rename, Extract) | P3 | L | Features |
-| 45 | FEAT-29 | P3 Backlog (14 items) | P3 | various | Features |
-| 46 | OPS-03 | Multi-System Routing | P3 | L | Ops |
+| 44 | FEAT-44 | TABL (Database Table) Create | P1 | S | Features |
+| 45 | FEAT-45 | DEVC (Package) Create | P1 | S | Features |
+| 46 | FEAT-46 | SRVB (Service Binding) Create | P2 | S | Features |
+| 47 | FEAT-47 | MSAG (Message Class) Read/Write | P2 | S | Features |
+| 48 | FEAT-05 | Code Refactoring (Rename, Extract) | P3 | L | Features |
+| 49 | FEAT-29 | P3 Backlog (14 items) | P3 | various | Features |
+| 50 | OPS-03 | Multi-System Routing | P3 | L | Ops |
 
 ---
 
@@ -157,9 +161,11 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 10. **FEAT-12** Fix Proposals / Auto-Fix (S) — safer than LLM-guessed fixes
 11. **FEAT-16** Error Intelligence (S) — actionable hints for SAP errors (subsumes SEC-03)
 12. ~~**FEAT-13** DDIC Domain/Data Element Write (S) — complete data modeling workflow~~ (**completed 2026-04-12**)
-13. **FEAT-18** Function Group Bulk Fetch (S) — token/round-trip savings
-14. **DOC-01** Copilot Studio Setup Guide (S) — critical for enterprise adoption
-15. **DOC-02** Basis Admin Security Guide (S) — admin audience needs clear guidance
+13. **FEAT-44** TABL (Database Table) Create (S) — blocks RAP stack creation; 4 competitors have this. Uses existing CRUD framework + `/sap/bc/adt/ddic/tables/` endpoint.
+14. **FEAT-45** DEVC (Package) Create (S) — blocks any greenfield development; 4 competitors have this. Endpoint: `/sap/bc/adt/packages`.
+15. **FEAT-18** Function Group Bulk Fetch (S) — token/round-trip savings
+16. **DOC-01** Copilot Studio Setup Guide (S) — critical for enterprise adoption
+17. **DOC-02** Basis Admin Security Guide (S) — admin audience needs clear guidance
 
 ### Phase C: ADT Feature Parity (P2) — Quick Wins
 13. **FEAT-32** Table Pagination / Offset (XS) — VSP has this, practical improvement
@@ -171,7 +177,9 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 19. **OPS-02** Health Check Enhancements (XS) — `/health/deep` with SAP connectivity check
 
 ### Phase D: ADT Feature Parity (P2) — Larger Items
-20. **FEAT-39** Transport Enhancements (S) — delete, reassign owner, transport type selection (K/W/T/S/R), recursive release. sapcli has full CTS lifecycle.
+20. **FEAT-46** SRVB (Service Binding) Create (S) — completes RAP stack lifecycle; sapcli + fr0ster have this. Vendor content type: `application/vnd.sap.adt.businessservices.v1+xml`.
+21. **FEAT-47** MSAG (Message Class) Read/Write (S) — used in RAP for exception classes and validation messages. Endpoint: `/sap/bc/adt/messageclass/`.
+22. **FEAT-39** Transport Enhancements (S) — delete, reassign owner, transport type selection (K/W/T/S/R), recursive release. sapcli has full CTS lifecycle.
 21. **FEAT-41** ABAP Unit Test Coverage (S) — statement-level coverage via `/runtime/traces/coverage/measurements/{id}` with paginated follow-up. sapcli + AWS Accelerator have this.
 22. **FEAT-42** ATC Output Formats (XS) — JUnit4, checkstyle, codeclimate formatters for CI/CD integration. sapcli has these.
 23. **FEAT-43** DDIC Auth & Misc Read (S) — Authorization Fields (`/authorizationfields`), Feature Toggles, Enhancement Implementations. sapcli added auth fields Apr 2026.
@@ -1090,6 +1098,129 @@ SAP_RATE_LIMIT_BURST=10  # burst allowance
 - Add `getFeatureToggle(name)` to `src/adt/client.ts`
 - Add both types to SAPRead handler
 - XML parsing in `src/adt/xml-parser.ts` for the `auth:auth` namespace
+
+---
+
+### FEAT-44: TABL (Database Table) Create
+| Field | Value |
+|-------|-------|
+| **Priority** | P1 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low |
+| **Usefulness** | Very High — blocks RAP stack creation from scratch |
+| **Status** | Not started |
+| **Source** | [RAP project analysis](https://github.com/Xexer/abap_rap_blog), [SAP-samples/cloud-abap-rap](https://github.com/SAP-samples/cloud-abap-rap), [feature matrix](../compare/00-feature-matrix.md) |
+
+**What:** Add create/update/delete support for traditional DDIC database tables (TABL) via SAPWrite. Tables are a prerequisite for CDS-based RAP development — root views reference persistent tables, and draft tables are required for managed BOs with draft.
+
+**Current gap:** ARC-1 can read tables (`SAPRead type=TABL`) and has the URL mapping (`/sap/bc/adt/ddic/tables/`), but `buildCreateXml()` has no TABL case and TABL is not in `SAPWRITE_TYPES_ONPREM`/`SAPWRITE_TYPES_BTP`. Two real-world RAP projects ([Xexer/abap_rap_blog](https://github.com/Xexer/abap_rap_blog) with 8 tables, [SAP-samples/cloud-abap-rap](https://github.com/SAP-samples/cloud-abap-rap) with 15 tables) cannot be created end-to-end.
+
+**Competitor support:**
+- **sapcli:** Full TABL CRUD via `POST /sap/bc/adt/ddic/tables/` + batch activation. XML serialization with `OrderedClassMembers` preserves element order.
+- **vibing-steampunk:** CreateTable tool in Focused mode with batch activation.
+- **fr0ster:** `HandlerCreate` routes to tables URL; auto-activates post-create (v5.0.7+).
+- **dassian-adt:** `abap_create` with 16 type auto-mappings including TABL.
+
+**Implementation:**
+- Add `'TABL'` to `SAPWRITE_TYPES_ONPREM` and `SAPWRITE_TYPES_BTP` in `src/handlers/tools.ts`
+- Add TABL case to `buildCreateXml()` in `src/handlers/intent.ts` — TABL is a DDIC metadata type (XML-only, no `/source/main`), similar to DOMA/DTEL
+- Add TABL to `isDdicMetadataType()` so updates use XML PUT (not source PUT)
+- Content-Type: `application/vnd.sap.adt.ddic.tables.v2+xml` (vendor-specific, like DOMA/DTEL)
+- Build XML with `<asx:abap>` envelope containing table fields, key definitions, and table properties
+- TABL requires activation after create (already supported via `SAPActivate`)
+- Add unit tests with XML fixtures from real SAP systems
+- **Note:** On BTP ABAP Cloud, prefer `define table entity` in DDLS over traditional TABL. Guard with feature detection if needed.
+
+---
+
+### FEAT-45: DEVC (Package) Create
+| Field | Value |
+|-------|-------|
+| **Priority** | P1 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low |
+| **Usefulness** | High — blocks greenfield development workflows |
+| **Status** | Not started |
+| **Source** | [RAP project analysis](https://github.com/Xexer/abap_rap_blog), [SAP-samples/cloud-abap-rap](https://github.com/SAP-samples/cloud-abap-rap), [feature matrix](../compare/00-feature-matrix.md) |
+
+**What:** Add package creation via SAPWrite or SAPManage. Packages are the container for all ABAP development objects — without package creation, LLMs cannot set up greenfield projects.
+
+**Current gap:** ARC-1 can read packages but not create them. The feature matrix shows 6 of 8 competitors support package creation.
+
+**Competitor support:**
+- **sapcli:** `POST /sap/bc/adt/packages` with full XML body (name, description, superPackage, softwareComponent, transportLayer). Accepts explicit `corrNr` for transport.
+- **vibing-steampunk:** CreatePackage tool in Focused mode. Note: package safety bypass bug #101 (SAP_ALLOWED_PACKAGES not enforced on create) — ARC-1 should avoid this.
+- **fr0ster:** Generic `HandlerCreate` routes to packages URL.
+- **dassian-adt:** `abap_create` with auto-derived software component + transport layer.
+
+**Implementation:**
+- Add `DEVC` to `objectBasePath()` → `/sap/bc/adt/packages/`
+- Add `buildCreateXml()` case for DEVC with fields: name, description, superPackage, softwareComponent, transportLayer, packageType (development/structure)
+- XML namespace: `http://www.sap.com/adt/packages` with `pak:package` root element
+- Transport handling: non-local packages require transport (reuse existing pre-flight check pattern)
+- Safety: enforce `checkPackage()` on the *parent* package (superPackage), not the new package name
+- No activation needed — packages are active on creation
+- Add to SAPManage or SAPWrite (TBD — SAPManage may be more appropriate since DEVC is infrastructure, not source code)
+
+---
+
+### FEAT-46: SRVB (Service Binding) Create
+| Field | Value |
+|-------|-------|
+| **Priority** | P2 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low |
+| **Usefulness** | Medium — completes RAP stack lifecycle (ARC-1 already has publish/unpublish) |
+| **Status** | Not started |
+| **Source** | [RAP project analysis](https://github.com/Xexer/abap_rap_blog), [SAP-samples/cloud-abap-rap](https://github.com/SAP-samples/cloud-abap-rap), [feature matrix](../compare/00-feature-matrix.md) |
+
+**What:** Add SRVB object creation to SAPWrite. ARC-1 already reads SRVB and can publish/unpublish via SAPManage, but cannot create the binding object itself. This is the last missing piece for a fully automated RAP stack lifecycle.
+
+**Current gap:** `objectBasePath()` already maps `SRVB` → `/sap/bc/adt/businessservices/bindings/`, but SRVB is not in `SAPWRITE_TYPES` and has no `buildCreateXml()` case.
+
+**Competitor support:**
+- **sapcli:** Full SRVB CRUD via `POST /sap/bc/adt/businessservices/bindings/` with vendor-specific content type.
+- **fr0ster:** `HandlerCreate` supports SRVB creation (v5.0.0+).
+- **vibing-steampunk:** No create, only publish/unpublish (same as ARC-1 today).
+- **dassian-adt:** No SRVB create.
+
+**Implementation:**
+- Add `'SRVB'` to `SAPWRITE_TYPES_ONPREM` and `SAPWRITE_TYPES_BTP` in `src/handlers/tools.ts`
+- Add SRVB case to `buildCreateXml()` — needs binding type (OData V2/V4), service version, referenced SRVD
+- Content-Type: `application/vnd.sap.adt.businessservices.v1+xml` (version-specific — newer SAP may need v2+; use FEAT-38 discovery if available)
+- Add to `needsVendorContentType()` and `vendorContentTypeForType()`
+- SRVB requires activation, then publish step (guide LLM to use SAPManage publish_srvb after create+activate)
+- **Note:** SRVB creation is the least critical gap — many teams create the binding once in ADT and then only interact via publish/unpublish.
+
+---
+
+### FEAT-47: MSAG (Message Class) Read/Write
+| Field | Value |
+|-------|-------|
+| **Priority** | P2 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low |
+| **Usefulness** | Medium — used in RAP exception classes and validation messages |
+| **Status** | Not started |
+| **Source** | [SAP-samples/cloud-abap-rap](https://github.com/SAP-samples/cloud-abap-rap), [feature matrix](../compare/00-feature-matrix.md) |
+
+**What:** Add read and write support for ABAP message classes (MSAG / T100). ARC-1 can already read T100 messages via `SAPRead type=MSAG` (message class listing), but cannot create message classes or add/update individual messages.
+
+**Current gap:** Message classes are used in RAP for structured error messages in exception classes (`zdmo_cx_rap_generator` → `zdmo_cm_rap_gen_msg`). Without MSAG write, LLMs must use hardcoded text in RAISEs instead of proper message classes.
+
+**Competitor support:**
+- **sapcli:** Full message class CRUD. Read via `/sap/bc/adt/messageclass/{name}`, individual messages via `/sap/bc/adt/messageclass/{name}/messages/{number}`.
+- **vibing-steampunk:** Message class read (T100 listing).
+- **fr0ster:** Message class read via `adt-clients` factory.
+- **dassian-adt:** No message class support.
+
+**Implementation:**
+- Add `MSAG` to `objectBasePath()` → `/sap/bc/adt/messageclass/`
+- Add `MSAG` to `SAPWRITE_TYPES_ONPREM` and `SAPWRITE_TYPES_BTP`
+- MSAG is a DDIC metadata type (XML-only, no source code)
+- XML body includes message class name, description, and message entries (number, type, short text, long text)
+- Add to `isDdicMetadataType()` for XML PUT updates
+- Content-Type: likely `application/vnd.sap.adt.messageclass.v2+xml` (vendor-specific)
 
 ---
 


### PR DESCRIPTION
## Summary

- Analyzed two real-world RAP projects ([Xexer/abap_rap_blog](https://github.com/Xexer/abap_rap_blog), [SAP-samples/cloud-abap-rap](https://github.com/SAP-samples/cloud-abap-rap)) to identify object types ARC-1 cannot yet create
- Added 4 new roadmap items (FEAT-44..47) for the identified gaps: TABL, DEVC, SRVB, MSAG
- Updated feature matrix with 5 new comparison rows (TABL, DEVC, SRVB, MSAG, DCLS)
- Created 4 detailed ralphex-compatible implementation plans based on deep research of [abap-adt-api](https://github.com/marcellourbani/abap-adt-api) (gold standard) and sapcli

### Plans overview

| Plan | Type | Key Finding |
|------|------|-------------|
| FEAT-44: TABL | Source-based (`blue:blueSource`, like BDEF) | Fields written via `/source/main`, NOT metadata XML |
| FEAT-45: DEVC | SAPManage (infrastructure, not SAPWrite) | `pak:package` XML, no activation needed |
| FEAT-46: SRVB | Metadata-write (like DOMA/DTEL) | Needs `isMetadataWriteType()` refactor, new serviceDefinition param |
| FEAT-47: MSAG | Source-based (simple creation) | Enhanced structured read + `/sap/bc/adt/messageclass/` endpoint |

## Test plan

- [ ] Plans are documentation-only — no code changes, no tests to run
- [ ] Verify plan format is valid for ralphex execution (`### Task N:` headers, checkboxes only in tasks, `## Validation Commands` present)
- [ ] Each plan can be executed with `ralphex docs/plans/feat-{44|45|46|47}-*.md`

https://claude.ai/code/session_012jXxxMGvcwihjxsAfMZ5hq