### PR TITLE
feat: add proactive ADT discovery MIME negotiation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ src/
 ├── adt/
 │   ├── client.ts               # ADT client facade (all read operations)
 │   ├── http.ts                 # HTTP transport (undici/fetch, CSRF, cookies, sessions)
+│   ├── discovery.ts            # ADT discovery (endpoint MIME map fetch + resolve)
 │   ├── errors.ts               # Typed errors (AdtApiError, AdtSafetyError, AdtNetworkError)
 │   ├── safety.ts               # Safety system (read-only, op filter, pkg filter)
 │   ├── features.ts             # Feature detection (auto/on/off)
@@ -181,6 +182,7 @@ tests/
 | Add new tool type | `src/handlers/tools.ts`, `src/handlers/schemas.ts`, `src/handlers/intent.ts` |
 | Add/modify tool input schema | `src/handlers/schemas.ts`, `src/handlers/tools.ts` |
 | Add DDIC domain/data element write | `src/adt/ddic-xml.ts`, `src/adt/crud.ts`, `src/handlers/intent.ts` |
+| Modify ADT service discovery / MIME types | `src/adt/discovery.ts`, `src/adt/http.ts` |
 | Improve DDIC save diagnostics (T100/line hints) | `src/adt/errors.ts` (`extractDdicDiagnostics`, `formatDdicDiagnostics`), `src/handlers/intent.ts` (`enrichWithSapDetails`, `formatErrorForLLM`) |
 | Add inactive syntax-check support | `src/adt/devtools.ts` (`syntaxCheck` options.version), `src/handlers/intent.ts` (`tryPostSaveSyntaxCheck`) |
 | Add method-level surgery | `src/context/method-surgery.ts` |
@@ -257,6 +259,7 @@ ADT Client Method (adt/client.ts, crud.ts, devtools.ts, etc.)
   ▼
 HTTP Request (adt/http.ts)
   │
+  ├─ Proactive MIME negotiation via `/sap/bc/adt/discovery` map (startup-cached)
   ├─ CSRF token management (auto-fetch via HEAD, refresh on 403)
   ├─ Content negotiation fallback (one-retry on 406/415 with header mutation)
   ├─ Cookie/session management

--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -2,7 +2,7 @@
 
 A comprehensive comparison of all SAP ADT/MCP projects against ARC-1.
 
-_Last updated: 2026-04-14 (fr0ster v5.1.1: 316 tools; dassian-adt: 53 tools, OAuth, multi-system; SAP Joule Q2 2026 GA announced)_
+_Last updated: 2026-04-14 (FEAT-38 delivered in ARC-1; fr0ster v5.1.1: 316 tools; dassian-adt: 53 tools, OAuth, multi-system; SAP Joule Q2 2026 GA announced)_
 
 ## Legend
 - ✅ = Supported
