### PR TITLE
fix: add MCP Registry OCI annotation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN npm prune --omit=dev
 # --- Runtime Stage -----------------------------------------------------------
 FROM node:22-alpine
 
+LABEL io.modelcontextprotocol.server.name="io.github.marianfoo/arc-1"
+
 # tini: proper PID 1 init (handles SIGTERM gracefully)
 # ca-certificates: needed for HTTPS connections to SAP systems
 RUN apk add --no-cache tini ca-certificates


### PR DESCRIPTION
## Summary
- Adds `LABEL io.modelcontextprotocol.server.name="io.github.marianfoo/arc-1"` to the runtime stage of the Dockerfile
- Required by the MCP Registry to validate OCI images during `mcp-publisher publish`
- Companion to #113 (which adds `mcpName` to package.json for the npm package validation)

## Test plan
- [ ] `docker build -t arc-1 .` succeeds
- [ ] `docker inspect arc-1 | jq '.[0].Config.Labels'` shows the annotation
- [ ] After release, `mcp-publisher publish` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)