### PR TITLE
fix: modificationSupport guard + CSRF HEAD→GET fallback for S/4HANA Public Cloud

### DIFF
--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -2,7 +2,7 @@
 
 A comprehensive comparison of all SAP ADT/MCP projects against ARC-1.
 
-_Last updated: 2026-04-16 (PR #134 merged 2026-04-16: SKTD read/write (Knowledge Transfer Documents); fr0ster v6.1.0: UpdateInterface BTP corrNr fix (not applicable to ARC-1 — centralized safeUpdateSource already handles), ServiceBindingVariant (V4 SRVB publish bug in devtools.ts), dump API simplified; VSP: lock-handle bug class resolved (modificationSupport guard — implement in ARC-1 crud.ts) + CSRF HEAD fails on S/4HANA Public Cloud issue #104 (add GET fallback in http.ts); abap-adt-api: Dynpro metadata proposal #44; dassian-adt deep analysis: 9 transport tools, 8 trace tools, abap_run endpoint confirmed; ARC-1 action items: fix V4 SRVB publish endpoint + add modificationSupport check to lockObject() + CSRF HEAD fallback)_
+_Last updated: 2026-04-16 (PR #134 merged 2026-04-16: SKTD read/write (Knowledge Transfer Documents); COMPAT-01 fixed 2026-04-16: `lockObject()` now guards on `MODIFICATION_SUPPORT=false`; COMPAT-02 fixed 2026-04-16: CSRF HEAD 403 fallback to GET in `http.ts`; COMPAT-03 already fixed 2026-04-15 in PR #130 (`9b0601c`) via V4 SRVB publish endpoint support; fr0ster v6.1.0 and dassian-adt deep analysis updates retained)_
 
 ## Legend
 - ✅ = Supported
@@ -271,9 +271,10 @@ The following items were incorrectly marked in the previous version and have sin
 | VSP stars | 273 | 279 | New issues: 103 (SAProuter support), 104 (CSRF HEAD 403 on S/4HANA public cloud) |
 | fr0ster stars | 29 | 35 | v6.1.0 |
 | sapcli stars | 77 | 79 | PR #149 merged (domain support), PR #147 (auth fields), HTTP refactor |
-| VSP lock-handle bug | ⚠️ (ongoing 423 errors) | ✅ (22517d4 — modificationSupport guard) | Root cause fixed: detect modificationSupport=false in lock response. ARC-1 crud.ts needs same fix. |
+| VSP lock-handle bug | ⚠️ (ongoing 423 errors) | ✅ (22517d4 — modificationSupport guard) | Root cause fixed in VSP; ARC-1 aligned with COMPAT-01 fix on 2026-04-16 (`lockObject` now checks `MODIFICATION_SUPPORT`/`modificationSupport`). |
 | VSP version | v2.39.0+ | v2.40.0+ (Apr 13-15 sprint) | cr-config-audit CLI tools, RecoverFailedCreate primitive, lock-handle fix |
-| S/4HANA Public Cloud CSRF | not tracked | ❌ ARC-1 may fail | VSP issue #104: HEAD request for CSRF fetch fails on S/4HANA Public Cloud (CL_ADT_WB_RES_APP returns 403). ARC-1 http.ts uses HEAD — verify GET fallback needed. |
+| S/4HANA Public Cloud CSRF | not tracked | ✅ fixed 2026-04-16 | VSP issue #104 confirmed the HEAD incompatibility. ARC-1 now retries CSRF fetch with GET when HEAD returns 403. |
+| ARC-1 V4 SRVB publish endpoint | not tracked | ✅ fixed 2026-04-15 (PR #130) | `publishServiceBinding()`/`unpublishServiceBinding()` now use resolved binding type (`odatav2`/`odatav4`) instead of hardcoded v2. |
 | ARC-1 SKTD (Knowledge Transfer Documents) | ❌ | ✅ (merged PR #134 2026-04-16) | PR #134 by lemaiwo — full SKTD read/write: `GET/PUT/POST /sap/bc/adt/documentation/ktd/documents/`, base64-decoded Markdown, create requires refObjectType, update preserves server-side metadata. |
 | GetProgFullCode (include traversal) availability | ✅ fr0ster | ✅ fr0ster (on-prem only) | fr0ster v6.1.0 deep analysis: uses `GET /sap/bc/adt/repository/nodestructure?objecttype=PROG/P&objectname={name}` + recursive include fetch. NOT available on BTP Cloud (missing node API). |
 | fr0ster Enhancements endpoint | noted | documented | fr0ster deep analysis: `GET /sap/bc/adt/programs/programs/{name}/source/main/enhancements/elements` (base64-encoded source, on-prem only); enhancement spot: `GET /sap/bc/adt/enhancements/enhsxsb/{spotName}`; on-prem only. |
@@ -296,7 +297,7 @@ The following items were incorrectly marked in the previous version and have sin
 
 ### Biggest Competitive Threats
 1. **vibing-steampunk** (279 stars) — Community favorite. Has Streamable HTTP (v2.38.0), SAML SSO (PR #97). Massive Apr sprint: i18n, gCTS, API release state, version history, code coverage, health analysis, rename preview, dead code analysis, package safety hardening, RecoverFailedCreate primitive. Defaults to hyperfocused mode (1 tool). Open issues: OAuth2 BTP request (#99), recurring lock handle bugs (fix in 22517d4), CSRF HEAD 403 on S/4HANA public cloud (#104), SAProuter support (#103).
-2. **fr0ster** (v6.1.0, 100+ releases, 35 stars) — Closest enterprise competitor. ~320 tools, 9 auth providers, TLS, RFC, embeddable. v6.0.0 BREAKING: simplified dump API + fixed UpdateInterface on BTP (corrNr bug — not applicable to ARC-1 due to centralized safeUpdateSource). v6.1.0: RFC decoupled from legacy system type. ARC-1 action: **fix V4 SRVB publish endpoint** (`devtools.ts` hardcodes `odatav2` — fails for OData V4 bindings).
+2. **fr0ster** (v6.1.0, 100+ releases, 35 stars) — Closest enterprise competitor. ~320 tools, 9 auth providers, TLS, RFC, embeddable. v6.0.0 BREAKING: simplified dump API + fixed UpdateInterface on BTP (corrNr bug — not applicable to ARC-1 due to centralized safeUpdateSource). v6.1.0: RFC decoupled from legacy system type. ARC-1 has already aligned on V4 SRVB publish endpoint support (PR #130, 2026-04-15).
 3. **dassian-adt** (33 stars, 53 tools) — Stabilized after explosive April sprint (0 → 33 stars, 25 → 53 tools in 2 weeks). OAuth/XSUAA/multi-system/per-user auth all added. Deep analysis (2026-04-16): 9 transport tools, 8 trace tools, abap_create_test_include confirmed. Still no new commits since Apr 14. Lacks: safety system, BTP Destination/PP, caching, linting.
 4. **SAP Joule / Official ABAP MCP Server** — SAP announced Q2 2026 GA for ABAP Cloud Extension for VS Code with built-in agentic AI. Initial scope: RAP UI service development. Will reshape landscape — community servers become complementary.
 5. **btp-odata-mcp** (120 stars) — Different category (OData not ADT). Dormant since Jan 2026. High stars but no recent development.
@@ -317,9 +318,9 @@ The following items were incorrectly marked in the previous version and have sin
 - ~~ADT service discovery / MIME negotiation (FEAT-38)~~ — ✅ completed 2026-04-14
 - ~~401 session timeout auto-retry (centralized gateway idle)~~ — ✅ Implemented in `src/adt/http.ts`
 - ~~TLS/HTTPS for HTTP Streamable~~ — downgraded to P3: most deployments use reverse proxy
-- **modificationSupport guard in lockObject()** — Root cause of all 423 `ExceptionResourceInvalidLockHandle` errors. ADT lock response includes `MODIFICATION_SUPPORT` flag; if `false` (released transport, read-only object), return LLM-friendly error instead of trying to lock. Fix `src/adt/crud.ts`. [Eval](vibing-steampunk/evaluations/22517d4-lock-handle-bug-class.md)
-- **CSRF HEAD fallback for S/4HANA Public Cloud** — `CL_ADT_WB_RES_APP` returns 403 for HEAD on S/4HANA Public Cloud and some on-prem S/4HANA 2023 FPS03. All write operations silently fail. Add GET fallback in `src/adt/http.ts`. [Eval](vibing-steampunk/evaluations/22517d4-lock-handle-bug-class.md) / VSP issue #104
-- **V4 SRVB publish endpoint bug** — `publishServiceBinding()` in `src/adt/devtools.ts` hardcodes `bindingtype=odatav2` — fails for OData V4 service bindings. Fix: pass binding type through and use `odatav4` for V4 bindings. [Eval](fr0ster/evaluations/51781d3-srvd-srvb-activate-variant.md)
+- ~~**modificationSupport guard in lockObject()**~~ — ✅ fixed 2026-04-16 in `src/adt/crud.ts`. Lock responses with explicit `MODIFICATION_SUPPORT=false`/`modificationSupport=false` now fail early with actionable 423 guidance. [Eval](vibing-steampunk/evaluations/22517d4-lock-handle-bug-class.md)
+- ~~**CSRF HEAD fallback for S/4HANA Public Cloud**~~ — ✅ fixed 2026-04-16 in `src/adt/http.ts`. CSRF fetch now retries with GET when HEAD returns 403. [Eval](vibing-steampunk/evaluations/22517d4-lock-handle-bug-class.md) / VSP issue #104
+- ~~**V4 SRVB publish endpoint bug**~~ — ✅ fixed 2026-04-15 in PR #130 (`9b0601c`). Publish/unpublish now respect resolved service binding type (`odatav2`/`odatav4`). [Eval](fr0ster/evaluations/51781d3-srvd-srvb-activate-variant.md)
 - ~~**BTP transport omission in safeUpdateSource()**~~ — **Likely NOT applicable.** ARC-1's centralized `safeUpdateSource()` already uses `transport ?? (lock.corrNr || undefined)` for all types — fr0ster's bug was per-handler (only `UpdateInterface` was missing it). Verify with BTP INTF update integration test. [Eval](fr0ster/evaluations/c2b8006-dump-simplify-updateintf-fix.md)
 
 **P1 — high-value gaps:**

--- a/docs/plans/completed/compat-fixes-01-02.md
+++ b/docs/plans/completed/compat-fixes-01-02.md
@@ -1,0 +1,163 @@
+# Compatibility Fixes: COMPAT-01 (modificationSupport guard) and COMPAT-02 (CSRF HEAD→GET fallback)
+
+## Overview
+
+This plan implements two P0 compatibility fixes discovered during cross-project competitor analysis (2026-04-16). Both affect ARC-1's behaviour on specific SAP system variants and cause cryptic, misleading errors for end users.
+
+**COMPAT-01** adds a pre-flight check to `lockObject()` in `src/adt/crud.ts`: the ADT lock response contains a `MODIFICATION_SUPPORT` field that indicates whether the object can actually be modified (it is `false` for objects in released transports or system-delivered objects). ARC-1 currently ignores this field and proceeds to the write request, which then fails with a cryptic HTTP 423 `ExceptionResourceInvalidLockHandle`. The fix detects this upfront and throws a clear, actionable error that the LLM can relay to the user.
+
+**COMPAT-02** fixes CSRF token fetching in `fetchCsrfToken()` in `src/adt/http.ts`: the current implementation uses an HTTP HEAD request to `/sap/bc/adt/core/discovery`. On S/4HANA Public Cloud and certain S/4HANA 2023 FPS03 on-premise systems, `CL_ADT_WB_RES_APP` returns HTTP 403 for HEAD requests (it requires GET). When this happens, ARC-1 throws an "access forbidden" error, which silently blocks ALL write operations on those system variants. The fix retries the CSRF fetch with GET when HEAD returns 403.
+
+**COMPAT-03** (V4 SRVB publish endpoint) was already fixed in commit `9b0601c` (PR #130, 2026-04-15) and is included only as a documentation clean-up step to mark it completed in the roadmap and feature matrix.
+
+Source: vibing-steampunk commit 22517d4 (modificationSupport fix), VSP issue #104 (CSRF HEAD), fr0ster commit 51781d3 (SRVB V4 confirm). Evaluations: `compare/vibing-steampunk/evaluations/22517d4-lock-handle-bug-class.md`, `compare/fr0ster/evaluations/51781d3-srvd-srvb-activate-variant.md`.
+
+## Context
+
+### Current State
+
+**COMPAT-01 — modificationSupport guard:**
+- `lockObject()` in `src/adt/crud.ts` (lines 23–45) parses `LOCK_HANDLE`, `CORRNR`, and `IS_LOCAL` from the ADT lock response XML using the `extractXmlValue()` helper (line 189–193).
+- It does **not** parse or check the `MODIFICATION_SUPPORT` field.
+- When `MODIFICATION_SUPPORT` is `false` (released transport, system-delivered object), SAP returns a valid lock handle — but any subsequent PUT/DELETE using that handle returns HTTP 423 `ExceptionResourceInvalidLockHandle`.
+- Error classification in `intent.ts` line 333 already handles 423 → `enqueue-error`, but the user sees a generic lock-conflict message with no actionable guidance.
+- Documented in `docs/roadmap.md` Phase A.6, cross-referenced to VSP issues #88, #91, #92 and abap-adt-api issues #30, #36.
+
+**COMPAT-02 — CSRF HEAD→GET fallback:**
+- `fetchCsrfToken()` in `src/adt/http.ts` (lines 669–761) sends `HEAD /sap/bc/adt/core/discovery` with `X-CSRF-Token: fetch`.
+- When HEAD returns 403 (lines 740–745), the code throws `AdtApiError("Access forbidden (403)")` — no fallback.
+- On S/4HANA Public Cloud (BTP ABAP Environment managed), `CL_ADT_WB_RES_APP` rejects HEAD and requires GET for CSRF fetch.
+- Result: ALL write operations fail on those system variants with a misleading auth error.
+- The existing 503-retry logic (lines 712–727) shows the pattern for retry-in-fetchCsrfToken.
+
+**COMPAT-03 — already done:**
+- `publishServiceBinding()` and `unpublishServiceBinding()` in `src/adt/devtools.ts` now accept a `serviceType` parameter (`'odatav2'` | `'odatav4'`), defaulting to `'odatav2'`.
+- `handleSAPActivate` in `src/handlers/intent.ts` (lines 2481–2499) calls `resolveServiceType()` which auto-detects V4 from SRVB metadata before publish/unpublish.
+- Roadmap and feature matrix still list COMPAT-03 as an outstanding P0 — this plan corrects that.
+
+### Target State
+
+- `lockObject()` returns an `AdtApiError` (status 423) with the message: *"Object cannot be modified: it is in a released or non-modifiable transport. To edit, assign the object to a new open correction request, or release the existing transport and create a new one."* — before attempting the write request.
+- `fetchCsrfToken()` retries with GET when HEAD returns 403, making write operations transparent on S/4HANA Public Cloud.
+- Roadmap and feature matrix reflect COMPAT-01 and COMPAT-02 as resolved, COMPAT-03 as already resolved (PR #130).
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/crud.ts` | COMPAT-01: `lockObject()` and `extractXmlValue()` — add `MODIFICATION_SUPPORT` check |
+| `src/adt/http.ts` | COMPAT-02: `fetchCsrfToken()` — add GET fallback when HEAD returns 403 |
+| `tests/unit/adt/crud.test.ts` | Unit tests for `lockObject()` |
+| `tests/unit/adt/http.test.ts` | Unit tests for `fetchCsrfToken()` CSRF fetch behaviour |
+| `docs/roadmap.md` | Mark COMPAT-01, COMPAT-02, COMPAT-03 as completed |
+| `compare/00-feature-matrix.md` | Update COMPAT corrections table entries |
+
+### Design Principles
+
+1. **Pre-flight over silent failure** — detect `modificationSupport=false` immediately at lock time and surface an actionable error. Do not let a locked-but-unwritable handle propagate into the write path.
+2. **Transparent fallback** — the CSRF GET fallback must be invisible to callers. No new config flag is needed; the fallback is automatic and logged as a warn audit event (consistent with the 503-retry pattern).
+3. **Exact-false check** — `MODIFICATION_SUPPORT` field is absent or `'true'` on normal objects. Only treat it as blocking when the value is explicitly `'false'` (lowercase, as returned by SAP). Check both ABAP XML uppercase field (`<MODIFICATION_SUPPORT>false</MODIFICATION_SUPPORT>`) and adtcore namespace lowercase form (`<adtcore:modificationSupport>false</adtcore:modificationSupport>`) — some systems return one or the other.
+4. **Error stays AdtApiError** — throw `new AdtApiError(message, 423, objectUrl)` so the existing `classifySapDomainError` in `intent.ts` (line 333) classifies it as `enqueue-error` and formats it with the existing LLM hint. No new error class needed.
+5. **Minimal surface change** — these are targeted bug fixes. No interface changes to `LockResult`, no new config options, no new tool parameters.
+
+## Development Approach
+
+Both fixes are surgical: one `extractXmlValue` call and a guard in `crud.ts`; one retry block in `http.ts`. Each has clear unit test coverage. Run `npm test` after each task. No integration tests are required (no new ADT endpoints touched), and no E2E tests (no change to MCP tool schema or protocol). The documentation task comes last.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+---
+
+### Task 1: COMPAT-01 — Add modificationSupport guard to lockObject()
+
+**Files:**
+- Modify: `src/adt/crud.ts`
+- Modify: `tests/unit/adt/crud.test.ts`
+
+`lockObject()` in `src/adt/crud.ts` parses the ADT lock response XML but ignores the `MODIFICATION_SUPPORT` field. When this field is `false`, the object lives in a released transport or is system-delivered — any subsequent write using the lock handle will fail with HTTP 423. This task adds a pre-flight check to detect this condition upfront and throw a clear error.
+
+- [ ] In `src/adt/crud.ts`, after extracting `isLocal` at line 42, add extraction for the `modificationSupport` flag. Use the existing `extractXmlValue` helper, but check two possible tag names since SAP returns different formats:
+  - `MODIFICATION_SUPPORT` (ABAP XML / `com.sap.adt.lock.result` vendor format, all-caps)
+  - `modificationSupport` (adtcore namespace format, camelCase, may appear as `adtcore:modificationSupport`)
+  - To handle both, extract raw value: first try `extractXmlValue(resp.body, 'MODIFICATION_SUPPORT')`, and if empty also try a simple regex for the namespace form: `/modificationSupport[^>]*>([^<]+)<\//` on `resp.body`. The combined check: if either returns the string `'false'`, the object is non-modifiable.
+- [ ] If `modificationSupport` is explicitly `'false'`, throw `new AdtApiError('Object cannot be modified: it is in a released or non-modifiable transport. To edit this object, assign it to a new open correction request (use SE09 to create one), or work with your basis team to create a new transport.', 423, objectUrl)`. Import `AdtApiError` from `'./errors.js'` (it's already used in the file via the safety import chain, but add the direct import if not present).
+- [ ] The `LockResult` return type does **not** need a new field — throw before returning when `false`. If the field is absent or `'true'`, continue returning `{ lockHandle, corrNr, isLocal }` unchanged.
+- [ ] In `tests/unit/adt/crud.test.ts`, add unit tests (~4 tests) to the `lockObject` describe block:
+  - `returns lock result when MODIFICATION_SUPPORT is absent (normal object)` — existing mock XML without `MODIFICATION_SUPPORT` should still resolve
+  - `returns lock result when MODIFICATION_SUPPORT is true` — lock response with `<MODIFICATION_SUPPORT>true</MODIFICATION_SUPPORT>` should resolve
+  - `throws AdtApiError 423 when MODIFICATION_SUPPORT is false (ABAP XML format)` — lock body with `<MODIFICATION_SUPPORT>false</MODIFICATION_SUPPORT>`, expect `rejects.toThrow(AdtApiError)` with statusCode 423
+  - `throws AdtApiError 423 when modificationSupport is false (adtcore namespace format)` — lock body with `<adtcore:modificationSupport>false</adtcore:modificationSupport>`, same assertion
+- [ ] Run `npm test` — all tests must pass
+
+---
+
+### Task 2: COMPAT-02 — CSRF HEAD→GET fallback for S/4HANA Public Cloud
+
+**Files:**
+- Modify: `src/adt/http.ts`
+- Modify: `tests/unit/adt/http.test.ts`
+
+`fetchCsrfToken()` in `src/adt/http.ts` (line ~669) uses HEAD to fetch the CSRF token. On S/4HANA Public Cloud and some S/4HANA 2023 FPS03 on-premise systems, `CL_ADT_WB_RES_APP` rejects HEAD with HTTP 403. Currently this throws immediately with a misleading "access forbidden" error, silently blocking all write operations on those systems. The fix: when HEAD returns 403, retry once with GET before raising an error.
+
+- [ ] In `fetchCsrfToken()` in `src/adt/http.ts`, after the 503-retry block (around line 727) and before `this.storeCookies(response)`, add a GET fallback:
+  ```typescript
+  // S/4HANA Public Cloud compat: CL_ADT_WB_RES_APP returns 403 for HEAD.
+  // Retry with GET — GET also returns the CSRF token via X-CSRF-Token response header.
+  if (response.status === 403) {
+    logger.emitAudit({
+      timestamp: new Date().toISOString(),
+      level: 'warn',
+      event: 'http_request',
+      method: 'HEAD',
+      path: '/sap/bc/adt/core/discovery',
+      statusCode: 403,
+      durationMs: 0,
+      errorBody: 'CSRF HEAD returned 403 — retrying with GET (S/4HANA Public Cloud compat)',
+    });
+    response = await this.doFetch(url, 'GET', headers);
+  }
+  ```
+- [ ] The existing error handling after `storeCookies` remains unchanged. If GET also returns 403, the existing 403-check at line ~740 will throw the appropriate error. If GET returns 401, the 401-check throws. This is correct — a double-403 means a real auth problem, not a HEAD-compat issue.
+- [ ] In `tests/unit/adt/http.test.ts`, add unit tests (~3 tests) to the `CSRF token handling` describe block:
+  - `retries CSRF fetch with GET when HEAD returns 403 (S/4HANA Public Cloud compat)` — mock HEAD → 403, then GET → 200 with `x-csrf-token: TOKEN`. Assert that the subsequent POST uses `TOKEN` and that `mockFetch` was called 3 times total (HEAD + GET + POST).
+  - `throws when both HEAD and GET return 403` — mock HEAD → 403, GET → 403. Assert `rejects.toThrow(AdtApiError)` with statusCode 403 and message containing "forbidden".
+  - `does not use GET fallback when HEAD returns 401` — mock HEAD → 401. Assert `rejects.toThrow(AdtApiError)` with statusCode 401 (not retried with GET — 401 is an auth failure, not a HEAD-compat issue; verify `mockFetch` is called only once for the CSRF fetch).
+- [ ] Run `npm test` — all tests must pass
+
+---
+
+### Task 3: Mark COMPAT-01/02/03 completed in docs and roadmap
+
+**Files:**
+- Modify: `docs/roadmap.md`
+- Modify: `compare/00-feature-matrix.md`
+
+This task updates the roadmap and feature matrix to reflect:
+- COMPAT-01 and COMPAT-02 as resolved by this PR
+- COMPAT-03 as already resolved in PR #130 (commit `9b0601c`, 2026-04-15) — the roadmap currently still lists it as outstanding P0
+
+**In `docs/roadmap.md`:**
+- [ ] In the overview table (around line 54–56), strike through COMPAT-01, COMPAT-02, and COMPAT-03 rows and change their "Compatibility" column to "Completed YYYY-MM-DD". For COMPAT-03 use "Completed 2026-04-15", for COMPAT-01/02 use today's date.
+- [ ] In the Phase A.6 section (around line 181–185), update each COMPAT entry to note its completion. Add a sentence for COMPAT-03 clarifying it was already fixed before this plan was written.
+- [ ] In the 2026-04-16 re-evaluation note (around line 167), update the text to reflect that COMPAT-03 was found to be already fixed (PR #130) and COMPAT-01/02 are being fixed in this PR.
+
+**In `compare/00-feature-matrix.md`:**
+- [ ] In the corrections/changes table (around line 274–277), update the `ARC-1 SKTD` row is separate — find the three COMPAT correction rows. Mark COMPAT-01, COMPAT-02 as "fixed YYYY-MM-DD" and COMPAT-03 as "fixed 2026-04-15 (PR #130)".
+- [ ] Update the "Last Updated" date at the top of the file.
+- [ ] Run `npm test` — all tests must pass (no code changes, just docs)
+
+---
+
+### Task 4: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass (expect ~1325+ tests)
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Manually verify `lockObject()` throws with status 423 when lock response contains `MODIFICATION_SUPPORT=false`
+- [ ] Manually verify `fetchCsrfToken()` retries with GET when HEAD returns 403: trace test calls with `mockFetch.mock.calls` assertions in the test
+- [ ] Confirm COMPAT-03 is marked as resolved in both `docs/roadmap.md` and `compare/00-feature-matrix.md` (not as a pending P0)
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,9 +51,9 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | ~~8~~ | ~~FEAT-16~~ | ~~Error Intelligence (Actionable Hints)~~ | ~~P1~~ | ~~S~~ | ~~Completed 2026-04-15~~ |
 | ~~9~~ | ~~FEAT-17~~ | ~~Type Auto-Mappings for SAPWrite~~ | ~~P1~~ | ~~XS~~ | ~~Completed 2026-04-14~~ |
 | 10 | FEAT-18 | Function Group Bulk Fetch | P1 | S | Features |
-| — | COMPAT-01 | modificationSupport guard in lockObject() | P0 | XS | Compatibility |
-| — | COMPAT-02 | CSRF HEAD→GET fallback (S/4HANA Public Cloud) | P0 | XS | Compatibility |
-| — | COMPAT-03 | V4 SRVB publish endpoint bug | P0 | XS | Compatibility |
+| ~~—~~ | ~~COMPAT-01~~ | ~~modificationSupport guard in lockObject()~~ | ~~P0~~ | ~~XS~~ | ~~Completed 2026-04-16~~ |
+| ~~—~~ | ~~COMPAT-02~~ | ~~CSRF HEAD→GET fallback (S/4HANA Public Cloud)~~ | ~~P0~~ | ~~XS~~ | ~~Completed 2026-04-16~~ |
+| ~~—~~ | ~~COMPAT-03~~ | ~~V4 SRVB publish endpoint bug~~ | ~~P0~~ | ~~XS~~ | ~~Completed 2026-04-15~~ |
 | — | COMPAT-04 | BTP transport omission in safeUpdateSource() — verify only | P2 | XS | Compatibility |
 | 11 | DOC-01 | Copilot Studio Setup Guide | P1 | S | Docs |
 | 12 | DOC-02 | Basis Admin Security Guide | P1 | S | Docs |
@@ -164,7 +164,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 >
 > **2026-04-14 priority re-evaluation:** dassian-adt's explosive growth (0→32 stars, 25→53 tools, OAuth/XSUAA, multi-system in 2 weeks) and SAP's confirmed Q2 2026 GA for official ABAP MCP Server increase urgency on fix proposals (FEAT-12↑P1), error intelligence (FEAT-16↑P1), and pretty print (FEAT-10↑P1). SAP Joule entering the space makes ARC-1's enterprise-grade safety/auth differentiation even more important.
 >
-> **2026-04-16 additions:** Cross-project competitor analysis (VSP, fr0ster, dassian-adt deep dive) found 3 new P0 compatibility bugs (COMPAT-01 through COMPAT-03) and 1 verify item (COMPAT-04 — likely not applicable to ARC-1). FR0ster reached v6.1.0 (35 stars). VSP confirmed modificationSupport guard as root cause of all 423 lock errors. S/4HANA Public Cloud CSRF HEAD bug affects ALL write operations for that platform. PR #134 (SKTD) merged 2026-04-16 — ARC-1-unique Knowledge Transfer Document support now live. Enhancement (BAdI) ADT endpoints confirmed from fr0ster analysis. GetProgFullCode confirmed on-prem only via nodestructure API.
+> **2026-04-16 additions:** Cross-project competitor analysis (VSP, fr0ster, dassian-adt deep dive) identified COMPAT-01..03 plus verify item COMPAT-04. Follow-up confirmed COMPAT-03 had already been fixed in PR #130 (commit `9b0601c`, completed 2026-04-15). COMPAT-01 and COMPAT-02 were fixed in this follow-up implementation (completed 2026-04-16). FR0ster reached v6.1.0 (35 stars). VSP confirmed modificationSupport guard as root cause of recurring 423 lock errors and surfaced S/4HANA Public Cloud CSRF HEAD incompatibility (#104). PR #134 (SKTD) merged 2026-04-16 — ARC-1-unique Knowledge Transfer Document support now live. Enhancement (BAdI) ADT endpoints confirmed from fr0ster analysis. GetProgFullCode confirmed on-prem only via nodestructure API.
 
 ### Phase A: Production Blockers (P0)
 1. ~~**FEAT-02** API Release Status / Clean Core (S)~~ — **completed 2026-04-10**
@@ -178,11 +178,11 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 ### Phase A.6: Compatibility Bug Fixes (P0) — identified 2026-04-16
 These bugs affect real-world deployments and were confirmed by cross-project competitor analysis:
 
-- **COMPAT-01: modificationSupport guard in lockObject()** (XS) — ADT lock response includes `MODIFICATION_SUPPORT` flag; if `false`, the object is in a released transport or system-delivered and cannot be locked. ARC-1 ignores this flag → cryptic 423 `ExceptionResourceInvalidLockHandle`. Fix: parse from lock response in `src/adt/crud.ts`, return actionable error if `false`. Source: VSP commit 22517d4 (root-cause fix for all recurring 423 issues). [Eval](../compare/vibing-steampunk/evaluations/22517d4-lock-handle-bug-class.md)
+- ~~**COMPAT-01: modificationSupport guard in lockObject()** (XS)~~ — **completed 2026-04-16.** `lockObject()` now checks both `MODIFICATION_SUPPORT` and namespaced `modificationSupport` for explicit `false` and returns a targeted `AdtApiError` (423) before write attempts. Source: VSP commit 22517d4. [Eval](../compare/vibing-steampunk/evaluations/22517d4-lock-handle-bug-class.md)
 
-- **COMPAT-02: CSRF HEAD→GET fallback (S/4HANA Public Cloud)** (XS) — `CL_ADT_WB_RES_APP` returns 403 for HEAD on S/4HANA Public Cloud and some S/4HANA 2023 FPS03 on-prem. ARC-1's `fetchCSRFToken()` in `src/adt/http.ts` uses HEAD → all write operations silently fail with a misleading "access forbidden" error. Fix: retry CSRF fetch with GET when HEAD returns 403. Source: VSP issue #104. [Eval](../compare/vibing-steampunk/evaluations/22517d4-lock-handle-bug-class.md)
+- ~~**COMPAT-02: CSRF HEAD→GET fallback (S/4HANA Public Cloud)** (XS)~~ — **completed 2026-04-16.** `fetchCsrfToken()` now retries with GET when HEAD returns 403, preserving existing 401/403 auth error behavior for true authorization failures. Source: VSP issue #104. [Eval](../compare/vibing-steampunk/evaluations/22517d4-lock-handle-bug-class.md)
 
-- **COMPAT-03: V4 SRVB publish endpoint bug** (XS) — `publishServiceBinding()` and `unpublishServiceBinding()` in `src/adt/devtools.ts` hardcode `bindingtype=odatav2`. OData V4 service bindings need `bindingtype=odatav4`. Fix: propagate binding type from `SAPManage publish_srvb` through to the publish URL. Source: fr0ster commit 51781d3 (ServiceBindingVariant). [Eval](../compare/fr0ster/evaluations/51781d3-srvd-srvb-activate-variant.md)
+- ~~**COMPAT-03: V4 SRVB publish endpoint bug** (XS)~~ — **already completed 2026-04-15** in PR #130 (commit `9b0601c`) before this compatibility plan was executed. `publishServiceBinding()`/`unpublishServiceBinding()` now propagate the resolved binding type (`odatav2` or `odatav4`) correctly. [Eval](../compare/fr0ster/evaluations/51781d3-srvd-srvb-activate-variant.md)
 
 - ~~**COMPAT-04: BTP transport omission in safeUpdateSource()**~~ — **Likely NOT applicable to ARC-1.** fr0ster's bug was per-handler transport wiring (`UpdateInterface` missing what `UpdateClass` had). ARC-1's centralized `safeUpdateSource()` handles ALL types with `effectiveTransport = transport ?? (lock.corrNr || undefined)` — the pattern already correctly omits `corrNr` when undefined. **Verify** with BTP Cloud INTF update integration test. Source: fr0ster commit c2b8006 + issue #61. [Eval](../compare/fr0ster/evaluations/c2b8006-dump-simplify-updateintf-fix.md)
 

--- a/src/adt/crud.ts
+++ b/src/adt/crud.ts
@@ -10,6 +10,7 @@
  * leaked locks on error, blocking the object for other developers.
  */
 
+import { AdtApiError } from './errors.js';
 import type { AdtHttpClient } from './http.js';
 import { checkOperation, OperationType, type SafetyConfig } from './safety.js';
 /** Lock result from SAP */
@@ -40,6 +41,17 @@ export async function lockObject(
   const lockHandle = extractXmlValue(resp.body, 'LOCK_HANDLE');
   const corrNr = extractXmlValue(resp.body, 'CORRNR');
   const isLocal = extractXmlValue(resp.body, 'IS_LOCAL') === 'X';
+  const modificationSupport = extractXmlValue(resp.body, 'MODIFICATION_SUPPORT');
+  const namespacedModificationSupportMatch = resp.body.match(/modificationSupport[^>]*>([^<]+)<\//);
+  const namespacedModificationSupport = namespacedModificationSupportMatch?.[1] ?? '';
+
+  if (modificationSupport === 'false' || namespacedModificationSupport === 'false') {
+    throw new AdtApiError(
+      'Object cannot be modified: it is in a released or non-modifiable transport. To edit this object, assign it to a new open correction request (use SE09 to create one), or work with your basis team to create a new transport.',
+      423,
+      objectUrl,
+    );
+  }
 
   return { lockHandle, corrNr, isLocal };
 }

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -726,6 +726,22 @@ export class AdtHttpClient {
         response = await this.doFetch(url, 'HEAD', headers);
       }
 
+      // S/4HANA Public Cloud compat: CL_ADT_WB_RES_APP returns 403 for HEAD.
+      // Retry with GET — GET also returns the CSRF token via X-CSRF-Token response header.
+      if (response.status === 403) {
+        logger.emitAudit({
+          timestamp: new Date().toISOString(),
+          level: 'warn',
+          event: 'http_request',
+          method: 'HEAD',
+          path: '/sap/bc/adt/core/discovery',
+          statusCode: 403,
+          durationMs: 0,
+          errorBody: 'CSRF HEAD returned 403 — retrying with GET (S/4HANA Public Cloud compat)',
+        });
+        response = await this.doFetch(url, 'GET', headers);
+      }
+
       // Store cookies from CSRF response — critical for session correlation
       this.storeCookies(response);
 

--- a/tests/unit/adt/crud.test.ts
+++ b/tests/unit/adt/crud.test.ts
@@ -9,7 +9,7 @@ import {
   updateObject,
   updateSource,
 } from '../../../src/adt/crud.js';
-import { AdtSafetyError } from '../../../src/adt/errors.js';
+import { AdtApiError, AdtSafetyError } from '../../../src/adt/errors.js';
 import type { AdtHttpClient } from '../../../src/adt/http.js';
 import { unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
 
@@ -62,6 +62,64 @@ describe('CRUD Operations', () => {
       const result = await lockObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/programs/programs/ZTEST');
       expect(result.corrNr).toBe('A4HK900100');
       expect(result.isLocal).toBe(false);
+    });
+
+    it('returns lock result when MODIFICATION_SUPPORT is absent (normal object)', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H2</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>';
+      const http = {
+        ...mockHttp(),
+        post: vi.fn().mockResolvedValue({ statusCode: 200, headers: {}, body: lockBody }),
+      } as unknown as AdtHttpClient;
+      const result = await lockObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/programs/programs/ZTEST');
+      expect(result).toEqual({ lockHandle: 'H2', corrNr: '', isLocal: true });
+    });
+
+    it('returns lock result when MODIFICATION_SUPPORT is true', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H3</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL></IS_LOCAL><MODIFICATION_SUPPORT>true</MODIFICATION_SUPPORT></DATA></asx:values></asx:abap>';
+      const http = {
+        ...mockHttp(),
+        post: vi.fn().mockResolvedValue({ statusCode: 200, headers: {}, body: lockBody }),
+      } as unknown as AdtHttpClient;
+      const result = await lockObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/programs/programs/ZTEST');
+      expect(result).toEqual({ lockHandle: 'H3', corrNr: '', isLocal: false });
+    });
+
+    it('throws AdtApiError 423 when MODIFICATION_SUPPORT is false (ABAP XML format)', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H4</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL></IS_LOCAL><MODIFICATION_SUPPORT>false</MODIFICATION_SUPPORT></DATA></asx:values></asx:abap>';
+      const http = {
+        ...mockHttp(),
+        post: vi.fn().mockResolvedValue({ statusCode: 200, headers: {}, body: lockBody }),
+      } as unknown as AdtHttpClient;
+      await expect(
+        lockObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/programs/programs/ZTEST'),
+      ).rejects.toMatchObject({
+        statusCode: 423,
+        message: expect.stringContaining('Object cannot be modified'),
+      });
+      await expect(lockObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/programs/programs/ZTEST')).rejects.toThrow(
+        AdtApiError,
+      );
+    });
+
+    it('throws AdtApiError 423 when modificationSupport is false (adtcore namespace format)', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml" xmlns:adtcore="http://www.sap.com/adt/core"><asx:values><DATA><LOCK_HANDLE>H5</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL></IS_LOCAL><adtcore:modificationSupport>false</adtcore:modificationSupport></DATA></asx:values></asx:abap>';
+      const http = {
+        ...mockHttp(),
+        post: vi.fn().mockResolvedValue({ statusCode: 200, headers: {}, body: lockBody }),
+      } as unknown as AdtHttpClient;
+      await expect(
+        lockObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/programs/programs/ZTEST'),
+      ).rejects.toMatchObject({
+        statusCode: 423,
+        message: expect.stringContaining('Object cannot be modified'),
+      });
+      await expect(lockObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/programs/programs/ZTEST')).rejects.toThrow(
+        AdtApiError,
+      );
     });
 
     it('sends LOCK action to correct URL', async () => {

--- a/tests/unit/adt/errors.test.ts
+++ b/tests/unit/adt/errors.test.ts
@@ -86,7 +86,7 @@ describe('AdtApiError', () => {
   describe('constructor deep error extraction', () => {
     it('extracts msgText from full responseBody when truncated message only yields HTML title', () => {
       // Simulate: first 500 chars only contain the HTML head (title), but full body has msgText deeper
-      const shortHtml = '<html><head><title>Application Server Error</title></head><body>' + 'x'.repeat(400);
+      const shortHtml = `<html><head><title>Application Server Error</title></head><body>${'x'.repeat(400)}`;
       const fullHtml =
         shortHtml +
         '<p class="detailText"><span id="msgText">Syntax error in program ZC_FBCLUBTP===================BD</span></p></body></html>';

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -173,6 +173,48 @@ describe('AdtHttpClient', () => {
       expect(fetchHeaders(1)['X-CSRF-Token']).toBe('TOKEN123');
     });
 
+    it('retries CSRF fetch with GET when HEAD returns 403 (S/4HANA Public Cloud compat)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(403, 'Forbidden'));
+      mockFetch.mockResolvedValueOnce(mockResponse(200, '', { 'x-csrf-token': 'TOKEN' }));
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      await client.post('/sap/bc/adt/checkruns', '<xml/>', 'application/xml');
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(fetchOptions(0).method).toBe('HEAD');
+      expect(fetchOptions(1).method).toBe('GET');
+      expect(fetchHeaders(2)['X-CSRF-Token']).toBe('TOKEN');
+    });
+
+    it('throws when both HEAD and GET return 403', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(403, 'Forbidden'));
+      mockFetch.mockResolvedValueOnce(mockResponse(403, 'Forbidden'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      try {
+        await client.fetchCsrfToken();
+        throw new Error('Expected fetchCsrfToken to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(AdtApiError);
+        expect(error).toMatchObject({
+          statusCode: 403,
+          message: expect.stringMatching(/forbidden/i),
+        });
+      }
+    });
+
+    it('does not use GET fallback when HEAD returns 401', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(401, 'Unauthorized'));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      await expect(client.fetchCsrfToken()).rejects.toMatchObject({
+        statusCode: 401,
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(fetchOptions(0).method).toBe('HEAD');
+    });
+
     it('does not re-fetch CSRF token for second POST', async () => {
       // CSRF fetch
       mockFetch.mockResolvedValueOnce(mockResponse(200, '', { 'x-csrf-token': 'T1' }));
@@ -323,6 +365,7 @@ describe('AdtHttpClient', () => {
     });
 
     it('throws AdtApiError on 403 during CSRF fetch', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(403, 'Forbidden'));
       mockFetch.mockResolvedValueOnce(mockResponse(403, 'Forbidden'));
 
       const client = new AdtHttpClient(getDefaultConfig());


### PR DESCRIPTION
## What's in this PR

Two P0 compatibility fixes that were silently breaking ARC-1 on specific SAP system variants.

### COMPAT-01: modificationSupport guard in `lockObject()` (`src/adt/crud.ts`)

**Problem:** The ADT lock response contains a `MODIFICATION_SUPPORT` field that is `false` when an object lives in a released transport or is system-delivered. ARC-1 ignored this field and proceeded to write — which then failed with a cryptic HTTP 423 `ExceptionResourceInvalidLockHandle`.

**Fix:** `lockObject()` now checks both `MODIFICATION_SUPPORT` (ABAP XML format) and `modificationSupport` (adtcore namespace format). If either is explicitly `'false'`, throws `AdtApiError(423)` with an actionable message *before* any write attempt — so the LLM can tell the user exactly what's wrong and how to fix it.

### COMPAT-02: CSRF HEAD→GET fallback in `fetchCsrfToken()` (`src/adt/http.ts`)

**Problem:** ARC-1 fetches the CSRF token via `HEAD /sap/bc/adt/core/discovery`. On **S/4HANA Public Cloud** and some S/4HANA 2023 FPS03 on-premise systems, `CL_ADT_WB_RES_APP` returns 403 for HEAD requests. ARC-1 threw immediately with "access forbidden" — silently blocking **all write operations** on those system variants.

**Fix:** When HEAD returns 403, retry once with GET (which succeeds on those systems). Logs a warn audit event for observability. Double-403 and 401 behaviour unchanged.

---

### Also in this PR
- **COMPAT-03** (V4 SRVB publish endpoint): was already fixed in PR #130 — roadmap + feature matrix updated to reflect this.
- `docs/roadmap.md` and `compare/00-feature-matrix.md`: all three COMPAT items marked completed.
- Plan filed to `docs/plans/completed/compat-fixes-01-02.md`.

## Test plan

- [x] 7 new unit tests (4 for COMPAT-01 in `crud.test.ts`, 3 for COMPAT-02 in `http.test.ts`)
- [x] `npm test` — 1870 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] Smoke test write operation on an S/4HANA Public Cloud instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)