### PR TITLE
fix: normalize SRVB bindingType and support OData V4 bindings

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,8 +58,8 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | 15 | FEAT-06 | Cloud Readiness Assessment | P2 | M | Features |
 | 16 | FEAT-09 | SQL Trace Monitoring | P2 | S | Features |
 | 17 | FEAT-10 | PrettyPrint (Code Formatting) | P1 ↑ | XS | Features |
-| 18 | FEAT-11 | Inactive Objects List | P2 | XS | Features | ✅ Completed |
-| 19 | FEAT-19 | Transport Contents (E071 List) | P2 | XS | Features | ✅ Completed (subsumed by FEAT-39) |
+| ~~18~~ | ~~FEAT-11~~ | ~~Inactive Objects List~~ | ~~P2~~ | ~~XS~~ | ~~Completed~~ |
+| ~~19~~ | ~~FEAT-19~~ | ~~Transport Contents (E071 List)~~ | ~~P2~~ | ~~XS~~ | ~~Completed (subsumed by FEAT-39)~~ |
 | 20 | FEAT-20 | Source Version / Revision History | P1 ↑ | S | Features |
 | 21 | FEAT-21 | ABAP Documentation (F1 Help) | P2 | XS | Features |
 | 22 | FEAT-22 | gCTS/abapGit Integration | P2 | M | Features |
@@ -79,15 +79,15 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | 36 | DOC-03 | SAP Community Blog Post | P2 | S | Docs |
 | 37 | FEAT-37 | DCL (Access Control) Read/Write | P1 | S | Features |
 | 38 | FEAT-38 | ADT Service Discovery (MIME Negotiation) | P0 | S | Features |
-| 39 | FEAT-39 | Transport Enhancements (delete, reassign, types) | P2 | S | Features | ✅ Completed (K/W/T types; S/R deferred) |
+| ~~39~~ | ~~FEAT-39~~ | ~~Transport Enhancements (delete, reassign, types)~~ | ~~P2~~ | ~~S~~ | ~~Completed (K/W/T types; S/R deferred)~~ |
 | ~~40~~ | ~~FEAT-40~~ | ~~FLP Launchpad Management (OData)~~ | ~~P1~~ | ~~M~~ | ~~Completed 2026-04-12~~ |
 | 41 | FEAT-41 | ABAP Unit Test Coverage (statement-level) | P2 | S | Features |
 | 42 | FEAT-42 | ATC Output Formats (JUnit4, checkstyle, codeclimate) | P2 | XS | Features |
 | 43 | FEAT-43 | DDIC Auth & Misc Read (Authorization Fields, Feature Toggles) | P2 | S | Features |
-| 44 | FEAT-44 | TABL (Database Table) Create | P1 | S | Features |
-| 45 | FEAT-45 | DEVC (Package) Create | P1 | S | Features | ✅ Completed (2026-04-14) |
+| ~~44~~ | ~~FEAT-44~~ | ~~TABL (Database Table) Create~~ | ~~P1~~ | ~~S~~ | ~~Completed 2026-04-14~~ |
+| ~~45~~ | ~~FEAT-45~~ | ~~DEVC (Package) Create~~ | ~~P1~~ | ~~S~~ | ~~Completed 2026-04-14~~ |
 | ~~46~~ | ~~FEAT-46~~ | ~~SRVB (Service Binding) Create~~ | ~~P2~~ | ~~S~~ | ~~Completed 2026-04-14~~ |
-| 47 | FEAT-47 | MSAG (Message Class) Read/Write | P2 | S | Features |
+| ~~47~~ | ~~FEAT-47~~ | ~~MSAG (Message Class) Read/Write~~ | ~~P2~~ | ~~S~~ | ~~Completed 2026-04-14~~ |
 | 48 | FEAT-05 | Code Refactoring (Rename, Extract) | P3 | L | Features |
 | 49 | FEAT-29 | P3 Backlog (14 items) | P3 | various | Features |
 | 50 | OPS-03 | Multi-System Routing | P3 | L | Ops |
@@ -98,13 +98,19 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 
 | ID | Feature | Completed | Category |
 |----|---------|-----------|----------|
+| FEAT-47 | MSAG (Message Class) Read/Write | 2026-04-14 | Features |
+| FEAT-45 | DEVC (Package) Create | 2026-04-14 | Features |
+| FEAT-44 | TABL (Database Table) Create | 2026-04-14 | Features |
 | — | RAP DDIC save diagnostics (structured errors + inactive syntax check) | 2026-04-14 | Features |
+| — | Abaplint type-gating + per-call lintBeforeWrite | 2026-04-14 | Features |
 | FEAT-46 | SRVB (Service Binding) Create | 2026-04-14 | Features |
+| FEAT-39 | Transport Enhancements (K/W/T types; S/R deferred) | 2026-04-13 | Features |
 | — | RAP Write Guard (feature-aware) | 2026-04-13 | Features |
 | FEAT-13 | DDIC Domain/Data Element Write | 2026-04-12 | Features |
 | FEAT-08 | Content-Type 415/406 Auto-Retry | 2026-04-12 | Features |
 | FEAT-14 | 401 Session Timeout Auto-Retry | 2026-04-12 | Features |
 | FEAT-15 | Namespace URL Encoding Audit | 2026-04-12 | Features |
+| FEAT-11 | Inactive Objects List | 2026-04-12 | Features |
 | FEAT-40 | FLP Launchpad Management (OData) | 2026-04-12 | Features |
 | SEC-08 | OAuth Security Hardening (RFC 9700) | 2026-04-08 | Security |
 | — | AFF Structured Class Read | 2026-04-08 |  Features |
