### PR TITLE
feat: extend abaplint CDS lint support for DDLS pre-write validation

### DIFF
--- a/docs/plans/completed/extend-abaplint-cds-support.md
+++ b/docs/plans/completed/extend-abaplint-cds-support.md
@@ -1,0 +1,162 @@
+# Extend abaplint CDS Lint Support
+
+## Overview
+
+abaplint has a full CDS parser and 6 CDS-specific rules (`cds_parser_error`, `cds_association_name`, `cds_comment_style`, `cds_field_order`, `cds_legacy_view`, `cds_naming`) that are currently unused by ARC-1. The pre-write lint gate (`intent.ts:2183`) skips all non-ABAP types with an outdated comment claiming "abaplint is an ABAP statement parser — it cannot parse CDS DDL." This is wrong for DDLS (CDS views) — abaplint parses them fully and catches real syntax errors (missing commas, wrong keywords, invalid constructs).
+
+This plan extends the lint system to leverage abaplint's CDS capabilities for DDLS objects, while correctly keeping BDEF/SRVD/SRVB/DDLX skipped (abaplint does NOT parse those — garbage input passes silently).
+
+**Key design decisions:**
+- Only DDLS gets pre-write lint — BDEF/SRVD/SRVB/DDLX remain skipped (verified: abaplint silently ignores them)
+- `cds_parser_error` is the only blocking rule for pre-write (catches real syntax errors)
+- `cds_naming` is disabled by default (too opinionated — enforces VDM prefixes like `ZI_`, `ZC_`)
+- `cds_legacy_view` is warning on on-prem (legacy views still valid), error on BTP
+- `cds_association_name`, `cds_comment_style`, `cds_field_order` are warnings (advisory, not blocking)
+- `detectFilename` is extended to handle SRVD, SRVB, TABL, DDLX for the SAPLint on-demand tool
+- The `define table` syntax is NOT supported by abaplint's CDS parser (fires false `cds_parser_error`), so TABL remains skipped for pre-write
+
+## Context
+
+### Current State
+
+- Pre-write lint gate at `intent.ts:2183` only allows `PROG, CLAS, INTF, FUNC, INCL`
+- All CDS types (DDLS, BDEF, SRVD, SRVB, DDLX, TABL) are skipped with a misleading comment
+- Presets (`cloud.ts`, `onprem.ts`) don't mention CDS rules — they're enabled by abaplint's defaults but never configured
+- `detectFilename` doesn't handle SRVD, SRVB, TABL, or DDLX — these fall through to `.clas.abap` default
+- SAPLint on-demand tool works for DDLS (detectFilename catches `define view` and `@`), but BDEF/SRVD/SRVB/DDLX get wrong extensions
+- Tool description says "Lint only applies to ABAP types (PROG, CLAS, INTF, FUNC) — CDS/BDEF/SRVD are always skipped automatically"
+
+### Target State
+
+- Pre-write lint gate includes DDLS — `cds_parser_error` blocks writes with syntax errors
+- Presets explicitly configure all 6 CDS rules with appropriate severities
+- `detectFilename` handles all source-based types: DDLS, BDEF, SRVD, SRVB, TABL, DDLX
+- Pre-write config (`buildPreWriteConfig`) includes `cds_parser_error` as a blocking rule for DDLS
+- Tool descriptions updated to reflect CDS lint support
+- Comment at `intent.ts:2178` corrected
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/lint/lint.ts` | `detectFilename()` — extend for SRVD, SRVB, TABL, DDLX |
+| `src/lint/config-builder.ts` | `buildPreWriteConfig()` — add `cds_parser_error`; `buildLintConfig()` presets |
+| `src/lint/presets/cloud.ts` | Add CDS rule configuration for cloud systems |
+| `src/lint/presets/onprem.ts` | Add CDS rule configuration for on-prem systems |
+| `src/handlers/intent.ts` | Pre-write lint gate (~line 2183) — add DDLS to allowed types; fix comment |
+| `src/handlers/tools.ts` | SAPLint tool description — update to mention CDS support |
+| `tests/unit/lint/lint.test.ts` | `detectFilename` tests — add SRVD, SRVB, TABL, DDLX cases |
+| `tests/unit/lint/lint-enhanced.test.ts` | Enhanced lint tests — add CDS-specific test cases |
+| `tests/unit/lint/config-builder.test.ts` | Config builder tests — verify CDS rules in presets and pre-write config |
+| `tests/unit/handlers/intent.test.ts` | Pre-write lint gate tests — add DDLS test cases |
+
+### Design Principles
+
+1. **Only extend where abaplint actually works** — DDLS is parsed with a real CDS parser; BDEF/SRVD/SRVB/DDLX are silently ignored (garbage passes). Never add a type that produces false positives or false negatives.
+2. **Pre-write blocks only on correctness errors** — `cds_parser_error` blocks; naming/style rules are warnings at most. Same philosophy as the existing ABAP pre-write gate.
+3. **Presets are explicit** — even though CDS rules are enabled in abaplint defaults, we configure them explicitly in our presets so admins can see and override them.
+4. **TABL (`define table`) stays skipped** — abaplint's CDS parser doesn't support `define table` syntax, so it would produce false `cds_parser_error` on valid tables. TABL uses a different ADT path anyway.
+
+## Development Approach
+
+Changes are layered bottom-up: detectFilename → presets → config-builder → intent gate → tool descriptions. Each layer has focused unit tests. No integration/E2E tests needed since the lint system is entirely offline (no SAP round-trips).
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Extend detectFilename for all source-based types
+
+**Files:**
+- Modify: `src/lint/lint.ts`
+- Modify: `tests/unit/lint/lint.test.ts`
+
+The `detectFilename()` function at `src/lint/lint.ts:166` currently handles CLASS, INTERFACE, FUNCTION, REPORT, DDLS (`define view` / `@`), and BDEF (`managed` / `unmanaged` / `abstract`). It does NOT detect SRVD (`define service`), SRVB, TABL (`define table`), or DDLX (`annotate view`). These fall through to the `.clas.abap` default, which causes incorrect parsing when passed to abaplint.
+
+- [ ] Add detection for `define service` → `.srvd.asrvd` in `detectFilename()` at `src/lint/lint.ts:166`
+- [ ] Add detection for `define table` → `.tabl.astabl` in `detectFilename()` (abaplint won't parse it, but the extension is correct for any future support)
+- [ ] Add detection for `annotate view` / `annotate entity` → `.ddlx.asddlx` in `detectFilename()`
+- [ ] Add detection for `projection;` (BDEF projection syntax) → `.bdef.asbdef` in `detectFilename()`
+- [ ] Add unit tests (~8 tests) in `tests/unit/lint/lint.test.ts` under the existing `detectFilename` describe block: test SRVD detection, TABL detection, DDLX detection, BDEF projection detection, and edge cases (leading whitespace, annotations before `define service`, etc.)
+- [ ] Run `npm test` — all tests must pass
+
+### Task 2: Add CDS rules to presets
+
+**Files:**
+- Modify: `src/lint/presets/cloud.ts`
+- Modify: `src/lint/presets/onprem.ts`
+- Modify: `tests/unit/lint/config-builder.test.ts`
+
+The presets currently only configure ABAP rules. abaplint's 6 CDS rules (`cds_parser_error`, `cds_association_name`, `cds_comment_style`, `cds_field_order`, `cds_legacy_view`, `cds_naming`) are enabled by default in abaplint's config but not explicitly configured by our presets. We need explicit configuration so admins can see what's enabled and our severity levels are intentional.
+
+**Cloud preset (`src/lint/presets/cloud.ts`):**
+- [ ] Add `cds_parser_error: { severity: 'Error' }` to `CLOUD_ERROR_RULES`
+- [ ] Add `cds_legacy_view: { severity: 'Error' }` to `CLOUD_ERROR_RULES` (legacy views not supported on BTP)
+- [ ] Add `cds_association_name: { severity: 'Warning' }`, `cds_comment_style: { severity: 'Warning' }`, `cds_field_order: { severity: 'Warning' }` to `CLOUD_WARNING_RULES`
+- [ ] Add `cds_naming` to `CLOUD_DISABLED_RULES` with comment "VDM naming prefixes are project-specific"
+
+**On-prem preset (`src/lint/presets/onprem.ts`):**
+- [ ] Add `cds_parser_error: { severity: 'Error' }` to `ONPREM_ERROR_RULES`
+- [ ] Add `cds_legacy_view: { severity: 'Warning' }` to `ONPREM_WARNING_RULES` (legacy views still valid on-prem)
+- [ ] Add `cds_association_name: { severity: 'Warning' }`, `cds_comment_style: { severity: 'Warning' }`, `cds_field_order: { severity: 'Warning' }` to `ONPREM_WARNING_RULES`
+- [ ] Add `cds_naming` to `ONPREM_DISABLED_RULES` with comment "VDM naming prefixes are project-specific"
+- [ ] Add unit tests (~4 tests) in `tests/unit/lint/config-builder.test.ts`: verify CDS rules appear in built configs for cloud and on-prem, verify `cds_naming` is disabled, verify `cds_legacy_view` severity differs between cloud (Error) and on-prem (Warning)
+- [ ] Run `npm test` — all tests must pass
+
+### Task 3: Add CDS parser error to pre-write config and extend lint gate to DDLS
+
+**Files:**
+- Modify: `src/lint/config-builder.ts`
+- Modify: `src/handlers/intent.ts`
+- Modify: `src/handlers/tools.ts`
+- Modify: `tests/unit/lint/config-builder.test.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+The pre-write config (`buildPreWriteConfig` at `src/lint/config-builder.ts:82`) disables all rules then enables only correctness rules. It does not include any CDS rules. The pre-write lint gate at `src/handlers/intent.ts:2183` restricts lint to `ABAP_ONLY_TYPES = new Set(['PROG', 'CLAS', 'INTF', 'FUNC', 'INCL'])`.
+
+**Config builder changes (`src/lint/config-builder.ts`):**
+- [ ] Add `cds_parser_error: { severity: 'Error' }` to the `preWriteRules` object in `buildPreWriteConfig()` at line ~94. This is a correctness rule (catches syntax errors in CDS DDL) and belongs in pre-write regardless of system type.
+- [ ] Add unit test in `tests/unit/lint/config-builder.test.ts`: verify `cds_parser_error` is enabled in pre-write config
+
+**Intent handler changes (`src/handlers/intent.ts`):**
+- [ ] At line ~2183, change `ABAP_ONLY_TYPES` to `LINTABLE_TYPES` and add `'DDLS'`: `const LINTABLE_TYPES = new Set(['PROG', 'CLAS', 'INTF', 'FUNC', 'INCL', 'DDLS']);`
+- [ ] Update the comment at line ~2178 to accurately reflect the current state: explain that DDLS is linted for CDS syntax errors, while BDEF/SRVD/SRVB/DDLX are skipped because abaplint doesn't parse them, and TABL is skipped because abaplint's CDS parser doesn't support `define table` syntax
+- [ ] Update the tool description for `lintBeforeWrite` in `src/handlers/tools.ts` at line ~501: change from "Lint only applies to ABAP types (PROG, CLAS, INTF, FUNC) — CDS/BDEF/SRVD are always skipped automatically." to "Lint applies to ABAP types (PROG, CLAS, INTF, FUNC) and DDLS (CDS views). BDEF/SRVD/SRVB/DDLX/TABL are skipped (not supported by offline linter)."
+- [ ] Add unit tests (~4 tests) in `tests/unit/handlers/intent.test.ts`: test that pre-write lint catches CDS syntax errors for DDLS, test that valid DDLS passes pre-write, test that BDEF/SRVD still bypass pre-write lint. Look for existing pre-write lint tests in the file and add CDS cases alongside them.
+- [ ] Run `npm test` — all tests must pass
+
+### Task 4: Add CDS lint tests and update SAPLint tool description
+
+**Files:**
+- Modify: `tests/unit/lint/lint.test.ts`
+- Modify: `tests/unit/lint/lint-enhanced.test.ts`
+- Modify: `src/handlers/tools.ts`
+
+The lint test files currently have no CDS-specific test cases. The SAPLint tool description in `src/handlers/tools.ts` at line ~672 doesn't mention CDS support.
+
+- [ ] Add a new `describe('CDS Lint')` block in `tests/unit/lint/lint.test.ts` with tests (~6 tests):
+  - `lintAbapSource` with valid CDS view → no `cds_parser_error`
+  - `lintAbapSource` with invalid CDS (missing comma) → `cds_parser_error` found
+  - `lintAbapSource` with bad association name → `cds_association_name` found
+  - `lintAbapSource` with wrong field order (association before key) → `cds_field_order` found
+  - `lintAbapSource` with legacy view (no `entity` keyword) → `cds_legacy_view` found
+  - `lintAbapSource` with BDEF source and `.bdef.asbdef` extension → no issues (abaplint doesn't parse BDEF)
+- [ ] Add CDS cases to `tests/unit/lint/lint-enhanced.test.ts` if it has relevant `lintAndFix` or `validateBeforeWrite` tests (~3 tests):
+  - `validateBeforeWrite` with valid CDS view → `pass: true`
+  - `validateBeforeWrite` with invalid CDS view → `pass: false`, errors include `cds_parser_error`
+  - `lintAndFix` with CDS view — verify it processes without errors (CDS rules generally don't have auto-fixes)
+- [ ] Update SAPLint tool description in `src/handlers/tools.ts` at line ~672: mention that SAPLint also checks CDS views (DDLS) for syntax errors, naming conventions, field order, and legacy view patterns. Keep it concise.
+- [ ] Run `npm test` — all tests must pass
+
+### Task 5: Final verification
+
+**Files:**
+- No modifications
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Verify manually that the CDS lint works end-to-end by running: `node -e "const {validateBeforeWrite} = require('./dist/lint/lint.js'); console.log(validateBeforeWrite('define view entity ZI_TEST as select from ztable { key f1 field2 }', 'zi_test.ddls.asddls'));"` — should show `pass: false` with `cds_parser_error`
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/research/rfc-integration-sap-rfc-lite.md
+++ b/docs/research/rfc-integration-sap-rfc-lite.md
@@ -1,0 +1,698 @@
+# RFC Integration Research: sap-rfc-lite
+
+**Date:** 2026-04-14
+**Status:** Research / Not yet decided — build only when explicitly requested
+**Package:** `@mcp-abap-adt/sap-rfc-lite` ([GitHub](https://github.com/fr0ster/sap-rfc-lite))
+
+---
+
+## 1. What is sap-rfc-lite?
+
+A lightweight Node.js native addon (C++ / N-API) providing Promise-based bindings for the SAP NetWeaver RFC SDK. It is a modern, zero-vulnerability replacement for the archived [node-rfc](https://github.com/SAP-archive/node-rfc) by SAP.
+
+| Property | Detail |
+|----------|--------|
+| Version | 0.1.1 (released 2026-04-01) |
+| License | Apache-2.0 |
+| Stars | 2 (very new) |
+| Source | ~2,200 lines (vs. ~14,200 in node-rfc) |
+| Runtime deps | 2 (`node-addon-api`, `node-gyp-build`) |
+| Vulnerabilities | 0 (vs. 24 in node-rfc) |
+| Node.js | >= 18 |
+| **Native dependency** | **Requires SAP NetWeaver RFC SDK C library** |
+| npm scope | `@mcp-abap-adt/sap-rfc-lite` (same org namespace) |
+
+### Why not node-rfc?
+
+SAP's original [node-rfc](https://github.com/SAP-archive/node-rfc) is archived, has 24 known vulnerabilities, 18 outdated dependencies (including `bluebird` — a Promise polyfill unnecessary since Node 8), and ~14,200 lines of code. SAP's proprietary replacement (`@sap-rfc/node-rfc-library`) requires a private npm registry and S-user with SAP Build Code license. `sap-rfc-lite` is the only viable open-source option.
+
+### API surface
+
+```typescript
+import { Client } from '@mcp-abap-adt/sap-rfc-lite';
+
+const client = new Client({
+  ashost: '10.0.0.1',
+  sysnr: '00',
+  client: '100',
+  user: 'USER',
+  passwd: 'PASSWORD',
+  lang: 'EN',
+});
+
+await client.open();
+const result = await client.call('STFC_CONNECTION', { REQUTEXT: 'Hello' });
+console.log(result.ECHOTEXT);
+await client.close();
+```
+
+Three methods: `open()`, `call(rfmName, rfmParams?)`, `close()`. Properties: `id` (number), `alive` (boolean).
+
+### Internal architecture
+
+```
+TypeScript (Promise API)  →  C++ N-API (AsyncWorker)  →  SAP NW RFC SDK (libsapnwrfc)
+src/ts/                      src/cpp/                    /usr/local/sap/nwrfcsdk/lib/
+```
+
+Each `client.call()` flows through two N-API async workers:
+1. **PrepareAsync** — gets function descriptor via `RfcGetFunctionDesc()`, sets parameters (worker thread)
+2. **InvokeAsync** — calls `RfcInvoke()`, extracts results (worker thread)
+
+Per-client `std::mutex` serializes operations within one connection. Multiple clients can run in parallel.
+
+### Type system
+
+```typescript
+type RfcVariable = string | number | Buffer;
+type RfcStructure = { [key: string]: RfcVariable | RfcStructure | RfcTable };
+type RfcTable = Array<RfcVariable | RfcStructure>;
+type RfcObject = { [key: string]: RfcVariable | RfcStructure | RfcTable };
+
+// Error types
+interface RfcLibError { name: 'RfcLibError'; code: number; key: string; message: string; ... }
+interface AbapError { name: 'ABAPError'; abapMsgClass: string; abapMsgNumber: string; ... }
+interface NodeRfcError { name: 'nodeRfcError'; message: string; }
+```
+
+### Hard requirements
+
+- **SAP NetWeaver RFC SDK** — proprietary C library, downloaded from SAP Support Portal (S-user required)
+- `SAPNWRFC_HOME` env var pointing to SDK root (containing `lib/` and `include/`)
+- C++ build toolchain at install time: node-gyp, C++17 compiler (MSVC on Windows, GCC on Linux, Clang on macOS)
+- Platform-specific: separate SDK downloads for Linux x64, macOS arm64/x64, Windows x64
+
+---
+
+## 2. Why RFC could be useful for ARC-1
+
+ADT (ABAP Development Tools) REST API covers most development scenarios, but RFC provides access to capabilities that ADT does not expose or exposes incompletely.
+
+### High-value use cases
+
+| Use case | RFC function module(s) | ADT equivalent | Gap filled |
+|----------|----------------------|----------------|------------|
+| **Read any table data** | `RFC_READ_TABLE`, `BBP_RFC_READ_TABLE` | `/sap/bc/adt/datapreview` (limited) | Full SELECT with WHERE clause, no 512-byte row limit |
+| **Execute ABAP report** | `RFC_ABAP_INSTALL_AND_RUN` | None | Run arbitrary ABAP code (**extremely dangerous**) |
+| **Transport operations** | `TRINT_*`, `TR_*` FMs | `/sap/bc/adt/cts/` (limited) | Release, import, add objects to transport |
+| **User info / authorization** | `BAPI_USER_GET_DETAIL`, `SUSR_*` | None | Check user authorizations programmatically |
+| **System info** | `RFC_SYSTEM_INFO`, `TH_SERVER_LIST` | `/sap/bc/adt/discovery` (limited) | Kernel version, DB info, app server list |
+| **DDIC metadata** | `DDIF_FIELDINFO_GET`, `DD_*` | ADT covers most | Some edge cases (append structures, search helps) |
+| **Background job management** | `BAPI_XBP_*`, `JOB_*` | None | Schedule, monitor, read job logs |
+| **Application log** | `BAL_*`, `APPL_LOG_READ_*` | None | Read SLG1 application logs |
+| **Message class texts** | `MESSAGE_TEXT_BUILD` | Limited | Build message texts with variables |
+| **Custom function modules** | Any customer Z* FM | None | Call customer-specific business logic |
+
+### What makes RFC different from ADT
+
+- **ADT = REST API** — HTTP-based, stateless (mostly), designed for Eclipse/VS Code tooling. ARC-1 controls which endpoints are exposed.
+- **RFC = binary protocol** — Direct function module invocation, full SAP type system (structures, tables, BCD numbers), stateful connections. Can call **any** function module in the system.
+
+RFC is fundamentally more powerful because it can call any of ~500,000+ function modules. This is both its strength and its danger.
+
+---
+
+## 3. Security analysis: Why RFC is dangerous
+
+### 3.1 Blast radius
+
+RFC access is essentially **remote code execution on the SAP system**. Key risks:
+
+| Risk | Example | Severity |
+|------|---------|----------|
+| **Data exfiltration** | `RFC_READ_TABLE` on `USR02` (password hashes), `PA0008` (salary data) | Critical |
+| **Arbitrary code execution** | `RFC_ABAP_INSTALL_AND_RUN` — runs any ABAP source | Critical |
+| **OS command execution** | `SXPG_COMMAND_EXECUTE`, `SXPG_CALL_SYSTEM` | Critical |
+| **System destabilization** | FMs that modify system tables, delete runtime data | Critical |
+| **Authorization bypass** | FMs that skip authority checks internally | High |
+| **Mass data modification** | BAPIs that update business objects (orders, invoices, master data) | High |
+| **User manipulation** | `BAPI_USER_CREATE`, `BAPI_USER_CHANGE`, `BAPI_USER_ACTGROUPS_ASSIGN` | High |
+| **Transport manipulation** | Releasing transports to production via `TRINT_RELEASE_REQUEST` | High |
+
+### 3.2 SAP-side authorization
+
+SAP checks RFC access via authorization object **S_RFC**:
+- `RFC_TYPE` — `FUNC` (function module) or `FUGR` (function group)
+- `RFC_NAME` — name pattern (supports wildcards like `Z*`)
+- `ACTVT` — activity (`16` = Execute)
+
+**Problem:** Many SAP systems have overly permissive `S_RFC` assignments. Dialog users often get `S_RFC` with `RFC_NAME = *` for convenience. The SAP user used by ARC-1 may have broad RFC access even if that wasn't intended for AI-driven automation.
+
+### 3.3 Comparison with current ADT risk model
+
+| Dimension | ADT (current) | RFC (proposed) |
+|-----------|--------------|----------------|
+| Protocol | HTTP REST | Binary RFC (proprietary) |
+| Attack surface | ~40 endpoints ARC-1 implements | Any of ~500,000+ function modules |
+| Safety model | Operation type checks + package filter | **Allowlist-only** (see section 4) |
+| ARC-1 control | Full — we choose which endpoints to expose | Limited — FM behavior is opaque to us |
+| Authentication | SAP user via HTTP Basic / OAuth | SAP user via RFC connection params |
+| What can go wrong | Create/modify ABAP objects in allowed packages | **Anything** the SAP user's S_RFC allows |
+
+**Key insight:** ADT's attack surface is bounded by the endpoints ARC-1 chooses to implement. RFC's attack surface is bounded only by what the admin puts in the allowlist — and by the SAP user's `S_RFC` authorizations. This is why the allowlist must be explicit and there must be no "allow all" default.
+
+---
+
+## 4. Integration design: Allowlist-only security model
+
+### 4.1 Core principle: Everything blocked unless explicitly allowed
+
+There is **no blocklist**. With ~500,000+ function modules in a typical SAP system, a blocklist is a losing strategy — you will always miss something dangerous. Instead:
+
+- **Empty allowlist = all RFC calls blocked** (default state)
+- Admin must explicitly list every function module that can be called
+- Wildcards supported but discouraged (e.g., `BAPI_MATERIAL_GET*` — use with caution)
+
+### 4.2 Activation requirements (defense in depth)
+
+RFC requires **all three layers** to be active. If any is missing, RFC is completely unavailable — the tool does not even appear in MCP tool listings.
+
+```
+Layer 1 — Server config:     ARC1_ENABLE_RFC=true           (env var / CLI flag, default: false)
+Layer 2 — Allowlist:         ARC1_RFC_ALLOWED_FMS="FM1,FM2" (must be non-empty)
+Layer 3 — Auth scope:        'rfc' scope in JWT / API key profile
+Layer 4 — SAP authorization: S_RFC on the SAP user          (enforced by SAP, not ARC-1)
+```
+
+### 4.3 New operation type
+
+```typescript
+// src/adt/safety.ts
+export const OperationType = {
+  // ... existing: R, S, Q, F, C, U, D, A, T, L, I, W, X ...
+  Rfc: 'G',  // new: RFC function module invocation
+} as const;
+```
+
+`G` is blocked by `readOnly` mode (RFC can modify data). It's also filterable via `allowedOps` / `disallowedOps`.
+
+### 4.4 New config flags
+
+```typescript
+// src/server/types.ts — ServerConfig additions
+enableRfc: boolean;           // default: false — master switch
+rfcAllowedFMs: string[];     // default: [] — empty = block ALL calls
+rfcMaxRows: number;           // default: 1000 — cap table read results
+```
+
+| Variable / Flag | Description | Default |
+|-----------------|-------------|---------|
+| `ARC1_ENABLE_RFC` / `--enable-rfc` | Master switch for RFC feature | `false` |
+| `ARC1_RFC_ALLOWED_FMS` / `--rfc-allowed-fms` | Comma-separated list of allowed function modules (supports wildcards) | `""` (empty = block all) |
+| `ARC1_RFC_MAX_ROWS` / `--rfc-max-rows` | Max rows returned by table-reading FMs | `1000` |
+
+### 4.5 New scope: `rfc`
+
+```typescript
+// src/handlers/intent.ts
+const TOOL_SCOPES: Record<string, string> = {
+  // ... existing ...
+  SAPRfc: 'rfc',  // new dedicated scope, separate from read/write/sql
+};
+```
+
+The `rfc` scope is **not implied by any other scope**. Having `write` does not grant `rfc`. Having `sql` does not grant `rfc`. It must be explicitly assigned.
+
+### 4.6 New profiles
+
+```typescript
+// src/server/config.ts — PROFILES additions
+'developer-rfc': {
+  readOnly: false,
+  blockData: false,
+  blockFreeSQL: true,
+  enableTransports: true,
+  enableRfc: true,
+  allowedPackages: ['$TMP'],
+},
+'developer-rfc-sql': {
+  readOnly: false,
+  blockData: false,
+  blockFreeSQL: false,
+  enableTransports: true,
+  enableRfc: true,
+  allowedPackages: ['$TMP'],
+},
+
+// PROFILE_SCOPES additions
+'developer-rfc': ['read', 'write', 'data', 'rfc'],
+'developer-rfc-sql': ['read', 'write', 'data', 'sql', 'rfc'],
+```
+
+**No viewer profile gets RFC.** RFC is inherently a write-equivalent capability because many FMs modify data. Even "read-only" FMs like `RFC_READ_TABLE` can be used for data exfiltration.
+
+### 4.7 New tool: SAPRfc
+
+```typescript
+{
+  name: 'SAPRfc',
+  description: 'Call SAP RFC function modules. Requires explicit server-side enablement and function module allowlisting by the administrator. Use RFC_GET_FUNCTION_INTERFACE to discover FM parameters before calling.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      action: {
+        type: 'string',
+        enum: ['call', 'describe'],
+        description: 'call = invoke FM, describe = get FM interface/parameters'
+      },
+      functionModule: {
+        type: 'string',
+        description: 'Function module name (must be in server allowlist)'
+      },
+      parameters: {
+        type: 'object',
+        description: 'Import parameters as key-value pairs'
+      },
+    },
+    required: ['action', 'functionModule'],
+  },
+}
+```
+
+The `describe` action calls `RFC_GET_FUNCTION_INTERFACE` to let the LLM discover what parameters an FM expects before calling it. This FM itself must also be in the allowlist.
+
+The tool is **only registered** when `config.enableRfc === true` AND the RFC SDK is available. It does not appear in tool listings otherwise.
+
+### 4.8 Safety check flow
+
+```
+SAPRfc call received
+  │
+  ├─ 1. Is enableRfc true?                    → No: error "RFC not enabled on this server"
+  ├─ 2. Is RFC SDK loaded?                    → No: error "RFC SDK not installed"
+  ├─ 3. Does user have 'rfc' scope?           → No: error "Missing 'rfc' scope"
+  ├─ 4. checkOperation(safety, 'G', 'RfcCall') → No: error "RFC blocked by safety config"
+  ├─ 5. Is rfcAllowedFMs non-empty?
+  │     └─ No (empty):                        → error "No FMs allowed (set ARC1_RFC_ALLOWED_FMS)"
+  ├─ 6. Does FM match any entry in allowlist? → No: error "FM 'X' not in allowlist"
+  │
+  ▼
+  Execute RFC call via sap-rfc-lite Client
+  (SAP-side S_RFC check happens here — may reject independently)
+```
+
+**No blocklist, no exceptions.** If a function module is not in `rfcAllowedFMs`, it cannot be called. Period.
+
+### 4.9 Allowlist examples
+
+```bash
+# Minimal: system info only
+ARC1_RFC_ALLOWED_FMS="RFC_SYSTEM_INFO,RFC_GET_FUNCTION_INTERFACE"
+
+# Read-focused: table data + metadata
+ARC1_RFC_ALLOWED_FMS="RFC_READ_TABLE,RFC_SYSTEM_INFO,DDIF_FIELDINFO_GET,RFC_GET_FUNCTION_INTERFACE"
+
+# Custom business logic
+ARC1_RFC_ALLOWED_FMS="Z_MY_CUSTOM_FM,Z_MY_OTHER_FM,RFC_GET_FUNCTION_INTERFACE"
+
+# Background jobs (use with caution)
+ARC1_RFC_ALLOWED_FMS="BAPI_XBP_JOB_SELECT,BAPI_XBP_JOB_STATUS_GET,BAL_LOG_READ,RFC_GET_FUNCTION_INTERFACE"
+
+# Wildcard (discouraged — review what Z* FMs exist first!)
+ARC1_RFC_ALLOWED_FMS="Z_SAFE_*,RFC_GET_FUNCTION_INTERFACE"
+```
+
+### 4.10 Audit logging
+
+Every RFC call is audit-logged with:
+- Function module name
+- Parameter keys (not values — could contain sensitive data like passwords, salary, PII)
+- User identity (from JWT / API key / SAP user)
+- Timestamp
+- Success/failure + error classification
+- Whether the FM was in allowlist (for debugging denied calls)
+
+---
+
+## 5. Deployment considerations
+
+### 5.1 Native dependency problem
+
+sap-rfc-lite requires the SAP NetWeaver RFC SDK, which:
+- Is **not open source** — requires SAP download from Support Portal (S-user or partner access)
+- Must be present at **npm install time** for C++ compilation via node-gyp
+- Is **platform-specific** (separate downloads for Linux x64, macOS arm64, macOS x64, Windows x64)
+- Adds **~50 MB** to the deployment footprint
+- Requires **C++17 compiler** and build tools
+
+This fundamentally changes ARC-1's deployment model for RFC-enabled scenarios:
+
+| Dimension | Current (ADT only) | With RFC |
+|-----------|-------------------|----------|
+| `npm install arc-1` | Just works | Needs RFC SDK pre-installed, or install succeeds but RFC unavailable |
+| Docker image | Self-contained, ~30 MB | Needs RFC SDK baked in, ~80+ MB |
+| Native dependencies | None (pure JS/TS) | C++ addon (node-gyp, node-addon-api) |
+| Platform support | Any OS with Node 22+ | Limited to platforms with RFC SDK builds |
+| BTP CF deployment | Standard `nodejs_buildpack` | Needs SDK bundled in app + extra env vars |
+
+### 5.2 Optional dependency strategy
+
+sap-rfc-lite is an **optional dependency** — ARC-1 installs and runs fine without it:
+
+```json
+// package.json
+"optionalDependencies": {
+  "@mcp-abap-adt/sap-rfc-lite": "^0.1.0"
+}
+```
+
+**How `optionalDependencies` works in npm:**
+- During `npm install`, npm **attempts** to install optional deps
+- If the install **fails** (e.g., no C++ compiler, no RFC SDK), npm **skips it silently** and continues
+- The rest of ARC-1 installs normally
+- No error, no broken install
+
+**At runtime**, ARC-1 loads the module dynamically:
+
+```typescript
+// src/rfc/loader.ts
+export async function loadRfcClient(): Promise<typeof import('@mcp-abap-adt/sap-rfc-lite') | null> {
+  try {
+    return await import('@mcp-abap-adt/sap-rfc-lite');
+  } catch {
+    return null;  // RFC SDK not installed — feature unavailable
+  }
+}
+```
+
+**What happens in each scenario:**
+
+| `ARC1_ENABLE_RFC` | SDK installed? | Behavior |
+|-------------------|---------------|----------|
+| `false` (default) | Doesn't matter | RFC feature completely hidden. No tool listed. No warning. |
+| `true` | No | Startup **warning**: `"RFC enabled but @mcp-abap-adt/sap-rfc-lite not available — install SAP NW RFC SDK and npm install"`. Server starts normally, SAPRfc tool not registered. |
+| `true` | Yes, but `rfcAllowedFMs` empty | Startup **warning**: `"RFC enabled but no function modules allowed — set ARC1_RFC_ALLOWED_FMS"`. SAPRfc tool registered but all calls rejected. |
+| `true` | Yes, `rfcAllowedFMs` set | RFC fully operational. SAPRfc tool registered with listed FMs callable. |
+
+**Key point:** The `import()` call is lazy — it only runs when RFC is enabled. No ARC-1 code path outside `src/rfc/` ever references the RFC module. If the package isn't installed, the `catch` block returns `null`, and ARC-1 treats it as "RFC not available."
+
+### 5.3 Docker deployment
+
+#### Standard image (no RFC) — unchanged
+
+```dockerfile
+# Dockerfile (existing, no changes)
+FROM node:22-slim AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY dist/ ./dist/
+# ... no RFC SDK, no native compilation needed
+```
+
+#### RFC-enabled image — separate Dockerfile or build arg
+
+```dockerfile
+# Dockerfile.rfc
+FROM node:22-slim AS builder
+
+# --- RFC SDK layer ---
+# SDK must be provided by the builder (not distributed publicly)
+COPY nwrfcsdk/ /usr/local/sap/nwrfcsdk/
+ENV SAPNWRFC_HOME=/usr/local/sap/nwrfcsdk
+ENV LD_LIBRARY_PATH=/usr/local/sap/nwrfcsdk/lib
+
+# Install build tools for native addon compilation
+RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev  # This now compiles sap-rfc-lite successfully
+COPY dist/ ./dist/
+
+# --- Runtime image ---
+FROM node:22-slim
+COPY --from=builder /usr/local/sap/nwrfcsdk/lib/ /usr/local/sap/nwrfcsdk/lib/
+ENV LD_LIBRARY_PATH=/usr/local/sap/nwrfcsdk/lib
+COPY --from=builder /app /app
+WORKDIR /app
+CMD ["node", "dist/index.js"]
+```
+
+**Image distribution:**
+
+| Image | Tag | Size | RFC |
+|-------|-----|------|-----|
+| `ghcr.io/marianfoo/arc-1:latest` | Standard | ~30 MB | No |
+| `ghcr.io/marianfoo/arc-1:rfc` | RFC-enabled | ~80+ MB | Yes |
+
+**Note:** The RFC-enabled Docker image cannot be published publicly because it contains the proprietary SAP NW RFC SDK. It would need to be built privately by each organization with their own SDK copy.
+
+### 5.4 BTP Cloud Foundry deployment (without Docker)
+
+Based on [SAP's official blog](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-rfc-connectivity-from-btp-node-js-buildpack-and-kyma/ba-p/13573993), RFC **does work** on BTP CF with the standard Node.js buildpack. Here's how:
+
+#### How it works
+
+1. **Bundle the RFC SDK in your app directory** — copy the `nwrfcsdk/` folder into the app root before `cf push`
+2. **Set env vars** in `manifest.yaml` / `mta.yaml`:
+   ```yaml
+   env:
+     SAPNWRFC_HOME_CLOUD: /tmp/app/nwrfcsdk       # Build-time: for node-gyp compilation
+     LD_LIBRARY_PATH: /home/vcap/app/nwrfcsdk/lib  # Runtime: for loading .so libraries
+   ```
+3. **The buildpack compiles** the native addon during staging (just like any node-gyp module)
+4. **At runtime**, the `.so` libraries are loaded from the bundled SDK
+
+#### What would change in mta.yaml
+
+```yaml
+# Current ARC-1 module (unchanged for non-RFC deployments)
+modules:
+  - name: arc1
+    type: nodejs
+    path: .
+    parameters:
+      memory: 256M
+      disk-quota: 512M
+
+# RFC-enabled variant would need:
+modules:
+  - name: arc1-rfc
+    type: nodejs
+    path: .
+    parameters:
+      memory: 384M          # More memory for native addon
+      disk-quota: 1024M     # RFC SDK adds ~50MB
+    properties:
+      SAPNWRFC_HOME_CLOUD: /tmp/app/nwrfcsdk
+      LD_LIBRARY_PATH: /home/vcap/app/nwrfcsdk/lib
+      ARC1_ENABLE_RFC: true
+      ARC1_RFC_ALLOWED_FMS: "RFC_READ_TABLE,RFC_SYSTEM_INFO"
+```
+
+#### Practical issues with BTP CF + RFC
+
+| Issue | Detail |
+|-------|--------|
+| **SDK bundling** | Must manually copy `nwrfcsdk/` into app root before every `cf push`. Not automatable via mta.yaml. |
+| **Upload size** | App upload grows from ~5 MB to ~55+ MB (SDK binaries). Slower deploys. |
+| **Platform lock-in** | SDK must be Linux x64 build (cflinuxfs4 = Ubuntu Jammy). Cannot use macOS/Windows SDK. |
+| **Rebuild on every push** | `npm install` during staging recompiles the C++ addon every time. Adds ~30s to staging. |
+| **No principal propagation for RFC** | BTP Destination Service supports HTTP destinations for PP, but **RFC destinations work differently** — they use connection parameters (ashost/sysnr), not HTTP proxy. Cloud Connector maps virtual hosts for RFC, but the PP flow (SAML assertion via `SAP-Connectivity-Authentication` header) is HTTP-only. RFC PP would need a different mechanism (SNC with X.509 certificates). |
+| **Cloud Connector RFC config** | Requires separate Cloud Connector configuration for RFC (not just HTTP). The CC admin must expose the SAP system's RFC port (sapgw00, typically 3300) as a virtual host, in addition to the existing HTTP mapping. |
+| **Licensing** | SAP NW RFC SDK is downloaded from SAP Support Portal. Uploading it as part of a CF app is redistribution within the BTP subaccount — should be covered by the customer's SAP license, but worth confirming. |
+
+#### RFC connectivity through Cloud Connector
+
+```
+                              Cloud Connector
+ARC-1 on BTP CF  ──RFC──►  [virtual host:3300]  ──RFC──►  SAP on-prem (sapgw00)
+                              │
+                              ├─ RFC mapping (separate from HTTP)
+                              └─ Access control (function name patterns possible)
+```
+
+RFC connection parameters use **websocket RFC (WS-RFC)** through Cloud Connector:
+
+```typescript
+const client = new Client({
+  dest: 'SAP_RFC_DEST',            // Or explicit parameters:
+  wshost: 'virtual-host',          // Cloud Connector virtual host
+  wsport: '443',                   // Cloud Connector port
+  client: '100',
+  // Authentication via Cloud Connector mapping
+});
+```
+
+#### BTP Kyma (Kubernetes) — simpler
+
+On Kyma, RFC works more naturally because you control the Docker image. The SDK is baked into the container image, and RFC connections go through Cloud Connector the same way. This is the recommended approach for RFC on BTP.
+
+### 5.5 Deployment recommendation matrix
+
+| Deployment model | RFC feasibility | Complexity | Recommended? |
+|-----------------|----------------|------------|--------------|
+| **Local stdio** (dev) | Works if SDK installed locally | Low | Yes (for development) |
+| **Docker** (self-hosted) | Works — bake SDK into image | Medium | Yes |
+| **BTP CF + Docker image** | Works — same as Docker | Medium | Yes |
+| **BTP CF + Node.js buildpack** | Works but awkward — bundle SDK in app | High | No — use Docker instead |
+| **BTP Kyma** | Works — SDK in container image | Medium | Yes |
+| **npm global install** | Only if SDK installed on host | Low | Niche use case |
+
+**Bottom line:** For BTP without Docker, it technically works but adds significant friction (manual SDK bundling, larger uploads, rebuild on every push, no PP for RFC). The Docker path is cleaner. For most BTP deployments, stick with the Docker image approach.
+
+---
+
+## 6. Codebase impact assessment
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `src/rfc/loader.ts` | Dynamic `import()` of sap-rfc-lite, availability check |
+| `src/rfc/client.ts` | RFC client wrapper: connection lifecycle, allowlist enforcement, timeout |
+| `src/rfc/safety.ts` | FM allowlist matching (exact match + wildcard support) |
+| `tests/unit/rfc/safety.test.ts` | Unit tests for allowlist matching logic |
+| `tests/unit/rfc/loader.test.ts` | Unit tests for dynamic import handling |
+| `tests/integration/rfc.integration.test.ts` | Integration tests (needs SAP system + RFC SDK) |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/adt/safety.ts` | Add `OperationType.Rfc = 'G'`, add to write-ops set |
+| `src/server/types.ts` | Add `enableRfc`, `rfcAllowedFMs`, `rfcMaxRows` to `ServerConfig` |
+| `src/server/config.ts` | Parse new flags + env vars, add `developer-rfc` / `developer-rfc-sql` profiles |
+| `src/handlers/intent.ts` | Add `SAPRfc` to `TOOL_SCOPES`, add `handleSAPRfc()` routing |
+| `src/handlers/tools.ts` | Add `SAPRfc` tool definition (conditional on `enableRfc` + SDK available) |
+| `src/handlers/schemas.ts` | Add Zod schema for SAPRfc input validation |
+| `src/server/server.ts` | Conditional RFC client initialization at startup |
+| `src/server/audit.ts` | RFC-specific audit fields (FM name, parameter keys) |
+| `package.json` | Add `@mcp-abap-adt/sap-rfc-lite` to `optionalDependencies` |
+
+### Not modified
+
+- No changes to any existing ADT operations or tools
+- No changes to existing tool behavior when RFC is disabled (the default)
+- No new required dependencies — RFC module is optional only
+- No changes to existing Docker image or mta.yaml (RFC variants are additive)
+
+---
+
+## 7. Maturity and risk assessment
+
+### Package maturity
+
+| Factor | Assessment | Risk |
+|--------|-----------|------|
+| Age | 2 weeks old (created 2026-04-01) | High — too new to trust in production |
+| Version | 0.1.1 | High — pre-1.0, API may change |
+| Stars | 2 | High — no community validation |
+| Contributors | 1 | High — bus factor of 1 |
+| Downloads | Unknown (very low) | High — not battle-tested |
+| Tests | Jest suite exists | Medium — quality/coverage unknown |
+| C++ code origin | Derived from SAP's node-rfc | Medium — base code is proven, modernization is new |
+| Maintenance | Active (commits in April 2026) | Medium — active now, sustainability unclear |
+
+### Risks
+
+1. **Immature package** — 0.1.1, 2 weeks old, single contributor. Could be abandoned at any time.
+2. **Native addon instability** — C++ N-API addons can have memory leaks, segfaults, thread safety issues, or platform-specific bugs that are much harder to debug than pure JS issues.
+3. **SAP RFC SDK licensing** — The SDK requires SAP licensing (S-user download). Distributing it in Docker images or CF apps may have legal implications depending on the customer's SAP contract.
+4. **Breaking changes** — Pre-1.0 package, API may change without notice.
+5. **Security of the C++ code** — Handles SAP Unicode strings, buffer conversions, pointer arithmetic. A bug here could be a memory safety issue. No security audit has been performed.
+6. **No connection pooling** — Each call opens/closes a connection, or we must build our own pool. No built-in timeout mechanism.
+
+### Mitigations
+
+1. **Dynamic import isolation** — if the package breaks or is abandoned, ARC-1 still works perfectly (RFC just becomes unavailable)
+2. **Pin exact version** in optionalDependencies to prevent surprise upgrades
+3. **C++ core is derived from SAP's node-rfc** — the fundamental RFC SDK interaction code is battle-tested across years of SAP usage
+4. **Wrap with timeout** — ARC-1 should enforce a configurable timeout per RFC call to prevent indefinite hangs
+5. **Test independently** — ARC-1's RFC unit tests should mock the native module; integration tests can verify real behavior
+
+---
+
+## 8. Alternative approaches
+
+### 8.1 Use ADT endpoints where possible
+
+Before reaching for RFC, check if an ADT endpoint covers the use case:
+
+| Scenario | ADT alternative | RFC needed? |
+|----------|----------------|-------------|
+| Table data | `/sap/bc/adt/datapreview` (current SAPQuery) | Only for 512-byte row limit workaround |
+| System info | `/sap/bc/adt/core/discovery` | Only for detailed kernel/DB info |
+| Transport ops | `/sap/bc/adt/cts/` (current SAPTransport) | Only for import/release edge cases |
+| Background jobs | None | **Yes** |
+| Application logs (SLG1) | None | **Yes** |
+| Custom Z* FMs | None | **Yes** |
+| User authorizations | None | **Yes** |
+
+**Recommendation:** Only integrate RFC for use cases that ADT genuinely cannot cover. Don't duplicate existing ADT capabilities over RFC.
+
+### 8.2 WebSocket RFC via HTTP
+
+Some SAP systems expose RFC over WebSocket (ICF service `/sap/bc/srt/rfc/sap/`). This would avoid the native dependency entirely but:
+- Not universally available
+- Less documented
+- Different authentication flow
+- Would need a custom implementation
+
+This is a long-term alternative worth investigating if the native dependency proves too burdensome.
+
+---
+
+## 9. Recommendation
+
+### Short term: Do not integrate yet
+
+1. **Package is too young** (2 weeks, v0.1.1) — wait for it to stabilize (target: v0.5+ with proven stability)
+2. **No concrete user request** — build when someone explicitly needs RFC access
+3. **High security risk** — this document captures the complete design for when the time comes
+4. **Deployment complexity** — native dependency adds friction to every deployment model
+
+### Medium term: Integrate as opt-in experimental feature
+
+When the package matures and a user explicitly requests it:
+
+1. Add as optional dependency with dynamic import
+2. Implement the **allowlist-only** safety model (section 4)
+3. Start with a recommended "safe starter" allowlist in documentation:
+   ```
+   RFC_SYSTEM_INFO, RFC_GET_FUNCTION_INTERFACE, DDIF_FIELDINFO_GET
+   ```
+4. Require explicit admin opt-in at every level (config + allowlist + scope)
+5. Separate Docker image variant for RFC-enabled deployments
+6. Do not support RFC in BTP CF buildpack mode — recommend Docker instead
+
+### Configuration when ready
+
+```bash
+# Minimal RFC setup — system info only
+ARC1_ENABLE_RFC=true
+ARC1_RFC_ALLOWED_FMS="RFC_SYSTEM_INFO,RFC_GET_FUNCTION_INTERFACE"
+ARC1_PROFILE=developer-rfc
+
+# With table reads
+ARC1_ENABLE_RFC=true
+ARC1_RFC_ALLOWED_FMS="RFC_READ_TABLE,RFC_SYSTEM_INFO,DDIF_FIELDINFO_GET,RFC_GET_FUNCTION_INTERFACE"
+ARC1_RFC_MAX_ROWS=500
+ARC1_PROFILE=developer-rfc
+
+# Via CLI
+arc-1 --enable-rfc --rfc-allowed-fms "RFC_READ_TABLE,RFC_SYSTEM_INFO" --rfc-max-rows 500
+```
+
+### Key design principles
+
+1. **Off by default** — RFC never activates without explicit `ARC1_ENABLE_RFC=true`
+2. **Allowlist-only, no blocklist** — with ~500K FMs, a blocklist is a losing game. Admin must explicitly list every allowed FM.
+3. **Empty allowlist = block all** — no "allow everything" shortcut exists
+4. **Dedicated scope** — `rfc` scope is separate from `read`/`write`/`sql`, not implied by any other scope
+5. **No tool listing when disabled** — `SAPRfc` tool is invisible when RFC is off or SDK is missing
+6. **Full audit trail** — every RFC call logged with FM name, user identity, parameter keys
+7. **Optional dependency** — ARC-1 installs and runs without RFC SDK present. Zero impact on non-RFC users.
+
+---
+
+## 10. Open questions
+
+1. **Connection pooling?** sap-rfc-lite has no pool. Should ARC-1 manage a connection pool (reuse connections across calls), or open/close per call? Pooling is more efficient but adds complexity and statefulness.
+2. **Timeout per call?** RFC calls can hang indefinitely if the SAP system is unresponsive. Should ARC-1 enforce a configurable timeout wrapper (e.g., `ARC1_RFC_TIMEOUT=30000`)?
+3. **FM metadata introspection?** Could `RFC_GET_FUNCTION_INTERFACE` be called automatically when the LLM requests an unknown FM, to show available parameters? Or should `describe` be an explicit action?
+4. **BTP principal propagation for RFC?** HTTP-based PP uses `SAP-Connectivity-Authentication` header through Cloud Connector. RFC PP would need SNC with X.509 certificates — different mechanism entirely. Is this a requirement or can RFC use a shared service account?
+5. **Parameter value logging?** Currently proposed to log keys only (values could contain PII, passwords, salary data). Should there be an opt-in `ARC1_RFC_LOG_VALUES=true` for full audit trails?
+6. **Wildcard allowlist safety?** Should wildcards like `Z*` or `BAPI_*` be allowed, or should the allowlist require exact FM names only? Wildcards are convenient but could accidentally allow dangerous FMs added later.
+7. **Should RFC calls be read-only by default?** Could introduce `ARC1_RFC_READ_ONLY=true` that intersects the allowlist with a curated list of known read-only FMs. Adds complexity but reduces risk.

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -2175,13 +2175,14 @@ function runPreWriteLint(
     return { blocked: false };
   }
 
-  // abaplint is an ABAP statement parser — it cannot parse CDS DDL, BDL (behavior
-  // definitions), or service definitions. Sending non-ABAP source through it produces
-  // false positives like "Expected CLASSDEFINITION" on perfectly valid `define table`,
-  // `projection;`, or `define service` syntax. Skip lint entirely for these types and
-  // let the SAP server-side compiler handle validation.
-  const ABAP_ONLY_TYPES = new Set(['PROG', 'CLAS', 'INTF', 'FUNC', 'INCL']);
-  if (!ABAP_ONLY_TYPES.has(type)) {
+  // abaplint supports ABAP source (PROG/CLAS/INTF/FUNC/INCL) and CDS views (DDLS) via
+  // its CDS parser. DDLS lint catches syntax errors (cds_parser_error) like missing commas,
+  // wrong keywords, and invalid DDL constructs. BDEF/SRVD/SRVB/DDLX are silently ignored
+  // by abaplint (no parser for those types — garbage passes without errors). TABL (define
+  // table syntax) is not supported by the CDS parser and produces false cds_parser_error.
+  // For unsupported types, SAP server-side compilation handles validation.
+  const LINTABLE_TYPES = new Set(['PROG', 'CLAS', 'INTF', 'FUNC', 'INCL', 'DDLS']);
+  if (!LINTABLE_TYPES.has(type)) {
     return { blocked: false };
   }
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -498,7 +498,7 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
           lintBeforeWrite: {
             type: 'boolean',
             description:
-              'Override server lint-before-write setting for this call. Set false to skip pre-write ABAP lint validation. Lint only applies to ABAP types (PROG, CLAS, INTF, FUNC) — CDS/BDEF/SRVD are always skipped automatically.',
+              'Override server lint-before-write setting for this call. Set false to skip pre-write lint validation. Lint applies to ABAP types (PROG, CLAS, INTF, FUNC) and CDS views (DDLS). BDEF/SRVD/SRVB/DDLX/TABL are skipped (not supported by offline linter).',
           },
           objects: {
             type: 'array',
@@ -670,9 +670,9 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
     {
       name: 'SAPLint',
       description:
-        'Run local abaplint rules on ABAP source code. System-aware: auto-selects cloud or on-prem rules based on detected system type.\n\n' +
+        'Run local abaplint rules on ABAP and CDS source code. System-aware: auto-selects cloud or on-prem rules based on detected system type.\n\n' +
         'Actions:\n' +
-        '- "lint": Check ABAP source for issues. Returns errors and warnings.\n' +
+        '- "lint": Check source for issues. Returns errors and warnings. Works for ABAP (PROG, CLAS, INTF, FUNC) and CDS views (DDLS) — catches syntax errors, naming conventions, field order, legacy view patterns.\n' +
         '- "lint_and_fix": Lint + auto-fix all fixable issues (keyword case, obsolete statements, etc.). Returns fixed source.\n' +
         '- "list_rules": List all available rules with current config. No source needed.\n\n' +
         'For server-side checks (ATC, syntax check, unit tests), use SAPDiagnose instead.',
@@ -684,7 +684,7 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
             enum: ['lint', 'lint_and_fix', 'list_rules'],
             description: 'Check type',
           },
-          source: { type: 'string', description: 'ABAP source code to lint (not needed for list_rules)' },
+          source: { type: 'string', description: 'ABAP or CDS source code to lint (not needed for list_rules)' },
           name: { type: 'string', description: 'Object name (used for filename detection)' },
           rules: {
             type: 'object',

--- a/src/lint/config-builder.ts
+++ b/src/lint/config-builder.ts
@@ -97,6 +97,8 @@ export function buildPreWriteConfig(options: LintConfigOptions = {}): Config {
     begin_end_names: { severity: 'Error' },
     unreachable_code: { severity: 'Error' },
     identical_conditions: { severity: 'Error' },
+    // CDS syntax errors (catches missing commas, wrong keywords, invalid DDL constructs)
+    cds_parser_error: { severity: 'Error' },
   };
 
   // Add cloud-specific blocking rules

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -167,15 +167,40 @@ export function detectFilename(source: string, objectName: string): string {
   // Strip leading comment lines ("! doc comments, * comments) and blank lines to find the first keyword
   const stripped = source.replace(/^(\s*(["*!].*)?[\r\n]*)*/m, '');
   const upper = stripped.toUpperCase().trimStart();
-  if (upper.startsWith('CLASS')) return `${objectName.toLowerCase()}.clas.abap`;
-  if (upper.startsWith('INTERFACE')) return `${objectName.toLowerCase()}.intf.abap`;
-  if (upper.startsWith('FUNCTION-POOL') || upper.startsWith('FUNCTION')) return `${objectName.toLowerCase()}.fugr.abap`;
-  if (upper.startsWith('REPORT') || upper.startsWith('PROGRAM')) return `${objectName.toLowerCase()}.prog.abap`;
-  if (upper.startsWith('DEFINE VIEW') || upper.startsWith('@')) return `${objectName.toLowerCase()}.ddls.asddls`;
-  if (upper.startsWith('MANAGED') || upper.startsWith('UNMANAGED') || upper.startsWith('ABSTRACT'))
-    return `${objectName.toLowerCase()}.bdef.asbdef`;
+  const name = objectName.toLowerCase();
+
+  // ABAP types — check first keyword
+  if (upper.startsWith('CLASS')) return `${name}.clas.abap`;
+  if (upper.startsWith('INTERFACE')) return `${name}.intf.abap`;
+  if (upper.startsWith('FUNCTION-POOL') || upper.startsWith('FUNCTION')) return `${name}.fugr.abap`;
+  if (upper.startsWith('REPORT') || upper.startsWith('PROGRAM')) return `${name}.prog.abap`;
+
+  // CDS/DDL types — check the first structural keyword (may be preceded by annotations)
+  // Strip leading annotations (@...\n) to find the actual define/annotate keyword
+  const afterAnnotations = upper.replace(/^(\s*@[^\n]*\n)*/m, '').trimStart();
+  if (afterAnnotations.startsWith('DEFINE TABLE')) return `${name}.tabl.astabl`;
+  if (afterAnnotations.startsWith('DEFINE SERVICE')) return `${name}.srvd.asrvd`;
+  if (afterAnnotations.startsWith('ANNOTATE VIEW') || afterAnnotations.startsWith('ANNOTATE ENTITY'))
+    return `${name}.ddlx.asddlx`;
+  if (afterAnnotations.startsWith('DEFINE VIEW') || afterAnnotations.startsWith('DEFINE ROOT VIEW'))
+    return `${name}.ddls.asddls`;
+  // Fallback: source starts with @ but keyword not matched — assume CDS view (most common)
+  if (upper.startsWith('@')) return `${name}.ddls.asddls`;
+
+  // BDEF types — behavior definitions
+  if (
+    upper.startsWith('MANAGED') ||
+    upper.startsWith('UNMANAGED') ||
+    upper.startsWith('ABSTRACT') ||
+    upper.startsWith('PROJECTION;') ||
+    upper.startsWith('PROJECTION\n') ||
+    upper.startsWith('PROJECTION\r') ||
+    upper.startsWith('PROJECTION ')
+  )
+    return `${name}.bdef.asbdef`;
+
   // Default to class (enables most rules)
-  return `${objectName.toLowerCase()}.clas.abap`;
+  return `${name}.clas.abap`;
 }
 
 /** Map abaplint severity to our severity levels */

--- a/src/lint/presets/cloud.ts
+++ b/src/lint/presets/cloud.ts
@@ -18,6 +18,10 @@ export const CLOUD_ERROR_RULES: RuleOverrides = {
   unreachable_code: { severity: 'Error' },
   identical_conditions: { severity: 'Error' },
 
+  // --- CDS correctness ---
+  cds_parser_error: { severity: 'Error' },
+  cds_legacy_view: { severity: 'Error' },
+
   // --- Cloud-specific constraints ---
   cloud_types: { severity: 'Error' },
   strict_sql: { severity: 'Error' },
@@ -59,6 +63,11 @@ export const CLOUD_ERROR_RULES: RuleOverrides = {
 
 /** Rules that produce warnings on cloud systems (advisory) */
 export const CLOUD_WARNING_RULES: RuleOverrides = {
+  // --- CDS style (advisory) ---
+  cds_association_name: { severity: 'Warning' },
+  cds_comment_style: { severity: 'Warning' },
+  cds_field_order: { severity: 'Warning' },
+
   prefer_inline: { severity: 'Warning' },
   keyword_case: {
     severity: 'Warning',
@@ -87,6 +96,8 @@ export const CLOUD_WARNING_RULES: RuleOverrides = {
 
 /** Rules explicitly disabled for cloud preset */
 export const CLOUD_DISABLED_RULES: string[] = [
+  // VDM naming prefixes (ZI_, ZC_, ZR_, etc.) are project-specific
+  'cds_naming',
   // Too noisy for MCP context — LLM generates code without doc comments
   'abapdoc',
   'description_empty',

--- a/src/lint/presets/onprem.ts
+++ b/src/lint/presets/onprem.ts
@@ -18,10 +18,19 @@ export const ONPREM_ERROR_RULES: RuleOverrides = {
   begin_end_names: { severity: 'Error' },
   unreachable_code: { severity: 'Error' },
   identical_conditions: { severity: 'Error' },
+
+  // --- CDS correctness ---
+  cds_parser_error: { severity: 'Error' },
 };
 
 /** Rules that produce warnings on on-premise systems (advisory) */
 export const ONPREM_WARNING_RULES: RuleOverrides = {
+  // --- CDS style (advisory) ---
+  cds_legacy_view: { severity: 'Warning' },
+  cds_association_name: { severity: 'Warning' },
+  cds_comment_style: { severity: 'Warning' },
+  cds_field_order: { severity: 'Warning' },
+
   obsolete_statement: {
     severity: 'Warning',
     refresh: true,
@@ -53,6 +62,8 @@ export const ONPREM_WARNING_RULES: RuleOverrides = {
 
 /** Rules explicitly disabled for on-premise preset */
 export const ONPREM_DISABLED_RULES: string[] = [
+  // VDM naming prefixes (ZI_, ZC_, ZR_, etc.) are project-specific
+  'cds_naming',
   // Cloud-only constraints (not applicable on-prem)
   'cloud_types',
   'strict_sql',

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -1440,6 +1440,66 @@ ENDCLASS.`,
     });
   });
 
+  describe('SAPWrite pre-write lint gate for DDLS', () => {
+    it('blocks DDLS write with CDS syntax errors', async () => {
+      const config = { ...DEFAULT_CONFIG, lintBeforeWrite: true };
+      const result = await handleToolCall(createClient(), config, 'SAPWrite', {
+        action: 'update',
+        type: 'DDLS',
+        name: 'ZI_TEST',
+        source: `define view entity ZI_TEST as select from ztable {
+  key field1
+  field2
+}`,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('Pre-write lint check failed');
+      expect(result.content[0]?.text).toContain('cds_parser_error');
+    });
+
+    it('allows valid DDLS through the gate', async () => {
+      const config = { ...DEFAULT_CONFIG, lintBeforeWrite: true };
+      const result = await handleToolCall(createClient(), config, 'SAPWrite', {
+        action: 'update',
+        type: 'DDLS',
+        name: 'ZI_TEST',
+        source: `define view entity ZI_TEST as select from ztable {
+  key field1,
+  field2
+}`,
+      });
+      if (result.content[0]?.text) {
+        expect(result.content[0]?.text).not.toContain('Pre-write lint check failed');
+      }
+    });
+
+    it('still skips BDEF for pre-write lint', async () => {
+      const config = { ...DEFAULT_CONFIG, lintBeforeWrite: true };
+      const result = await handleToolCall(createClient(), config, 'SAPWrite', {
+        action: 'update',
+        type: 'BDEF',
+        name: 'ZI_TEST',
+        source: 'this is total garbage that should not trigger lint',
+      });
+      if (result.content[0]?.text) {
+        expect(result.content[0]?.text).not.toContain('Pre-write lint check failed');
+      }
+    });
+
+    it('still skips SRVD for pre-write lint', async () => {
+      const config = { ...DEFAULT_CONFIG, lintBeforeWrite: true };
+      const result = await handleToolCall(createClient(), config, 'SAPWrite', {
+        action: 'update',
+        type: 'SRVD',
+        name: 'ZSD_TEST',
+        source: 'this is total garbage that should not trigger lint',
+      });
+      if (result.content[0]?.text) {
+        expect(result.content[0]?.text).not.toContain('Pre-write lint check failed');
+      }
+    });
+  });
+
   // ─── Unknown Tool ──────────────────────────────────────────────────
 
   describe('unknown tool', () => {

--- a/tests/unit/lint/config-builder.test.ts
+++ b/tests/unit/lint/config-builder.test.ts
@@ -146,6 +146,55 @@ describe('Config Builder', () => {
       expect(rules.cloud_types).toBe(false);
       expect(rules.strict_sql).toBe(false);
     });
+
+    it('includes cds_parser_error for all system types', () => {
+      for (const systemType of ['btp', 'onprem'] as const) {
+        const config = buildPreWriteConfig({ systemType });
+        const rules = config.get().rules as Record<string, unknown>;
+        expect(rules.cds_parser_error).toBeTruthy();
+        expect((rules.cds_parser_error as Record<string, unknown>).severity).toBe('Error');
+      }
+    });
+  });
+
+  describe('CDS rules in presets', () => {
+    it('enables cds_parser_error as Error for both presets', () => {
+      for (const systemType of ['btp', 'onprem'] as const) {
+        const config = buildLintConfig({ systemType });
+        const rules = config.get().rules as Record<string, unknown>;
+        expect(rules.cds_parser_error).toBeTruthy();
+        expect((rules.cds_parser_error as Record<string, unknown>).severity).toBe('Error');
+      }
+    });
+
+    it('disables cds_naming for both presets', () => {
+      for (const systemType of ['btp', 'onprem'] as const) {
+        const config = buildLintConfig({ systemType });
+        const rules = config.get().rules as Record<string, unknown>;
+        expect(rules.cds_naming).toBe(false);
+      }
+    });
+
+    it('sets cds_legacy_view as Error on BTP, Warning on on-prem', () => {
+      const btpConfig = buildLintConfig({ systemType: 'btp' });
+      const btpRules = btpConfig.get().rules as Record<string, unknown>;
+      expect((btpRules.cds_legacy_view as Record<string, unknown>).severity).toBe('Error');
+
+      const onpremConfig = buildLintConfig({ systemType: 'onprem' });
+      const onpremRules = onpremConfig.get().rules as Record<string, unknown>;
+      expect((onpremRules.cds_legacy_view as Record<string, unknown>).severity).toBe('Warning');
+    });
+
+    it('sets CDS style rules as Warning for both presets', () => {
+      for (const systemType of ['btp', 'onprem'] as const) {
+        const config = buildLintConfig({ systemType });
+        const rules = config.get().rules as Record<string, unknown>;
+        for (const rule of ['cds_association_name', 'cds_comment_style', 'cds_field_order']) {
+          expect(rules[rule]).toBeTruthy();
+          expect((rules[rule] as Record<string, unknown>).severity).toBe('Warning');
+        }
+      }
+    });
   });
 
   describe('listRulesFromConfig', () => {

--- a/tests/unit/lint/lint.test.ts
+++ b/tests/unit/lint/lint.test.ts
@@ -1,5 +1,6 @@
+import { Config, Version } from '@abaplint/core';
 import { describe, expect, it } from 'vitest';
-import { detectFilename, lintAbapSource } from '../../../src/lint/lint.js';
+import { detectFilename, lintAbapSource, validateBeforeWrite } from '../../../src/lint/lint.js';
 
 describe('ABAP Lint', () => {
   describe('lintAbapSource', () => {
@@ -76,8 +77,142 @@ ENDCLASS.`;
       expect(detectFilename('managed implementation in class zbp_test', 'Z_TEST')).toBe('z_test.bdef.asbdef');
     });
 
+    it('detects BDEF projection as .bdef.asbdef', () => {
+      expect(detectFilename('projection;\ndefine behavior for ZC_TRAVEL', 'ZC_TRAVEL')).toBe('zc_travel.bdef.asbdef');
+    });
+
+    it('detects SRVD (define service) as .srvd.asrvd', () => {
+      expect(
+        detectFilename(
+          "@EndUserText.label: 'My Service'\ndefine service ZSD_TRAVEL {\n  expose ZI_TRAVEL;\n}",
+          'ZSD_TRAVEL',
+        ),
+      ).toBe('zsd_travel.srvd.asrvd');
+    });
+
+    it('detects SRVD without annotation as .srvd.asrvd', () => {
+      expect(detectFilename('define service ZSD_TRAVEL {\n  expose ZI_TRAVEL;\n}', 'ZSD_TRAVEL')).toBe(
+        'zsd_travel.srvd.asrvd',
+      );
+    });
+
+    it('detects TABL (define table) as .tabl.astabl', () => {
+      expect(
+        detectFilename(
+          "@EndUserText.label: 'Test'\n@AbapCatalog.tableCategory: #TRANSPARENT\ndefine table ztable {\n  key f1 : abap.char(10);\n}",
+          'ZTABLE',
+        ),
+      ).toBe('ztable.tabl.astabl');
+    });
+
+    it('detects DDLX (annotate view) as .ddlx.asddlx', () => {
+      expect(
+        detectFilename(
+          '@Metadata.layer: #CUSTOMER\nannotate view ZI_TRAVEL with {\n  @UI.lineItem: [{ position: 10 }]\n  TravelId;\n}',
+          'ZI_TRAVEL',
+        ),
+      ).toBe('zi_travel.ddlx.asddlx');
+    });
+
+    it('detects DDLX (annotate entity) as .ddlx.asddlx', () => {
+      expect(detectFilename('annotate entity ZI_TRAVEL with {\n  TravelId;\n}', 'ZI_TRAVEL')).toBe(
+        'zi_travel.ddlx.asddlx',
+      );
+    });
+
+    it('detects CDS root view as .ddls.asddls', () => {
+      expect(detectFilename('define root view entity ZR_TRAVEL as select from ztravel { key id }', 'ZR_TRAVEL')).toBe(
+        'zr_travel.ddls.asddls',
+      );
+    });
+
     it('defaults to .clas.abap for unknown', () => {
       expect(detectFilename('DATA lv_test TYPE string.', 'UNKNOWN')).toBe('unknown.clas.abap');
+    });
+  });
+
+  describe('CDS Lint', () => {
+    it('returns no cds_parser_error for valid CDS view', () => {
+      const source = `define view entity ZI_TEST as select from ztable {
+  key field1,
+  field2
+}`;
+      const results = lintAbapSource(source, 'zi_test.ddls.asddls');
+      const parserErrors = results.filter((r) => r.rule === 'cds_parser_error');
+      expect(parserErrors).toHaveLength(0);
+    });
+
+    it('returns cds_parser_error for invalid CDS (missing comma)', () => {
+      const source = `define view entity ZI_TEST as select from ztable {
+  key field1
+  field2
+}`;
+      const results = lintAbapSource(source, 'zi_test.ddls.asddls');
+      const parserErrors = results.filter((r) => r.rule === 'cds_parser_error');
+      expect(parserErrors.length).toBeGreaterThan(0);
+      expect(parserErrors[0].severity).toBe('error');
+    });
+
+    it('returns cds_association_name for bad association name', () => {
+      const source = `define view entity ZI_TEST as select from ztable
+  association [0..*] to zi_other as BadName on BadName.id = ztable.id {
+  key field1
+}`;
+      const results = lintAbapSource(source, 'zi_test.ddls.asddls');
+      const nameErrors = results.filter((r) => r.rule === 'cds_association_name');
+      expect(nameErrors.length).toBeGreaterThan(0);
+      expect(nameErrors[0].message).toContain('underscore');
+    });
+
+    it('returns cds_field_order for associations before key fields', () => {
+      const source = `define view entity ZI_TEST as select from ztable
+  association [0..*] to zi_other as _Other on _Other.id = ztable.id {
+  _Other,
+  key field1
+}`;
+      const results = lintAbapSource(source, 'zi_test.ddls.asddls');
+      const orderErrors = results.filter((r) => r.rule === 'cds_field_order');
+      expect(orderErrors.length).toBeGreaterThan(0);
+    });
+
+    it('returns cds_legacy_view for view without entity keyword (Cloud version)', () => {
+      const source = `@AbapCatalog.sqlViewName: 'ZSQL_TEST'
+define view ZI_TEST as select from ztable {
+  key field1
+}`;
+      // cds_legacy_view only fires with Cloud version (legacy views not supported on BTP)
+      const cloudConfig = Config.getDefault(Version.Cloud);
+      const results = lintAbapSource(source, 'zi_test.ddls.asddls', cloudConfig);
+      const legacyErrors = results.filter((r) => r.rule === 'cds_legacy_view');
+      expect(legacyErrors.length).toBeGreaterThan(0);
+    });
+
+    it('returns no issues for BDEF source (abaplint does not parse BDEF)', () => {
+      const source = 'this is total garbage that abaplint silently ignores for BDEF';
+      const results = lintAbapSource(source, 'zi_test.bdef.asbdef');
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('CDS validateBeforeWrite', () => {
+    it('passes for valid CDS view', () => {
+      const source = `define view entity ZI_TEST as select from ztable {
+  key field1,
+  field2
+}`;
+      const result = validateBeforeWrite(source, 'zi_test.ddls.asddls');
+      expect(result.pass).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('fails for CDS view with syntax error', () => {
+      const source = `define view entity ZI_TEST as select from ztable {
+  key field1
+  field2
+}`;
+      const result = validateBeforeWrite(source, 'zi_test.ddls.asddls');
+      expect(result.pass).toBe(false);
+      expect(result.errors.some((e) => e.rule === 'cds_parser_error')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Enable CDS lint for DDLS objects** in the pre-write validation gate — abaplint's CDS parser catches syntax errors (missing commas, wrong keywords, invalid DDL) before writing to SAP, preventing failed server-side saves
- **Add 6 CDS rules** to cloud/onprem presets with appropriate severities: `cds_parser_error` (Error), `cds_legacy_view` (Error on BTP, Warning on-prem), `cds_association_name`/`cds_comment_style`/`cds_field_order` (Warning), `cds_naming` (disabled — VDM prefixes too opinionated)
- **Extend `detectFilename()`** for SRVD (`define service`), TABL (`define table`), DDLX (`annotate view/entity`), and BDEF projection syntax
- BDEF/SRVD/SRVB/DDLX/TABL correctly remain skipped for pre-write (abaplint doesn't parse those types)

## Context

The pre-write lint gate previously skipped all non-ABAP types with a comment claiming "abaplint cannot parse CDS DDL." This was incorrect for DDLS — abaplint has a full CDS parser and 6 CDS-specific rules. Verified via testing that abaplint correctly parses CDS views, projections, abstract entities, hierarchies, and table functions, but does NOT parse BDEF/SRVD/SRVB/DDLX (garbage passes silently).

## Test plan

- [x] 1662 unit tests pass (55 files)
- [x] TypeScript type check passes
- [x] Biome lint/format passes
- [x] New tests: 8 `detectFilename` cases, 4 CDS preset tests, 1 pre-write config test, 4 DDLS pre-write gate tests, 8 CDS lint tests (parser error, association name, field order, legacy view, BDEF bypass, validateBeforeWrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)