@@ -189,7 +189,7 @@ _Last updated: 2026-04-14 (fr0ster v5.1.1: 316 tools; dassian-adt: 53 tools, OAu
 
 | Feature | ARC-1 | vibing-steampunk | mcp-abap-abap-adt-api | mcp-abap-adt (mario) | AWS Accelerator | fr0ster | btp-odata-mcp | dassian-adt / abap-mcpb | sapcli |
 |---------|-------|-----------------|----------------------|---------------------|-----------------|---------|---------------|------------------------|--------|
-| Feature auto-detection | ✅ (6 probes) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (ADT discovery/MIME) |
+| Feature auto-detection | ✅ (7 probes + ADT discovery/MIME) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (ADT discovery/MIME) |
 | Caching (SQLite) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | UI5/Fiori BSP | ❌ | ⚠️ (3 read-only; 4 write tools disabled — ADT filestore returns 405) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ (OData upload/download) |
 | abapGit/gCTS | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ | ✅ (full gCTS + checkout/checkin) |
@@ -297,7 +297,7 @@ The following items were incorrectly marked in the previous version and have sin
 
 **P0 — production blockers:**
 - ~~415/406 content-type auto-retry (SAP version compatibility)~~ — ✅ Implemented: one-retry negotiation fallback in `src/adt/http.ts`, endpoint-specific CTS media types, lock `corrNr` auto-propagation. fr0ster v4.5.0 added per-endpoint header caching (P3 optimization ARC-1 doesn't need yet). [Deep dive](fr0ster/evaluations/v4.5.0-release-deep-dive.md)
-- ADT service discovery / MIME negotiation (FEAT-38) — probe once at startup, eliminate 415/406 guesswork
+- ~~ADT service discovery / MIME negotiation (FEAT-38)~~ — ✅ completed 2026-04-14 (startup probe + proactive header selection + retry fallback)
 - ~~401 session timeout auto-retry (centralized gateway idle)~~ — ✅ Implemented: guard-protected single retry with session reset + re-auth in `src/adt/http.ts`. Handles both Basic Auth (on-prem) and Bearer token refresh (BTP).
 - ~~TLS/HTTPS for HTTP Streamable~~ — downgraded to P3: most deployments use reverse proxy (BTP gorouter, nginx, K8s Ingress)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ flowchart TB
         end
 
         subgraph TransportLayer["Transport Layer"]
-            HTTP[http.ts<br/>CSRF · Sessions · Auth]
+            HTTP[http.ts<br/>Discovery MIME · CSRF · Sessions · Auth]
         end
 
         subgraph Packages["Supporting Packages"]
@@ -99,6 +99,7 @@ sequenceDiagram
         Note over Safety,ADT: For SAPWrite create/batch_create:<br/>AFF metadata validation runs here<br/>(bundled JSON schemas from SAP/abap-file-formats)
         Safety->>ADT: Execute operation
         ADT->>HTTP: HTTP request
+        HTTP->>HTTP: Resolve Accept/Content-Type via discovery map
         HTTP->>HTTP: Add CSRF token + cookies
         HTTP->>SAP: HTTPS
         SAP-->>HTTP: Response
@@ -169,7 +170,8 @@ arc-1/
 │   │   └── tools.ts                # Tool definitions (names, descriptions, schemas)
 │   ├── adt/
 │   │   ├── client.ts               # ADT client facade (all read operations)
-│   │   ├── http.ts                 # HTTP transport (axios, CSRF, cookies, sessions)
+│   │   ├── http.ts                 # HTTP transport (undici/fetch, discovery MIME, CSRF, cookies, sessions)
+│   │   ├── discovery.ts            # ADT service discovery parser/lookup for MIME negotiation
 │   │   ├── errors.ts               # Typed error classes (AdtApiError, AdtSafetyError)
 │   │   ├── safety.ts               # Safety system (read-only, op filter, pkg filter)
 │   │   ├── features.ts             # Feature detection (auto/on/off)

--- a/docs/plans/completed/adt-service-discovery-mime-negotiation.md
+++ b/docs/plans/completed/adt-service-discovery-mime-negotiation.md
@@ -1,0 +1,269 @@
+# FEAT-38: ADT Service Discovery (MIME Negotiation)
+
+## Overview
+
+Implement proactive ADT service discovery by fetching and parsing `GET /sap/bc/adt/discovery` at startup. This Atom Publishing Protocol (AtomPub) service document (~300 KB, ~500 collections across ~115 workspaces) declares which MIME types each ADT endpoint accepts. By caching this mapping once at startup, ARC-1 can send correct `Accept` and `Content-Type` headers from the first request, eliminating 415/406 content negotiation retries entirely.
+
+sapcli has implemented this pattern since 2018 in `sap/adt/core.py` — it stores `Map<endpointPath, string[]>` of accepted MIME types and looks them up before every request. ARC-1 currently uses reactive retry logic (FEAT-08, already completed) as a fallback. FEAT-38 is the proactive complement: probe once, get it right for all subsequent requests.
+
+Key design decisions:
+1. **Fetch during startup probe** — run alongside existing `probeFeatures()` in `src/adt/features.ts`
+2. **Store on AdtHttpClient** — the HTTP layer owns header selection, not the caller
+3. **Graceful degradation** — if discovery fails (404, timeout), fall through to existing FEAT-08 retry logic
+4. **Cache in SQLite** — reuse existing cache infrastructure for persistence across restarts
+
+## Context
+
+### Current State
+
+- `src/adt/http.ts:397-476` has reactive 406/415 retry with `inferAcceptFromError()` — works but adds one round-trip per mismatch per session
+- `src/adt/features.ts` runs 8+ probes at startup using `GET` against SAP endpoints — discovery would be a new parallel probe
+- `parseSystemInfo()` in `src/adt/xml-parser.ts:265-294` already parses the Atom service document from `/sap/bc/adt/core/discovery` for `SAPRead SYSTEM` — but this endpoint returns an **empty** service document (no workspaces/collections)
+- The **full** discovery document lives at `/sap/bc/adt/discovery` (no `core` segment) and returns ~300 KB of XML with 115 workspaces and ~500 collections
+- Each `<app:collection href="/sap/bc/adt/...">` contains 0-N `<app:accept>` elements listing supported MIME types (e.g., `application/vnd.sap.adt.oo.classes.v4+xml`)
+- **Critical**: Both discovery endpoints return 406 if `Accept: application/xml` is sent — must use `Accept: application/atomsvc+xml` or `Accept: */*`
+- `src/server/server.ts:156-204` runs `runStartupProbe()` which calls `probeFeatures()` and stores results via `setCachedFeatures()`
+- sapcli pattern: lazy-init `_collection_types: dict[str, list[str]]` on `Connection`, populated on first property access, cached for session lifetime
+
+### Target State
+
+- At startup, `GET /sap/bc/adt/discovery` is fetched and parsed into a `Map<string, string[]>` mapping endpoint paths to their accepted MIME types
+- Before each HTTP request, `AdtHttpClient` looks up the endpoint path in the discovery map and uses the first matching MIME type as `Accept` header (if no explicit Accept was passed by the caller)
+- For write requests, the Content-Type is similarly looked up from the discovery map
+- If discovery is unavailable, behavior falls through to existing defaults + FEAT-08 retry
+- Discovery results are cached in SQLite (if caching enabled) with a TTL matching cache warmup patterns
+- Per-endpoint header caching from successful retries (the gap noted in `compare/fr0ster/evaluations/b059736-adt-clients-415-negotiation.md`) is also implemented, providing a learning fallback
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/discovery.ts` | **New** — fetch, parse, and cache the ADT discovery document |
+| `src/adt/http.ts` | Integrate discovery map into request method; apply MIME types before each request |
+| `src/adt/features.ts` | Add discovery fetch to startup probe (parallel with existing probes) |
+| `src/adt/types.ts` | Add `DiscoveryMap` type and extend `ResolvedFeatures` with discovery data |
+| `src/adt/xml-parser.ts` | Add `parseDiscoveryDocument()` parser for the AtomPub service document |
+| `src/server/server.ts` | Pass discovery results through startup probe to cached state |
+| `src/handlers/intent.ts` | Access cached discovery data for logging/diagnostics |
+| `tests/unit/adt/discovery.test.ts` | **New** — unit tests for discovery parsing and MIME resolution |
+| `tests/unit/adt/http.test.ts` | Tests for discovery-aware header selection |
+| `tests/fixtures/xml/discovery.xml` | **New** — XML fixture for ADT discovery response |
+
+### Design Principles
+
+1. **Proactive over reactive** — discover MIME types once at startup rather than retrying on every mismatch. FEAT-08 retry remains as defense-in-depth for endpoints not in the discovery map.
+2. **Callers still override** — when `client.getProgram()` passes explicit `Accept: text/plain`, discovery doesn't interfere. Discovery only fills in defaults when no explicit header is set.
+3. **Graceful degradation** — if `/sap/bc/adt/discovery` returns 404 (older systems), 403 (insufficient auth), or times out, the feature silently degrades. No startup failure.
+4. **Path normalization** — discovery hrefs may be relative or absolute; normalize to `/sap/bc/adt/...` paths for consistent lookup.
+5. **Prefer newest version** — when multiple MIME versions are listed (e.g., `v2+xml`, `v4+xml`), store them in order. Callers that don't specify a version get the list and can pick appropriately.
+6. **Minimal coupling** — discovery is owned by the HTTP layer. Higher-level code (client.ts, intent.ts) doesn't need to know about MIME types.
+
+## Development Approach
+
+Bottom-up: parser first, then HTTP integration, then startup wiring, then tests, then docs. Each task is self-contained and can be verified independently.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: XML parser for ADT discovery document
+
+**Files:**
+- Create: `tests/fixtures/xml/discovery.xml`
+- Modify: `src/adt/xml-parser.ts`
+- Create: `tests/unit/adt/discovery.test.ts` (parser tests only)
+
+Add a `parseDiscoveryDocument()` function that parses the AtomPub XML from `/sap/bc/adt/discovery` into a `Map<string, string[]>` mapping endpoint paths to accepted MIME types.
+
+The XML structure is an Atom Publishing Protocol service document:
+```xml
+<app:service xmlns:app="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom">
+  <app:workspace>
+    <atom:title>Workspace Name</atom:title>
+    <app:collection href="/sap/bc/adt/oo/classes">
+      <atom:title>Classes</atom:title>
+      <app:accept>application/vnd.sap.adt.oo.classes.v4+xml</app:accept>
+      <app:accept>text/html</app:accept>
+    </app:collection>
+  </app:workspace>
+</app:service>
+```
+
+- [ ] Create `tests/fixtures/xml/discovery.xml` with a representative subset of the real discovery response. Include at least: a workspace with multiple collections (e.g., `oo/classes`, `oo/interfaces`, `programs/programs`, `ddic/ddl/sources`, `ddic/domains`, `packages`, `cts/transportrequests`, `activation`, `abapunit/testruns`), each with realistic `<app:accept>` MIME types. Include edge cases: collection with no `<app:accept>` elements, collection with single accept, collection with multiple accepts (versioned: v1, v2, v4). Use real MIME types observed on SAP A4H 758 (e.g., `application/vnd.sap.adt.oo.classes.v4+xml`, `application/vnd.sap.adt.programs.programs.v2+xml`, `application/vnd.sap.adt.functions.groups.v3+xml`).
+- [ ] Add `parseDiscoveryDocument(xml: string): Map<string, string[]>` to `src/adt/xml-parser.ts`. Use the existing shared `parser` instance (fast-xml-parser v5 with `removeNSPrefix: true`). After namespace stripping, the structure is: `service > workspace[] > collection[]`. For each collection, extract `@_href` (the endpoint path) and all `accept` text content values. Normalize `href` to start with `/sap/bc/adt/` (strip any leading `https://host:port` prefix if present). Add `'collection'` and `'accept'` to the `isArray` list in the parser config so they're always arrays even for single elements. Add `'workspace'` to the isArray list too. Return a `Map<string, string[]>` where keys are normalized paths and values are arrays of MIME type strings.
+- [ ] Add unit tests (~10 tests) in `tests/unit/adt/discovery.test.ts`:
+  - Parses full fixture into correct map size
+  - Collection with multiple accepts returns all types in order
+  - Collection with no accepts is omitted from map (or has empty array)
+  - Collection with single accept returns single-element array
+  - Handles `href` with absolute URL (strips host prefix)
+  - Handles empty XML (returns empty map)
+  - Handles malformed XML (returns empty map, no throw)
+  - `workspace` and `collection` elements with missing attributes are skipped
+  - Real MIME types are preserved exactly (no lowercasing, no trimming)
+  - Duplicate hrefs: later collection overwrites earlier (or merges — pick one and document)
+- [ ] Run `npm test` — all tests must pass
+
+### Task 2: Discovery module — fetch, resolve, cache
+
+**Files:**
+- Create: `src/adt/discovery.ts`
+- Modify: `src/adt/types.ts`
+- Modify: `tests/unit/adt/discovery.test.ts` (add fetch/resolve tests)
+
+Create a new `src/adt/discovery.ts` module that handles fetching the discovery document and resolving MIME types for request paths.
+
+- [ ] Add types to `src/adt/types.ts`: add `discoveryMap?: Map<string, string[]>` to `ResolvedFeatures` interface. Also export a type alias `DiscoveryMap = Map<string, string[]>` for convenience.
+- [ ] Create `src/adt/discovery.ts` with the following exports:
+  - `fetchDiscoveryDocument(client: AdtHttpClient): Promise<Map<string, string[]>>` — calls `client.get('/sap/bc/adt/discovery', { Accept: 'application/atomsvc+xml' })`, parses with `parseDiscoveryDocument()`, returns the map. On any error (404, 406, timeout, parse failure), logs a warning via `logger` and returns an empty map. Must not throw — this is a startup probe.
+  - `resolveAcceptType(discoveryMap: Map<string, string[]>, path: string): string | undefined` — given a request path like `/sap/bc/adt/oo/classes/ZCL_FOO/source/main`, finds the best matching collection. The discovery map contains collection-level paths (e.g., `/sap/bc/adt/oo/classes`), so the resolution must match the request path as a prefix. Walk through map keys, find the longest prefix match. Return the first (highest-priority) MIME type from the matched collection, or `undefined` if no match.
+  - `resolveContentType(discoveryMap: Map<string, string[]>, path: string): string | undefined` — same logic as `resolveAcceptType()` but for Content-Type. In the discovery document, `<app:accept>` lists what the endpoint accepts for both read (Accept) and write (Content-Type). Return the first MIME type, or `undefined`.
+- [ ] Add unit tests (~12 tests) to `tests/unit/adt/discovery.test.ts`:
+  - `fetchDiscoveryDocument` success: mock fetch returns discovery XML fixture, verify map is populated correctly
+  - `fetchDiscoveryDocument` 404: returns empty map, no throw
+  - `fetchDiscoveryDocument` 406: returns empty map (graceful degradation)
+  - `fetchDiscoveryDocument` network error: returns empty map
+  - `resolveAcceptType` exact match: `/sap/bc/adt/oo/classes` matches collection `/sap/bc/adt/oo/classes`
+  - `resolveAcceptType` prefix match: `/sap/bc/adt/oo/classes/ZCL_FOO/source/main` matches `/sap/bc/adt/oo/classes`
+  - `resolveAcceptType` longest prefix: `/sap/bc/adt/oo/classes/ZCL_FOO` matches `/sap/bc/adt/oo/classes` not `/sap/bc/adt/oo`
+  - `resolveAcceptType` no match: returns undefined
+  - `resolveAcceptType` empty map: returns undefined
+  - `resolveContentType` returns first type from matched collection
+  - Multiple collections: each resolves independently
+  - Path with query params: strips query before matching
+- [ ] Run `npm test` — all tests must pass
+
+### Task 3: Integrate discovery into AdtHttpClient
+
+**Files:**
+- Modify: `src/adt/http.ts`
+- Modify: `tests/unit/adt/http.test.ts`
+
+Wire the discovery map into the HTTP client so that request headers are automatically set based on discovered MIME types.
+
+- [ ] Add a `discoveryMap` property to `AdtHttpClient` class in `src/adt/http.ts`: `private discoveryMap: Map<string, string[]> = new Map()`. Add a setter method: `setDiscoveryMap(map: Map<string, string[]>): void` to allow the startup probe to inject the discovery results.
+- [ ] Add a `private negotiatedHeaders: Map<string, { accept?: string; contentType?: string }> = new Map()` for per-endpoint header caching from successful retries (the gap vs. fr0ster noted in `compare/fr0ster/evaluations/b059736-adt-clients-415-negotiation.md`).
+- [ ] In the `request()` method (line ~161), after building the default `Accept: '*/*'` header and before merging `extraHeaders`, add discovery-based header resolution:
+  ```typescript
+  // Discovery-based MIME resolution: use discovered type if no explicit Accept/Content-Type
+  if (!extraHeaders?.Accept) {
+    // Check per-endpoint cache first (from previous successful retries)
+    const cached = this.negotiatedHeaders.get(path);
+    if (cached?.accept) {
+      headers.Accept = cached.accept;
+    } else {
+      const discovered = resolveAcceptType(this.discoveryMap, path);
+      if (discovered) headers.Accept = discovered;
+    }
+  }
+  if (contentType === undefined) {
+    const cached = this.negotiatedHeaders.get(path);
+    if (cached?.contentType) {
+      headers['Content-Type'] = cached.contentType;
+    }
+  }
+  ```
+  Import `resolveAcceptType` from `./discovery.js`.
+- [ ] In the 406/415 retry success path (around line ~460), after a successful retry with fallback headers, cache the winning headers:
+  ```typescript
+  // Cache successful negotiation for future requests to this endpoint
+  this.negotiatedHeaders.set(path, {
+    accept: fallbackHeaders.Accept !== headers.Accept ? fallbackHeaders.Accept : undefined,
+    contentType: fallbackHeaders['Content-Type'] !== (contentType ?? headers['Content-Type']) ? fallbackHeaders['Content-Type'] : undefined,
+  });
+  ```
+- [ ] In `withStatefulSession()` (line ~148), copy `discoveryMap` and `negotiatedHeaders` to the session client so stateful sessions also benefit from discovery.
+- [ ] Add unit tests (~8 tests) to `tests/unit/adt/http.test.ts`:
+  - Request with no explicit Accept uses discovered type
+  - Request with explicit Accept header is NOT overridden by discovery
+  - Request to unknown path falls through to default `*/*`
+  - Empty discovery map: default behavior unchanged
+  - After 406 retry succeeds, next request to same path uses cached header
+  - After 415 retry succeeds, next request to same path uses cached Content-Type
+  - Stateful session inherits discovery map
+  - Discovery + explicit extraHeaders: explicit wins
+- [ ] Run `npm test` — all tests must pass
+
+### Task 4: Wire discovery into startup probe
+
+**Files:**
+- Modify: `src/adt/features.ts`
+- Modify: `src/server/server.ts`
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/adt/features.test.ts`
+
+Connect discovery fetching to the existing startup probe flow so it runs in parallel with feature detection.
+
+- [ ] In `src/adt/features.ts`, modify `probeFeatures()` to also fetch the discovery document in parallel with existing probes. Import `fetchDiscoveryDocument` from `./discovery.js`. Add it to the `Promise.all()` at line ~94:
+  ```typescript
+  const [probeResults, systemDetection, textSearchResult, authProbeResult, discoveryResult] = await Promise.all([
+    // ... existing probes ...
+    fetchDiscoveryDocument(client),
+  ]);
+  ```
+  Store the result on `resolved.discoveryMap = discoveryResult`.
+- [ ] In `src/server/server.ts`, in `runStartupProbe()` (line ~156), after `setCachedFeatures(features)`, also set the discovery map on the shared client's HTTP instance. This requires passing the client reference or storing discovery separately. The cleanest approach: add `setCachedDiscovery(map: Map<string, string[]>)` to `intent.ts` (alongside `setCachedFeatures`), and in `server.ts` call it with `features.discoveryMap`. Then in `createServer()`, when creating per-request clients, inject the cached discovery map via `client.http.setDiscoveryMap(getCachedDiscovery())`.
+- [ ] In `src/handlers/intent.ts`, add module-level storage for the discovery map:
+  ```typescript
+  let cachedDiscovery: Map<string, string[]> = new Map();
+  export function setCachedDiscovery(map: Map<string, string[]>): void { cachedDiscovery = map; }
+  export function getCachedDiscovery(): Map<string, string[]> { return cachedDiscovery; }
+  ```
+- [ ] In `src/server/server.ts`, in the tool call handler where the AdtClient is created for each request, inject the discovery map: `client.http.setDiscoveryMap(getCachedDiscovery())`. This ensures every request (including per-user PP clients) benefits from the shared discovery data.
+- [ ] Add/update unit tests (~5 tests) in `tests/unit/adt/features.test.ts`:
+  - `probeFeatures` calls `fetchDiscoveryDocument` and includes result in resolved features
+  - Discovery failure doesn't block feature probing (other probes still succeed)
+  - `discoveryMap` is populated on `ResolvedFeatures` when discovery succeeds
+  - `discoveryMap` is empty (not undefined) when discovery fails
+- [ ] Run `npm test` — all tests must pass
+
+### Task 5: Integration and E2E testing
+
+**Files:**
+- Modify: `tests/integration/adt.integration.test.ts` (if integration tests exist for this area)
+- Modify: `tests/e2e/smoke.e2e.test.ts` (verify discovery doesn't break existing smoke tests)
+
+Verify the feature works end-to-end on a real SAP system.
+
+- [ ] Add an integration test in `tests/integration/adt.integration.test.ts` that calls `fetchDiscoveryDocument()` against the live test system and verifies: (a) the map is non-empty, (b) key endpoints like `/sap/bc/adt/oo/classes` and `/sap/bc/adt/programs/programs` are present, (c) MIME types follow the expected `application/vnd.sap.adt.*` pattern. Use `requireOrSkip()` for credentials check.
+- [ ] Add an integration test that verifies `resolveAcceptType()` returns sensible types for known endpoints (classes, programs, DDL sources, transports).
+- [ ] Verify existing E2E smoke tests still pass — discovery should be transparent. Run `npm run test:e2e` against a running MCP server with the new code. All existing SAPRead operations (PROG, CLAS, TABL, STRU, DOMA, DTEL, SYSTEM) should work identically.
+- [ ] If any E2E test fails due to MIME type changes (unlikely but possible), investigate whether the discovered type is correct and the previous hardcoded type was wrong, or vice versa. Fix accordingly.
+- [ ] Run `npm test` — all unit tests must pass
+
+### Task 6: Documentation and roadmap updates
+
+**Files:**
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+- Modify: `docs/tools.md` (if it mentions content negotiation or MIME handling)
+- Modify: `docs/architecture.md` (if it describes the request flow)
+
+Update all project documentation to reflect the new discovery feature.
+
+- [ ] In `docs/roadmap.md`:
+  - Strike through FEAT-38 in the priority table (line ~81): `| ~~38~~ | ~~FEAT-38~~ | ~~ADT Service Discovery (MIME Negotiation)~~ | ~~P0~~ | ~~S~~ | ~~Completed YYYY-MM-DD~~ |`
+  - Update the Phase A.5 section (line ~166) to mark as completed
+  - Add entry to the Completed Features section with today's date
+  - Update the FEAT-38 detail section (line ~994) status to "Completed"
+- [ ] In `compare/00-feature-matrix.md`:
+  - Find the FEAT-38 / discovery row and mark ARC-1 as having this capability (change from open to completed)
+  - Update "Last Updated" date
+- [ ] In `CLAUDE.md`:
+  - Add `src/adt/discovery.ts` to the codebase structure tree under `src/adt/`
+  - Add a row to the "Key Files for Common Tasks" table: `| Modify ADT service discovery / MIME types | src/adt/discovery.ts, src/adt/http.ts |`
+  - Update the "Architecture: Request Flow" section to mention discovery-based header selection
+- [ ] Check `docs/architecture.md` and `docs/tools.md` — if they describe content negotiation or the 415/406 retry, add a note about proactive discovery
+- [ ] Run `npm run lint` — no errors
+
+### Task 7: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Verify discovery module loads correctly: check that `import { fetchDiscoveryDocument, resolveAcceptType } from './discovery.js'` works without circular dependency issues
+- [ ] Review that the 406/415 retry logic in `http.ts` still works as fallback when discovery map is empty (regression check)
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -78,7 +78,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | 35 | OPS-02 | Health Check Enhancements | P2 | XS | Ops |
 | 36 | DOC-03 | SAP Community Blog Post | P2 | S | Docs |
 | 37 | FEAT-37 | DCL (Access Control) Read/Write | P1 | S | Features |
-| 38 | FEAT-38 | ADT Service Discovery (MIME Negotiation) | P0 | S | Features |
+| ~~38~~ | ~~FEAT-38~~ | ~~ADT Service Discovery (MIME Negotiation)~~ | ~~P0~~ | ~~S~~ | ~~Completed 2026-04-14~~ |
 | ~~39~~ | ~~FEAT-39~~ | ~~Transport Enhancements (delete, reassign, types)~~ | ~~P2~~ | ~~S~~ | ~~Completed (K/W/T types; S/R deferred)~~ |
 | ~~40~~ | ~~FEAT-40~~ | ~~FLP Launchpad Management (OData)~~ | ~~P1~~ | ~~M~~ | ~~Completed 2026-04-12~~ |
 | 41 | FEAT-41 | ABAP Unit Test Coverage (statement-level) | P2 | S | Features |
@@ -98,6 +98,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 
 | ID | Feature | Completed | Category |
 |----|---------|-----------|----------|
+| FEAT-38 | ADT Service Discovery (MIME Negotiation) | 2026-04-14 | Features |
 | FEAT-12 | Fix Proposals / Auto-Fix from ATC | 2026-04-14 | Features |
 | FEAT-47 | MSAG (Message Class) Read/Write | 2026-04-14 | Features |
 | FEAT-45 | DEVC (Package) Create | 2026-04-14 | Features |
@@ -163,7 +164,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 4. ~~**FEAT-15** Namespace URL Encoding Audit (XS)~~ — **completed 2026-04-12** (audit confirmed `encodeURIComponent` consistency; XML attribute escaping hardened in `devtools.ts`)
 
 ### Phase A.5: Proactive Compatibility (P0)
-6. **FEAT-38** ADT Service Discovery / MIME Negotiation (S) — probe `/sap/bc/adt/discovery` once at startup to learn supported MIME types per endpoint; eliminates 415/406 retries entirely. sapcli has had this since 2018. Supersedes reactive FEAT-08 approach.
+6. ~~**FEAT-38** ADT Service Discovery / MIME Negotiation (S)~~ — **completed 2026-04-14** (startup probe fetches `/sap/bc/adt/discovery`, request-time MIME selection uses cached map, 406/415 retry remains fallback)
 
 ### Phase B: Core Value Features (P1)
 7. **FEAT-37** DCL (Access Control) Read/Write (S) — missing CDS access control objects; sapcli, VSP have this. Critical for RAP development workflow.
@@ -998,7 +999,7 @@ SAP_RATE_LIMIT_BURST=10  # burst allowance
 | **Effort** | S (1-2 days) |
 | **Risk** | Low |
 | **Usefulness** | Very High — eliminates 415/406 content-type errors proactively |
-| **Status** | Not started |
+| **Status** | Completed (2026-04-14) |
 | **Source** | [sapcli comparison](../compare/09-sapcli.md), sapcli `sap/adt/discovery.py` |
 
 **What:** Call `GET /sap/bc/adt/discovery` at startup to learn which MIME type versions each ADT endpoint supports. Cache the accepted Content-Type/Accept values per endpoint. Use correct headers from the start instead of guessing and retrying on 415/406.
@@ -1007,13 +1008,13 @@ SAP_RATE_LIMIT_BURST=10  # burst allowance
 
 **Why this is better than FEAT-08 alone:** FEAT-08 retries after failure (1 extra round-trip per mismatch). FEAT-38 probes once at startup and gets it right the first time for all subsequent requests. Combined approach: discovery at startup + FEAT-08 retry as fallback.
 
-**Implementation:**
-- Add `fetchDiscovery()` to `src/adt/http.ts` — parses `/sap/bc/adt/discovery` XML into a `Map<endpointPath, { accept: string[], contentType: string[] }>`
-- Call during `AdtHttpClient` initialization (alongside CSRF fetch, which already hits `/sap/bc/adt/core/discovery`)
-- Store in `AdtHttpClient` instance; cache in SQLite if caching enabled
-- Before each request, look up endpoint in discovery map; use correct MIME types
-- Fallback to current behavior if discovery fails or endpoint not in map
-- Add to `src/adt/features.ts` as a feature probe
+**Implementation (2026-04-14):**
+- Added `src/adt/discovery.ts` with `fetchDiscoveryDocument()`, `resolveAcceptType()`, and `resolveContentType()`
+- Added `parseDiscoveryDocument()` to `src/adt/xml-parser.ts` and discovery fixture/tests
+- `probeFeatures()` now fetches `/sap/bc/adt/discovery` in parallel and stores `discoveryMap` on `ResolvedFeatures`
+- `AdtHttpClient` now uses startup-cached discovery map for proactive `Accept`/`Content-Type` defaults
+- 406/415 retry logic now caches successful negotiated headers per endpoint as a learning fallback
+- Startup wiring injects cached discovery into all request clients (shared and per-user PP)
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -367,7 +367,7 @@ Manage CTS transport requests (SE09/SE10 equivalent): list, get details, create 
 
 **List defaults:** Without parameters, `list` returns modifiable transports (status D) for the current SAP user, across all transport types (Workbench, Customizing, Transport of Copies). Query params follow sapcli's `workbench_params()` pattern (`requestType=KWT`, `requestStatus`).
 
-**Protocol compatibility:** ARC-1 uses endpoint-specific CTS media types and includes a one-retry content negotiation fallback (406/415) for SAP version variance.
+**Protocol compatibility:** ARC-1 uses startup ADT service discovery (`/sap/bc/adt/discovery`) to proactively select endpoint MIME types, with endpoint-specific CTS media types and a one-retry 406/415 fallback as defense-in-depth.
 
 **Note:** Most actions require `--enable-transports`. The `check` action works without it (read-only).
 

--- a/src/adt/discovery.ts
+++ b/src/adt/discovery.ts
@@ -1,0 +1,96 @@
+import { logger } from '../server/logger.js';
+import { AdtApiError } from './errors.js';
+import type { AdtHttpClient } from './http.js';
+import type { DiscoveryMap } from './types.js';
+import { parseDiscoveryDocument } from './xml-parser.js';
+
+/**
+ * Fetch ADT discovery service document.
+ *
+ * Graceful degradation: never throws, always returns a map.
+ */
+export async function fetchDiscoveryDocument(client: AdtHttpClient): Promise<DiscoveryMap> {
+  try {
+    const resp = await client.get('/sap/bc/adt/discovery', { Accept: 'application/atomsvc+xml' });
+    return parseDiscoveryDocument(resp.body);
+  } catch (err) {
+    const reason =
+      err instanceof AdtApiError
+        ? `HTTP ${err.statusCode}`
+        : err instanceof Error
+          ? err.message
+          : String(err ?? 'unknown');
+    logger.warn(`ADT discovery unavailable (${reason}) — continuing without proactive MIME negotiation`);
+    return new Map();
+  }
+}
+
+/** Resolve best matching Accept type for a request path. */
+export function resolveAcceptType(discoveryMap: DiscoveryMap, path: string): string | undefined {
+  const types = resolveTypesForPath(discoveryMap, path);
+  return types?.[0];
+}
+
+/** Resolve best matching Content-Type for a request path. */
+export function resolveContentType(discoveryMap: DiscoveryMap, path: string): string | undefined {
+  const types = resolveTypesForPath(discoveryMap, path);
+  return types?.[0];
+}
+
+function resolveTypesForPath(discoveryMap: DiscoveryMap, rawPath: string): string[] | undefined {
+  if (discoveryMap.size === 0) return undefined;
+
+  const path = normalizeRequestPath(rawPath);
+  if (!path) return undefined;
+
+  let matchedPath: string | undefined;
+  for (const key of discoveryMap.keys()) {
+    if (!isPrefixMatch(key, path)) continue;
+    if (!matchedPath || key.length > matchedPath.length) {
+      matchedPath = key;
+    }
+  }
+
+  return matchedPath ? discoveryMap.get(matchedPath) : undefined;
+}
+
+function normalizeRequestPath(rawPath: string): string {
+  if (!rawPath) return '';
+
+  let path = rawPath.trim();
+  if (!path) return '';
+
+  if (/^https?:\/\//i.test(path)) {
+    try {
+      const url = new URL(path);
+      path = url.pathname;
+    } catch {
+      return '';
+    }
+  }
+
+  const hashIdx = path.indexOf('#');
+  if (hashIdx >= 0) {
+    path = path.slice(0, hashIdx);
+  }
+
+  const queryIdx = path.indexOf('?');
+  if (queryIdx >= 0) {
+    path = path.slice(0, queryIdx);
+  }
+
+  if (!path.startsWith('/')) {
+    path = `/${path}`;
+  }
+
+  if (path.length > 1 && path.endsWith('/')) {
+    path = path.slice(0, -1);
+  }
+
+  return path;
+}
+
+function isPrefixMatch(prefix: string, path: string): boolean {
+  if (path === prefix) return true;
+  return path.startsWith(`${prefix}/`);
+}

--- a/src/adt/discovery.ts
+++ b/src/adt/discovery.ts
@@ -45,7 +45,7 @@ function resolveTypesForPath(discoveryMap: DiscoveryMap, rawPath: string): strin
 
   let matchedPath: string | undefined;
   for (const key of discoveryMap.keys()) {
-    if (!isPrefixMatch(key, path)) continue;
+    if (!isShallowMatch(key, path)) continue;
     if (!matchedPath || key.length > matchedPath.length) {
       matchedPath = key;
     }
@@ -90,7 +90,24 @@ function normalizeRequestPath(rawPath: string): string {
   return path;
 }
 
-function isPrefixMatch(prefix: string, path: string): boolean {
-  if (path === prefix) return true;
-  return path.startsWith(`${prefix}/`);
+/**
+ * Match if path is the collection itself or at most one segment deeper (object name).
+ *
+ * Discovery MIME types describe the collection endpoint (e.g., /sap/bc/adt/oo/classes).
+ * They apply to the collection and to direct child resources (object metadata reads/writes),
+ * but NOT to deeper sub-resources like /source/main or /includes/testclasses — those
+ * require different Accept headers (typically text/plain or *\/*).
+ *
+ * Examples for collection "/sap/bc/adt/oo/classes":
+ *   ✓ /sap/bc/adt/oo/classes                        (exact)
+ *   ✓ /sap/bc/adt/oo/classes/ZCL_FOO                (1 segment deeper — metadata)
+ *   ✗ /sap/bc/adt/oo/classes/ZCL_FOO/source/main    (3 segments deeper — source code)
+ *   ✗ /sap/bc/adt/oo/classes/ZCL_FOO/includes/defs  (3 segments deeper — includes)
+ */
+function isShallowMatch(collectionPath: string, requestPath: string): boolean {
+  if (requestPath === collectionPath) return true;
+  if (!requestPath.startsWith(`${collectionPath}/`)) return false;
+  // Check depth: only allow one additional segment after the collection path
+  const remainder = requestPath.slice(collectionPath.length + 1);
+  return !remainder.includes('/');
 }

--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -19,6 +19,7 @@
 
 import { Version } from '@abaplint/core';
 import type { FeatureConfig, FeatureMode } from './config.js';
+import { fetchDiscoveryDocument } from './discovery.js';
 import { AdtApiError } from './errors.js';
 import type { AdtHttpClient } from './http.js';
 import type { AuthProbeResult, FeatureStatus, ResolvedFeatures, SystemType } from './types.js';
@@ -90,8 +91,8 @@ export async function probeFeatures(
   // Only probe features that are in "auto" mode
   const probesToRun = PROBES.filter((p) => modeMap[p.id] === 'auto');
 
-  // Run feature probes + system detection + text search probe + auth probe in parallel
-  const [probeResults, systemDetection, textSearchResult, authProbeResult] = await Promise.all([
+  // Run feature probes + system detection + text search probe + auth probe + discovery in parallel
+  const [probeResults, systemDetection, textSearchResult, authProbeResult, discoveryMap] = await Promise.all([
     Promise.all(
       probesToRun.map(async (probe) => {
         try {
@@ -114,6 +115,7 @@ export async function probeFeatures(
     detectSystemFromComponents(client),
     probeTextSearch(client),
     probeAuthorization(client),
+    fetchDiscoveryDocument(client),
   ]);
 
   // Build result map
@@ -142,6 +144,7 @@ export async function probeFeatures(
   }
   resolved.textSearch = textSearchResult;
   resolved.authProbe = authProbeResult;
+  resolved.discoveryMap = discoveryMap;
   return resolved;
 }
 

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -30,6 +30,7 @@
 import { Agent, Client, type Dispatcher, fetch as undiciFetch } from 'undici';
 import { logger } from '../server/logger.js';
 import type { BTPProxyConfig } from './btp.js';
+import { resolveAcceptType, resolveContentType } from './discovery.js';
 import { AdtApiError, AdtNetworkError } from './errors.js';
 
 /** Session type for ADT requests */
@@ -79,6 +80,8 @@ export interface AdtResponse {
  * Not a generic HTTP client: it's purpose-built for SAP ADT REST API conventions.
  */
 export class AdtHttpClient {
+  private discoveryMap: Map<string, string[]> = new Map();
+  private negotiatedHeaders: Map<string, { accept?: string; contentType?: string }> = new Map();
   private csrfToken = '';
   private dispatcher: Dispatcher | undefined;
   private config: AdtHttpConfig;
@@ -106,6 +109,11 @@ export class AdtHttpClient {
     if (!config.btpProxy && config.insecure) {
       this.dispatcher = new Agent({ connect: { rejectUnauthorized: false } });
     }
+  }
+
+  /** Inject startup discovery data used for proactive MIME negotiation. */
+  setDiscoveryMap(map: Map<string, string[]>): void {
+    this.discoveryMap = map;
   }
 
   /** GET request */
@@ -154,6 +162,8 @@ export class AdtHttpClient {
     // Share CSRF token and cookies so we don't need to re-fetch
     sessionClient.csrfToken = this.csrfToken;
     sessionClient.cookieJar = new Map(this.cookieJar);
+    sessionClient.discoveryMap = this.discoveryMap;
+    sessionClient.negotiatedHeaders = new Map(this.negotiatedHeaders);
     return fn(sessionClient);
   }
 
@@ -170,10 +180,34 @@ export class AdtHttpClient {
       await this.fetchCsrfToken();
     }
 
-    const headers: Record<string, string> = {
-      Accept: '*/*',
-      ...extraHeaders,
-    };
+    const headers: Record<string, string> = { Accept: '*/*' };
+    const negotiationKey = this.normalizeHeaderCacheKey(path);
+
+    if (!extraHeaders?.Accept) {
+      const cached = this.resolveNegotiatedHeaders(negotiationKey);
+      if (cached?.accept) {
+        headers.Accept = cached.accept;
+      } else {
+        const discoveredAccept = resolveAcceptType(this.discoveryMap, path);
+        if (discoveredAccept) {
+          headers.Accept = discoveredAccept;
+        }
+      }
+    }
+
+    if (isModifyingMethod(method) && contentType === undefined && !extraHeaders?.['Content-Type']) {
+      const cached = this.resolveNegotiatedHeaders(negotiationKey);
+      if (cached?.contentType) {
+        headers['Content-Type'] = cached.contentType;
+      } else {
+        const discoveredContentType = resolveContentType(this.discoveryMap, path);
+        if (discoveredContentType) {
+          headers['Content-Type'] = discoveredContentType;
+        }
+      }
+    }
+
+    Object.assign(headers, extraHeaders);
 
     if (isModifyingMethod(method)) {
       headers['X-CSRF-Token'] = this.csrfToken;
@@ -436,6 +470,9 @@ export class AdtHttpClient {
         }
 
         if (headersChanged) {
+          const retryAccept = fallbackHeaders.Accept;
+          const retryContentType = fallbackHeaders['Content-Type'];
+
           logger.emitAudit({
             timestamp: new Date().toISOString(),
             level: 'warn',
@@ -458,6 +495,18 @@ export class AdtHttpClient {
           }
 
           const retryResult = this.handleResponse(retryResp.status, retryResp.headers, retryBody, path);
+
+          const currentContentType = contentType ?? headers['Content-Type'];
+          const negotiated: { accept?: string; contentType?: string } = {};
+          if (retryAccept !== headers.Accept) {
+            negotiated.accept = retryAccept;
+          }
+          if (retryContentType !== currentContentType) {
+            negotiated.contentType = retryContentType;
+          }
+          if (negotiated.accept || negotiated.contentType) {
+            this.negotiatedHeaders.set(negotiationKey, negotiated);
+          }
 
           logger.emitAudit({
             timestamp: new Date().toISOString(),
@@ -514,6 +563,30 @@ export class AdtHttpClient {
       const message = err instanceof Error ? err.message : String(err);
       throw new AdtNetworkError(message, err instanceof Error ? err : undefined);
     }
+  }
+
+  private normalizeHeaderCacheKey(path: string): string {
+    const withoutHash = path.split('#')[0] ?? path;
+    const withoutQuery = withoutHash.split('?')[0] ?? withoutHash;
+    if (!withoutQuery) return '/';
+    return withoutQuery.endsWith('/') && withoutQuery.length > 1 ? withoutQuery.slice(0, -1) : withoutQuery;
+  }
+
+  private resolveNegotiatedHeaders(path: string): { accept?: string; contentType?: string } | undefined {
+    let matched: { accept?: string; contentType?: string } | undefined;
+    let matchedPathLength = -1;
+
+    for (const [prefix, headers] of this.negotiatedHeaders.entries()) {
+      const isExact = path === prefix;
+      const isChild = path.startsWith(`${prefix}/`);
+      if (!isExact && !isChild) continue;
+      if (prefix.length > matchedPathLength) {
+        matched = headers;
+        matchedPathLength = prefix.length;
+      }
+    }
+
+    return matched;
   }
 
   /** Handle response: throw on error status, return normalized response */

--- a/src/adt/types.ts
+++ b/src/adt/types.ts
@@ -35,6 +35,9 @@ export interface FeatureStatus {
 /** SAP system type: BTP ABAP Environment or on-premise */
 export type SystemType = 'btp' | 'onprem';
 
+/** ADT discovery map: endpoint path -> accepted MIME types */
+export type DiscoveryMap = Map<string, string[]>;
+
 /** Resolved features after probing */
 export interface ResolvedFeatures {
   hana: FeatureStatus;
@@ -53,6 +56,8 @@ export interface ResolvedFeatures {
   textSearch?: { available: boolean; reason?: string };
   /** Authorization probe results — search and transport access */
   authProbe?: AuthProbeResult;
+  /** ADT discovery MIME map used by HTTP content negotiation */
+  discoveryMap?: DiscoveryMap;
 }
 
 /** Authorization probe result from startup probing */

--- a/src/adt/xml-parser.ts
+++ b/src/adt/xml-parser.ts
@@ -80,6 +80,9 @@ const parser = new XMLParser({
       'access',
       'successor',
       'messages',
+      'workspace',
+      'collection',
+      'accept',
     ].includes(name);
   },
   parseAttributeValue: false, // Keep attributes as strings
@@ -291,6 +294,91 @@ export function parseSystemInfo(
   }
 
   return { user: username ?? '', collections };
+}
+
+/**
+ * Parse ADT discovery service document into endpoint -> accepted MIME types.
+ *
+ * The service document is AtomPub:
+ * service > workspace[] > collection[] > accept[]
+ */
+export function parseDiscoveryDocument(xml: string): Map<string, string[]> {
+  if (!xml?.trim()) return new Map();
+
+  try {
+    const parsed = parseXml(xml);
+    const service = (parsed.service ?? {}) as Record<string, unknown>;
+    const workspaces = Array.isArray(service.workspace)
+      ? service.workspace
+      : service.workspace
+        ? [service.workspace]
+        : [];
+
+    const discoveryMap = new Map<string, string[]>();
+
+    for (const ws of workspaces as Array<Record<string, unknown>>) {
+      const collections = Array.isArray(ws.collection) ? ws.collection : ws.collection ? [ws.collection] : [];
+      for (const collection of collections as Array<Record<string, unknown>>) {
+        const href = String(collection['@_href'] ?? '');
+        const normalizedPath = normalizeDiscoveryPath(href);
+        if (!normalizedPath) continue;
+
+        const acceptsRaw = Array.isArray(collection.accept)
+          ? collection.accept
+          : collection.accept != null
+            ? [collection.accept]
+            : [];
+
+        const accepts = acceptsRaw.map((value) => String(value)).filter((value) => value.length > 0);
+
+        // Collections without <app:accept> are not useful for negotiation.
+        if (accepts.length === 0) continue;
+
+        // If href is duplicated, keep the last definition from the document.
+        discoveryMap.set(normalizedPath, accepts);
+      }
+    }
+
+    return discoveryMap;
+  } catch {
+    return new Map();
+  }
+}
+
+function normalizeDiscoveryPath(href: string): string | undefined {
+  if (!href) return undefined;
+
+  let path = href.trim();
+  if (!path) return undefined;
+
+  // Absolute URL -> extract pathname.
+  if (/^https?:\/\//i.test(path)) {
+    try {
+      path = new URL(path).pathname;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // Normalize leading slash.
+  if (!path.startsWith('/')) {
+    path = `/${path}`;
+  }
+
+  // Keep only ADT paths.
+  const adtPrefix = '/sap/bc/adt/';
+  if (!path.startsWith(adtPrefix)) {
+    const idx = path.indexOf(adtPrefix);
+    if (idx < 0) return undefined;
+    path = path.slice(idx);
+  }
+
+  // Remove trailing slash for stable map keys.
+  if (path.length > adtPrefix.length && path.endsWith('/')) {
+    path = path.slice(0, -1);
+  }
+
+  return path;
 }
 
 /**

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -2995,6 +2995,7 @@ async function handleSAPContext(
 
 /** Cached feature status — populated on first probe */
 let cachedFeatures: ResolvedFeatures | undefined;
+let cachedDiscovery: Map<string, string[]> = new Map();
 
 async function handleSAPManage(
   client: AdtClient,
@@ -3296,6 +3297,7 @@ async function handleSAPManage(
 /** Reset cached features (for testing) */
 export function resetCachedFeatures(): void {
   cachedFeatures = undefined;
+  cachedDiscovery = new Map();
 }
 
 /** Set cached features directly (for testing BTP mode, etc.) */
@@ -3306,4 +3308,14 @@ export function setCachedFeatures(features: ResolvedFeatures | undefined): void 
 /** Get cached features (for tool definition adaptation) */
 export function getCachedFeatures(): ResolvedFeatures | undefined {
   return cachedFeatures;
+}
+
+/** Set startup-cached ADT discovery MIME map. */
+export function setCachedDiscovery(map: Map<string, string[]>): void {
+  cachedDiscovery = map;
+}
+
+/** Get startup-cached ADT discovery MIME map. */
+export function getCachedDiscovery(): Map<string, string[]> {
+  return cachedDiscovery;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -18,9 +18,11 @@ import type { Cache } from '../cache/cache.js';
 import { CachingLayer } from '../cache/caching-layer.js';
 import { MemoryCache } from '../cache/memory.js';
 import {
+  getCachedDiscovery,
   getCachedFeatures,
   handleToolCall,
   hasRequiredScope,
+  setCachedDiscovery,
   setCachedFeatures,
   TOOL_SCOPES,
 } from '../handlers/intent.js';
@@ -197,7 +199,9 @@ export function runStartupProbe(
         }
       }
       setCachedFeatures(features);
+      setCachedDiscovery(features.discoveryMap ?? new Map());
     } catch {
+      setCachedDiscovery(new Map());
       // Probe failed (e.g., SAP system unreachable) — continue with default tool set
     }
   })();
@@ -311,6 +315,9 @@ export function createServer(
       } as Record<string, unknown>;
     }
 
+    // Inject startup discovery MIME map (shared for default and per-user clients).
+    client.http.setDiscoveryMap(getCachedDiscovery());
+
     // Per-request safety: merge server ceiling with JWT scopes.
     // Scopes can only restrict further, never expand beyond server config.
     let effectiveClient = client;
@@ -318,6 +325,7 @@ export function createServer(
       const effectiveSafety = deriveUserSafety(client.safety, extra.authInfo.scopes);
       effectiveClient = client.withSafety(effectiveSafety);
     }
+    effectiveClient.http.setDiscoveryMap(getCachedDiscovery());
 
     const result = await handleToolCall(
       effectiveClient,

--- a/tests/fixtures/xml/discovery.xml
+++ b/tests/fixtures/xml/discovery.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<app:service xmlns:app="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom">
+  <app:workspace>
+    <atom:title>ABAP Development</atom:title>
+    <app:collection href="/sap/bc/adt/oo/classes">
+      <atom:title>Classes</atom:title>
+      <app:accept>application/vnd.sap.adt.oo.classes.v2+xml</app:accept>
+      <app:accept>application/vnd.sap.adt.oo.classes.v4+xml</app:accept>
+      <app:accept>text/html</app:accept>
+    </app:collection>
+    <app:collection href="https://a4h.example.local:443/sap/bc/adt/oo/interfaces">
+      <atom:title>Interfaces</atom:title>
+      <app:accept>application/vnd.sap.adt.oo.interfaces.v2+xml</app:accept>
+    </app:collection>
+    <app:collection href="/sap/bc/adt/programs/programs">
+      <atom:title>Programs</atom:title>
+      <app:accept>application/vnd.sap.adt.programs.programs.v2+xml</app:accept>
+    </app:collection>
+    <app:collection href="/sap/bc/adt/ddic/ddl/sources">
+      <atom:title>CDS Sources</atom:title>
+      <app:accept>application/vnd.sap.adt.ddic.ddl.sources.v2+xml</app:accept>
+      <app:accept>application/*</app:accept>
+    </app:collection>
+    <app:collection href="/sap/bc/adt/ddic/domains">
+      <atom:title>Domains</atom:title>
+      <app:accept>application/vnd.sap.adt.domains.v2+xml</app:accept>
+    </app:collection>
+    <app:collection href="/sap/bc/adt/packages">
+      <atom:title>Packages</atom:title>
+      <app:accept>application/vnd.sap.adt.packages.v2+xml</app:accept>
+    </app:collection>
+    <app:collection href="/sap/bc/adt/functions/groups">
+      <atom:title>Function Groups</atom:title>
+      <app:accept>application/vnd.sap.adt.functions.groups.v1+xml</app:accept>
+      <app:accept>application/vnd.sap.adt.functions.groups.v3+xml</app:accept>
+    </app:collection>
+    <app:collection href="/sap/bc/adt/activation">
+      <atom:title>Activation</atom:title>
+    </app:collection>
+  </app:workspace>
+  <app:workspace>
+    <atom:title>Workflow</atom:title>
+    <app:collection href="/sap/bc/adt/cts/transportrequests">
+      <atom:title>Transport Requests</atom:title>
+      <app:accept>application/vnd.sap.adt.transportrequests.v2+xml</app:accept>
+      <app:accept>application/xml</app:accept>
+    </app:collection>
+    <app:collection href="/sap/bc/adt/abapunit/testruns">
+      <atom:title>ABAP Unit</atom:title>
+      <app:accept>application/vnd.sap.adt.abapunit.testruns.v2+xml</app:accept>
+    </app:collection>
+    <app:collection>
+      <atom:title>Missing href</atom:title>
+      <app:accept>application/vnd.sap.adt.ignored.v1+xml</app:accept>
+    </app:collection>
+    <app:collection href="/sap/bc/adt/programs/programs">
+      <atom:title>Programs override</atom:title>
+      <app:accept>application/vnd.sap.adt.programs.programs.v2+xml</app:accept>
+      <app:accept>text/plain</app:accept>
+    </app:collection>
+  </app:workspace>
+</app:service>

--- a/tests/integration/adt.integration.test.ts
+++ b/tests/integration/adt.integration.test.ts
@@ -10,6 +10,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { AdtClient } from '../../src/adt/client.js';
 import { getDump, listDumps, listTraces } from '../../src/adt/diagnostics.js';
+import { fetchDiscoveryDocument, resolveAcceptType } from '../../src/adt/discovery.js';
 import { AdtApiError } from '../../src/adt/errors.js';
 import {
   createCatalog,
@@ -60,6 +61,47 @@ describe('ADT Integration Tests', () => {
         expect(comp.release).toBeTruthy();
         // description may be empty for some components
         expect(typeof comp.description).toBe('string');
+      }
+    });
+  });
+
+  // ─── ADT Discovery (MIME Negotiation) ─────────────────────────
+
+  describe('discovery MIME negotiation', () => {
+    it('fetches discovery map with key ADT endpoints and MIME types', async (ctx) => {
+      const discoveryMap = await fetchDiscoveryDocument(client.http);
+      const nonEmptyMap = discoveryMap.size > 0 ? discoveryMap : undefined;
+      requireOrSkip(ctx, nonEmptyMap, SkipReason.BACKEND_UNSUPPORTED);
+
+      expect(nonEmptyMap.has('/sap/bc/adt/oo/classes')).toBe(true);
+      expect(nonEmptyMap.has('/sap/bc/adt/programs/programs')).toBe(true);
+
+      const classesTypes = nonEmptyMap.get('/sap/bc/adt/oo/classes') ?? [];
+      expect(classesTypes.length).toBeGreaterThan(0);
+      expect(classesTypes[0]).toMatch(/^application\/vnd\.sap\.adt\./);
+    });
+
+    it('resolveAcceptType returns sensible MIME type for known endpoints', async (ctx) => {
+      const discoveryMap = await fetchDiscoveryDocument(client.http);
+      const nonEmptyMap = discoveryMap.size > 0 ? discoveryMap : undefined;
+      requireOrSkip(ctx, nonEmptyMap, SkipReason.BACKEND_UNSUPPORTED);
+
+      const classes = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/oo/classes/CL_ABAP_CHAR_UTILITIES/source/main');
+      const programs = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/programs/programs/RSHOWTIM/source/main');
+      const ddls = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL/source/main');
+      const transports = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/cts/transportrequests?user=DEVELOPER');
+
+      expect(classes).toBeTruthy();
+      expect(programs).toBeTruthy();
+      expect(classes).toMatch(/^application\/vnd\.sap\.adt\./);
+      expect(programs).toMatch(/^application\/vnd\.sap\.adt\./);
+
+      // DDL/transports may be missing depending on backend release/authorizations.
+      if (ddls) {
+        expect(ddls).toMatch(/^application\/vnd\.sap\.adt\./);
+      }
+      if (transports) {
+        expect(transports).toMatch(/^application\/vnd\.sap\.adt\./);
       }
     });
   });

--- a/tests/integration/adt.integration.test.ts
+++ b/tests/integration/adt.integration.test.ts
@@ -86,10 +86,15 @@ describe('ADT Integration Tests', () => {
       const nonEmptyMap = discoveryMap.size > 0 ? discoveryMap : undefined;
       requireOrSkip(ctx, nonEmptyMap, SkipReason.BACKEND_UNSUPPORTED);
 
-      const classes = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/oo/classes/CL_ABAP_CHAR_UTILITIES/source/main');
-      const programs = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/programs/programs/RSHOWTIM/source/main');
-      const ddls = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL/source/main');
+      // Shallow match: object-level metadata paths resolve to discovered MIME types
+      const classes = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/oo/classes/CL_ABAP_CHAR_UTILITIES');
+      const programs = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/programs/programs/RSHOWTIM');
+      const ddls = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL');
       const transports = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/cts/transportrequests?user=DEVELOPER');
+
+      // Deep sub-resource paths (source/main) should NOT resolve — different Accept needed
+      const classSource = resolveAcceptType(nonEmptyMap, '/sap/bc/adt/oo/classes/CL_ABAP_CHAR_UTILITIES/source/main');
+      expect(classSource).toBeUndefined();
 
       expect(classes).toBeTruthy();
       expect(programs).toBeTruthy();

--- a/tests/unit/adt/discovery.test.ts
+++ b/tests/unit/adt/discovery.test.ts
@@ -127,16 +127,24 @@ describe('ADT Discovery', () => {
       expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes')).toBe('application/vnd.sap.adt.oo.classes.v4+xml');
     });
 
-    it('resolves prefix path matches', () => {
+    it('resolves one-level-deep path (object metadata)', () => {
       const map = new Map<string, string[]>([
         ['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']],
       ]);
-      expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes/ZCL_FOO/source/main')).toBe(
+      expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes/ZCL_FOO')).toBe(
         'application/vnd.sap.adt.oo.classes.v4+xml',
       );
     });
 
-    it('uses longest prefix match', () => {
+    it('does NOT resolve deep sub-resource paths (source/main)', () => {
+      const map = new Map<string, string[]>([
+        ['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']],
+      ]);
+      // Discovery MIME types are for collection/metadata, not source code sub-resources
+      expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes/ZCL_FOO/source/main')).toBeUndefined();
+    });
+
+    it('uses longest shallow match', () => {
       const map = new Map<string, string[]>([
         ['/sap/bc/adt/oo', ['application/vnd.sap.adt.oo.v1+xml']],
         ['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']],
@@ -157,13 +165,15 @@ describe('ADT Discovery', () => {
       expect(resolveAcceptType(new Map(), '/sap/bc/adt/oo/classes')).toBeUndefined();
     });
 
-    it('resolveContentType returns first type from matched collection', () => {
+    it('resolveContentType returns first type for shallow match', () => {
       const map = new Map<string, string[]>([
         ['/sap/bc/adt/ddic/ddl/sources', ['application/vnd.sap.adt.ddic.ddl.sources.v2+xml', 'application/*']],
       ]);
-      expect(resolveContentType(map, '/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL/source/main')).toBe(
+      expect(resolveContentType(map, '/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL')).toBe(
         'application/vnd.sap.adt.ddic.ddl.sources.v2+xml',
       );
+      // Deep sub-resources should NOT match
+      expect(resolveContentType(map, '/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL/source/main')).toBeUndefined();
     });
 
     it('resolves independently across multiple collections', () => {
@@ -171,12 +181,15 @@ describe('ADT Discovery', () => {
         ['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']],
         ['/sap/bc/adt/programs/programs', ['application/vnd.sap.adt.programs.programs.v2+xml']],
       ]);
-      expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes/ZCL_FOO/source/main')).toBe(
+      // One level deep (object metadata) — matches
+      expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes/ZCL_FOO')).toBe(
         'application/vnd.sap.adt.oo.classes.v4+xml',
       );
-      expect(resolveAcceptType(map, '/sap/bc/adt/programs/programs/ZREP/source/main')).toBe(
+      expect(resolveAcceptType(map, '/sap/bc/adt/programs/programs/ZREP')).toBe(
         'application/vnd.sap.adt.programs.programs.v2+xml',
       );
+      // Deep sub-resources — no match
+      expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes/ZCL_FOO/source/main')).toBeUndefined();
     });
 
     it('ignores query parameters during matching', () => {

--- a/tests/unit/adt/discovery.test.ts
+++ b/tests/unit/adt/discovery.test.ts
@@ -1,0 +1,191 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { fetchDiscoveryDocument, resolveAcceptType, resolveContentType } from '../../../src/adt/discovery.js';
+import type { AdtHttpClient } from '../../../src/adt/http.js';
+import { parseDiscoveryDocument } from '../../../src/adt/xml-parser.js';
+
+const fixturesDir = join(import.meta.dirname, '../../fixtures/xml');
+const loadFixture = (name: string) => readFileSync(join(fixturesDir, name), 'utf-8');
+
+describe('ADT Discovery', () => {
+  describe('parseDiscoveryDocument', () => {
+    it('parses fixture into expected map size', () => {
+      const xml = loadFixture('discovery.xml');
+      const map = parseDiscoveryDocument(xml);
+      expect(map.size).toBe(9);
+    });
+
+    it('returns multiple accepts in order', () => {
+      const xml = loadFixture('discovery.xml');
+      const map = parseDiscoveryDocument(xml);
+      expect(map.get('/sap/bc/adt/oo/classes')).toEqual([
+        'application/vnd.sap.adt.oo.classes.v2+xml',
+        'application/vnd.sap.adt.oo.classes.v4+xml',
+        'text/html',
+      ]);
+    });
+
+    it('omits collections without accepts', () => {
+      const xml = loadFixture('discovery.xml');
+      const map = parseDiscoveryDocument(xml);
+      expect(map.has('/sap/bc/adt/activation')).toBe(false);
+    });
+
+    it('returns single accept as one-element array', () => {
+      const xml = loadFixture('discovery.xml');
+      const map = parseDiscoveryDocument(xml);
+      expect(map.get('/sap/bc/adt/ddic/domains')).toEqual(['application/vnd.sap.adt.domains.v2+xml']);
+    });
+
+    it('normalizes absolute href URLs to ADT paths', () => {
+      const xml = loadFixture('discovery.xml');
+      const map = parseDiscoveryDocument(xml);
+      expect(map.has('/sap/bc/adt/oo/interfaces')).toBe(true);
+    });
+
+    it('returns empty map for empty XML', () => {
+      expect(parseDiscoveryDocument('')).toEqual(new Map());
+    });
+
+    it('returns empty map for malformed XML without throwing', () => {
+      expect(parseDiscoveryDocument('<app:service><app:workspace>')).toEqual(new Map());
+    });
+
+    it('skips collections missing href', () => {
+      const xml = loadFixture('discovery.xml');
+      const map = parseDiscoveryDocument(xml);
+      expect(map.has('')).toBe(false);
+      expect(map.size).toBe(9);
+    });
+
+    it('preserves MIME types exactly', () => {
+      const xml = loadFixture('discovery.xml');
+      const map = parseDiscoveryDocument(xml);
+      const types = map.get('/sap/bc/adt/functions/groups');
+      expect(types).toEqual([
+        'application/vnd.sap.adt.functions.groups.v1+xml',
+        'application/vnd.sap.adt.functions.groups.v3+xml',
+      ]);
+    });
+
+    it('overwrites duplicate href with latest collection', () => {
+      const xml = loadFixture('discovery.xml');
+      const map = parseDiscoveryDocument(xml);
+      expect(map.get('/sap/bc/adt/programs/programs')).toEqual([
+        'application/vnd.sap.adt.programs.programs.v2+xml',
+        'text/plain',
+      ]);
+    });
+  });
+
+  describe('fetchDiscoveryDocument', () => {
+    function mockClient(getImpl: (path: string, headers?: Record<string, string>) => Promise<{ body: string }>) {
+      return { get: vi.fn().mockImplementation(getImpl) } as unknown as AdtHttpClient;
+    }
+
+    it('fetches and parses discovery document successfully', async () => {
+      const xml = loadFixture('discovery.xml');
+      const client = mockClient(async () => ({ body: xml }));
+      const map = await fetchDiscoveryDocument(client);
+      expect(map.size).toBe(9);
+      expect((client as any).get).toHaveBeenCalledWith('/sap/bc/adt/discovery', {
+        Accept: 'application/atomsvc+xml',
+      });
+    });
+
+    it('returns empty map on 404', async () => {
+      const client = mockClient(async () => {
+        throw { statusCode: 404 };
+      });
+      const map = await fetchDiscoveryDocument(client);
+      expect(map).toEqual(new Map());
+    });
+
+    it('returns empty map on 406', async () => {
+      const client = mockClient(async () => {
+        throw { statusCode: 406 };
+      });
+      const map = await fetchDiscoveryDocument(client);
+      expect(map).toEqual(new Map());
+    });
+
+    it('returns empty map on network errors', async () => {
+      const client = mockClient(async () => {
+        throw new Error('ECONNRESET');
+      });
+      const map = await fetchDiscoveryDocument(client);
+      expect(map).toEqual(new Map());
+    });
+  });
+
+  describe('resolveAcceptType / resolveContentType', () => {
+    it('resolves exact path matches', () => {
+      const map = new Map<string, string[]>([
+        ['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']],
+      ]);
+      expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes')).toBe('application/vnd.sap.adt.oo.classes.v4+xml');
+    });
+
+    it('resolves prefix path matches', () => {
+      const map = new Map<string, string[]>([
+        ['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']],
+      ]);
+      expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes/ZCL_FOO/source/main')).toBe(
+        'application/vnd.sap.adt.oo.classes.v4+xml',
+      );
+    });
+
+    it('uses longest prefix match', () => {
+      const map = new Map<string, string[]>([
+        ['/sap/bc/adt/oo', ['application/vnd.sap.adt.oo.v1+xml']],
+        ['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']],
+      ]);
+      expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes/ZCL_FOO')).toBe(
+        'application/vnd.sap.adt.oo.classes.v4+xml',
+      );
+    });
+
+    it('returns undefined when no collection matches', () => {
+      const map = new Map<string, string[]>([
+        ['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']],
+      ]);
+      expect(resolveAcceptType(map, '/sap/bc/adt/unknown/path')).toBeUndefined();
+    });
+
+    it('returns undefined for an empty discovery map', () => {
+      expect(resolveAcceptType(new Map(), '/sap/bc/adt/oo/classes')).toBeUndefined();
+    });
+
+    it('resolveContentType returns first type from matched collection', () => {
+      const map = new Map<string, string[]>([
+        ['/sap/bc/adt/ddic/ddl/sources', ['application/vnd.sap.adt.ddic.ddl.sources.v2+xml', 'application/*']],
+      ]);
+      expect(resolveContentType(map, '/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL/source/main')).toBe(
+        'application/vnd.sap.adt.ddic.ddl.sources.v2+xml',
+      );
+    });
+
+    it('resolves independently across multiple collections', () => {
+      const map = new Map<string, string[]>([
+        ['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']],
+        ['/sap/bc/adt/programs/programs', ['application/vnd.sap.adt.programs.programs.v2+xml']],
+      ]);
+      expect(resolveAcceptType(map, '/sap/bc/adt/oo/classes/ZCL_FOO/source/main')).toBe(
+        'application/vnd.sap.adt.oo.classes.v4+xml',
+      );
+      expect(resolveAcceptType(map, '/sap/bc/adt/programs/programs/ZREP/source/main')).toBe(
+        'application/vnd.sap.adt.programs.programs.v2+xml',
+      );
+    });
+
+    it('ignores query parameters during matching', () => {
+      const map = new Map<string, string[]>([
+        ['/sap/bc/adt/repository/informationsystem/search', ['application/vnd.sap.adt.repository.search.v1+xml']],
+      ]);
+      expect(
+        resolveAcceptType(map, '/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=ZCL*'),
+      ).toBe('application/vnd.sap.adt.repository.search.v1+xml');
+    });
+  });
+});

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -6,6 +6,7 @@ import {
   detectSystemType,
   mapSapReleaseToAbaplintVersion,
   probeAuthorization,
+  probeFeatures,
   probeTextSearch,
   resolveWithoutProbing,
 } from '../../../src/adt/features.js';
@@ -248,6 +249,93 @@ describe('Feature Detection', () => {
         { name: 'sap_cloud', release: '100', description: 'SAP Cloud' },
       ];
       expect(detectSystemType(components)).toBe('btp');
+    });
+  });
+
+  // ─── probeFeatures (with discovery) ───────────────────────────────
+
+  describe('probeFeatures', () => {
+    const defaultConfig: FeatureConfig = {
+      hana: 'auto',
+      abapGit: 'auto',
+      rap: 'auto',
+      amdp: 'auto',
+      ui5: 'auto',
+      transport: 'auto',
+      ui5repo: 'auto',
+      flp: 'auto',
+    };
+
+    const componentsXml = `<?xml version="1.0" encoding="utf-8"?>
+<atom:feed xmlns:atom="http://www.w3.org/2005/Atom">
+  <atom:entry>
+    <atom:id>SAP_BASIS</atom:id>
+    <atom:title>758;SAPKB75801;0001;SAP Basis Component</atom:title>
+  </atom:entry>
+  <atom:entry>
+    <atom:id>SAP_ABA</atom:id>
+    <atom:title>758;SAPK-75801INSAPABA;0001;SAP Application Basis</atom:title>
+  </atom:entry>
+</atom:feed>`;
+
+    const discoveryXml = `<?xml version="1.0" encoding="utf-8"?>
+<app:service xmlns:app="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom">
+  <app:workspace>
+    <app:collection href="/sap/bc/adt/oo/classes">
+      <app:accept>application/vnd.sap.adt.oo.classes.v4+xml</app:accept>
+    </app:collection>
+  </app:workspace>
+</app:service>`;
+
+    function mockProbeClient(options?: { discoveryFails?: boolean }): AdtHttpClient {
+      return {
+        get: vi.fn().mockImplementation((url: string) => {
+          if (url === '/sap/bc/adt/discovery') {
+            if (options?.discoveryFails) {
+              return Promise.reject(new Error('Discovery unavailable'));
+            }
+            return Promise.resolve({ statusCode: 200, body: discoveryXml });
+          }
+          if (url === '/sap/bc/adt/system/components') {
+            return Promise.resolve({ statusCode: 200, body: componentsXml });
+          }
+          return Promise.resolve({ statusCode: 200, body: '' });
+        }),
+      } as unknown as AdtHttpClient;
+    }
+
+    it('includes discovery map from startup probe', async () => {
+      const client = mockProbeClient();
+      const result = await probeFeatures(client, defaultConfig);
+
+      expect(result.discoveryMap).toBeDefined();
+      expect(result.discoveryMap?.get('/sap/bc/adt/oo/classes')).toEqual(['application/vnd.sap.adt.oo.classes.v4+xml']);
+    });
+
+    it('calls discovery endpoint as part of probeFeatures', async () => {
+      const client = mockProbeClient();
+      await probeFeatures(client, defaultConfig);
+
+      expect((client as any).get).toHaveBeenCalledWith('/sap/bc/adt/discovery', {
+        Accept: 'application/atomsvc+xml',
+      });
+    });
+
+    it('does not fail feature probing when discovery request fails', async () => {
+      const client = mockProbeClient({ discoveryFails: true });
+      const result = await probeFeatures(client, defaultConfig);
+
+      expect(result.hana.available).toBe(true);
+      expect(result.textSearch?.available).toBe(true);
+      expect(result.discoveryMap).toEqual(new Map());
+    });
+
+    it('sets discoveryMap to empty map when discovery fails', async () => {
+      const client = mockProbeClient({ discoveryFails: true });
+      const result = await probeFeatures(client, defaultConfig);
+
+      expect(result.discoveryMap).toBeDefined();
+      expect(result.discoveryMap?.size).toBe(0);
     });
   });
 

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -612,6 +612,108 @@ describe('AdtHttpClient', () => {
     });
   });
 
+  // ─── Proactive MIME Discovery ─────────────────────────────────────
+
+  describe('discovery-aware header selection', () => {
+    it('uses discovered Accept when no explicit Accept header is provided', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      client.setDiscoveryMap(new Map([['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']]]));
+
+      await client.get('/sap/bc/adt/oo/classes/ZCL_FOO/source/main');
+      expect(fetchHeaders(0).Accept).toBe('application/vnd.sap.adt.oo.classes.v4+xml');
+    });
+
+    it('does not override explicit Accept with discovery result', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      client.setDiscoveryMap(new Map([['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']]]));
+
+      await client.get('/sap/bc/adt/oo/classes/ZCL_FOO/source/main', { Accept: 'application/xml' });
+      expect(fetchHeaders(0).Accept).toBe('application/xml');
+    });
+
+    it('falls back to default Accept for unknown paths', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      client.setDiscoveryMap(new Map([['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']]]));
+
+      await client.get('/sap/bc/adt/unmapped/endpoint');
+      expect(fetchHeaders(0).Accept).toBe('*/*');
+    });
+
+    it('keeps default behavior when discovery map is empty', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      await client.get('/sap/bc/adt/programs/programs/ZHELLO/source/main');
+      expect(fetchHeaders(0).Accept).toBe('*/*');
+    });
+
+    it('caches successful 406 retry headers for later requests', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(406, 'Not Acceptable'));
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok2'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      await client.get('/sap/bc/adt/repository/informationsystem/search', { Accept: 'application/custom+xml' });
+      await client.get('/sap/bc/adt/repository/informationsystem/search');
+
+      expect(fetchHeaders(2).Accept).toBe('application/xml');
+    });
+
+    it('caches successful 415 retry Content-Type for later writes', async () => {
+      // CSRF fetch
+      mockFetch.mockResolvedValueOnce(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      // First POST and retry
+      mockFetch.mockResolvedValueOnce(mockResponse(415, 'Unsupported'));
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+      // Second POST should use cached Content-Type
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok2'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      await client.post('/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL/source/main', '<source/>', 'text/xml');
+      await client.post('/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL/source/main', '<source2/>');
+
+      expect(fetchHeaders(3)['Content-Type']).toBe('application/xml');
+    });
+
+    it('stateful sessions inherit discovery map', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      client.setDiscoveryMap(new Map([['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']]]));
+
+      await client.withStatefulSession(async (session) => {
+        await session.get('/sap/bc/adt/oo/classes/ZCL_SESSION/source/main');
+      });
+
+      expect(fetchHeaders(0).Accept).toBe('application/vnd.sap.adt.oo.classes.v4+xml');
+      expect(fetchHeaders(0)['X-sap-adt-sessiontype']).toBe('stateful');
+    });
+
+    it('explicit extra headers win over discovery for Accept and Content-Type', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      client.setDiscoveryMap(
+        new Map([['/sap/bc/adt/ddic/ddl/sources', ['application/vnd.sap.adt.ddic.ddl.sources.v2+xml']]]),
+      );
+
+      await client.post('/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL/source/main', '<source/>', undefined, {
+        Accept: 'application/json',
+        'Content-Type': 'text/plain',
+      });
+
+      expect(fetchHeaders(1).Accept).toBe('application/json');
+      expect(fetchHeaders(1)['Content-Type']).toBe('text/plain');
+    });
+  });
+
   // ─── 406/415 Content Negotiation Retry ─────────────────────────────
 
   describe('406/415 content negotiation retry', () => {

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -615,14 +615,24 @@ describe('AdtHttpClient', () => {
   // ─── Proactive MIME Discovery ─────────────────────────────────────
 
   describe('discovery-aware header selection', () => {
-    it('uses discovered Accept when no explicit Accept header is provided', async () => {
+    it('uses discovered Accept for object-level paths (shallow match)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      client.setDiscoveryMap(new Map([['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']]]));
+
+      await client.get('/sap/bc/adt/oo/classes/ZCL_FOO');
+      expect(fetchHeaders(0).Accept).toBe('application/vnd.sap.adt.oo.classes.v4+xml');
+    });
+
+    it('does NOT apply discovery to deep sub-resource paths like /source/main', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
 
       const client = new AdtHttpClient(getDefaultConfig());
       client.setDiscoveryMap(new Map([['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']]]));
 
       await client.get('/sap/bc/adt/oo/classes/ZCL_FOO/source/main');
-      expect(fetchHeaders(0).Accept).toBe('application/vnd.sap.adt.oo.classes.v4+xml');
+      expect(fetchHeaders(0).Accept).toBe('*/*');
     });
 
     it('does not override explicit Accept with discovery result', async () => {
@@ -631,7 +641,7 @@ describe('AdtHttpClient', () => {
       const client = new AdtHttpClient(getDefaultConfig());
       client.setDiscoveryMap(new Map([['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']]]));
 
-      await client.get('/sap/bc/adt/oo/classes/ZCL_FOO/source/main', { Accept: 'application/xml' });
+      await client.get('/sap/bc/adt/oo/classes/ZCL_FOO', { Accept: 'application/xml' });
       expect(fetchHeaders(0).Accept).toBe('application/xml');
     });
 
@@ -688,7 +698,7 @@ describe('AdtHttpClient', () => {
       client.setDiscoveryMap(new Map([['/sap/bc/adt/oo/classes', ['application/vnd.sap.adt.oo.classes.v4+xml']]]));
 
       await client.withStatefulSession(async (session) => {
-        await session.get('/sap/bc/adt/oo/classes/ZCL_SESSION/source/main');
+        await session.get('/sap/bc/adt/oo/classes/ZCL_SESSION');
       });
 
       expect(fetchHeaders(0).Accept).toBe('application/vnd.sap.adt.oo.classes.v4+xml');
@@ -704,7 +714,7 @@ describe('AdtHttpClient', () => {
         new Map([['/sap/bc/adt/ddic/ddl/sources', ['application/vnd.sap.adt.ddic.ddl.sources.v2+xml']]]),
       );
 
-      await client.post('/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL/source/main', '<source/>', undefined, {
+      await client.post('/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL', '<source/>', undefined, {
         Accept: 'application/json',
         'Content-Type': 'text/plain',
       });


### PR DESCRIPTION
## Summary
- add proactive ADT service discovery via /sap/bc/adt/discovery and parse endpoint MIME types
- wire discovery-aware Accept and Content-Type selection into AdtHttpClient with retry-learned header caching fallback
- run discovery during startup probing and inject cached discovery map into shared and per-user request clients
- add unit and integration tests plus a discovery XML fixture
- update roadmap, architecture, tool reference, and feature matrix docs; move FEAT-38 plan to completed

## Validation
- npm test
- npm run typecheck
- npm run lint