@@ -176,16 +182,16 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 ### Phase C: ADT Feature Parity (P2) — Quick Wins
 13. **FEAT-32** Table Pagination / Offset (XS) — VSP has this, practical improvement
 14. ~~**FEAT-10** PrettyPrint (XS) — **promoted to P1/Phase B** (dassian-adt + VSP have it)~~
-15. **FEAT-11** Inactive Objects List (XS) — development workflow
-16. **FEAT-19** Transport Contents (XS) — review objects before release
+15. ~~**FEAT-11** Inactive Objects List (XS)~~ — **completed** (via SAPRead type=INACTIVE_OBJECTS)
+16. ~~**FEAT-19** Transport Contents (XS)~~ — **completed** (subsumed by FEAT-39)
 17. **FEAT-21** ABAP Documentation / F1 Help (XS) — real docs instead of hallucination
 18. **FEAT-28** SAP Compatibility Hardening (S) — 7 compat fixes bundled (expanded Apr 8)
 19. **OPS-02** Health Check Enhancements (XS) — `/health/deep` with SAP connectivity check
 
 ### Phase D: ADT Feature Parity (P2) — Larger Items
 20. ~~**FEAT-46** SRVB (Service Binding) Create (S)~~ — **completed 2026-04-14** (SAPWrite now supports SRVB create/update/delete + batch_create; create guidance points to activate + publish flow).
-21. **FEAT-47** MSAG (Message Class) Read/Write (S) — used in RAP for exception classes and validation messages. Endpoint: `/sap/bc/adt/messageclass/`.
-22. **FEAT-39** Transport Enhancements (S) — delete, reassign owner, transport type selection (K/W/T/S/R), recursive release. sapcli has full CTS lifecycle.
+21. ~~**FEAT-47** MSAG (Message Class) Read/Write (S)~~ — **completed 2026-04-14** (SAPRead type=MSAG + SAPWrite/SAPManage MSAG create/update/delete)
+22. ~~**FEAT-39** Transport Enhancements (S)~~ — **completed 2026-04-13** (K/W/T types; S/R deferred). sapcli has full CTS lifecycle.
 21. **FEAT-41** ABAP Unit Test Coverage (S) — statement-level coverage via `/runtime/traces/coverage/measurements/{id}` with paginated follow-up. sapcli + AWS Accelerator have this.
 22. **FEAT-42** ATC Output Formats (XS) — JUnit4, checkstyle, codeclimate formatters for CI/CD integration. sapcli has these.
 23. **FEAT-43** DDIC Auth & Misc Read (S) — Authorization Fields (`/authorizationfields`), Feature Toggles, Enhancement Implementations. sapcli added auth fields Apr 2026.
@@ -258,7 +264,7 @@ SAP confirmed GA of ABAP Cloud Extension for VS Code with built-in agentic AI po
 | **Effort** | S (1-2 days) |
 | **Risk** | Low |
 | **Usefulness** | Low — most deployments use reverse proxy for TLS termination |
-| **Status** | Completed (2026-04-12) |
+| **Status** | Not started |
 | **Source** | [fr0ster tracker: TLS evaluation](../compare/fr0ster/evaluations/tls-https-support.md) |
 
 **What:** Add native TLS support to the HTTP Streamable transport. fr0ster added this in v4.6.0 with `--tls-cert`/`--tls-key` flags. Currently ARC-1 requires a reverse proxy (nginx, CF router) for HTTPS.
@@ -348,7 +354,7 @@ SAP confirmed GA of ABAP Cloud Extension for VS Code with built-in agentic AI po
 | **Effort** | S (1-2 days) |
 | **Risk** | Low |
 | **Usefulness** | High — safer than LLM-guessed fixes |
-| **Status** | Completed (2026-04-14) |
+| **Status** | Not started |
 | **Source** | [abap-adt-api eval](../compare/abap-adt-api/evaluations/issue-37-quickfix.md) |
 
 **What:** When ATC or syntax check finds an issue, SAP's fix proposal API (`/sap/bc/adt/quickfixes`) suggests the exact correction. Expose this via SAPDiagnose or SAPWrite so the LLM can apply verified fixes instead of guessing.
@@ -389,10 +395,12 @@ SAP confirmed GA of ABAP Cloud Extension for VS Code with built-in agentic AI po
 | **Effort** | S (1-2 days) |
 | **Risk** | Low |
 | **Usefulness** | High — directly improves admin control and LLM UX |
-| **Status** | Not started |
+| **Status** | Partially implemented (2026-04-14) |
 | **Source** | Dassian pattern, Roadmap SEC-03 |
 
 **What:** When SAP returns common errors (409 locked, 423 enqueued, 403 auth, 415 content type), return actionable hints: "Object locked by user X — check SM12", "Authorization failed — check SU53/PFCG", "Transport required — check SE09". Subsumes SEC-03 (S_DEVELOP awareness).
+
+**Partial implementation (2026-04-14):** PR #119 added structured DDIC diagnostics (`extractDdicDiagnostics`, `formatDdicDiagnostics` in `src/adt/errors.ts`) with T100KEY parsing, line-number extraction, and deduplication. The `formatErrorForLLM()` function in `src/handlers/intent.ts` now provides DDIC-specific hints for 400/409 save errors. Remaining: broader error classification for 409/423/403 with SAP transaction hints (SM12, SU53, SE09).
 
 **Why:** Supports **centralized admin control** — admins and LLMs get clear guidance instead of raw SAP error HTML. Dassian does this well with its error intelligence pattern.
 
