### PR TITLE
fix: wait for Docker image before publishing to MCP Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
   # This makes ARC-1 discoverable in VS Code (@mcp search), GitHub MCP Registry,
   # and other MCP clients that consume the registry API.
   publish-mcp-registry:
-    needs: [release-please, publish-npm]
+    needs: [release-please, publish-npm, publish-docker-merge]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Fix `publish-mcp-registry` job to wait for `publish-docker-merge` before running
- The MCP Registry validates that the OCI image (`ghcr.io/marianfoo/arc-1:<version>`) exists, so the Docker build+push must complete first

**Root cause:** `needs: [release-please, publish-npm]` was missing `publish-docker-merge`, so the registry publish ran before the Docker image was available.

**Fix:** `needs: [release-please, publish-npm, publish-docker-merge]`

## Test plan

- [ ] Next release triggers all three jobs in correct order: npm + docker (parallel) → mcp-registry (after both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)