### PR TITLE
fix: add mcpName for MCP Registry publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "arc-1",
   "version": "0.6.2",
+  "mcpName": "io.github.marianfoo/arc-1",
   "description": "ARC-1 — MCP Server for SAP ABAP Systems",
   "author": "Marian Zeis",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Adds `"mcpName": "io.github.marianfoo/arc-1"` to `package.json`, required by the MCP Registry for npm package validation during `mcp-publisher publish`
- Without this field, the registry returns a 400 error asking for it to be present in the published npm package

## Context
The MCP Registry validates the `mcpName` field against what's published on npm. This needs to be released to npm (via release-please) before `mcp-publisher publish` will succeed.

## Test plan
- [ ] Verify `package.json` is valid JSON
- [ ] After npm publish, verify `mcp-publisher publish` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)