### PR TITLE
feat: implement FEAT-46 SRVB create in SAPWrite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ src/
 │   ├── btp.ts                  # BTP Destination Service + Connectivity proxy
 │   ├── cookies.ts, oauth.ts    # Cookie parsing, OAuth 2.0 for BTP ABAP
 │   ├── crud.ts                 # CRUD operations (lock, create, update, delete)
-│   ├── ddic-xml.ts             # DDIC metadata XML builders (DOMA/DTEL create/update payloads)
+│   ├── ddic-xml.ts             # Metadata XML builders (DOMA/DTEL/SRVB create/update payloads)
 │   ├── devtools.ts             # Syntax check, activate, publish SRVB, unit tests
 │   ├── diagnostics.ts          # Short dumps (ST22), ABAP profiler traces
 │   ├── codeintel.ts            # Find def, refs, where-used, completion
@@ -405,7 +405,7 @@ import { mockResponse } from '../../helpers/mock-fetch.js';
 
 - Integration: `TEST_SAP_*` env vars, `getTestClient()` factory, sequential execution, CRUD uses `generateUniqueName()`
 - E2E: MCP SDK client, `connectClient()`/`callTool()`/`expectToolSuccess()` helpers, 120s timeout, sequential
-- E2E RAP lifecycle: `tests/e2e/rap-write.e2e.test.ts` — DDLS/BDEF/SRVD create+activate+delete (skips gracefully when `rap.available=false`)
+- E2E RAP lifecycle: `tests/e2e/rap-write.e2e.test.ts` — DDLS/BDEF/SRVD/SRVB create+activate+publish+delete (skips gracefully when `rap.available=false`)
 - BTP: local only (not CI), needs `TEST_BTP_SERVICE_KEY_FILE`, interactive browser login
 - CI telemetry: `scripts/ci/` aggregates JSON reports into GitHub step summaries. Coverage is informational only.
 

--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -113,7 +113,7 @@ _Last updated: 2026-04-13 (fr0ster v5.0.8: 14 activation tools, 303 total)_
 | EditSource (surgical) | ✅ (edit_method) | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ✅ (edit_method, Apr 2026) | ❌ |
 | CloneObject | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
 | Execute ABAP | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ✅ | ✅ (abap run) |