@@ -1157,12 +1165,12 @@ SAP_RATE_LIMIT_BURST=10  # burst allowance
 | **Effort** | S (1-2 days) |
 | **Risk** | Low |
 | **Usefulness** | High — blocks greenfield development workflows |
-| **Status** | Not started |
+| **Status** | Completed (2026-04-14) |
 | **Source** | [RAP project analysis](https://github.com/Xexer/abap_rap_blog), [SAP-samples/cloud-abap-rap](https://github.com/SAP-samples/cloud-abap-rap), [feature matrix](../compare/00-feature-matrix.md) |
 
 **What:** Add package creation via SAPManage. Packages are the container for all ABAP development objects.
 
-**Current state:** Implemented in SAPManage (`create_package`, `delete_package`) with ADT endpoint `/sap/bc/adt/packages`.
+**Implemented (2026-04-14):** SAPManage actions `create_package` and `delete_package` with ADT endpoint `/sap/bc/adt/packages`.
 
 **Competitor support:**
 - **sapcli:** `POST /sap/bc/adt/packages` with full XML body (name, description, superPackage, softwareComponent, transportLayer). Accepts explicit `corrNr` for transport.
@@ -1206,7 +1214,7 @@ SAP_RATE_LIMIT_BURST=10  # burst allowance
 - **vibing-steampunk:** No create, only publish/unpublish.
 - **dassian-adt:** No SRVB create.
 
-**Note:** SRVB creation is now covered end-to-end; remaining RAP lifecycle gaps are DCL and TABL/package bootstrapping items (FEAT-37 / FEAT-44 / FEAT-45).
+**Note:** SRVB creation is now covered end-to-end; remaining RAP lifecycle gap is DCL (FEAT-37). TABL (FEAT-44), DEVC (FEAT-45), and MSAG (FEAT-47) were completed 2026-04-14.
 
 ---
 

--- a/research/skill-expansion-suggestions.md
+++ b/research/skill-expansion-suggestions.md
@@ -1,0 +1,185 @@
+# Skill Expansion Suggestions
+
+Research notes from analyzing [superclaude-for-sap](https://github.com/babamba2/superclaude-for-sap) and brainstorming how similar patterns could work in ARC-1's architecture. None of these are committed to — they're ideas to keep in mind for future development.
+
+---
+
+## 1. SPRO Skill — SAP Customizing Explorer
+
+**Idea:** A skill that helps users explore SPRO customizing configuration. Given a module or business scenario, it reads relevant customizing tables, explains the config, and identifies gaps.
+
+**How it would work in ARC-1:**
+- Bundle a condensed reference of ~50 key customizing tables across FI/CO/SD/MM/PP/WM/HR (inspired by superclaude's per-module `configs/*/spro.md` files, but condensed)
+- Live-query config tables via `SAPRead(type="TABLE_CONTENTS")` or `SAPQuery` — no local caching like superclaude's `extract-spro.mjs`
+- Cross-reference with SAP docs via mcp-sap-docs `search()`
+- Fall back to table structure only (`SAPRead(type="TABL")`) when `blockData=true`
+
+**Superclaude's approach:** 15 module-specific directories, each with `spro.md` (config paths + tables), `tcodes.md`, `tables.md`, `bapi.md`, `enhancements.md`, `workflows.md`. Static reference files, plus a live extraction script.
+
+**ARC-1 advantage:** Live queries every time — always current, no stale cache. ARC-1's `SAPRead(type="TABLE_CONTENTS")` already supports this.
+
+**Open questions:**
+- Is there enough demand for customizing exploration vs. development tasks?
+- Should the reference be a separate file or embedded in the skill?
+- Which modules to prioritize? FI/SD/MM cover most users
+
+---
+
+## 2. Table/Data Allowlists — Server-Side Safety Enhancement
+
+**Idea:** Add per-table allowlist/blocklist to complement the existing all-or-nothing `blockData`/`blockFreeSQL` flags.
+
+**Current state:**
+- `blockData=true` blocks ALL table preview — binary on/off
+- `blockFreeSQL=true` blocks ALL freestyle SQL — binary on/off
+- No per-table filtering exists
+- Package allowlist exists for writes (`allowedPackages`) but not for data reads
+
+**Proposed config options:**
+```
+SAP_ALLOWED_TABLES / --allowed-tables     # Whitelist (e.g., "T001,T001W,MARA,Z*")
+SAP_BLOCKED_TABLES / --blocked-tables     # Blacklist (e.g., "USR02,PA0001,BNKA")
+```
+
+**Semantics:**
+- `allowedTables` set → only listed tables queryable (whitelist mode)
+- `blockedTables` set → listed tables blocked, all others allowed (blacklist mode)
+- Both support wildcards (`Z*`, `PA*`)
+- `blockedTables` takes precedence over `allowedTables`
+- Applies to both `SAPRead(type="TABLE_CONTENTS")` and `SAPQuery` (parse SQL for table names)
+
+**Default blocklist seed** (inspired by superclaude's `table_exception.md`, ~200 categorized tables):
+- Auth: `USR02`, `AGR_1251`, `RFCDES`
+- HR/PII: `PA0001`-`PA0008`, `HRP1000`, `PCL1`, `PCL2`
+- Banking: `BNKA`, `KNBK`, `REGUH`, `PAYR`
+- Credentials: `RSECTAB`, `RFCDES`
+
+Could be opt-in via `--blocked-tables=@default` or new safety profiles (`viewer-safe`, `developer-safe`).
+
+**Files that would be touched:**
+- `src/adt/safety.ts` — `allowedTables`, `blockedTables`, `isTableAllowed()`, `checkTable()`
+- `src/server/types.ts` — new fields on `SafetyConfig`
+- `src/server/config.ts` — parse new CLI flags / env vars
+- `src/handlers/intent.ts` — `checkTable()` before `getTableContents()` and `runQuery()`
+- New: `src/adt/sql-tables.ts` — simple SQL table name extractor for SAPQuery enforcement
+
+**Superclaude's approach:** Prompt-layer blocklist in `exceptions/table_exception.md` + a `block-forbidden-tables.mjs` hook that intercepts tool calls client-side. Categories: Banking/Payment, PII, Auth/Security, HR/Payroll, Tax/IDs, Audit Logs.
+
+**ARC-1 advantage:** Server-side enforcement — can't be bypassed by prompt injection or client misconfiguration.
+
+---
+
+## 3. Ralph Skill — Self-Correcting Development Loop
+
+**Idea:** A persistence loop that keeps working on a task until ALL verification gates pass: syntax clean, activation successful, unit tests green.
+
+**Trigger phrases:** "ralph", "don't stop", "must activate", "keep going until it works", "finish this"
+
+**Gate mapping to ARC-1 tools:**
+
+| Gate | ARC-1 Tool |
+|---|---|
+| Pre-write lint | `SAPLint(action="lint", source=...)` |
+| Write code | `SAPWrite(action="edit_method", ...)` for surgical fixes |
+| Syntax check | `SAPDiagnose(action="syntax", type=..., name=...)` |
+| Activation | `SAPActivate(objects=[...])` |
+| Unit tests | `SAPDiagnose(action="unittest", type="CLAS", name=...)` |
+
+**Loop logic:**
+1. Read existing code via `SAPRead`, get deps via `SAPContext`
+2. Lint proposed code via `SAPLint` (offline, no SAP round-trip)
+3. Write via `SAPWrite(action="edit_method")` — surgical method editing
+4. Gate 1: `SAPDiagnose(action="syntax")` → 0 errors
+5. Gate 2: `SAPActivate(objects=[...])` → success
+6. Gate 3: `SAPDiagnose(action="unittest")` → all pass (skip if no test class)
+7. If any gate fails: read error, fix, go back to step 2
+8. Bail after 3 consecutive failures on the same error
+
+**Error recovery intelligence:**
+- Syntax error → read error message, identify line, fix via `edit_method`
+- Activation error → check missing dependencies via `SAPContext`, create if needed
+- Test failure → read test method, fix implementation (never the test)
+
+**Differences from superclaude's ralph:**
+
+| Aspect | superclaude | ARC-1 |
+|---|---|---|
+| State tracking | `.sc4sap/ralph/prd.json` + `progress.txt` files | Conversation context (no filesystem) |
+| Agent personas | "sap-architect", "sap-developer", "sap-critic" | Single LLM, no persona switching |
+| Method editing | Full class replacement via `UpdateClass` | `edit_method` — surgical, much less error-prone |
+| Pre-write lint | Not present | `SAPLint` — ARC-1 advantage |
+| Tool names | `GetAbapAST`, `GetAbapSemanticAnalysis` | `SAPDiagnose(action="syntax")` — single unified tool |
+
+---
+
+## 4. Autopilot Skill — Autonomous Development Pipeline
+
+**Idea:** Takes a brief SAP requirement (2-3 sentences) and handles the full lifecycle autonomously: probe → research → design → plan (wait for approval) → implement → verify → review → report.
+
+**Phase mapping to ARC-1 tools:**
+
+| Phase | Tools |
+|---|---|
+| 0. Probe | `SAPManage(action="probe")` |
+| 1. Research | `SAPSearch`, `SAPRead`, `SAPContext`, `search()` (mcp-sap-docs) |
+| 2. Design & Plan | Present plan, **wait for user approval** |
+| 3. Transport | `SAPTransport(action="check"/"create")` |
+| 4. Implement | `SAPWrite(action="batch_create")`, fallback to sequential |
+| 5. Verify | Ralph loop (syntax → activate → test, max 3 retries) |
+| 6. Review | `SAPDiagnose(action="atc")`, re-read all objects, check quality |
+| 7. Report | Summary of created objects, transport, test results |
+
+**Key design: Autopilot embeds ralph as its verification phase.** Ralph is the building block; autopilot orchestrates the full pipeline around it.
+
+**Differences from superclaude's autopilot:**
+
+| Aspect | superclaude | ARC-1 |
+|---|---|---|
+| Agent coordination | Named agents (architect, developer, tester, reviewer) | Single LLM orchestrates all phases |
+| State persistence | `.sc4sap/autopilot/` directory | Conversation context |
+| Batch operations | Sequential creates | `batch_create` — all objects at once |
+| Cancel mechanism | `/sc4sap:cancel` command | Natural interruption |
+| Pre-skill chaining | Checks for existing deep-interview/ralplan outputs | Standalone — does its own gathering |
+| User approval gate | No mandatory approval before implementation | Phase 2 requires explicit user approval |
+
+---
+
+## 5. Other Ideas Worth Noting
+
+### Pre-Compaction Context Preservation
+Superclaude's `pre-compact.mjs` hook saves active transport numbers, recent object names, module context before Claude Code compacts the context window. ARC-1 could expose a `SAPContext` action for "session state" that returns a compact summary of recently-touched objects and active transports.
+
+### ABAP Release Feature Matrix
+Superclaude's `abap-release-reference.md` maps features to ABAP releases (when inline declarations, constructor expressions, RAP, EML became available). Useful for code generation. ARC-1's `features.ts` already does runtime detection — a skill reference could formalize the "check before generating" convention.
+
+### SAP Version Reference (ECC vs S/4HANA)
+Table renames (BSEG→ACDOCA, MKPF→MATDOC, KNA1→BUT000), MATNR length changes, output management shifts. Useful for migration skills and code generation targeting specific system versions.
+
+### Status Line Template
+A recommended Claude Code statusline showing SAP SID, safety profile, connection health, and read-only mode indicator.
+
+### Session-Start Probe Hook
+A Claude Code hook that auto-runs `SAPManage(action="probe")` at session start and injects system info into the conversation context.
+
+---
+
+## What to Skip
+
+- **24 module-specific agent personas** — prompt bloat, SAP knowledge better served via mcp-sap-docs
+- **SPRO live extraction script** — risky (SELECT * on config tables), ARC-1 queries live anyway
+- **Keyword detection hooks** — brittle ("don't stop" → autopilot), explicit `/skill` invocation is better
+- **Plugin manifest format** — ARC-1 is multi-client, not Claude Code-only
+- **Naming convention files** — too ECC-specific, ARC-1's probe-first approach handles system differences at runtime
+
+---
+
+## Priority Assessment
+
+| Idea | Impact | Effort | Dependencies |
+|---|---|---|---|
+| Ralph | High — most universally useful | Medium — skill only | None |
+| Autopilot | High — flagship skill | Medium — skill only | Ralph (embeds it) |
+| Table allowlists | High — safety feature | Medium — server code changes | None |
+| SPRO | Medium — niche use case | Low — skill + reference file | None |
+| Pre-compaction | Low — UX improvement | Low | None |
+| Release matrix | Low — already have features.ts | Low | None |

--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -64,6 +64,43 @@ export interface ServiceBindingCreateParams {
   bindingType?: string;
   category?: '0' | '1';
   version?: string;
+  odataVersion?: string;
+}
+
+/**
+ * Normalize LLM-friendly binding type strings into SAP ADT values.
+ *
+ * SAP ADT expects:
+ *   - `srvb:type`     = "ODATA" (always)
+ *   - `srvb:version`  = "V2" | "V4" (OData protocol version on <srvb:binding>)
+ *   - `srvb:category` = "0" (UI) | "1" (Web API)
+ *
+ * LLMs commonly send human-readable values like "ODataV4-UI", "ODATA_V2_WEB_API",
+ * "OData V4 - Web API", etc. This function parses them into the correct triple.
+ */
+export function normalizeSrvbBindingType(input?: string): {
+  type: string;
+  odataVersion: string;
+  category?: '0' | '1';
+} {
+  if (!input?.trim()) return { type: 'ODATA', odataVersion: 'V2' };
+
+  const normalized = input
+    .trim()
+    .toUpperCase()
+    .replace(/[\s_-]+/g, '');
+
+  // Extract OData version: look for V4 or V2 in the string
+  let odataVersion = 'V2'; // default
+  if (normalized.includes('V4')) odataVersion = 'V4';
+  else if (normalized.includes('V2')) odataVersion = 'V2';
+
+  // Extract category hint from the string
+  let category: '0' | '1' | undefined;
+  if (normalized.includes('WEBAPI') || normalized.includes('API')) category = '1';
+  else if (normalized.includes('UI')) category = '0';
+
+  return { type: 'ODATA', odataVersion, category };
 }
 
 const DTEL_MAX_LABEL_LENGTHS = {
@@ -270,8 +307,11 @@ export function buildPackageXml(params: PackageCreateParams): string {
 }
 
 export function buildServiceBindingXml(params: ServiceBindingCreateParams): string {
-  const bindingType = params.bindingType?.trim() || 'ODATA';
-  const category = params.category === '1' ? '1' : '0';
+  const normalized = normalizeSrvbBindingType(params.bindingType);
+  // Explicit category from params takes precedence, then hint from bindingType string, then default '0'
+  const category = params.category ?? normalized.category ?? '0';
+  // Explicit odataVersion from params takes precedence, then parsed from bindingType
+  const odataVersion = params.odataVersion?.trim().toUpperCase() || normalized.odataVersion;
   const serviceVersion = params.version?.trim() || '0001';
 
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -289,7 +329,7 @@ export function buildServiceBindingXml(params: ServiceBindingCreateParams): stri
       <srvb:serviceDefinition adtcore:name="${escapeXml(params.serviceDefinition)}"/>
     </srvb:content>
   </srvb:services>
-  <srvb:binding srvb:category="${category}" srvb:type="${escapeXml(bindingType)}" srvb:version="V2">
+  <srvb:binding srvb:category="${category}" srvb:type="${escapeXml(normalized.type)}" srvb:version="${escapeXml(odataVersion)}">
     <srvb:implementation adtcore:name=""/>
   </srvb:binding>
 </srvb:serviceBinding>`;

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -1189,6 +1189,7 @@ function getMetadataWriteProperties(input: Record<string, unknown>): Record<stri
     bindingType: input.bindingType,
     category: input.category,
     version: input.version,
+    odataVersion: input.odataVersion,
   };
 
   return props;
@@ -1272,6 +1273,7 @@ async function mergeMetadataWriteProperties(
         bindingType: provided.bindingType ?? existing.bindingType,
         category: provided.category ?? normalizeSrvbCategory(existing.bindingCategory),
         version: provided.version ?? existing.serviceVersion,
+        odataVersion: provided.odataVersion ?? existing.odataVersion,
       };
     }
   } catch {
@@ -1511,7 +1513,8 @@ export function buildCreateXml(
         throw new Error('SRVB create/update requires "serviceDefinition" (referenced SRVD name).');
       }
       const categoryRaw = properties?.category;
-      const category = categoryRaw === '1' || categoryRaw === 1 ? '1' : '0';
+      const category =
+        categoryRaw === '1' || categoryRaw === 1 ? '1' : categoryRaw === '0' || categoryRaw === 0 ? '0' : undefined;
       const params: ServiceBindingCreateParams = {
         name,
         description,
@@ -1520,6 +1523,7 @@ export function buildCreateXml(
         bindingType: properties?.bindingType ? String(properties.bindingType) : undefined,
         category,
         version: properties?.version ? String(properties.version) : undefined,
+        odataVersion: properties?.odataVersion ? String(properties.odataVersion) : undefined,
       };
       return buildServiceBindingXml(params);
     }

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -190,6 +190,7 @@ const batchObjectSchemaOnprem = z.object({
   messages: z.array(messageClassMessageSchema).optional(),
   serviceDefinition: z.string().optional(),
   bindingType: z.string().optional(),
+  odataVersion: z.enum(['V2', 'V4']).optional(),
   category: z.enum(['0', '1']).optional(),
   version: z.string().optional(),
 });
@@ -223,6 +224,7 @@ const batchObjectSchemaBtp = z.object({
   messages: z.array(messageClassMessageSchema).optional(),
   serviceDefinition: z.string().optional(),
   bindingType: z.string().optional(),
+  odataVersion: z.enum(['V2', 'V4']).optional(),
   category: z.enum(['0', '1']).optional(),
   version: z.string().optional(),
 });
@@ -260,6 +262,7 @@ export const SAPWriteSchema = z.object({
   messages: z.array(messageClassMessageSchema).optional(),
   serviceDefinition: z.string().optional(),
   bindingType: z.string().optional(),
+  odataVersion: z.enum(['V2', 'V4']).optional(),
   category: z.enum(['0', '1']).optional(),
   version: z.string().optional(),
   lintBeforeWrite: z.coerce.boolean().optional(),
@@ -299,6 +302,7 @@ export const SAPWriteSchemaBtp = z.object({
   messages: z.array(messageClassMessageSchema).optional(),
   serviceDefinition: z.string().optional(),
   bindingType: z.string().optional(),
+  odataVersion: z.enum(['V2', 'V4']).optional(),
   category: z.enum(['0', '1']).optional(),
   version: z.string().optional(),
   lintBeforeWrite: z.coerce.boolean().optional(),

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -123,7 +123,8 @@ const SAPWRITE_DESC_ONPREM =
   'TABL uses source-based writes via /source/main (define table syntax), similar to DDLS/BDEF/SRVD. ' +
   'DOMA/DTEL use metadata XML writes (not /source/main): provide DDIC fields like dataType, length, fixedValues, typeKind, labels, searchHelp. ' +
   'MSAG (message classes) use metadata XML writes: provide "messages" array with {number, shortText} entries. Create empty then update, or provide messages at creation. ' +
-  'SRVB (service bindings) use metadata XML writes: provide serviceDefinition (SRVD name) plus optional bindingType/category. ' +
+  'SRVB (service bindings) use metadata XML writes: provide serviceDefinition (SRVD name), odataVersion ("V2"/"V4"), optional category (0=UI, 1=Web API). ' +
+  'bindingType accepts human-readable values like "ODataV4-UI" which are auto-normalized. ' +
   'For edit_method: surgically replace a single method body in a CLAS without sending the full class source. ' +
   'Provide just the new method implementation code in "source" — 95% fewer tokens than full-class updates. ' +
   'For batch_create: create and activate multiple objects in a single call — ideal for RAP stacks (TABL → DDLS → BDEF → SRVD). Pass "objects" array with dependency order.';
@@ -133,7 +134,8 @@ const SAPWRITE_DESC_BTP =
   'TABL supports custom table source writes via /source/main (define table syntax). ' +
   'DOMA/DTEL use metadata XML writes (not /source/main): provide DDIC fields like dataType, length, fixedValues, typeKind, labels, searchHelp. ' +
   'MSAG (message classes) use metadata XML writes: provide "messages" array with {number, shortText} entries. ' +
-  'SRVB (service bindings) use metadata XML writes: provide serviceDefinition (SRVD name) plus optional bindingType/category. ' +
+  'SRVB (service bindings) use metadata XML writes: provide serviceDefinition (SRVD name), odataVersion ("V2"/"V4"), optional category (0=UI, 1=Web API). ' +
+  'bindingType accepts human-readable values like "ODataV4-UI" which are auto-normalized. ' +
   'Must use ABAP Cloud language version (no classic statements). Only Z*/Y* namespace allowed on BTP. ' +
   'For edit_method: surgically replace a single method body in a CLAS without sending the full class source. ' +
   'For batch_create: create and activate multiple objects in a single call — ideal for RAP stacks (TABL → DDLS → BDEF → SRVD).';
@@ -488,13 +490,23 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
           defaultComponentName: { type: 'string', description: 'DTEL: default component name' },
           changeDocument: { type: 'boolean', description: 'DTEL: enable change document flag' },
           serviceDefinition: { type: 'string', description: 'SRVB: service definition name (SRVD) to bind to' },
-          bindingType: { type: 'string', description: 'SRVB: binding type (default: ODATA)' },
+          bindingType: {
+            type: 'string',
+            description:
+              'SRVB: binding type — accepts human-readable values like "ODataV4-UI", "OData V2 - Web API", "ODATA_V4" which are auto-normalized to SAP ADT values (type=ODATA, correct odataVersion + category)',
+          },
+          odataVersion: {
+            type: 'string',
+            enum: ['V2', 'V4'],
+            description: 'SRVB: OData protocol version (default: V2). Overrides version inferred from bindingType.',
+          },
           category: {
             type: 'string',
             enum: ['0', '1'],
-            description: 'SRVB: binding category (0=UI, 1=Web API; default: 0)',
+            description:
+              'SRVB: binding category (0=UI, 1=Web API; default: 0). Overrides category inferred from bindingType.',
           },
-          version: { type: 'string', description: 'SRVB: service version (default: 0001)' },
+          version: { type: 'string', description: 'SRVB: service version number (default: 0001)' },
           lintBeforeWrite: {
             type: 'boolean',
             description:
@@ -547,13 +559,21 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
                 defaultComponentName: { type: 'string', description: 'DTEL: default component name' },
                 changeDocument: { type: 'boolean', description: 'DTEL: change document flag' },
                 serviceDefinition: { type: 'string', description: 'SRVB: service definition (SRVD)' },
-                bindingType: { type: 'string', description: 'SRVB: binding type (default ODATA)' },
+                bindingType: {
+                  type: 'string',
+                  description: 'SRVB: binding type — accepts human-readable values like "ODataV4-UI" (auto-normalized)',
+                },
+                odataVersion: {
+                  type: 'string',
+                  enum: ['V2', 'V4'],
+                  description: 'SRVB: OData protocol version (default: V2)',
+                },
                 category: {
                   type: 'string',
                   enum: ['0', '1'],
                   description: 'SRVB: binding category (0=UI, 1=Web API)',
                 },
-                version: { type: 'string', description: 'SRVB: service version (default 0001)' },
+                version: { type: 'string', description: 'SRVB: service version number (default 0001)' },
               },
               required: ['type', 'name'],
             },

--- a/tests/e2e/rap-write.e2e.test.ts
+++ b/tests/e2e/rap-write.e2e.test.ts
@@ -619,6 +619,7 @@ describe('E2E RAP write lifecycle tests', () => {
           name: srvbName,
           package: '$TMP',
           serviceDefinition: srvdName,
+          odataVersion: 'V4',
           category: '0',
         }),
       );

--- a/tests/unit/adt/ddic-xml.test.ts
+++ b/tests/unit/adt/ddic-xml.test.ts
@@ -5,6 +5,7 @@ import {
   buildMessageClassXml,
   buildPackageXml,
   buildServiceBindingXml,
+  normalizeSrvbBindingType,
 } from '../../../src/adt/ddic-xml.js';
 
 describe('ddic-xml builders', () => {
@@ -312,6 +313,50 @@ describe('ddic-xml builders', () => {
     });
   });
 
+  describe('normalizeSrvbBindingType', () => {
+    it('defaults to ODATA V2 when no input', () => {
+      expect(normalizeSrvbBindingType()).toEqual({ type: 'ODATA', odataVersion: 'V2' });
+      expect(normalizeSrvbBindingType('')).toEqual({ type: 'ODATA', odataVersion: 'V2' });
+      expect(normalizeSrvbBindingType(undefined)).toEqual({ type: 'ODATA', odataVersion: 'V2' });
+    });
+
+    it('normalizes "ODataV4-UI" to ODATA V4 category 0', () => {
+      expect(normalizeSrvbBindingType('ODataV4-UI')).toEqual({ type: 'ODATA', odataVersion: 'V4', category: '0' });
+    });
+
+    it('normalizes "OData V4 - UI" to ODATA V4 category 0', () => {
+      expect(normalizeSrvbBindingType('OData V4 - UI')).toEqual({ type: 'ODATA', odataVersion: 'V4', category: '0' });
+    });
+
+    it('normalizes "OData V2 - Web API" to ODATA V2 category 1', () => {
+      expect(normalizeSrvbBindingType('OData V2 - Web API')).toEqual({
+        type: 'ODATA',
+        odataVersion: 'V2',
+        category: '1',
+      });
+    });
+
+    it('normalizes "ODATA_V4" to ODATA V4', () => {
+      expect(normalizeSrvbBindingType('ODATA_V4')).toEqual({ type: 'ODATA', odataVersion: 'V4' });
+    });
+
+    it('normalizes "ODATA_V4_WEB_API" to ODATA V4 category 1', () => {
+      expect(normalizeSrvbBindingType('ODATA_V4_WEB_API')).toEqual({
+        type: 'ODATA',
+        odataVersion: 'V4',
+        category: '1',
+      });
+    });
+
+    it('normalizes plain "ODATA" to V2', () => {
+      expect(normalizeSrvbBindingType('ODATA')).toEqual({ type: 'ODATA', odataVersion: 'V2' });
+    });
+
+    it('is case insensitive', () => {
+      expect(normalizeSrvbBindingType('odatav4-ui')).toEqual({ type: 'ODATA', odataVersion: 'V4', category: '0' });
+    });
+  });
+
   describe('buildServiceBindingXml', () => {
     it('builds basic service binding XML with SRVB/SVB type', () => {
       const xml = buildServiceBindingXml({
@@ -341,7 +386,7 @@ describe('ddic-xml builders', () => {
       expect(xml).toContain('<srvb:serviceDefinition adtcore:name="ZSD_TRAVEL"/>');
     });
 
-    it('uses default category=0 and bindingType=ODATA', () => {
+    it('uses default category=0, bindingType=ODATA, odataVersion=V2', () => {
       const xml = buildServiceBindingXml({
         name: 'ZSB_DEFAULTS',
         description: 'Defaults',
@@ -352,7 +397,7 @@ describe('ddic-xml builders', () => {
       expect(xml).toContain('<srvb:binding srvb:category="0" srvb:type="ODATA" srvb:version="V2">');
     });
 
-    it('supports category=1 for alternate binding category', () => {
+    it('supports category=1 for Web API binding', () => {
       const xml = buildServiceBindingXml({
         name: 'ZSB_UI',
         description: 'UI binding',
@@ -362,6 +407,56 @@ describe('ddic-xml builders', () => {
       });
 
       expect(xml).toContain('<srvb:binding srvb:category="1" srvb:type="ODATA" srvb:version="V2">');
+    });
+
+    it('normalizes "ODataV4-UI" bindingType to ODATA V4 category 0', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB_V4',
+        description: 'V4 UI binding',
+        package: '$TMP',
+        serviceDefinition: 'ZSD_V4',
+        bindingType: 'ODataV4-UI',
+      });
+
+      expect(xml).toContain('<srvb:binding srvb:category="0" srvb:type="ODATA" srvb:version="V4">');
+    });
+
+    it('normalizes "OData V4 - Web API" bindingType', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB_V4_API',
+        description: 'V4 Web API binding',
+        package: '$TMP',
+        serviceDefinition: 'ZSD_V4_API',
+        bindingType: 'OData V4 - Web API',
+      });
+
+      expect(xml).toContain('<srvb:binding srvb:category="1" srvb:type="ODATA" srvb:version="V4">');
+    });
+
+    it('explicit category overrides bindingType hint', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB_OVERRIDE',
+        description: 'Override test',
+        package: '$TMP',
+        serviceDefinition: 'ZSD_OVERRIDE',
+        bindingType: 'ODataV4-UI', // hints category=0
+        category: '1', // explicit override to Web API
+      });
+
+      expect(xml).toContain('<srvb:binding srvb:category="1" srvb:type="ODATA" srvb:version="V4">');
+    });
+
+    it('explicit odataVersion overrides bindingType hint', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB_OVER_VER',
+        description: 'Override version test',
+        package: '$TMP',
+        serviceDefinition: 'ZSD_OVER_VER',
+        bindingType: 'ODataV4-UI', // hints V4
+        odataVersion: 'V2', // explicit override to V2
+      });
+
+      expect(xml).toContain('<srvb:binding srvb:category="0" srvb:type="ODATA" srvb:version="V2">');
     });
   });
 
@@ -385,7 +480,6 @@ describe('ddic-xml builders', () => {
       description: 'Service "A&B" <binding>',
       package: '$TMP',
       serviceDefinition: 'ZSD_<TEST>&',
-      bindingType: 'ODATA"&',
     });
 
     expect(domainXml).toContain('&quot;A&amp;B&quot; &lt;test&gt; &apos;apostrophe&apos;');
@@ -395,6 +489,7 @@ describe('ddic-xml builders', () => {
     expect(dtelXml).toContain('<dtel:shortFieldLabel>A&amp;B</dtel:shortFieldLabel>');
     expect(srvbXml).toContain('Service &quot;A&amp;B&quot; &lt;binding&gt;');
     expect(srvbXml).toContain('<srvb:serviceDefinition adtcore:name="ZSD_&lt;TEST&gt;&amp;"/>');
-    expect(srvbXml).toContain('srvb:type="ODATA&quot;&amp;"');
+    // bindingType is normalized — srvb:type is always "ODATA"
+    expect(srvbXml).toContain('srvb:type="ODATA"');
   });
 });


### PR DESCRIPTION
## Summary
- SRVB creation was failing with 500 when LLMs sent human-readable `bindingType` values like `"ODataV4-UI"` — these were passed raw into `srvb:type` (SAP expects `"ODATA"`) and the OData protocol version was hardcoded to `V2`
- Added `normalizeSrvbBindingType()` to parse LLM-friendly strings (e.g. `"OData V4 - Web API"`, `"ODATA_V4_UI"`) into correct SAP ADT XML values (`type=ODATA`, `odataVersion=V2/V4`, `category=0/1`)
- Added `odataVersion` parameter (`V2`/`V4`) to all SRVB tool schemas, with explicit params overriding inferred hints from `bindingType`

## Test plan
- [x] All 1650 unit tests pass (including 10 new normalization + V4 XML generation tests)
- [x] TypeScript typecheck passes
- [x] Biome lint/format passes
- [ ] E2E RAP write test creates V4 binding (updated `rap-write.e2e.test.ts` to pass `odataVersion: 'V4'`)
- [ ] Manual test: create SRVB with `bindingType: "ODataV4-UI"` → verify 200 (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)