-| RAP CRUD (BDEF, SRVD, DDLX, SRVB) | ✅ (DDLS, DDLX, BDEF, SRVD write) | ⚠️ (some) | ❌ | ❌ | ✅ (BDEF, SRVD, SRVB) | ✅ (all incl. DDLX) | N/A | ❌ | ⚠️ (DDLS, DCL, BDEF write; SRVB publish) |
+| RAP CRUD (BDEF, SRVD, DDLX, SRVB) | ✅ (DDLS, DDLX, BDEF, SRVD, SRVB write) | ⚠️ (some) | ❌ | ❌ | ✅ (BDEF, SRVD, SRVB) | ✅ (all incl. DDLX) | N/A | ❌ | ⚠️ (DDLS, DCL, BDEF write; SRVB publish) |
 | Domain write (DOMA) | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | N/A | ❌ | ⚠️ (PR #149 in progress) |
 | Data element write (DTEL) | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | N/A | ❌ | ✅ |
 | Multi-object batch creation | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
@@ -122,7 +122,7 @@ _Last updated: 2026-04-13 (fr0ster v5.0.8: 14 activation tools, 303 total)_
 | Create test class | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ | ✅ (class write test_classes) |
 | Table write (TABL) | ❌ (FEAT-44) | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ | ✅ |
 | Package create (DEVC) | ❌ (FEAT-45) | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ | ✅ |
-| Service binding create (SRVB) | ❌ (FEAT-46) | ❌ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ | ✅ |
+| Service binding create (SRVB) | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | N/A | ❌ | ✅ |
 | Message class write (MSAG) | ❌ (FEAT-47) | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ✅ |
 | DCL write (DCLS) | ❌ (FEAT-37) | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ✅ |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # ARC-1 Roadmap
 
-**Last Updated:** 2026-04-12
+**Last Updated:** 2026-04-14
 **Project:** ARC-1 (ABAP Relay Connector) — MCP Server for SAP ABAP Systems
 **Repository:** https://github.com/marianfoo/arc-1
 
@@ -86,7 +86,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | 43 | FEAT-43 | DDIC Auth & Misc Read (Authorization Fields, Feature Toggles) | P2 | S | Features |
 | 44 | FEAT-44 | TABL (Database Table) Create | P1 | S | Features |
 | 45 | FEAT-45 | DEVC (Package) Create | P1 | S | Features |
-| 46 | FEAT-46 | SRVB (Service Binding) Create | P2 | S | Features |
+| ~~46~~ | ~~FEAT-46~~ | ~~SRVB (Service Binding) Create~~ | ~~P2~~ | ~~S~~ | ~~Completed 2026-04-14~~ |
 | 47 | FEAT-47 | MSAG (Message Class) Read/Write | P2 | S | Features |
 | 48 | FEAT-05 | Code Refactoring (Rename, Extract) | P3 | L | Features |
 | 49 | FEAT-29 | P3 Backlog (14 items) | P3 | various | Features |
@@ -98,6 +98,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 
 | ID | Feature | Completed | Category |
 |----|---------|-----------|----------|
+| FEAT-46 | SRVB (Service Binding) Create | 2026-04-14 | Features |
 | — | RAP Write Guard (feature-aware) | 2026-04-13 | Features |
 | FEAT-13 | DDIC Domain/Data Element Write | 2026-04-12 | Features |
 | FEAT-08 | Content-Type 415/406 Auto-Retry | 2026-04-12 | Features |
@@ -177,7 +178,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 19. **OPS-02** Health Check Enhancements (XS) — `/health/deep` with SAP connectivity check
 
 ### Phase D: ADT Feature Parity (P2) — Larger Items
-20. **FEAT-46** SRVB (Service Binding) Create (S) — completes RAP stack lifecycle; sapcli + fr0ster have this. Vendor content type: `application/vnd.sap.adt.businessservices.v1+xml`.
+20. ~~**FEAT-46** SRVB (Service Binding) Create (S)~~ — **completed 2026-04-14** (SAPWrite now supports SRVB create/update/delete + batch_create; create guidance points to activate + publish flow).
 21. **FEAT-47** MSAG (Message Class) Read/Write (S) — used in RAP for exception classes and validation messages. Endpoint: `/sap/bc/adt/messageclass/`.
 22. **FEAT-39** Transport Enhancements (S) — delete, reassign owner, transport type selection (K/W/T/S/R), recursive release. sapcli has full CTS lifecycle.
 21. **FEAT-41** ABAP Unit Test Coverage (S) — statement-level coverage via `/runtime/traces/coverage/measurements/{id}` with paginated follow-up. sapcli + AWS Accelerator have this.
@@ -1171,26 +1172,26 @@ SAP_RATE_LIMIT_BURST=10  # burst allowance
 | **Effort** | S (1-2 days) |
 | **Risk** | Low |
 | **Usefulness** | Medium — completes RAP stack lifecycle (ARC-1 already has publish/unpublish) |
-| **Status** | Not started |
+| **Status** | Complete (2026-04-14) |
 | **Source** | [RAP project analysis](https://github.com/Xexer/abap_rap_blog), [SAP-samples/cloud-abap-rap](https://github.com/SAP-samples/cloud-abap-rap), [feature matrix](../compare/00-feature-matrix.md) |
 
-**What:** Add SRVB object creation to SAPWrite. ARC-1 already reads SRVB and can publish/unpublish via SAPManage, but cannot create the binding object itself. This is the last missing piece for a fully automated RAP stack lifecycle.
+**What:** Add SRVB object creation to SAPWrite. ARC-1 already reads SRVB and can publish/unpublish via SAPActivate.
 
-**Current gap:** `objectBasePath()` already maps `SRVB` → `/sap/bc/adt/businessservices/bindings/`, but SRVB is not in `SAPWRITE_TYPES` and has no `buildCreateXml()` case.
+**Implemented (2026-04-14):**
+- Added `SRVB` to SAPWrite type enums and input schemas (on-prem + BTP).
+- Added SRVB XML builder (`srvb:serviceBinding`) with `serviceDefinition`, `bindingType`, `category`, `version`.
+- Added `buildCreateXml()` SRVB case and metadata-write routing (XML PUT update path, no `/source/main`).
+- Added vendor content type for SRVB updates: `application/vnd.sap.adt.businessservices.servicebinding.v2+xml`.
+- Added SAPWrite create response hint to run activation then `publish_srvb`.
+- Added unit + E2E coverage for create/update/delete/batch_create and publish lifecycle.
 
-**Competitor support:**
+**Competitor support (reference):**
 - **sapcli:** Full SRVB CRUD via `POST /sap/bc/adt/businessservices/bindings/` with vendor-specific content type.
 - **fr0ster:** `HandlerCreate` supports SRVB creation (v5.0.0+).
-- **vibing-steampunk:** No create, only publish/unpublish (same as ARC-1 today).
+- **vibing-steampunk:** No create, only publish/unpublish.
 - **dassian-adt:** No SRVB create.
 
-**Implementation:**
-- Add `'SRVB'` to `SAPWRITE_TYPES_ONPREM` and `SAPWRITE_TYPES_BTP` in `src/handlers/tools.ts`
-- Add SRVB case to `buildCreateXml()` — needs binding type (OData V2/V4), service version, referenced SRVD
-- Content-Type: `application/vnd.sap.adt.businessservices.v1+xml` (version-specific — newer SAP may need v2+; use FEAT-38 discovery if available)
-- Add to `needsVendorContentType()` and `vendorContentTypeForType()`
-- SRVB requires activation, then publish step (guide LLM to use SAPManage publish_srvb after create+activate)
-- **Note:** SRVB creation is the least critical gap — many teams create the binding once in ADT and then only interact via publish/unpublish.
+**Note:** SRVB creation is now covered end-to-end; remaining RAP lifecycle gaps are DCL and TABL/package bootstrapping items (FEAT-37 / FEAT-44 / FEAT-45).
 
 ---
 
@@ -1567,7 +1568,7 @@ Based on independent security review against RFC 9700 (reports/2026-04-08-001-oa
 | Method-Level Surgery | `edit_method` in SAPWrite, `list_methods`/`get_method` in SAPContext (95% token reduction) |
 | Runtime Diagnostics | SAPDiagnose — short dumps (ST22), ABAP profiler traces |
 | DDIC Completeness | Structures, domains, data elements, DDLX, transactions, BOR objects, T100 messages |
-| RAP CRUD | DDLS, DDLX, BDEF, SRVD write + SRVB read |
+| RAP CRUD | DDLS, DDLX, BDEF, SRVD, SRVB write |
 | Context Compression | SAPContext with AST-based dependency extraction (7-30x reduction) |
 | Where-Used Analysis | Scope-based where-used in SAPNavigate (#38) |
 | Class Hierarchy | SAPNavigate hierarchy action via SEOMETAREL SQL |
@@ -1601,7 +1602,7 @@ Based on independent security review against RFC 9700 (reports/2026-04-08-001-oa
 | Runtime Diagnostics | SAPDiagnose — short dumps (ST22), ABAP profiler traces | Complete (2026-04-01) |
 | DDIC Completeness | FEAT-04: DOMA, DTEL, STRU, DDLX, TRAN, BOR, T100, variants | Complete (2026-04-01) |
 | DDIC Domain/Data Element Write | FEAT-13: DOMA/DTEL create, update, delete, batch_create in SAPWrite | Complete (2026-04-12) |
-| RAP CRUD | DDLS/DDLX/BDEF/SRVD write, SRVB read, batch activation | Complete (2026-04-01) |
+| RAP CRUD | DDLS/DDLX/BDEF/SRVD/SRVB write, batch activation | Complete (2026-04-14) |
 | Context Compression | SAPContext with AST-based dependency extraction (7-30x reduction) | Complete (2026-04-01) |
 | MCP Elicitation | Interactive confirmations for destructive operations | Complete (2026-04-01) |
 | BTP ABAP Environment | OAuth 2.0 browser login, direct BTP connectivity | Complete (2026-04-01) |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -138,7 +138,7 @@ Create or update ABAP source code. Handles lock/modify/unlock automatically.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `action` | string | Yes | `create`, `update`, `delete`, `edit_method`, or `batch_create` |
-| `type` | string | No | `PROG`, `CLAS`, `INTF`, `FUNC`, `INCL`, `DDLS`, `DDLX`, `BDEF`, `SRVD`, `DOMA`, `DTEL` (for single object actions) |
+| `type` | string | No | `PROG`, `CLAS`, `INTF`, `FUNC`, `INCL`, `DDLS`, `DDLX`, `BDEF`, `SRVD`, `SRVB`, `DOMA`, `DTEL` (for single object actions) |
 | `name` | string | No | Object name (for single object actions) |
 | `source` | string | No | ABAP source code (for create/update/edit_method) |
 | `method` | string | No | For `edit_method`: method name to replace (e.g., `"get_name"`) |
@@ -165,9 +165,13 @@ Create or update ABAP source code. Handles lock/modify/unlock automatically.
 | `setGetParameter` | string | No | DTEL: SET/GET parameter ID |
 | `defaultComponentName` | string | No | DTEL: default component name |
 | `changeDocument` | boolean | No | DTEL: change document flag |
+| `serviceDefinition` | string | No | SRVB: referenced service definition name (SRVD). Required for SRVB create. |
+| `bindingType` | string | No | SRVB: binding type (default `ODATA`) |
+| `category` | string | No | SRVB: binding category (`0` = UI, `1` = Web API; default `0`) |
+| `version` | string | No | SRVB: service version for binding metadata (default `0001`) |
 | `objects` | array | No | For `batch_create`: ordered list of objects (see below) |
 
-**DDIC metadata writes:** `DOMA` and `DTEL` use structured XML payloads (content-type `application/vnd.sap.adt.*.v2+xml`) and do **not** use `/source/main`.
+**Metadata XML writes:** `DOMA`, `DTEL`, and `SRVB` use structured XML payloads and do **not** use `/source/main`. `SRVB` create uses wildcard content type (`application/*`) and SRVB update uses vendor type (`application/vnd.sap.adt.businessservices.servicebinding.v2+xml`).
 
 **BDEF creation:** Uses SAP's `blue:blueSource` XML format with content-type `application/vnd.sap.adt.blues.v1+xml`. BDEF objects are created with `type="BDEF"` and require a `source` parameter containing the behavior definition.
 
@@ -188,7 +192,8 @@ SAPWrite(action="batch_create", package="ZDEV", transport="K900123", objects=[
   {type:"DDLS", name:"ZI_TRAVEL", source:"define root view..."},
   {type:"BDEF", name:"ZI_TRAVEL", source:"managed implementation..."},
   {type:"SRVD", name:"ZSD_TRAVEL", source:"define service..."},
-  {type:"CLAS", name:"ZBP_I_TRAVEL", source:"CLASS zbp_i_travel..."}
+  {type:"CLAS", name:"ZBP_I_TRAVEL", source:"CLASS zbp_i_travel..."},
+  {type:"SRVB", name:"ZSB_TRAVEL_O4", serviceDefinition:"ZSD_TRAVEL", category:"0"}
 ])
 
 SAPWrite(action="create", type="DOMA", name="ZSTATUS", package="$TMP",
@@ -198,6 +203,9 @@ SAPWrite(action="create", type="DOMA", name="ZSTATUS", package="$TMP",
 SAPWrite(action="create", type="DTEL", name="ZSTATUS", package="$TMP",
   typeKind="domain", typeName="ZSTATUS",
   shortLabel="Status", mediumLabel="Order Status")
+
+SAPWrite(action="create", type="SRVB", name="ZSB_TRAVEL_O4", package="$TMP",
+  serviceDefinition="ZSD_TRAVEL", category="0")
 ```
 
 **Transport behavior:**

--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -47,6 +47,16 @@ export interface DataElementCreateParams {
   changeDocument?: boolean;
 }
 
+export interface ServiceBindingCreateParams {
+  name: string;
+  description: string;
+  package: string;
+  serviceDefinition: string;
+  bindingType?: string;
+  category?: '0' | '1';
+  version?: string;
+}
+
 const DTEL_MAX_LABEL_LENGTHS = {
   short: 10,
   medium: 20,
@@ -185,4 +195,30 @@ export function buildDataElementXml(params: DataElementCreateParams): string {
     <dtel:deactivateBIDIFiltering>false</dtel:deactivateBIDIFiltering>
   </dtel:dataElement>
 </blue:wbobj>`;
+}
+
+export function buildServiceBindingXml(params: ServiceBindingCreateParams): string {
+  const bindingType = params.bindingType?.trim() || 'ODATA';
+  const category = params.category === '1' ? '1' : '0';
+  const serviceVersion = params.version?.trim() || '0001';
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<srvb:serviceBinding xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings"
+                     xmlns:adtcore="http://www.sap.com/adt/core"
+                     adtcore:description="${escapeXml(params.description)}"
+                     adtcore:name="${escapeXml(params.name)}"
+                     adtcore:type="SRVB/SVB"
+                     adtcore:language="EN"
+                     adtcore:masterLanguage="EN"
+                     adtcore:responsible="DEVELOPER">
+  <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>
+  <srvb:services srvb:name="${escapeXml(params.name)}">
+    <srvb:content srvb:version="${escapeXml(serviceVersion)}">
+      <srvb:serviceDefinition adtcore:name="${escapeXml(params.serviceDefinition)}"/>
+    </srvb:content>
+  </srvb:services>
+  <srvb:binding srvb:category="${category}" srvb:type="${escapeXml(bindingType)}" srvb:version="V2">
+    <srvb:implementation adtcore:name=""/>
+  </srvb:binding>
+</srvb:serviceBinding>`;
 }

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -33,8 +33,10 @@ import {
 import {
   buildDataElementXml,
   buildDomainXml,
+  buildServiceBindingXml,
   type DataElementCreateParams,
   type DomainCreateParams,
+  type ServiceBindingCreateParams,
 } from '../adt/ddic-xml.js';
 import {
   type ActivationResult,
@@ -1037,15 +1039,23 @@ function buildLintConfigOptions(config: ServerConfig, ruleOverrides?: RuleOverri
 
 const DOMAIN_V2_CONTENT_TYPE = 'application/vnd.sap.adt.domains.v2+xml; charset=utf-8';
 const DATAELEMENT_V2_CONTENT_TYPE = 'application/vnd.sap.adt.dataelements.v2+xml; charset=utf-8';
+const SERVICEBINDING_V2_CONTENT_TYPE = 'application/vnd.sap.adt.businessservices.servicebinding.v2+xml; charset=utf-8';
 const BDEF_CONTENT_TYPE = 'application/vnd.sap.adt.blues.v1+xml';
 
-function isDdicMetadataType(type: string): boolean {
-  return type === 'DOMA' || type === 'DTEL';
+function isMetadataWriteType(type: string): boolean {
+  return type === 'DOMA' || type === 'DTEL' || type === 'SRVB';
 }
 
 /** Types that require a specific vendor content type for creation (not application/*) */
 function needsVendorContentType(type: string): boolean {
   return type === 'DOMA' || type === 'DTEL' || type === 'BDEF';
+}
+
+/** Content type used for create POST */
+function createContentTypeForType(type: string): string {
+  // SRVB creation works with wildcard content type; updates use vendor v2 type.
+  if (type === 'SRVB') return 'application/*';
+  return needsVendorContentType(type) ? vendorContentTypeForType(type) : 'application/*';
 }
 
 /**
@@ -1073,6 +1083,8 @@ function vendorContentTypeForType(type: string): string {
       return DOMAIN_V2_CONTENT_TYPE;
     case 'DTEL':
       return DATAELEMENT_V2_CONTENT_TYPE;
+    case 'SRVB':
+      return SERVICEBINDING_V2_CONTENT_TYPE;
     case 'BDEF':
       return BDEF_CONTENT_TYPE;
     default:
@@ -1094,7 +1106,7 @@ function toBoolean(value: unknown): boolean | undefined {
   return undefined;
 }
 
-function getDdicWriteProperties(input: Record<string, unknown>): Record<string, unknown> {
+function getMetadataWriteProperties(input: Record<string, unknown>): Record<string, unknown> {
   const props: Record<string, unknown> = {
     dataType: input.dataType,
     length: input.length,
@@ -1117,6 +1129,10 @@ function getDdicWriteProperties(input: Record<string, unknown>): Record<string, 
     setGetParameter: input.setGetParameter,
     defaultComponentName: input.defaultComponentName,
     changeDocument: input.changeDocument,
+    serviceDefinition: input.serviceDefinition,
+    bindingType: input.bindingType,
+    category: input.category,
+    version: input.version,
   };
 
   return props;
@@ -1131,7 +1147,13 @@ function getDdicWriteProperties(input: Record<string, unknown>): Record<string, 
  * Internal _description and _package fields carry the existing values
  * for the caller to use as fallbacks.
  */
-async function mergeDdicProperties(
+function normalizeSrvbCategory(value: unknown): '0' | '1' | undefined {
+  if (value === '0' || value === 0 || value === 'UI') return '0';
+  if (value === '1' || value === 1 || value === 'Web API') return '1';
+  return undefined;
+}
+
+async function mergeMetadataWriteProperties(
   client: AdtClient,
   type: string,
   name: string,
@@ -1174,6 +1196,18 @@ async function mergeDdicProperties(
         setGetParameter: provided.setGetParameter,
         defaultComponentName: provided.defaultComponentName ?? existing.defaultComponentName,
         changeDocument: provided.changeDocument,
+      };
+    }
+    if (type === 'SRVB') {
+      const existingRaw = await client.getSrvb(name);
+      const existing = JSON.parse(existingRaw) as Record<string, unknown>;
+      return {
+        _description: existing.description,
+        _package: existing.package,
+        serviceDefinition: provided.serviceDefinition ?? existing.serviceDefinition,
+        bindingType: provided.bindingType ?? existing.bindingType,
+        category: provided.category ?? normalizeSrvbCategory(existing.bindingCategory),
+        version: provided.version ?? existing.serviceVersion,
       };
     }
   } catch {
@@ -1394,6 +1428,24 @@ export function buildCreateXml(
                  srvd:srvdSourceType="S">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </srvd:srvdSource>`;
+    case 'SRVB': {
+      const serviceDefinition = String(properties?.serviceDefinition ?? '').trim();
+      if (!serviceDefinition) {
+        throw new Error('SRVB create/update requires "serviceDefinition" (referenced SRVD name).');
+      }
+      const categoryRaw = properties?.category;
+      const category = categoryRaw === '1' || categoryRaw === 1 ? '1' : '0';
+      const params: ServiceBindingCreateParams = {
+        name,
+        description,
+        package: pkg,
+        serviceDefinition,
+        bindingType: properties?.bindingType ? String(properties.bindingType) : undefined,
+        category,
+        version: properties?.version ? String(properties.version) : undefined,
+      };
+      return buildServiceBindingXml(params);
+    }
     case 'DDLX':
       return `<?xml version="1.0" encoding="UTF-8"?>
 <ddlx:ddlxSource xmlns:ddlx="http://www.sap.com/adt/ddic/ddlxsources"
@@ -1581,12 +1633,12 @@ async function handleSAPWrite(
     case 'update': {
       const existingPackage = await enforcePackageForExistingObject();
 
-      if (isDdicMetadataType(type)) {
-        // DDIC updates are full-XML-replace — we must fetch existing metadata
+      if (isMetadataWriteType(type)) {
+        // Metadata updates are full-XML-replace — we must fetch existing metadata
         // and merge with provided fields so omitted fields keep their current values.
         // Without this, updating just labels would reset dataType/typeKind to defaults.
-        const ddicProps = getDdicWriteProperties(args);
-        const mergedProps = await mergeDdicProperties(client, type, name, ddicProps);
+        const metadataProps = getMetadataWriteProperties(args);
+        const mergedProps = await mergeMetadataWriteProperties(client, type, name, metadataProps);
         const description = String(args.description ?? mergedProps._description ?? name);
         const pkg = String(args.package ?? existingPackage ?? mergedProps._package ?? '$TMP');
         const body = buildCreateXml(type, name, pkg, description, mergedProps);
@@ -1664,22 +1716,22 @@ async function handleSAPWrite(
       // Build type-specific creation XML body.
       // SAP ADT requires the root element to match the object type —
       // a generic objectReferences body returns 400 "System expected the element ...".
-      const ddicProperties = getDdicWriteProperties(args);
-      const body = buildCreateXml(type, name, pkg, description, ddicProperties);
+      const metadataProperties = getMetadataWriteProperties(args);
+      const body = buildCreateXml(type, name, pkg, description, metadataProperties);
 
       // Step 1: Create the object (metadata only)
       const createUrl = objectUrl.replace(/\/[^/]+$/, ''); // parent collection URL
       // DOMA/DTEL/BDEF require vendor-specific content types; all other types use
       // 'application/*' — the wildcard lets the SAP server resolve the correct
       // handler (matching how ADT Eclipse and abap-adt-api send requests).
-      const contentType = needsVendorContentType(type) ? vendorContentTypeForType(type) : 'application/*';
+      const contentType = createContentTypeForType(type);
       const result = await createObject(client.http, client.safety, createUrl, body, contentType, effectiveTransport);
 
-      if (isDdicMetadataType(type)) {
+      if (isMetadataWriteType(type)) {
         // SAP's DTEL POST ignores labels, searchHelp, etc. — they require a follow-up PUT.
         // Use withStatefulSession directly (not safeUpdateObject) to keep the lock cycle
         // on the main client's session, avoiding lock contention with subsequent operations.
-        if (type === 'DTEL' && dtelNeedsPostCreateUpdate(ddicProperties)) {
+        if (type === 'DTEL' && dtelNeedsPostCreateUpdate(metadataProperties)) {
           const ct = vendorContentTypeForType(type);
           await client.http.withStatefulSession(async (session) => {
             const lock = await lockObject(session, client.safety, objectUrl);
@@ -1692,7 +1744,11 @@ async function handleSAPWrite(
           });
         }
         cachingLayer?.invalidate(type, name);
-        return textResult(`Created ${type} ${name} in package ${pkg}.\n${result}`);
+        const followUpHint =
+          type === 'SRVB'
+            ? `\n\nNext steps:\n1. SAPActivate(type="SRVB", name="${name}")\n2. SAPActivate(action="publish_srvb", name="${name}")`
+            : '';
+        return textResult(`Created ${type} ${name} in package ${pkg}.\n${result}${followUpHint}`);
       }
 
       // Step 2: Write source code if provided
@@ -1813,7 +1869,7 @@ async function handleSAPWrite(
       for (const obj of objects) {
         const objType = String(obj.type ?? '');
         const objName = String(obj.name ?? '');
-        const metadataObject = isDdicMetadataType(objType);
+        const metadataObject = isMetadataWriteType(objType);
         const objSource = obj.source ? String(obj.source) : undefined;
         const objDescription = String(obj.description ?? objName);
 
@@ -1848,14 +1904,13 @@ async function handleSAPWrite(
           // Step 1: Create the object
           const objUrl = objectUrlForType(objType, objName);
           const createUrl = objUrl.replace(/\/[^/]+$/, '');
-          const objDdicProps = getDdicWriteProperties(obj);
-          const body = buildCreateXml(objType, objName, pkg, objDescription, objDdicProps);
-          const contentType =
-            metadataObject || needsVendorContentType(objType) ? vendorContentTypeForType(objType) : 'application/*';
+          const objMetadataProps = getMetadataWriteProperties(obj);
+          const body = buildCreateXml(objType, objName, pkg, objDescription, objMetadataProps);
+          const contentType = createContentTypeForType(objType);
           await createObject(client.http, client.safety, createUrl, body, contentType, batchTransport);
 
           // Step 1b: DTEL POST ignores labels — follow up with PUT on main session
-          if (objType === 'DTEL' && dtelNeedsPostCreateUpdate(objDdicProps)) {
+          if (objType === 'DTEL' && dtelNeedsPostCreateUpdate(objMetadataProps)) {
             await client.http.withStatefulSession(async (session) => {
               const lock = await lockObject(session, client.safety, objUrl);
               const lockTransport = batchTransport ?? (lock.corrNr || undefined);

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -130,10 +130,11 @@ const SAPWRITE_TYPES_ONPREM = [
   'DDLX',
   'BDEF',
   'SRVD',
+  'SRVB',
   'DOMA',
   'DTEL',
 ] as const;
-const SAPWRITE_TYPES_BTP = ['CLAS', 'INTF', 'DDLS', 'DDLX', 'BDEF', 'SRVD', 'DOMA', 'DTEL'] as const;
+const SAPWRITE_TYPES_BTP = ['CLAS', 'INTF', 'DDLS', 'DDLX', 'BDEF', 'SRVD', 'SRVB', 'DOMA', 'DTEL'] as const;
 
 const ddicFixedValueSchema = z.object({
   low: z.string(),
@@ -167,6 +168,10 @@ const batchObjectSchemaOnprem = z.object({
   setGetParameter: z.string().optional(),
   defaultComponentName: z.string().optional(),
   changeDocument: z.coerce.boolean().optional(),
+  serviceDefinition: z.string().optional(),
+  bindingType: z.string().optional(),
+  category: z.enum(['0', '1']).optional(),
+  version: z.string().optional(),
 });
 
 const batchObjectSchemaBtp = z.object({
@@ -195,6 +200,10 @@ const batchObjectSchemaBtp = z.object({
   setGetParameter: z.string().optional(),
   defaultComponentName: z.string().optional(),
   changeDocument: z.coerce.boolean().optional(),
+  serviceDefinition: z.string().optional(),
+  bindingType: z.string().optional(),
+  category: z.enum(['0', '1']).optional(),
+  version: z.string().optional(),
 });
 
 export const SAPWriteSchema = z.object({
@@ -227,6 +236,10 @@ export const SAPWriteSchema = z.object({
   setGetParameter: z.string().optional(),
   defaultComponentName: z.string().optional(),
   changeDocument: z.coerce.boolean().optional(),
+  serviceDefinition: z.string().optional(),
+  bindingType: z.string().optional(),
+  category: z.enum(['0', '1']).optional(),
+  version: z.string().optional(),
   objects: z.array(batchObjectSchemaOnprem).optional(),
 });
 
@@ -260,6 +273,10 @@ export const SAPWriteSchemaBtp = z.object({
   setGetParameter: z.string().optional(),
   defaultComponentName: z.string().optional(),
   changeDocument: z.coerce.boolean().optional(),
+  serviceDefinition: z.string().optional(),
+  bindingType: z.string().optional(),
+  category: z.enum(['0', '1']).optional(),
+  version: z.string().optional(),
   objects: z.array(batchObjectSchemaBtp).optional(),
 });
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -100,19 +100,32 @@ const SAPREAD_DESC_BTP =
 
 // ─── SAPWrite Types ─────────────────────────────────────────────────
 
-const SAPWRITE_TYPES_ONPREM = ['PROG', 'CLAS', 'INTF', 'FUNC', 'INCL', 'DDLS', 'DDLX', 'BDEF', 'SRVD', 'DOMA', 'DTEL'];
-const SAPWRITE_TYPES_BTP = ['CLAS', 'INTF', 'DDLS', 'DDLX', 'BDEF', 'SRVD', 'DOMA', 'DTEL'];
+const SAPWRITE_TYPES_ONPREM = [
+  'PROG',
+  'CLAS',
+  'INTF',
+  'FUNC',
+  'INCL',
+  'DDLS',
+  'DDLX',
+  'BDEF',
+  'SRVD',
+  'SRVB',
+  'DOMA',
+  'DTEL',
+];
+const SAPWRITE_TYPES_BTP = ['CLAS', 'INTF', 'DDLS', 'DDLX', 'BDEF', 'SRVD', 'SRVB', 'DOMA', 'DTEL'];
 
 const SAPWRITE_DESC_ONPREM =
-  'Create or update ABAP source code and DDIC metadata. Handles lock/modify/unlock automatically. Supports PROG, CLAS, INTF, FUNC, INCL, DDLS, DDLX, BDEF, SRVD, DOMA, DTEL. ' +
-  'DOMA/DTEL use metadata XML writes (not /source/main): provide DDIC fields like dataType, length, fixedValues, typeKind, labels, searchHelp. ' +
+  'Create or update ABAP source code and metadata objects. Handles lock/modify/unlock automatically. Supports PROG, CLAS, INTF, FUNC, INCL, DDLS, DDLX, BDEF, SRVD, SRVB, DOMA, DTEL. ' +
+  'DOMA/DTEL/SRVB use metadata XML writes (not /source/main): DOMA/DTEL need DDIC fields, SRVB needs serviceDefinition plus optional bindingType/category. ' +
   'For edit_method: surgically replace a single method body in a CLAS without sending the full class source. ' +
   'Provide just the new method implementation code in "source" — 95% fewer tokens than full-class updates. ' +
   'For batch_create: create and activate multiple objects in a single call — ideal for RAP stacks. Pass "objects" array with dependency order.';
 
 const SAPWRITE_DESC_BTP =
-  'Create or update ABAP source code and DDIC metadata (BTP ABAP Environment). Handles lock/modify/unlock automatically. Supports CLAS, INTF, DDLS, DDLX, BDEF, SRVD, DOMA, DTEL. ' +
-  'DOMA/DTEL use metadata XML writes (not /source/main): provide DDIC fields like dataType, length, fixedValues, typeKind, labels, searchHelp. ' +
+  'Create or update ABAP source code and metadata objects (BTP ABAP Environment). Handles lock/modify/unlock automatically. Supports CLAS, INTF, DDLS, DDLX, BDEF, SRVD, SRVB, DOMA, DTEL. ' +
+  'DOMA/DTEL/SRVB use metadata XML writes (not /source/main): DOMA/DTEL need DDIC fields, SRVB needs serviceDefinition plus optional bindingType/category. ' +
   'Must use ABAP Cloud language version (no classic statements). Only Z*/Y* namespace allowed on BTP. ' +
   'For edit_method: surgically replace a single method body in a CLAS without sending the full class source. ' +
   'For batch_create: create and activate multiple objects in a single call — ideal for RAP stacks.';
@@ -460,6 +473,14 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
           setGetParameter: { type: 'string', description: 'DTEL: SET/GET parameter ID' },
           defaultComponentName: { type: 'string', description: 'DTEL: default component name' },
           changeDocument: { type: 'boolean', description: 'DTEL: enable change document flag' },
+          serviceDefinition: { type: 'string', description: 'SRVB: service definition name (SRVD) to bind to' },
+          bindingType: { type: 'string', description: 'SRVB: binding type (default: ODATA)' },
+          category: {
+            type: 'string',
+            enum: ['0', '1'],
+            description: 'SRVB: binding category (0=UI, 1=Web API; default: 0)',
+          },
+          version: { type: 'string', description: 'SRVB: service version (default: 0001)' },
           objects: {
             type: 'array',
             items: {
@@ -506,6 +527,14 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
                 setGetParameter: { type: 'string', description: 'DTEL: SET/GET parameter ID' },
                 defaultComponentName: { type: 'string', description: 'DTEL: default component name' },
                 changeDocument: { type: 'boolean', description: 'DTEL: change document flag' },
+                serviceDefinition: { type: 'string', description: 'SRVB: service definition (SRVD)' },
+                bindingType: { type: 'string', description: 'SRVB: binding type (default ODATA)' },
+                category: {
+                  type: 'string',
+                  enum: ['0', '1'],
+                  description: 'SRVB: binding category (0=UI, 1=Web API)',
+                },
+                version: { type: 'string', description: 'SRVB: service version (default 0001)' },
               },
               required: ['type', 'name'],
             },

--- a/tests/e2e/rap-write.e2e.test.ts
+++ b/tests/e2e/rap-write.e2e.test.ts
@@ -360,7 +360,171 @@ describe('E2E RAP write lifecycle tests', () => {
     }
   });
 
-  // ── Test 4: batch_create for RAP stack ─────────────────────────────
+  // ── Test 4: SRVB lifecycle (create -> activate -> publish) ────────
+
+  it('SAPWrite create SRVB, activate, publish, unpublish, delete', async (ctx) => {
+    requireOrSkip(ctx, rapAvailable, 'RAP/CDS not available on test system');
+
+    const tableName = uniqueName('ZARC1_ST_');
+    const viewName = uniqueName('ZARC1_SV_');
+    const bdefName = viewName;
+    const bpClassName = uniqueName('ZBP_ARC1_S');
+    const srvdName = uniqueName('ZARC1_SD_');
+    const srvbName = uniqueName('ZARC1_SB_');
+
+    const tableSource = [
+      `@EndUserText.label: 'ARC1 SRVB stack table'`,
+      '@AbapCatalog.enhancement.category: #NOT_EXTENSIBLE',
+      '@AbapCatalog.tableCategory: #TRANSPARENT',
+      '@AbapCatalog.deliveryClass: #A',
+      '@AbapCatalog.dataMaintenance: #RESTRICTED',
+      `define table ${tableName.toLowerCase()} {`,
+      '  key client : abap.clnt not null;',
+      '  key id     : sysuuid_x16 not null;',
+      '  name       : abap.char(40);',
+      '}',
+    ].join('\n');
+
+    const viewSource = [
+      `@EndUserText.label: 'ARC1 SRVB stack view'`,
+      '@AccessControl.authorizationCheck: #NOT_ALLOWED',
+      `define root view entity ${viewName}`,
+      `  as select from ${tableName.toLowerCase()}`,
+      '{',
+      '  key id   as Id,',
+      '  name     as Name',
+      '}',
+    ].join('\n');
+
+    const bpClassSource = [
+      `CLASS ${bpClassName.toLowerCase()} DEFINITION`,
+      '  PUBLIC ABSTRACT FINAL',
+      `  FOR BEHAVIOR OF ${viewName.toLowerCase()}.`,
+      'ENDCLASS.',
+      '',
+      `CLASS ${bpClassName.toLowerCase()} IMPLEMENTATION.`,
+      'ENDCLASS.',
+    ].join('\n');
+
+    const bdefSource = [
+      `managed implementation in class ${bpClassName.toLowerCase()} unique;`,
+      'strict;',
+      '',
+      `define behavior for ${viewName} alias ${viewName.slice(-10)}`,
+      `persistent table ${tableName.toLowerCase()}`,
+      'lock master',
+      'authorization master ( instance )',
+      '{',
+      '  field ( readonly ) Id;',
+      '  create;',
+      '  update;',
+      '  delete;',
+      '}',
+    ].join('\n');
+
+    const srvdSource = [
+      `@EndUserText.label: 'ARC1 SRVB stack service definition'`,
+      `define service ${srvdName} {`,
+      `  expose ${viewName} as TestEntity;`,
+      '}',
+    ].join('\n');
+
+    try {
+      expectToolSuccess(
+        await callTool(client, 'SAPWrite', {
+          action: 'create',
+          type: 'DDLS',
+          name: tableName,
+          source: tableSource,
+          package: '$TMP',
+        }),
+      );
+      expectToolSuccess(await callTool(client, 'SAPActivate', { type: 'DDLS', name: tableName }));
+
+      expectToolSuccess(
+        await callTool(client, 'SAPWrite', {
+          action: 'create',
+          type: 'DDLS',
+          name: viewName,
+          source: viewSource,
+          package: '$TMP',
+        }),
+      );
+      expectToolSuccess(await callTool(client, 'SAPActivate', { type: 'DDLS', name: viewName }));
+
+      expectToolSuccess(
+        await callTool(client, 'SAPWrite', {
+          action: 'create',
+          type: 'CLAS',
+          name: bpClassName,
+          source: bpClassSource,
+          package: '$TMP',
+        }),
+      );
+
+      expectToolSuccess(
+        await callTool(client, 'SAPWrite', {
+          action: 'create',
+          type: 'BDEF',
+          name: bdefName,
+          source: bdefSource,
+          package: '$TMP',
+        }),
+      );
+      expectToolSuccess(
+        await callTool(client, 'SAPActivate', {
+          objects: [
+            { type: 'CLAS', name: bpClassName },
+            { type: 'BDEF', name: bdefName },
+          ],
+        }),
+      );
+
+      expectToolSuccess(
+        await callTool(client, 'SAPWrite', {
+          action: 'create',
+          type: 'SRVD',
+          name: srvdName,
+          source: srvdSource,
+          package: '$TMP',
+        }),
+      );
+      expectToolSuccess(await callTool(client, 'SAPActivate', { type: 'SRVD', name: srvdName }));
+
+      expectToolSuccess(
+        await callTool(client, 'SAPWrite', {
+          action: 'create',
+          type: 'SRVB',
+          name: srvbName,
+          package: '$TMP',
+          serviceDefinition: srvdName,
+          category: '0',
+        }),
+      );
+      expectToolSuccess(await callTool(client, 'SAPActivate', { type: 'SRVB', name: srvbName }));
+
+      const readSrvbResult = await callTool(client, 'SAPRead', {
+        type: 'SRVB',
+        name: srvbName,
+      });
+      const srvbText = expectToolSuccess(readSrvbResult);
+      const parsed = JSON.parse(srvbText);
+      expect(parsed.name).toBe(srvbName);
+      expect(parsed.serviceDefinition).toBe(srvdName);
+
+      expectToolSuccess(await callTool(client, 'SAPActivate', { action: 'publish_srvb', name: srvbName }));
+      expectToolSuccess(await callTool(client, 'SAPActivate', { action: 'unpublish_srvb', name: srvbName }));
+    } finally {
+      await bestEffortDelete(client, 'SRVB', srvbName);
+      await bestEffortDelete(client, 'SRVD', srvdName);
+      await bestEffortDelete(client, 'BDEF', bdefName);
+      await bestEffortDelete(client, 'CLAS', bpClassName);
+      await bestEffortDelete(client, 'DDLS', viewName);
+      await bestEffortDelete(client, 'DDLS', tableName);
+    }
+  });
+
+  // ── Test 5: batch_create for RAP stack ─────────────────────────────
 
   it('SAPWrite batch_create for table entity + CDS view', async (ctx) => {
     requireOrSkip(ctx, rapAvailable, 'RAP/CDS not available on test system');

--- a/tests/unit/adt/ddic-xml.test.ts
+++ b/tests/unit/adt/ddic-xml.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildDataElementXml, buildDomainXml } from '../../../src/adt/ddic-xml.js';
+import { buildDataElementXml, buildDomainXml, buildServiceBindingXml } from '../../../src/adt/ddic-xml.js';
 
 describe('ddic-xml builders', () => {
   describe('buildDomainXml', () => {
@@ -190,6 +190,59 @@ describe('ddic-xml builders', () => {
     });
   });
 
+  describe('buildServiceBindingXml', () => {
+    it('builds basic service binding XML with SRVB/SVB type', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB_TRAVEL_O4',
+        description: 'Travel service binding',
+        package: '$TMP',
+        serviceDefinition: 'ZSD_TRAVEL',
+      });
+
+      expect(xml).toContain('<srvb:serviceBinding');
+      expect(xml).toContain('xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings"');
+      expect(xml).toContain('adtcore:type="SRVB/SVB"');
+      expect(xml).toContain('adtcore:name="ZSB_TRAVEL_O4"');
+      expect(xml).toContain('<adtcore:packageRef adtcore:name="$TMP"/>');
+    });
+
+    it('includes nested service definition reference', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB_TRAVEL_O4',
+        description: 'Travel service binding',
+        package: '$TMP',
+        serviceDefinition: 'ZSD_TRAVEL',
+      });
+
+      expect(xml).toContain('<srvb:services srvb:name="ZSB_TRAVEL_O4">');
+      expect(xml).toContain('<srvb:content srvb:version="0001">');
+      expect(xml).toContain('<srvb:serviceDefinition adtcore:name="ZSD_TRAVEL"/>');
+    });
+
+    it('uses default category=0 and bindingType=ODATA', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB_DEFAULTS',
+        description: 'Defaults',
+        package: '$TMP',
+        serviceDefinition: 'ZSD_DEFAULTS',
+      });
+
+      expect(xml).toContain('<srvb:binding srvb:category="0" srvb:type="ODATA" srvb:version="V2">');
+    });
+
+    it('supports category=1 for alternate binding category', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB_UI',
+        description: 'UI binding',
+        package: '$TMP',
+        serviceDefinition: 'ZSD_UI',
+        category: '1',
+      });
+
+      expect(xml).toContain('<srvb:binding srvb:category="1" srvb:type="ODATA" srvb:version="V2">');
+    });
+  });
+
   it('escapes XML special characters', () => {
     const domainXml = buildDomainXml({
       name: 'ZDOMA',
@@ -205,11 +258,21 @@ describe('ddic-xml builders', () => {
       package: '$TMP',
       shortLabel: 'A&B',
     });
+    const srvbXml = buildServiceBindingXml({
+      name: 'ZSB_XML',
+      description: 'Service "A&B" <binding>',
+      package: '$TMP',
+      serviceDefinition: 'ZSD_<TEST>&',
+      bindingType: 'ODATA"&',
+    });
 
     expect(domainXml).toContain('&quot;A&amp;B&quot; &lt;test&gt; &apos;apostrophe&apos;');
     expect(domainXml).toContain('<doma:low>A&amp;B</doma:low>');
     expect(domainXml).toContain('<doma:text>A &lt; B</doma:text>');
     expect(dtelXml).toContain('Data &quot;element&quot;');
     expect(dtelXml).toContain('<dtel:shortFieldLabel>A&amp;B</dtel:shortFieldLabel>');
+    expect(srvbXml).toContain('Service &quot;A&amp;B&quot; &lt;binding&gt;');
+    expect(srvbXml).toContain('<srvb:serviceDefinition adtcore:name="ZSD_&lt;TEST&gt;&amp;"/>');
+    expect(srvbXml).toContain('srvb:type="ODATA&quot;&amp;"');
   });
 });

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -3356,7 +3356,7 @@ ENDCLASS.`;
     });
   });
 
-  describe('SAPWrite DOMA/DTEL metadata writes', () => {
+  describe('SAPWrite metadata writes (DOMA/DTEL/SRVB)', () => {
     it('creates DOMA with v2 content type and no source PUT', async () => {
       mockFetch.mockReset();
       const calls: Array<{ method: string; url: string; contentType?: string }> = [];
@@ -3569,6 +3569,180 @@ ENDCLASS.`;
       expect(calls.some((c) => c.method === 'PUT')).toBe(false);
     });
 
+    it('creates SRVB with service binding XML and publish hint', async () => {
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string; contentType?: string; body?: string }> = [];
+      mockFetch.mockImplementation(
+        (
+          url: string | URL,
+          opts?: { method?: string; headers?: Record<string, string>; body?: string | Buffer | null },
+        ) => {
+          const method = opts?.method ?? 'GET';
+          const headers = (opts?.headers ?? {}) as Record<string, string>;
+          calls.push({
+            method,
+            url: String(url),
+            contentType: headers['content-type'] ?? headers['Content-Type'],
+            body: typeof opts?.body === 'string' ? opts.body : undefined,
+          });
+          return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+        },
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'create',
+        type: 'SRVB',
+        name: 'ZSB_TRAVEL_O4',
+        package: '$TMP',
+        serviceDefinition: 'ZSD_TRAVEL',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('Created SRVB ZSB_TRAVEL_O4');
+      expect(result.content[0]?.text).toContain('SAPActivate(type="SRVB", name="ZSB_TRAVEL_O4")');
+      expect(result.content[0]?.text).toContain('SAPActivate(action="publish_srvb", name="ZSB_TRAVEL_O4")');
+      const createCall = calls.find(
+        (c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/businessservices/bindings'),
+      );
+      expect(createCall?.contentType).toContain('application/*');
+      expect(createCall?.body).toContain('<srvb:serviceBinding');
+      expect(createCall?.body).toContain('adtcore:type="SRVB/SVB"');
+      expect(createCall?.body).toContain('<srvb:serviceDefinition adtcore:name="ZSD_TRAVEL"/>');
+      expect(calls.some((c) => c.method === 'PUT' && c.url.includes('/source/main'))).toBe(false);
+    });
+
+    it('fails SRVB create when serviceDefinition is missing', async () => {
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'create',
+        type: 'SRVB',
+        name: 'ZSB_TRAVEL_O4',
+        package: '$TMP',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('serviceDefinition');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('updates SRVB via metadata PUT with vendor content type (no source/main)', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>';
+      const srvbReadXml = `<?xml version="1.0" encoding="utf-8"?>
+<srvb:serviceBinding xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings" xmlns:adtcore="http://www.sap.com/adt/core"
+  adtcore:name="ZSB_TRAVEL_O4" adtcore:type="SRVB/SVB" adtcore:description="Travel binding" srvb:published="false" srvb:bindingCreated="true">
+  <adtcore:packageRef adtcore:name="$TMP"/>
+  <srvb:services srvb:name="ZSB_TRAVEL_O4">
+    <srvb:content srvb:version="0001">
+      <srvb:serviceDefinition adtcore:name="ZSD_TRAVEL"/>
+    </srvb:content>
+  </srvb:services>
+  <srvb:binding srvb:type="ODATA" srvb:version="V4" srvb:category="0">
+    <srvb:implementation adtcore:name="ZSB_TRAVEL_O4"/>
+  </srvb:binding>
+</srvb:serviceBinding>`;
+
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string; contentType?: string; body?: string }> = [];
+      mockFetch.mockImplementation(
+        (
+          url: string | URL,
+          opts?: { method?: string; headers?: Record<string, string>; body?: string | Buffer | null },
+        ) => {
+          const method = opts?.method ?? 'GET';
+          const headers = (opts?.headers ?? {}) as Record<string, string>;
+          const urlStr = String(url);
+          calls.push({
+            method,
+            url: urlStr,
+            contentType: headers['content-type'] ?? headers['Content-Type'],
+            body: typeof opts?.body === 'string' ? opts.body : undefined,
+          });
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/businessservices/bindings/ZSB_TRAVEL_O4')) {
+            return Promise.resolve(mockResponse(200, srvbReadXml, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'POST' && urlStr.includes('_action=LOCK')) {
+            return Promise.resolve(mockResponse(200, lockBody, { 'x-csrf-token': 'T' }));
+          }
+          return Promise.resolve(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+        },
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'update',
+        type: 'SRVB',
+        name: 'ZSB_TRAVEL_O4',
+        package: '$TMP',
+        bindingType: 'ODATA',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const putCall = calls.find((c) => c.method === 'PUT');
+      expect(putCall?.url).toContain('/sap/bc/adt/businessservices/bindings/ZSB_TRAVEL_O4?lockHandle=');
+      expect(putCall?.url).not.toContain('/source/main');
+      expect(putCall?.contentType).toContain('application/vnd.sap.adt.businessservices.servicebinding.v2+xml');
+      expect(putCall?.body).toContain('<srvb:serviceBinding');
+    });
+
+    it('deletes SRVB via lock/delete/unlock sequence', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>';
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string }> = [];
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = opts?.method ?? 'GET';
+        const urlStr = String(url);
+        calls.push({ method, url: urlStr });
+        if (method === 'POST' && urlStr.includes('_action=LOCK')) {
+          return Promise.resolve(mockResponse(200, lockBody, { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'delete',
+        type: 'SRVB',
+        name: 'ZSB_TRAVEL_O4',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(calls.some((c) => c.method === 'POST' && c.url.includes('_action=LOCK'))).toBe(true);
+      expect(calls.some((c) => c.method === 'DELETE' && c.url.includes('/sap/bc/adt/businessservices/bindings/'))).toBe(
+        true,
+      );
+      expect(calls.some((c) => c.method === 'POST' && c.url.includes('_action=UNLOCK'))).toBe(true);
+    });
+
+    it('batch_create supports SRVB as metadata object', async () => {
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string }> = [];
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        calls.push({ method: opts?.method ?? 'GET', url: String(url) });
+        return Promise.resolve(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const config = { ...DEFAULT_CONFIG, lintBeforeWrite: false };
+      const result = await handleToolCall(createClient(), config, 'SAPWrite', {
+        action: 'batch_create',
+        package: '$TMP',
+        objects: [
+          { type: 'SRVD', name: 'ZSD_TRAVEL', source: 'define service ZSD_TRAVEL {}' },
+          { type: 'SRVB', name: 'ZSB_TRAVEL_O4', serviceDefinition: 'ZSD_TRAVEL', category: '0' },
+        ],
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('ZSD_TRAVEL (SRVD) ✓');
+      expect(result.content[0]?.text).toContain('ZSB_TRAVEL_O4 (SRVB) ✓');
+      expect(
+        calls.some(
+          (c) =>
+            c.method === 'PUT' &&
+            c.url.includes('/sap/bc/adt/businessservices/bindings/') &&
+            c.url.includes('/source/main'),
+        ),
+      ).toBe(false);
+    });
+
     it('respects package restrictions for DOMA create', async () => {
       const restrictedClient = new AdtClient({
         baseUrl: 'http://sap:8000',
@@ -3603,6 +3777,24 @@ ENDCLASS.`;
         typeKind: 'predefinedAbapType',
         dataType: 'CHAR',
         length: 10,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('blocked');
+    });
+
+    it('blocks SRVB create in read-only mode', async () => {
+      const readOnlyClient = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'admin',
+        password: 'secret',
+        safety: { ...unrestrictedSafetyConfig(), readOnly: true },
+      });
+      const result = await handleToolCall(readOnlyClient, DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'create',
+        type: 'SRVB',
+        name: 'ZSB_TRAVEL_O4',
+        package: '$TMP',
+        serviceDefinition: 'ZSD_TRAVEL',
       });
       expect(result.isError).toBe(true);
       expect(result.content[0]?.text).toContain('blocked');
@@ -4009,6 +4201,23 @@ ENDCLASS.`;
       expect(xml).toContain('adtcore:name="ZC_TRAVEL"');
       expect(xml).toContain('adtcore:description="Travel Metadata Ext"');
       expect(xml).toContain('<adtcore:packageRef adtcore:name="ZPACKAGE"/>');
+    });
+
+    it('returns correct XML for SRVB', () => {
+      const xml = buildCreateXml('SRVB', 'ZSB_TRAVEL_O4', 'ZPACKAGE', 'Travel service binding', {
+        serviceDefinition: 'ZSD_TRAVEL',
+        category: '0',
+      });
+      expect(xml).toContain('<srvb:serviceBinding');
+      expect(xml).toContain('adtcore:type="SRVB/SVB"');
+      expect(xml).toContain('<srvb:serviceDefinition adtcore:name="ZSD_TRAVEL"/>');
+      expect(xml).toContain('<srvb:binding srvb:category="0" srvb:type="ODATA" srvb:version="V2">');
+    });
+
+    it('throws for SRVB when serviceDefinition is missing', () => {
+      expect(() => buildCreateXml('SRVB', 'ZSB_TRAVEL_O4', 'ZPACKAGE', 'Travel service binding')).toThrow(
+        'serviceDefinition',
+      );
     });
 
     it('returns domain metadata XML for DOMA', () => {

--- a/tests/unit/handlers/schemas.test.ts
+++ b/tests/unit/handlers/schemas.test.ts
@@ -208,6 +208,27 @@ describe('SAPWriteSchema', () => {
     }
   });
 
+  it('accepts SRVB fields and validates category enum', () => {
+    const srvb = SAPWriteSchema.safeParse({
+      action: 'create',
+      type: 'SRVB',
+      name: 'ZSB_TRAVEL_O4',
+      serviceDefinition: 'ZSD_TRAVEL',
+      bindingType: 'ODATA',
+      category: '0',
+    });
+    expect(srvb.success).toBe(true);
+
+    const invalidCategory = SAPWriteSchema.safeParse({
+      action: 'create',
+      type: 'SRVB',
+      name: 'ZSB_TRAVEL_O4',
+      serviceDefinition: 'ZSD_TRAVEL',
+      category: '2',
+    });
+    expect(invalidCategory.success).toBe(false);
+  });
+
   it('accepts edit_method with all fields', () => {
     const result = SAPWriteSchema.safeParse({
       action: 'edit_method',
@@ -278,6 +299,9 @@ describe('SAPWriteSchemaBtp', () => {
   it('accepts BTP types', () => {
     expect(SAPWriteSchemaBtp.safeParse({ action: 'create', type: 'CLAS', name: 'Z' }).success).toBe(true);
     expect(SAPWriteSchemaBtp.safeParse({ action: 'create', type: 'DDLS', name: 'Z' }).success).toBe(true);
+    expect(
+      SAPWriteSchemaBtp.safeParse({ action: 'create', type: 'SRVB', name: 'ZSB', serviceDefinition: 'ZSD' }).success,
+    ).toBe(true);
     expect(SAPWriteSchemaBtp.safeParse({ action: 'create', type: 'DOMA', name: 'ZDOMAIN' }).success).toBe(true);
     expect(SAPWriteSchemaBtp.safeParse({ action: 'create', type: 'DTEL', name: 'ZDELEM' }).success).toBe(true);
   });

--- a/tests/unit/handlers/tools.test.ts
+++ b/tests/unit/handlers/tools.test.ts
@@ -279,7 +279,7 @@ describe('Tool Definitions', () => {
       expect(typeEnum).toContain('SRVB');
     });
 
-    it('includes DDLS, DDLX, BDEF, SRVD, DOMA, DTEL in SAPWrite types on both BTP and on-prem', () => {
+    it('includes DDLS, DDLX, BDEF, SRVD, SRVB, DOMA, DTEL in SAPWrite types on both BTP and on-prem', () => {
       for (const config of [btpConfig, onpremConfig]) {
         const tools = getToolDefinitions(config);
         const sapWrite = tools.find((t) => t.name === 'SAPWrite')!;
@@ -290,6 +290,7 @@ describe('Tool Definitions', () => {
         expect(typeEnum).toContain('DDLX');
         expect(typeEnum).toContain('BDEF');
         expect(typeEnum).toContain('SRVD');
+        expect(typeEnum).toContain('SRVB');
         expect(typeEnum).toContain('DOMA');
         expect(typeEnum).toContain('DTEL');
       }
@@ -329,6 +330,7 @@ describe('Tool Definitions', () => {
       expect(typeEnum).not.toContain('FUNC');
       expect(typeEnum).toContain('CLAS');
       expect(typeEnum).toContain('INTF');
+      expect(typeEnum).toContain('SRVB');
       expect(typeEnum).toContain('DOMA');
       expect(typeEnum).toContain('DTEL');
     });


### PR DESCRIPTION
## Summary
- add SRVB metadata XML builder and wire it into SAPWrite create/update/delete/batch_create
- add SRVB write params (`serviceDefinition`, `bindingType`, `category`, `version`) to schemas and tool definitions
- route SRVB through metadata write flow (XML PUT, no `/source/main`), with vendor content type on update
- add create response guidance for follow-up activation + publish
- add unit coverage for XML, schemas, tools, and intent handler SRVB paths
- add RAP E2E lifecycle test for SRVB create/activate/publish/unpublish/delete
- update docs and roadmap/feature matrix entries for FEAT-46 completion

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`
