### PR TITLE
feat: SAPLint PrettyPrint (ADT code formatter)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,7 @@ tests/
 | Modify hyperfocused mode | `src/handlers/hyperfocused.ts`, `src/handlers/tools.ts` |
 | Add XML response parser | `src/adt/xml-parser.ts` |
 | Add safety check | `src/adt/safety.ts` |
+| Add/modify PrettyPrint action | `src/adt/devtools.ts`, `src/handlers/intent.ts` (handleSAPLint), `src/handlers/tools.ts`, `src/handlers/schemas.ts` |
 | Add lint rule config | `src/lint/lint.ts`, `src/lint/config-builder.ts`, `src/lint/presets/` |
 | Add dependency pattern | `src/context/deps.ts` |
 | Add CDS dependency pattern | `src/context/cds-deps.ts` |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The 11 tools are designed from real LLM interaction feedback:
 | **SAPQuery** | Execute ABAP SQL with table-not-found suggestions |
 | **SAPTransport** | CTS transport management (list/create/release/delete/reassign), transport requirement checks, and reverse lookup history (`action="history"`) |
 | **SAPContext** | Compressed dependency context (`action="deps"`), reverse dependency lookup (`action="usages"`), and CDS upstream/downstream impact analysis (`action="impact"` for DDLS) |
-| **SAPLint** | Local ABAP lint (system-aware presets, auto-fix, pre-write validation) |
+| **SAPLint** | Local ABAP lint (system-aware presets, auto-fix, pre-write validation) + ADT PrettyPrint (server-side formatting) |
 | **SAPDiagnose** | Syntax check, ABAP Unit tests, ATC code quality, short dumps, profiler traces |
 | **SAPManage** | Feature probing — detect what the system supports before acting |
 

--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -2,7 +2,7 @@
 
 A comprehensive comparison of all SAP ADT/MCP projects against ARC-1.
 
-_Last updated: 2026-04-17 (FEAT-49 implemented: object → transport reverse lookup via `SAPTransport(action="history")`; FEAT-33 implemented: CDS impact analysis via `SAPContext(action="impact")`; FEAT-43 implemented: AUTH/FTG2/ENHO SAPRead support; PR #134 merged 2026-04-16: SKTD read/write (Knowledge Transfer Documents); COMPAT-01 fixed 2026-04-16: `lockObject()` now guards on `MODIFICATION_SUPPORT=false`; COMPAT-02 fixed 2026-04-16: CSRF HEAD 403 fallback to GET in `http.ts`; COMPAT-03 already fixed 2026-04-15 in PR #130 (`9b0601c`) via V4 SRVB publish endpoint support; fr0ster v6.1.0 and dassian-adt deep analysis updates retained)_
+_Last updated: 2026-04-17 (FEAT-10 implemented: ADT PrettyPrint + formatter settings via SAPLint; FEAT-49 implemented: object → transport reverse lookup via `SAPTransport(action="history")`; FEAT-33 implemented: CDS impact analysis via `SAPContext(action="impact")`; FEAT-43 implemented: AUTH/FTG2/ENHO SAPRead support; PR #134 merged 2026-04-16: SKTD read/write (Knowledge Transfer Documents); COMPAT-01 fixed 2026-04-16: `lockObject()` now guards on `MODIFICATION_SUPPORT=false`; COMPAT-02 fixed 2026-04-16: CSRF HEAD 403 fallback to GET in `http.ts`; COMPAT-03 already fixed 2026-04-15 in PR #130 (`9b0601c`) via V4 SRVB publish endpoint support; fr0ster v6.1.0 and dassian-adt deep analysis updates retained)_
 
 ## Legend
 - ✅ = Supported
@@ -157,7 +157,7 @@ _Last updated: 2026-04-17 (FEAT-49 implemented: object → transport reverse loo
 | CDS unit tests | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ❌ |
 | API release state (clean core) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
 | Fix proposals | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ (Apr 2026) | ❌ |
-| PrettyPrint | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ (Apr 2026) | ❌ |
+| PrettyPrint | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | N/A | ✅ (Apr 2026) | ❌ |
 | Migration analysis | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | N/A | ❌ | ❌ |
 
 ## 9. Transport / CTS

--- a/docs/plans/completed/prettyprint-adt-formatter.md
+++ b/docs/plans/completed/prettyprint-adt-formatter.md
@@ -1,0 +1,276 @@
+# PrettyPrint (ADT Code Formatter)
+
+## Overview
+
+Add ABAP PrettyPrint via SAP's native ADT `prettyprinter` endpoint as a new **SAPLint** action (`format`), plus settings read/write actions. This is FEAT-10 from `docs/roadmap.md`: dassian-adt and VSP both ship PrettyPrint; ARC-1 currently does not. Placing it on SAPLint (alongside `lint` and `lint_and_fix`) keeps all code-quality / formatting operations under one tool.
+
+Unlike the existing SAPLint actions (which run offline via `@abaplint/core`), PrettyPrint hits the SAP system. It uses the system-wide formatter settings (indentation on/off, keyword style `keywordUpper`/`keywordLower`/`keywordAuto`/`none`) — so the format always matches whatever the ABAP developer community on that SAP system has agreed on. That is the main reason this exists alongside `lint_and_fix`: `lint_and_fix` enforces abaplint's opinionated rules; `format` enforces the SAP system's own settings.
+
+Endpoints verified live against the A4H test system (see `INFRASTRUCTURE.md`):
+- `POST /sap/bc/adt/abapsource/prettyprinter` — body is raw ABAP source (`text/plain; charset=utf-8`), response is formatted ABAP source (`text/plain`). Requires CSRF token (auto-managed by `AdtHttpClient.post`).
+- `GET /sap/bc/adt/abapsource/prettyprinter/settings` — returns `<abapformatter:PrettyPrinterSettings indentation="true" style="keywordUpper" xmlns:abapformatter="http://www.sap.com/adt/prettyprintersettings"/>` under `Accept: application/vnd.sap.adt.ppsettings.v2+xml`.
+- `PUT /sap/bc/adt/abapsource/prettyprinter/settings` with same body shape writes global settings.
+
+## Context
+
+### Current State
+
+- `src/handlers/intent.ts:1073-1128` — `handleSAPLint` supports only `lint`, `lint_and_fix`, `list_rules`. The `_client` parameter is prefixed with `_` because none of these actions hit SAP.
+- `src/adt/devtools.ts` has `syntaxCheck`, `activate`, `runUnitTests`, `runAtcCheck`, `getFixProposals`, `applyFixProposal`, `publishServiceBinding` etc. No PrettyPrint.
+- `compare/00-feature-matrix.md:160` — ARC-1 PrettyPrint row is `❌`.
+- `docs/roadmap.md:48,560` — FEAT-10 listed as P1, XS, **Not started**.
+
+### Target State
+
+- A new `format` action on SAPLint that POSTs source to `/sap/bc/adt/abapsource/prettyprinter` and returns formatted source.
+- Two settings actions on SAPLint: `get_formatter_settings` (GET) and `set_formatter_settings` (PUT).
+- Full unit test coverage for the new client functions (mocked `undici`).
+- Smoke E2E test that calls `SAPLint(action="format")` against the A4H test system.
+- Docs/roadmap/feature matrix updated.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/devtools.ts` | Host the new `prettyPrint`, `getPrettyPrinterSettings`, `setPrettyPrinterSettings` client functions |
+| `src/adt/safety.ts` | `OperationType.Intelligence` ('I') for `format`, `OperationType.Read`/`OperationType.Update` for settings |
+| `src/handlers/intent.ts` | `handleSAPLint` — add three new action cases; drop `_client` underscore since `format` + settings use it |
+| `src/handlers/tools.ts` | SAPLint tool definition — extend description + action enum |
+| `src/handlers/schemas.ts` | `SAPLintSchema` — extend action enum + add `indentation`, `style` optional fields |
+| `tests/unit/adt/devtools.test.ts` | Unit tests for the three new functions (mocked HTTP) |
+| `tests/unit/handlers/intent.test.ts` (if present) | Add action-dispatch tests for SAPLint `format`/settings |
+| `tests/e2e/smoke.e2e.test.ts` | Add one `SAPLint format` smoke test against A4H |
+| `docs/tools.md` | SAPLint section — document three new actions |
+| `CLAUDE.md` | "Key Files for Common Tasks" — note SAPLint now has server-side actions |
+| `docs/roadmap.md` | Move FEAT-10 from "Not yet implemented" to "Completed" |
+| `compare/00-feature-matrix.md` | PrettyPrint row — flip ARC-1 ❌ → ✅ |
+| `README.md` | SAPLint bullet — mention PrettyPrint |
+
+### Design Principles
+
+1. **Host on SAPLint, not a new tool.** The user mental model "I want this code formatted" sits next to "I want this code linted". XS feature — no new tool, no new scope.
+2. **Use `OperationType.Intelligence` for `format`.** It's a stateless transformation of provided source — not a read of a SAP object, not a write. Mirrors how completion/code-intelligence is classified.
+3. **`set_formatter_settings` is gated by `readOnly`.** It modifies system-wide state; use `OperationType.Update` so `--read-only=true` (default) blocks it.
+4. **No lock/unlock cycle.** PrettyPrint is stateless; no transport; no package check needed (source is supplied by the caller, not an SAP object ref).
+5. **CSRF handled by `AdtHttpClient.post`.** Pattern already proven in `devtools.ts` — `checkOperation` then `http.post(path, body, 'text/plain; charset=utf-8', { Accept: 'text/plain' })`.
+6. **Return raw text for `format`.** Do not wrap in JSON — consumers will feed the result straight back into SAPWrite. Use `textResult(resp.body)`.
+7. **Return structured JSON for `*_formatter_settings`.** `{ indentation: boolean, style: 'keywordUpper' | 'keywordLower' | 'keywordAuto' | 'none' }`.
+
+## Development Approach
+
+- Build bottom-up: add client functions first, then wire through the handler, then schema/tool-def, then tests, then docs.
+- Every task ends with `npm test` to catch regressions.
+- Do **not** invoke the live A4H system from unit tests — mock `undici` following the existing pattern in `tests/unit/adt/devtools.test.ts:18-27`.
+- The E2E smoke test is optional but low-cost (one POST) and confirms end-to-end wiring.
+- Biome formatting is auto-fixed by the pre-commit hook — don't hand-format.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add `prettyPrint` + settings client functions in `src/adt/devtools.ts`
+
+**Files:**
+- Modify: `src/adt/devtools.ts`
+
+Add three new exported functions to the devtools module. Mirror the signature and safety-check style of the existing `syntaxCheck` function at `src/adt/devtools.ts:17-36`. The endpoints were verified live against the A4H test system.
+
+- [ ] Add `export async function prettyPrint(http: AdtHttpClient, safety: SafetyConfig, source: string): Promise<string>`:
+  - Call `checkOperation(safety, OperationType.Intelligence, 'PrettyPrint')`
+  - Call `http.post('/sap/bc/adt/abapsource/prettyprinter', source, 'text/plain; charset=utf-8', { Accept: 'text/plain' })`
+  - Return `resp.body`
+- [ ] Add `export interface PrettyPrinterSettings { indentation: boolean; style: 'keywordUpper' | 'keywordLower' | 'keywordAuto' | 'none' }`
+- [ ] Add `export async function getPrettyPrinterSettings(http: AdtHttpClient, safety: SafetyConfig): Promise<PrettyPrinterSettings>`:
+  - Call `checkOperation(safety, OperationType.Read, 'GetPrettyPrinterSettings')`
+  - Call `http.get('/sap/bc/adt/abapsource/prettyprinter/settings', { Accept: 'application/vnd.sap.adt.ppsettings.v2+xml' })`
+  - Parse the XML (use `parseXml` from `./xml-parser.js` like other devtools functions). Extract `@_abapformatter:indentation` ("true"/"false") and `@_abapformatter:style` from the root `abapformatter:PrettyPrinterSettings` element. Default to `{ indentation: true, style: 'keywordUpper' }` if attributes are missing.
+- [ ] Add `export async function setPrettyPrinterSettings(http: AdtHttpClient, safety: SafetyConfig, settings: PrettyPrinterSettings): Promise<void>`:
+  - Call `checkOperation(safety, OperationType.Update, 'SetPrettyPrinterSettings')`
+  - Build XML body: `<?xml version="1.0" encoding="utf-8"?><abapformatter:PrettyPrinterSettings abapformatter:indentation="${settings.indentation}" abapformatter:style="${settings.style}" xmlns:abapformatter="http://www.sap.com/adt/prettyprintersettings"/>`
+  - Call `http.put('/sap/bc/adt/abapsource/prettyprinter/settings', body, 'application/vnd.sap.adt.ppsettings.v2+xml')`
+- [ ] Update the module header comment (line 1-8) to list PrettyPrint among the tools.
+- [ ] Run `npm run typecheck` — no errors.
+- [ ] Run `npm test` — all existing tests must still pass.
+
+### Task 2: Unit tests for the three new client functions
+
+**Files:**
+- Modify: `tests/unit/adt/devtools.test.ts`
+
+Mirror the mock pattern already at `tests/unit/adt/devtools.test.ts:18-27` (`mockHttp` factory). Unit tests must not hit the network.
+
+- [ ] Import `prettyPrint`, `getPrettyPrinterSettings`, `setPrettyPrinterSettings` from `../../../src/adt/devtools.js` (add to the existing import block at lines 1-13).
+- [ ] Add `describe('prettyPrint', ...)` block (~4 tests):
+  - Returns formatted source on 200: mock `post` to return body `"REPORT ztest.\nDATA lv TYPE string.\n"`; assert returned string matches.
+  - Passes `text/plain; charset=utf-8` Content-Type and `Accept: text/plain`: assert `post` was called with those exact args.
+  - Hits the correct endpoint path `/sap/bc/adt/abapsource/prettyprinter`: assert `post.mock.calls[0][0]`.
+  - Blocked by `readOnly`? No — `Intelligence` is a read-class op, so a readOnly config must still allow it. Assert no throw on `readOnly: true` config (use `defaultSafetyConfig()`).
+- [ ] Add `describe('getPrettyPrinterSettings', ...)` block (~3 tests):
+  - Parses a realistic XML response `<abapformatter:PrettyPrinterSettings abapformatter:indentation="true" abapformatter:style="keywordUpper" xmlns:abapformatter="http://www.sap.com/adt/prettyprintersettings"/>` → `{ indentation: true, style: 'keywordUpper' }`.
+  - Parses `indentation="false"` and `style="keywordLower"` correctly.
+  - Falls back to `{ indentation: true, style: 'keywordUpper' }` when attributes are missing.
+- [ ] Add `describe('setPrettyPrinterSettings', ...)` block (~3 tests):
+  - Sends the expected XML body (assert `put.mock.calls[0][1]` contains both attributes).
+  - Uses the `application/vnd.sap.adt.ppsettings.v2+xml` Content-Type.
+  - Throws `AdtSafetyError` when called with a `readOnly: true` config (this is a write op — use `defaultSafetyConfig()` and assert `.toThrow(AdtSafetyError)`).
+- [ ] Run `npm test` — all tests (new + existing) pass.
+
+### Task 3: Extend `SAPLintSchema` in `src/handlers/schemas.ts`
+
+**Files:**
+- Modify: `src/handlers/schemas.ts`
+
+The Zod schema at `src/handlers/schemas.ts:394-399` restricts `action` to three values. Extend it.
+
+- [ ] Change the `action` enum to `['lint', 'lint_and_fix', 'list_rules', 'format', 'get_formatter_settings', 'set_formatter_settings']`.
+- [ ] Add optional fields for the `set_formatter_settings` payload:
+  - `indentation: z.coerce.boolean().optional()`
+  - `style: z.enum(['keywordUpper', 'keywordLower', 'keywordAuto', 'none']).optional()`
+- [ ] Do NOT add conditional required-ness via `.refine()` — keep it consistent with `SAPDiagnoseSchema` (all fields optional, handler validates). The handler (Task 5) validates action-specific requirements with `errorResult()`.
+- [ ] Run `npm run typecheck` — no errors.
+- [ ] Run `npm test` — all tests pass.
+
+### Task 4: Extend SAPLint tool definition in `src/handlers/tools.ts`
+
+**Files:**
+- Modify: `src/handlers/tools.ts`
+
+The tool definition at `src/handlers/tools.ts:738-766` is what the MCP client sees. Update it to advertise the new actions.
+
+- [ ] Extend the `description` string (line 741-747) to mention the three new actions. Keep the "Actions:" bullet list style. Add:
+  - `- "format": Pretty-print ABAP source via SAP's ADT formatter (uses the SAP system's global formatter settings). Requires source. Returns the formatted source.`
+  - `- "get_formatter_settings": Read the SAP system's global PrettyPrinter settings (indentation, keyword style). No params.`
+  - `- "set_formatter_settings": Update the SAP system's global PrettyPrinter settings. Requires indentation (bool) and/or style (keywordUpper|keywordLower|keywordAuto|none). Blocked in read-only mode.`
+- [ ] Add a short note that `format` calls SAP (vs `lint`/`lint_and_fix`/`list_rules` which run offline). E.g. at the end of the description: `Note: lint/lint_and_fix/list_rules run locally; format/*_formatter_settings call the SAP system.`
+- [ ] Extend the `action` enum in `inputSchema.properties.action.enum` from `['lint', 'lint_and_fix', 'list_rules']` to include the three new actions.
+- [ ] Add `indentation: { type: 'boolean', description: 'PrettyPrinter: indent source (for set_formatter_settings)' }` and `style: { type: 'string', enum: ['keywordUpper', 'keywordLower', 'keywordAuto', 'none'], description: 'PrettyPrinter: keyword casing (for set_formatter_settings)' }` to `inputSchema.properties`.
+- [ ] Run `npm run typecheck` — no errors.
+- [ ] Run `npm test` — all tests pass.
+
+### Task 5: Wire the new actions into `handleSAPLint` in `src/handlers/intent.ts`
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+
+The handler at `src/handlers/intent.ts:1075-1128` currently treats `_client` as unused. Two of the three new actions need the live ADT client.
+
+- [ ] Rename `_client: AdtClient` → `client: AdtClient` in the function signature at line 1076. Update the comment at line 1073-1074 to say "Some actions (format, *_formatter_settings) hit SAP; others run offline via @abaplint/core."
+- [ ] Import the three new functions at the top of `intent.ts` from `../adt/devtools.js` (find the existing import block that imports from `../adt/devtools.js` — add `prettyPrint`, `getPrettyPrinterSettings`, `setPrettyPrinterSettings`, and the `PrettyPrinterSettings` type).
+- [ ] Add three new `case` branches inside the `switch (action)` at line 1084, before the `default` at line 1123:
+  - `case 'format': { const source = String(args.source ?? ''); if (!source) return errorResult('"source" is required for format action.'); const formatted = await prettyPrint(client.http, client.safety, source); return textResult(formatted); }`
+  - `case 'get_formatter_settings': { const settings = await getPrettyPrinterSettings(client.http, client.safety); return textResult(JSON.stringify(settings, null, 2)); }`
+  - `case 'set_formatter_settings': { const indentation = args.indentation as boolean | undefined; const style = args.style as PrettyPrinterSettings['style'] | undefined; if (indentation === undefined && !style) return errorResult('At least one of "indentation" or "style" is required for set_formatter_settings.'); const current = await getPrettyPrinterSettings(client.http, client.safety); const next: PrettyPrinterSettings = { indentation: indentation ?? current.indentation, style: style ?? current.style }; await setPrettyPrinterSettings(client.http, client.safety, next); return textResult(JSON.stringify(next, null, 2)); }`
+- [ ] Update the error message in the `default` branch at line 1125 to list all six actions.
+- [ ] Run `npm run typecheck` — no errors.
+- [ ] Run `npm test` — all tests pass.
+
+### Task 6: Handler unit tests for the three new actions
+
+**Files:**
+- Modify: `tests/unit/handlers/intent.test.ts` (if it exists) OR create `tests/unit/handlers/saplint-format.test.ts`
+
+First check whether `tests/unit/handlers/intent.test.ts` exists. If yes, add to it; if no, create a new focused test file. Use `vi.mock` to stub the devtools functions so we test handler wiring in isolation.
+
+- [ ] Add test: `SAPLint format` happy path — mock `prettyPrint` to return a known string, dispatch `SAPLint` with `{ action: 'format', source: 'report ztest.' }`, assert result text equals the mocked return value.
+- [ ] Add test: `SAPLint format` without source returns error "\"source\" is required for format action.".
+- [ ] Add test: `SAPLint get_formatter_settings` — mock `getPrettyPrinterSettings` to return `{ indentation: true, style: 'keywordUpper' }`, assert result is that JSON.
+- [ ] Add test: `SAPLint set_formatter_settings` with only `style` preserves existing `indentation` (mock `getPrettyPrinterSettings` for the merge path, assert `setPrettyPrinterSettings` called with merged settings).
+- [ ] Add test: `SAPLint set_formatter_settings` with neither `indentation` nor `style` returns error.
+- [ ] Add test: `SAPLint` with an unknown action mentions `format`/`get_formatter_settings`/`set_formatter_settings` in the error message (regression-guards Task 5's `default` update).
+- [ ] Run `npm test` — all tests pass.
+
+### Task 7: E2E smoke test for `SAPLint format` against the A4H system
+
+**Files:**
+- Modify: `tests/e2e/smoke.e2e.test.ts`
+
+The existing SAPLint smoke test is at `tests/e2e/smoke.e2e.test.ts:168-177`. Add a second test immediately after it. The test hits the live SAP system via the running MCP server (see `tests/e2e/helpers.ts`).
+
+- [ ] Add a new `it('SAPLint — formats ABAP source via ADT PrettyPrinter', ...)` test:
+  - Call `callTool(client, 'SAPLint', { action: 'format', source: 'report ztest.\ndata lv type string.\n' })`.
+  - `expectToolSuccess(result)` to extract the text body.
+  - Assert the response includes uppercased keywords (`REPORT`, `DATA`) — the A4H default is `keywordUpper`. Use case-sensitive `.toContain('REPORT')` and `.toContain('DATA')`.
+  - Do NOT assert exact whitespace — SAP's formatter is free to change indentation based on system settings.
+- [ ] Add a second `it('SAPLint — reads formatter settings', ...)` test:
+  - Call `callTool(client, 'SAPLint', { action: 'get_formatter_settings' })`.
+  - Parse the JSON body; assert it has `indentation` (boolean) and `style` (one of the four enum values).
+- [ ] Do NOT add an E2E test for `set_formatter_settings` — that would mutate global state on the test system; rely on unit tests.
+- [ ] Run `npm run test:e2e` if you can (requires running MCP server per `CLAUDE.md`). If the MCP server isn't running, `npm test` still covers the unit path — note this in the task summary.
+
+### Task 8: Documentation updates — SAPLint, CLAUDE.md, feature matrix, roadmap
+
+**Files:**
+- Modify: `docs/tools.md`
+- Modify: `CLAUDE.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `docs/roadmap.md`
+- Modify: `README.md`
+
+Update all artifacts per the ralphex-plan skill's doc-audit checklist.
+
+- [ ] **`docs/tools.md`** — at `docs/tools.md:486` (SAPLint section):
+  - Extend the `action` row in the Parameters table to list all six actions.
+  - Add `indentation` and `style` rows to the Parameters table (with short descriptions).
+  - Add three bullets to the "Actions:" list (after the `list_rules` bullet at line 503) for `format`, `get_formatter_settings`, `set_formatter_settings`.
+  - Add a "Response shapes" entry for `format` (plain text — formatted source) and for the settings actions (JSON `{ indentation, style }`).
+  - Add three new example lines at the end of the Examples block (line ~544):
+    ```
+    SAPLint(action="format", source="report ztest. data lv type string.")
+    SAPLint(action="get_formatter_settings")
+    SAPLint(action="set_formatter_settings", style="keywordLower")
+    ```
+  - Add a note: `format` and `*_formatter_settings` hit the SAP system (unlike the local actions).
+- [ ] **`CLAUDE.md`** — "Key Files for Common Tasks" table: add a row `| Add/modify PrettyPrint action | \`src/adt/devtools.ts\`, \`src/handlers/intent.ts\` (handleSAPLint), \`src/handlers/tools.ts\`, \`src/handlers/schemas.ts\` |`. Place it near the SAPLint-related rows (grep for `SAPLint` / `abaplint` in the table).
+- [ ] **`compare/00-feature-matrix.md:160`** — change the ARC-1 column (first data column) from `❌` to `✅` on the PrettyPrint row. Also update any "Last Updated" date near the top of the file if present.
+- [ ] **`docs/roadmap.md`**:
+  - Remove the `FEAT-10` row from the "Not Yet Implemented" overview table (line 48) — re-number subsequent rows in that section.
+  - Add `| FEAT-10 | PrettyPrint (Code Formatting) | 2026-04-17 | Features |` to the "Overview: Completed" table (line 88 area), in the correct date order.
+  - Replace the `FEAT-10` detail block at line 560-576:
+    - Change `**Status**` to `Done`
+    - Replace the `**Why not:**` block with a short "**Resolution:**" paragraph pointing to `docs/plans/completed/prettyprint-adt-formatter.md` and noting that it's exposed as SAPLint actions `format` / `get_formatter_settings` / `set_formatter_settings`.
+  - Remove or update the `2026-04-14 priority re-evaluation` sentence (line 148) that mentions pretty-print urgency — at minimum add "(completed)" next to FEAT-10.
+  - Remove the `FEAT-10` line at line 190 (already a stale `~~...~~` strikethrough) if it's now redundant.
+- [ ] **`README.md:81`** — extend the SAPLint row: `| **SAPLint** | Local ABAP lint (system-aware presets, auto-fix, pre-write validation) + ADT PrettyPrint (server-side formatting) |`.
+- [ ] No new config flags or env vars are introduced, so `docs/cli-guide.md`, `.env.example`, `src/server/config.ts`, `src/server/types.ts` do NOT need updates.
+- [ ] No changes to authentication/scope model, so `docs/authorization.md`, `docs/security-guide.md`, `xs-security.json` do NOT need updates (SAPLint already maps to `read` scope in `TOOL_SCOPES` at `src/handlers/intent.ts:141` — the new actions inherit that, and the handler-level safety check gates `set_formatter_settings` via `readOnly`).
+- [ ] Run `npm test` — all tests pass.
+
+### Task 9: Skills audit — update `.claude/commands/*.md` if they reference SAPLint actions
+
+**Files:**
+- Modify (conditionally): `.claude/commands/implement-feature.md`, `.claude/commands/compare-projects.md`, `.claude/commands/update-competitor-tracker.md`, `.claude/commands/ralphex-plan.md`
+
+The ralphex-plan skill mandates a skills audit. Keep this scoped — only touch skills that reference SAPLint or PrettyPrint.
+
+- [ ] Grep `.claude/commands/` for `SAPLint`, `lint_and_fix`, `PrettyPrint`, `pretty`. If any skill lists SAPLint's action set, extend it with `format`, `get_formatter_settings`, `set_formatter_settings`.
+- [ ] If `implement-feature.md` has a formatting-related step, mention that `SAPLint(action="format")` is now available as an alternative to `lint_and_fix`.
+- [ ] No changes are required to the ralphex-plan skill itself.
+- [ ] If the grep finds no references, this task is a no-op (document that in the task summary).
+- [ ] Run `npm test` — all tests pass.
+
+### Task 10: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass.
+- [ ] Run typecheck: `npm run typecheck` — no errors.
+- [ ] Run lint: `npm run lint` — no errors. (Biome fixes are auto-applied by the pre-commit hook; only hard errors need manual attention.)
+- [ ] Manual sanity check against A4H:
+  ```bash
+  curl -sS -u DEVELOPER:UBqEYcdvsVLtkiiCU1UHdKeT -H "sap-client: 001" \
+    -c /tmp/c.txt -b /tmp/c.txt -I -X HEAD \
+    "http://65.109.59.210:50000/sap/bc/adt/abapsource/prettyprinter" \
+    -H "x-csrf-token: fetch"
+  # Extract x-csrf-token from response headers, then:
+  curl -sS -u DEVELOPER:UBqEYcdvsVLtkiiCU1UHdKeT -H "sap-client: 001" \
+    -b /tmp/c.txt -c /tmp/c.txt \
+    -H "x-csrf-token: <token>" \
+    -H "Content-Type: text/plain; charset=utf-8" -H "Accept: text/plain" \
+    -X POST "http://65.109.59.210:50000/sap/bc/adt/abapsource/prettyprinter" \
+    --data-binary $'report ztest.\ndata lv type string.\n'
+  ```
+  Expect uppercased keywords in the response (matches the default `keywordUpper` style).
+- [ ] Verify `docs/roadmap.md` renders correctly (no broken table rows, FEAT-10 moved to Completed section).
+- [ ] Verify `compare/00-feature-matrix.md` row 160 shows ARC-1 as `✅`.
+- [ ] Move this plan file from `docs/plans/prettyprint-adt-formatter.md` to `docs/plans/completed/prettyprint-adt-formatter.md`.
+- [ ] Stage a single commit with message `feat: FEAT-10 SAPLint PrettyPrint (ADT code formatter)` — the release-please `feat:` prefix triggers a minor bump.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,39 +45,38 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | ~~—~~ | ~~COMPAT-02~~ | ~~CSRF HEAD→GET fallback (S/4HANA Public Cloud)~~ | ~~P0~~ | ~~XS~~ | ~~Completed 2026-04-16~~ |
 | ~~—~~ | ~~COMPAT-03~~ | ~~V4 SRVB publish endpoint bug~~ | ~~P0~~ | ~~XS~~ | ~~Completed 2026-04-15~~ |
 | 1 | FEAT-18 | Function Group Bulk Fetch | P1 | S | Features |
-| 2 | FEAT-10 | PrettyPrint (Code Formatting) | P1 | XS | Features |
-| 3 | FEAT-20 | Source Version / Revision History | P1 | S | Features |
+| 2 | FEAT-20 | Source Version / Revision History | P1 | S | Features |
 | ~~—~~ | ~~FEAT-49~~ | ~~Object Transport History (Reverse Lookup)~~ | ~~P1~~ | ~~S~~ | ~~Completed 2026-04-17~~ |
-| 5 | DOC-01 | Copilot Studio Setup Guide | P1 | S | Docs |
-| 6 | DOC-02 | Basis Admin Security Guide | P1 | S | Docs |
-| 7 | FEAT-24 | CompareSource (Diff) | P2 ↑ | S | Features |
-| 8 | FEAT-32 | Table Pagination / Offset | P2 | XS | Features |
-| 9 | FEAT-21 | ABAP Documentation (F1 Help) | P2 | XS | Features |
-| 10 | FEAT-28 | SAP Compatibility Hardening | P2 | S | Features |
-| 11 | OPS-02 | Health Check Enhancements | P2 | XS | Ops |
-| 12 | FEAT-41 | ABAP Unit Test Coverage (statement-level) | P2 | S | Features |
-| 13 | FEAT-42 | ATC Output Formats (JUnit4, checkstyle, codeclimate) | P2 | XS | Features |
+| 3 | DOC-01 | Copilot Studio Setup Guide | P1 | S | Docs |
+| 4 | DOC-02 | Basis Admin Security Guide | P1 | S | Docs |
+| 5 | FEAT-24 | CompareSource (Diff) | P2 ↑ | S | Features |
+| 6 | FEAT-32 | Table Pagination / Offset | P2 | XS | Features |
+| 7 | FEAT-21 | ABAP Documentation (F1 Help) | P2 | XS | Features |
+| 8 | FEAT-28 | SAP Compatibility Hardening | P2 | S | Features |
+| 9 | OPS-02 | Health Check Enhancements | P2 | XS | Ops |
+| 10 | FEAT-41 | ABAP Unit Test Coverage (statement-level) | P2 | S | Features |
+| 11 | FEAT-42 | ATC Output Formats (JUnit4, checkstyle, codeclimate) | P2 | XS | Features |
 | ~~—~~ | ~~FEAT-43~~ | ~~DDIC Auth & Misc Read (Authorization Fields, Feature Toggles, Enhancement Implementations)~~ | ~~P2~~ | ~~S~~ | ~~Completed 2026-04-17~~ |
-| 15 | FEAT-09 | SQL Trace Monitoring | P2 | S | Features |
-| 16 | SEC-05 | Rate Limiting | P2 | S | Security |
-| 17 | FEAT-31 | Code Coverage from Unit Tests | P2 | S | Features |
-| ~~18~~ | ~~FEAT-33~~ | ~~CDS Impact Analysis~~ | ~~P2~~ | ~~S~~ | ~~Completed 2026-04-16~~ |
-| 19 | FEAT-26 | MCP Client Config Snippets | P2 | S | Features |
-| 20 | FEAT-25 | CDS Unit Tests | P2 | S | Features |
-| 21 | FEAT-23 | GetProgFullCode (Include Traversal) | P2 | S | Features |
-| 22 | FEAT-36 | Type Information (SAPNavigate) | P2 | S | Features |
-| 23 | FEAT-27 | Migration Analysis (ECC->S/4) | P2 | S | Features |
-| 24 | FEAT-06 | Cloud Readiness Assessment | P2 | M | Features |
-| 25 | FEAT-03 | Enhancement Framework (BAdI) | P2 | M | Features |
-| 26 | FEAT-22 | gCTS/abapGit Integration | P2 | M | Features |
-| 27 | FEAT-34 | i18n Translation Management | P2 | M | Features |
-| 28 | FEAT-30 | ABAP Cleaner Integration | P2 | M | Features |
-| 29 | DOC-03 | SAP Community Blog Post | P2 | S | Docs |
+| 12 | FEAT-09 | SQL Trace Monitoring | P2 | S | Features |
+| 13 | SEC-05 | Rate Limiting | P2 | S | Security |
+| 14 | FEAT-31 | Code Coverage from Unit Tests | P2 | S | Features |
+| ~~—~~ | ~~FEAT-33~~ | ~~CDS Impact Analysis~~ | ~~P2~~ | ~~S~~ | ~~Completed 2026-04-16~~ |
+| 15 | FEAT-26 | MCP Client Config Snippets | P2 | S | Features |
+| 16 | FEAT-25 | CDS Unit Tests | P2 | S | Features |
+| 17 | FEAT-23 | GetProgFullCode (Include Traversal) | P2 | S | Features |
+| 18 | FEAT-36 | Type Information (SAPNavigate) | P2 | S | Features |
+| 19 | FEAT-27 | Migration Analysis (ECC->S/4) | P2 | S | Features |
+| 20 | FEAT-06 | Cloud Readiness Assessment | P2 | M | Features |
+| 21 | FEAT-03 | Enhancement Framework (BAdI) | P2 | M | Features |
+| 22 | FEAT-22 | gCTS/abapGit Integration | P2 | M | Features |
+| 23 | FEAT-34 | i18n Translation Management | P2 | M | Features |
+| 24 | FEAT-30 | ABAP Cleaner Integration | P2 | M | Features |
+| 25 | DOC-03 | SAP Community Blog Post | P2 | S | Docs |
 | — | COMPAT-04 | BTP transport omission in safeUpdateSource() — verify only | P2 | XS | Compatibility |
-| 30 | FEAT-07 | TLS/HTTPS for HTTP Streamable | P3 | S | Features |
-| 31 | FEAT-05 | Code Refactoring (Rename, Extract) | P3 | L | Features |
-| 32 | FEAT-29 | P3 Backlog (14 items) | P3 | various | Features |
-| 33 | OPS-03 | Multi-System Routing | P3 | L | Ops |
+| 28 | FEAT-07 | TLS/HTTPS for HTTP Streamable | P3 | S | Features |
+| 29 | FEAT-05 | Code Refactoring (Rename, Extract) | P3 | L | Features |
+| 30 | FEAT-29 | P3 Backlog (14 items) | P3 | various | Features |
+| 31 | OPS-03 | Multi-System Routing | P3 | L | Ops |
 
 ---
 
@@ -86,8 +85,9 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | ID | Feature | Completed | Category |
 |----|---------|-----------|----------|
 | FEAT-49 | Object Transport History (Reverse Lookup) | 2026-04-17 | Features |
-| FEAT-33 | CDS Impact Analysis | 2026-04-16 | Features |
+| FEAT-10 | PrettyPrint (Code Formatting) | 2026-04-17 | Features |
 | FEAT-43 | DDIC Auth & Misc Read (Authorization Fields, Feature Toggles, Enhancement Implementations) | 2026-04-17 | Features |
+| FEAT-33 | CDS Impact Analysis | 2026-04-16 | Features |
 | FEAT-38 | ADT Service Discovery (MIME Negotiation) | 2026-04-15 | Features |
 | FEAT-16 | Error Intelligence (Actionable Hints) | 2026-04-15 | Features |
 | FEAT-37 | DCL (Access Control) Read/Write | 2026-04-15 | Features |
@@ -147,7 +147,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 
 > Priorities are assigned based on which [core design principle](#vision) a feature serves. Sourced from 4 competitor trackers ([fr0ster](../compare/fr0ster/overview.md), [VSP](../compare/vibing-steampunk/overview.md), [abap-adt-api](../compare/abap-adt-api/overview.md), [dassian-adt](../compare/07-dassian-adt.md)) and the [cross-project feature matrix](../compare/00-feature-matrix.md).
 >
-> **2026-04-14 priority re-evaluation:** dassian-adt's explosive growth (0→32 stars, 25→53 tools, OAuth/XSUAA, multi-system in 2 weeks) and SAP's confirmed Q2 2026 GA for official ABAP MCP Server increase urgency on fix proposals (FEAT-12↑P1), error intelligence (FEAT-16↑P1), and pretty print (FEAT-10↑P1). SAP Joule entering the space makes ARC-1's enterprise-grade safety/auth differentiation even more important.
+> **2026-04-14 priority re-evaluation:** dassian-adt's explosive growth (0→32 stars, 25→53 tools, OAuth/XSUAA, multi-system in 2 weeks) and SAP's confirmed Q2 2026 GA for official ABAP MCP Server increase urgency on fix proposals (FEAT-12↑P1), error intelligence (FEAT-16↑P1), and pretty print (FEAT-10↑P1, completed 2026-04-17). SAP Joule entering the space makes ARC-1's enterprise-grade safety/auth differentiation even more important.
 >
 > **2026-04-16 additions:** Cross-project competitor analysis (VSP, fr0ster, dassian-adt deep dive) identified COMPAT-01..03 plus verify item COMPAT-04. Follow-up confirmed COMPAT-03 had already been fixed in PR #130 (commit `9b0601c`, completed 2026-04-15). COMPAT-01 and COMPAT-02 were fixed in this follow-up (completed 2026-04-16). FR0ster reached v6.1.0 (35 stars). VSP confirmed modificationSupport guard as root cause of recurring 423 lock errors and surfaced S/4HANA Public Cloud CSRF HEAD incompatibility (#104). PR #134 (SKTD) merged 2026-04-16 — ARC-1-unique Knowledge Transfer Document support now live. Enhancement (BAdI) ADT endpoints confirmed from fr0ster analysis. GetProgFullCode confirmed on-prem only via nodestructure API. Added **FEAT-49** (Object Transport History) at P1 — reverse lookup ("which transports contain this object?") is the missing link for transport-scoped code review (fr0ster#30). Enriched **FEAT-20** (revisions) with concrete ADT endpoint details; upgraded **FEAT-24** (diff) rationale — the trio (FEAT-49→FEAT-20→FEAT-24) enables the full code review workflow no competitor has end-to-end. Overview table re-sorted by actual priority (P0→P1→P2→P3).
 
@@ -181,7 +181,7 @@ These bugs affect real-world deployments and were confirmed by cross-project com
 13. ~~**FEAT-44** TABL (Database Table) Create (S)~~ — **completed 2026-04-14** (source-based TABL create/update/delete + batch_create support in SAPWrite)
 14. ~~**FEAT-45** DEVC (Package) Create (S)~~ — **completed 2026-04-14**. Endpoint: `/sap/bc/adt/packages`.
 15. **FEAT-18** Function Group Bulk Fetch (S) — token/round-trip savings. dassian-adt has parallel fetch (objectstructure + Promise.all pattern confirmed).
-16. **FEAT-10** PrettyPrint (XS) — **↑ Upgraded from P2:** dassian-adt and VSP both have this. XS effort, high visibility.
+16. ~~**FEAT-10** PrettyPrint (XS)~~ — **completed 2026-04-17** (`SAPLint` actions: `format`, `get_formatter_settings`, `set_formatter_settings`).
 17. **FEAT-20** Source Version / Revision History (S) — **↑ Upgraded from P2:** dassian-adt added `abap_get_revisions`. Enables diff and rollback workflows. ADT endpoints confirmed: `{sourceUrl}/versions` (Atom feed) + `{versionUri}` for source at revision.
 18. ~~**FEAT-49** Object Transport History / Reverse Lookup (S)~~ — **completed 2026-04-17.** Implemented as `SAPTransport(action="history")` using per-object `GET {objectUrl}/transports` endpoint with `transportchecks` fallback for candidate transports.
 19. **DOC-01** Copilot Studio Setup Guide (S) — critical for enterprise adoption
@@ -189,12 +189,11 @@ These bugs affect real-world deployments and were confirmed by cross-project com
 
 ### Phase C: ADT Feature Parity (P2) — Quick Wins
 13. **FEAT-32** Table Pagination / Offset (XS) — VSP has this, practical improvement
-14. ~~**FEAT-10** PrettyPrint (XS) — **promoted to P1/Phase B** (dassian-adt + VSP have it)~~
-15. ~~**FEAT-11** Inactive Objects List (XS)~~ — **completed** (via SAPRead type=INACTIVE_OBJECTS)
-16. ~~**FEAT-19** Transport Contents (XS)~~ — **completed** (subsumed by FEAT-39)
-17. **FEAT-21** ABAP Documentation / F1 Help (XS) — real docs instead of hallucination
-18. **FEAT-28** SAP Compatibility Hardening (S) — 7 compat fixes bundled (expanded Apr 8)
-19. **OPS-02** Health Check Enhancements (XS) — `/health/deep` with SAP connectivity check
+14. ~~**FEAT-11** Inactive Objects List (XS)~~ — **completed** (via SAPRead type=INACTIVE_OBJECTS)
+15. ~~**FEAT-19** Transport Contents (XS)~~ — **completed** (subsumed by FEAT-39)
+16. **FEAT-21** ABAP Documentation / F1 Help (XS) — real docs instead of hallucination
+17. **FEAT-28** SAP Compatibility Hardening (S) — 7 compat fixes bundled (expanded Apr 8)
+18. **OPS-02** Health Check Enhancements (XS) — `/health/deep` with SAP connectivity check
 
 ### Phase D: ADT Feature Parity (P2) — Larger Items
 20. ~~**FEAT-46** SRVB (Service Binding) Create (S)~~ — **completed 2026-04-14** (SAPWrite now supports SRVB create/update/delete + batch_create; create guidance points to activate + publish flow).
@@ -562,18 +561,18 @@ Note: The `/enhancements/elements` endpoint is **on-prem only** (SAP BTP ABAP Cl
 ### FEAT-10: PrettyPrint (Code Formatting)
 | Field | Value |
 |-------|-------|
-| **Priority** | P2 |
+| **Priority** | P1 |
 | **Effort** | XS (< 1 day) |
 | **Risk** | Low |
 | **Usefulness** | Medium — code formatting via ADT API |
-| **Status** | Not started |
+| **Status** | Done |
 | **Source** | [Feature matrix #14](../compare/00-feature-matrix.md) |
 
 **What:** Format ABAP source code via ADT's PrettyPrint API. VSP and mcp-abap-abap-adt-api have this. Also includes get/set PrettyPrinter settings.
 
 **Why:** Consistent code formatting is important for readability and team standards.
 
-**Why not:** `SAPLint` with auto-fix already handles code formatting (indentation, spacing, line breaks, keyword casing) via `@abaplint/core` — locally, without a SAP round-trip. ADT PrettyPrint adds 100ms+ network latency for zero additional value over the local formatter. Code formatting is stateless and doesn't need SAP's ADT. Users who want IDE-style formatting use their IDE, not an MCP server.
+**Resolution:** Implemented as three `SAPLint` actions: `format` (server-side ADT PrettyPrint), `get_formatter_settings`, and `set_formatter_settings`. Formatter settings are read/written via `/sap/bc/adt/abapsource/prettyprinter/settings`, while source formatting uses `/sap/bc/adt/abapsource/prettyprinter`. See implementation plan and checklist in [docs/plans/completed/prettyprint-adt-formatter.md](./plans/completed/prettyprint-adt-formatter.md).
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -557,9 +557,11 @@ Run local abaplint rules on ABAP source code. System-aware: auto-selects cloud o
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | string | Yes | `lint`, `lint_and_fix`, or `list_rules` |
-| `source` | string | No | ABAP source code (for `lint` and `lint_and_fix`) |
+| `action` | string | Yes | `lint`, `lint_and_fix`, `list_rules`, `format`, `get_formatter_settings`, or `set_formatter_settings` |
+| `source` | string | No | ABAP source code (for `lint`, `lint_and_fix`, and `format`) |
 | `name` | string | No | Object name (used for filename detection) |
+| `indentation` | boolean | No | PrettyPrinter indentation toggle (for `set_formatter_settings`) |
+| `style` | string | No | PrettyPrinter keyword style: `keywordUpper`, `keywordLower`, `keywordAuto`, or `none` (for `set_formatter_settings`) |
 | `rules` | object | No | Rule overrides: `{ "rule_name": false }` to disable, `{ "rule_name": { "severity": "Warning" } }` to configure |
 
 **Actions:**
@@ -567,6 +569,9 @@ Run local abaplint rules on ABAP source code. System-aware: auto-selects cloud o
 - **`lint`** — Check ABAP source for issues. Returns errors and warnings with line/column positions.
 - **`lint_and_fix`** — Lint + auto-fix all fixable issues (keyword case, obsolete statements, etc.). Returns the fixed source code alongside remaining unfixable issues.
 - **`list_rules`** — List all available rules with current config (preset, enabled/disabled status, severity). No source needed.
+- **`format`** — Pretty-print ABAP source via SAP ADT PrettyPrinter using the SAP system's global formatter settings. Returns formatted source text.
+- **`get_formatter_settings`** — Read SAP global PrettyPrinter settings (indentation + keyword style).
+- **`set_formatter_settings`** — Update SAP global PrettyPrinter settings. Provide at least one of `indentation` or `style`. Blocked in read-only mode.
 
 **System-Aware Presets:**
 
@@ -577,6 +582,10 @@ The lint rules auto-configure based on the detected SAP system:
 **Pre-Write Validation:**
 
 When `--lint-before-write` is enabled (default: true), SAPWrite automatically runs a strict subset of lint rules before writing to SAP. Parser errors and cloud violations block the write. Style issues (keyword case, indentation) never block writes.
+
+**Execution mode note:**
+
+`lint`, `lint_and_fix`, and `list_rules` run locally in ARC-1. `format` and `*_formatter_settings` actions call the SAP system (ADT PrettyPrinter endpoints).
 
 **Custom Configuration:**
 
@@ -602,12 +611,18 @@ Rules from the config file are merged on top of the auto-detected preset (cloud/
 - **`lint`** returns: `[{ rule, message, line, column, endLine, endColumn, severity }]`
 - **`lint_and_fix`** returns: `{ fixedSource, appliedFixes, fixedRules, remainingIssues }` — use `fixedSource` as the corrected code
 - **`list_rules`** returns: `{ preset, abapVersion, enabledRules, disabledRules, rules }` — shows active config
+- **`format`** returns: plain text (formatted ABAP source)
+- **`get_formatter_settings`** returns: `{ indentation, style }`
+- **`set_formatter_settings`** returns: `{ indentation, style }` (effective merged settings)
 
 **Examples:**
 ```
 SAPLint(action="lint", source="DATA lv_test TYPE string.\nlv_test = 'hello'.")
 SAPLint(action="lint_and_fix", source="data lv_x type i.\nadd 1 to lv_x.", name="ZCL_TEST")
 SAPLint(action="list_rules")
+SAPLint(action="format", source="report ztest. data lv type string.")
+SAPLint(action="get_formatter_settings")
+SAPLint(action="set_formatter_settings", style="keywordLower")
 SAPLint(action="lint", source="...", rules={"line_length": {"severity": "Error", "length": 80}})
 ```
 

--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -2,6 +2,7 @@
  * Development tools for SAP ADT.
  *
  * - SyntaxCheck: compile-time validation
+ * - PrettyPrint: server-side ABAP formatting
  * - Activate: publish objects to the main repository
  * - RunUnitTests: execute ABAP unit tests
  * - RunATCCheck: ABAP Test Cockpit (code quality)
@@ -33,6 +34,60 @@ export async function syntaxCheck(
   });
 
   return parseSyntaxCheckResult(resp.body);
+}
+
+export interface PrettyPrinterSettings {
+  indentation: boolean;
+  style: 'keywordUpper' | 'keywordLower' | 'keywordAuto' | 'none';
+}
+
+/** Format ABAP source code via ADT PrettyPrinter */
+export async function prettyPrint(http: AdtHttpClient, safety: SafetyConfig, source: string): Promise<string> {
+  checkOperation(safety, OperationType.Intelligence, 'PrettyPrint');
+
+  const resp = await http.post('/sap/bc/adt/abapsource/prettyprinter', source, 'text/plain; charset=utf-8', {
+    Accept: 'text/plain',
+  });
+  return resp.body;
+}
+
+/** Read system-wide ADT PrettyPrinter settings */
+export async function getPrettyPrinterSettings(
+  http: AdtHttpClient,
+  safety: SafetyConfig,
+): Promise<PrettyPrinterSettings> {
+  checkOperation(safety, OperationType.Read, 'GetPrettyPrinterSettings');
+
+  const resp = await http.get('/sap/bc/adt/abapsource/prettyprinter/settings', {
+    Accept: 'application/vnd.sap.adt.ppsettings.v2+xml',
+  });
+
+  const parsed = parseXml(resp.body);
+  const root = (parsed.PrettyPrinterSettings as Record<string, unknown> | undefined) ?? {};
+
+  const rawIndentation = root['@_indentation'];
+  const rawStyle = String(root['@_style'] ?? '');
+  const validStyle: PrettyPrinterSettings['style'] =
+    rawStyle === 'keywordUpper' || rawStyle === 'keywordLower' || rawStyle === 'keywordAuto' || rawStyle === 'none'
+      ? rawStyle
+      : 'keywordUpper';
+
+  return {
+    indentation: rawIndentation == null ? true : String(rawIndentation).toLowerCase() === 'true',
+    style: validStyle,
+  };
+}
+
+/** Update system-wide ADT PrettyPrinter settings */
+export async function setPrettyPrinterSettings(
+  http: AdtHttpClient,
+  safety: SafetyConfig,
+  settings: PrettyPrinterSettings,
+): Promise<void> {
+  checkOperation(safety, OperationType.Update, 'SetPrettyPrinterSettings');
+
+  const body = `<?xml version="1.0" encoding="utf-8"?><abapformatter:PrettyPrinterSettings abapformatter:indentation="${settings.indentation}" abapformatter:style="${settings.style}" xmlns:abapformatter="http://www.sap.com/adt/prettyprintersettings"/>`;
+  await http.put('/sap/bc/adt/abapsource/prettyprinter/settings', body, 'application/vnd.sap.adt.ppsettings.v2+xml');
 }
 
 /** Structured message from an activation response */

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -51,9 +51,13 @@ import {
   activateBatch,
   applyFixProposal,
   getFixProposals,
+  getPrettyPrinterSettings,
+  type PrettyPrinterSettings,
+  prettyPrint,
   publishServiceBinding,
   runAtcCheck,
   runUnitTests,
+  setPrettyPrinterSettings,
   syntaxCheck,
   unpublishServiceBinding,
 } from '../adt/devtools.js';
@@ -1072,10 +1076,9 @@ async function handleSAPQuery(client: AdtClient, args: Record<string, unknown>):
   }
 }
 
-// _client unused: SAPLint runs offline via @abaplint/core (no SAP round-trip).
-// Signature matches other handlers for consistency with handleToolCall dispatch.
+// Some SAPLint actions run offline (@abaplint/core), others call SAP ADT formatter APIs.
 async function handleSAPLint(
-  _client: AdtClient,
+  client: AdtClient,
   args: Record<string, unknown>,
   config: ServerConfig,
 ): Promise<ToolResult> {
@@ -1122,9 +1125,33 @@ async function handleSAPLint(
         ),
       );
     }
+    case 'format': {
+      const source = String(args.source ?? '');
+      if (!source) return errorResult('"source" is required for format action.');
+      const formatted = await prettyPrint(client.http, client.safety, source);
+      return textResult(formatted);
+    }
+    case 'get_formatter_settings': {
+      const settings = await getPrettyPrinterSettings(client.http, client.safety);
+      return textResult(JSON.stringify(settings, null, 2));
+    }
+    case 'set_formatter_settings': {
+      const indentation = args.indentation as boolean | undefined;
+      const style = args.style as PrettyPrinterSettings['style'] | undefined;
+      if (indentation === undefined && style === undefined) {
+        return errorResult('At least one of "indentation" or "style" is required for set_formatter_settings.');
+      }
+      const current = await getPrettyPrinterSettings(client.http, client.safety);
+      const next: PrettyPrinterSettings = {
+        indentation: indentation ?? current.indentation,
+        style: style ?? current.style,
+      };
+      await setPrettyPrinterSettings(client.http, client.safety, next);
+      return textResult(JSON.stringify(next, null, 2));
+    }
     default:
       return errorResult(
-        `Unknown SAPLint action: "${action}". Supported: lint, lint_and_fix, list_rules. For atc/syntax/unittest, use SAPDiagnose instead.`,
+        `Unknown SAPLint action: "${action}". Supported: lint, lint_and_fix, list_rules, format, get_formatter_settings, set_formatter_settings. For atc/syntax/unittest, use SAPDiagnose instead.`,
       );
   }
 }

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -392,9 +392,11 @@ export const SAPNavigateSchema = z.object({
 // ─── SAPLint ────────────────────────────────────────────────────────
 
 export const SAPLintSchema = z.object({
-  action: z.enum(['lint', 'lint_and_fix', 'list_rules']),
+  action: z.enum(['lint', 'lint_and_fix', 'list_rules', 'format', 'get_formatter_settings', 'set_formatter_settings']),
   source: z.string().optional(),
   name: z.string().optional(),
+  indentation: z.coerce.boolean().optional(),
+  style: z.enum(['keywordUpper', 'keywordLower', 'keywordAuto', 'none']).optional(),
   rules: z.record(z.string(), z.any()).optional(),
 });
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -745,18 +745,34 @@ export function getToolDefinitions(config: ServerConfig, textSearchAvailable?: b
         'Actions:\n' +
         '- "lint": Check source for issues. Returns errors and warnings. Works for ABAP (PROG, CLAS, INTF, FUNC) and CDS views (DDLS) — catches syntax errors, naming conventions, field order, legacy view patterns.\n' +
         '- "lint_and_fix": Lint + auto-fix all fixable issues (keyword case, obsolete statements, etc.). Returns fixed source.\n' +
-        '- "list_rules": List all available rules with current config. No source needed.\n\n' +
-        'For server-side checks (ATC, syntax check, unit tests), use SAPDiagnose instead.',
+        '- "list_rules": List all available rules with current config. No source needed.\n' +
+        '- "format": Pretty-print ABAP source via SAP\'s ADT formatter (uses the SAP system\'s global formatter settings). Requires source. Returns the formatted source.\n' +
+        '- "get_formatter_settings": Read the SAP system\'s global PrettyPrinter settings (indentation, keyword style). No params.\n' +
+        '- "set_formatter_settings": Update the SAP system\'s global PrettyPrinter settings. Requires indentation (bool) and/or style (keywordUpper|keywordLower|keywordAuto|none). Blocked in read-only mode.\n\n' +
+        'For server-side checks (ATC, syntax check, unit tests), use SAPDiagnose instead.\n' +
+        'Note: lint/lint_and_fix/list_rules run locally; format/*_formatter_settings call the SAP system.',
       inputSchema: {
         type: 'object',
         properties: {
           action: {
             type: 'string',
-            enum: ['lint', 'lint_and_fix', 'list_rules'],
+            enum: ['lint', 'lint_and_fix', 'list_rules', 'format', 'get_formatter_settings', 'set_formatter_settings'],
             description: 'Check type',
           },
-          source: { type: 'string', description: 'ABAP or CDS source code to lint (not needed for list_rules)' },
+          source: {
+            type: 'string',
+            description: 'ABAP or CDS source code to lint/format (not needed for list_rules/get_formatter_settings)',
+          },
           name: { type: 'string', description: 'Object name (used for filename detection)' },
+          indentation: {
+            type: 'boolean',
+            description: 'PrettyPrinter: indent source (for set_formatter_settings)',
+          },
+          style: {
+            type: 'string',
+            enum: ['keywordUpper', 'keywordLower', 'keywordAuto', 'none'],
+            description: 'PrettyPrinter: keyword casing (for set_formatter_settings)',
+          },
           rules: {
             type: 'object',
             description:

--- a/tests/e2e/smoke.e2e.test.ts
+++ b/tests/e2e/smoke.e2e.test.ts
@@ -176,6 +176,24 @@ describe('E2E Smoke Tests', () => {
     expect(Array.isArray(issues)).toBe(true);
   });
 
+  it('SAPLint — formats ABAP source via ADT PrettyPrinter', async () => {
+    const result = await callTool(client, 'SAPLint', {
+      action: 'format',
+      source: 'report ztest.\ndata lv type string.\n',
+    });
+    const text = expectToolSuccess(result);
+    expect(text).toContain('REPORT');
+    expect(text).toContain('DATA');
+  });
+
+  it('SAPLint — reads formatter settings', async () => {
+    const result = await callTool(client, 'SAPLint', { action: 'get_formatter_settings' });
+    const text = expectToolSuccess(result);
+    const settings = JSON.parse(text);
+    expect(typeof settings.indentation).toBe('boolean');
+    expect(['keywordUpper', 'keywordLower', 'keywordAuto', 'none']).toContain(settings.style);
+  });
+
   // ── SAPManage ──────────────────────────────────────────────────
 
   it('SAPManage probe — detects system features', async () => {

--- a/tests/unit/adt/devtools.test.ts
+++ b/tests/unit/adt/devtools.test.ts
@@ -4,16 +4,19 @@ import {
   activateBatch,
   applyFixProposal,
   getFixProposals,
+  getPrettyPrinterSettings,
   parseActivationResult,
+  prettyPrint,
   publishServiceBinding,
   runAtcCheck,
   runUnitTests,
+  setPrettyPrinterSettings,
   syntaxCheck,
   unpublishServiceBinding,
 } from '../../../src/adt/devtools.js';
 import { AdtApiError, AdtSafetyError } from '../../../src/adt/errors.js';
 import type { AdtHttpClient } from '../../../src/adt/http.js';
-import { unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
+import { defaultSafetyConfig, unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
 
 function mockHttp(responseBody = ''): AdtHttpClient {
   return {
@@ -132,6 +135,95 @@ describe('DevTools', () => {
       const http = mockHttp();
       const safety = { ...unrestrictedSafetyConfig(), disallowedOps: 'R' };
       await expect(syntaxCheck(http, safety, '/sap/bc/adt/programs/programs/ZTEST')).rejects.toThrow(AdtSafetyError);
+    });
+  });
+
+  // ─── prettyPrint ──────────────────────────────────────────────────
+
+  describe('prettyPrint', () => {
+    it('returns formatted source on success', async () => {
+      const formatted = 'REPORT ztest.\nDATA lv TYPE string.\n';
+      const http = mockHttp(formatted);
+      const result = await prettyPrint(http, unrestrictedSafetyConfig(), 'report ztest.\ndata lv type string.\n');
+      expect(result).toBe(formatted);
+    });
+
+    it('passes text/plain content type and accept header', async () => {
+      const http = mockHttp('REPORT ztest.\n');
+      await prettyPrint(http, unrestrictedSafetyConfig(), 'report ztest.\n');
+      expect(http.post).toHaveBeenCalledWith(
+        '/sap/bc/adt/abapsource/prettyprinter',
+        'report ztest.\n',
+        'text/plain; charset=utf-8',
+        { Accept: 'text/plain' },
+      );
+    });
+
+    it('hits the PrettyPrinter endpoint path', async () => {
+      const http = mockHttp('REPORT ztest.\n');
+      await prettyPrint(http, unrestrictedSafetyConfig(), 'report ztest.\n');
+      const path = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(path).toBe('/sap/bc/adt/abapsource/prettyprinter');
+    });
+
+    it('is allowed in read-only mode (intelligence operation)', async () => {
+      const http = mockHttp('REPORT ztest.\n');
+      await expect(prettyPrint(http, defaultSafetyConfig(), 'report ztest.\n')).resolves.toBe('REPORT ztest.\n');
+    });
+  });
+
+  // ─── PrettyPrinter settings ───────────────────────────────────────
+
+  describe('getPrettyPrinterSettings', () => {
+    it('parses formatter settings from XML response', async () => {
+      const xml =
+        '<abapformatter:PrettyPrinterSettings abapformatter:indentation="true" abapformatter:style="keywordUpper" xmlns:abapformatter="http://www.sap.com/adt/prettyprintersettings"/>';
+      const http = mockHttp(xml);
+      const settings = await getPrettyPrinterSettings(http, unrestrictedSafetyConfig());
+      expect(settings).toEqual({ indentation: true, style: 'keywordUpper' });
+    });
+
+    it('parses false indentation and lowercase keyword style', async () => {
+      const xml =
+        '<abapformatter:PrettyPrinterSettings abapformatter:indentation="false" abapformatter:style="keywordLower" xmlns:abapformatter="http://www.sap.com/adt/prettyprintersettings"/>';
+      const http = mockHttp(xml);
+      const settings = await getPrettyPrinterSettings(http, unrestrictedSafetyConfig());
+      expect(settings).toEqual({ indentation: false, style: 'keywordLower' });
+    });
+
+    it('falls back to defaults when attributes are missing', async () => {
+      const xml =
+        '<abapformatter:PrettyPrinterSettings xmlns:abapformatter="http://www.sap.com/adt/prettyprintersettings"/>';
+      const http = mockHttp(xml);
+      const settings = await getPrettyPrinterSettings(http, unrestrictedSafetyConfig());
+      expect(settings).toEqual({ indentation: true, style: 'keywordUpper' });
+    });
+  });
+
+  describe('setPrettyPrinterSettings', () => {
+    it('sends expected XML body with formatter attributes', async () => {
+      const http = mockHttp('');
+      await setPrettyPrinterSettings(http, unrestrictedSafetyConfig(), { indentation: false, style: 'keywordLower' });
+      const body = (http.put as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
+      expect(body).toContain('abapformatter:indentation="false"');
+      expect(body).toContain('abapformatter:style="keywordLower"');
+    });
+
+    it('uses ppsettings v2 content type', async () => {
+      const http = mockHttp('');
+      await setPrettyPrinterSettings(http, unrestrictedSafetyConfig(), { indentation: true, style: 'keywordUpper' });
+      expect(http.put).toHaveBeenCalledWith(
+        '/sap/bc/adt/abapsource/prettyprinter/settings',
+        expect.any(String),
+        'application/vnd.sap.adt.ppsettings.v2+xml',
+      );
+    });
+
+    it('is blocked in read-only mode', async () => {
+      const http = mockHttp('');
+      await expect(
+        setPrettyPrinterSettings(http, defaultSafetyConfig(), { indentation: true, style: 'keywordUpper' }),
+      ).rejects.toThrow(AdtSafetyError);
     });
   });
 

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -1226,6 +1226,9 @@ describe('Intent Handler', () => {
       expect(result.content[0]?.text).toContain('lint');
       expect(result.content[0]?.text).toContain('lint_and_fix');
       expect(result.content[0]?.text).toContain('list_rules');
+      expect(result.content[0]?.text).toContain('format');
+      expect(result.content[0]?.text).toContain('get_formatter_settings');
+      expect(result.content[0]?.text).toContain('set_formatter_settings');
     });
 
     it('returns Zod validation error for atc (not a valid SAPLint action)', async () => {
@@ -1344,6 +1347,123 @@ ENDCLASS.`;
       // With length=10, many lines should trigger line_length
       const lineIssues = issues.filter((i: { rule: string }) => i.rule === 'line_length');
       expect(lineIssues.length).toBeGreaterThan(0);
+    });
+
+    it('format returns pretty-printed source via ADT endpoint', async () => {
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      const source = 'report ztest.\ndata lv type string.\n';
+      const formatted = 'REPORT ztest.\nDATA lv TYPE string.\n';
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string; body?: string | Buffer }) => {
+        const method = opts?.method ?? 'GET';
+        const urlStr = String(url);
+        calls.push({
+          method,
+          url: urlStr,
+          body: typeof opts?.body === 'string' ? opts.body : undefined,
+        });
+        if (method === 'HEAD' && urlStr.includes('/sap/bc/adt/core/discovery')) {
+          return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'mock-csrf-token' }));
+        }
+        if (method === 'POST' && urlStr.includes('/sap/bc/adt/abapsource/prettyprinter')) {
+          return Promise.resolve(mockResponse(200, formatted, { 'x-csrf-token': 'mock-csrf-token' }));
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'mock-csrf-token' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPLint', {
+        action: 'format',
+        source,
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toBe(formatted);
+      const formatCall = calls.find((c) => c.method === 'POST' && c.url.includes('/abapsource/prettyprinter'));
+      expect(formatCall).toBeDefined();
+      expect(formatCall?.body).toBe(source);
+    });
+
+    it('format requires source', async () => {
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPLint', {
+        action: 'format',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('"source" is required for format action.');
+    });
+
+    it('get_formatter_settings returns parsed settings as JSON', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = opts?.method ?? 'GET';
+        const urlStr = String(url);
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/abapsource/prettyprinter/settings')) {
+          return Promise.resolve(
+            mockResponse(
+              200,
+              '<abapformatter:PrettyPrinterSettings abapformatter:indentation="true" abapformatter:style="keywordUpper" xmlns:abapformatter="http://www.sap.com/adt/prettyprintersettings"/>',
+            ),
+          );
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'mock-csrf-token' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPLint', {
+        action: 'get_formatter_settings',
+      });
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text);
+      expect(parsed).toEqual({ indentation: true, style: 'keywordUpper' });
+    });
+
+    it('set_formatter_settings merges with current values when only style is provided', async () => {
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string; body?: string | Buffer }) => {
+        const method = opts?.method ?? 'GET';
+        const urlStr = String(url);
+        calls.push({
+          method,
+          url: urlStr,
+          body: typeof opts?.body === 'string' ? opts.body : undefined,
+        });
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/abapsource/prettyprinter/settings')) {
+          return Promise.resolve(
+            mockResponse(
+              200,
+              '<abapformatter:PrettyPrinterSettings abapformatter:indentation="false" abapformatter:style="keywordUpper" xmlns:abapformatter="http://www.sap.com/adt/prettyprintersettings"/>',
+            ),
+          );
+        }
+        if (method === 'HEAD' && urlStr.includes('/sap/bc/adt/core/discovery')) {
+          return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'mock-csrf-token' }));
+        }
+        if (method === 'PUT' && urlStr.includes('/sap/bc/adt/abapsource/prettyprinter/settings')) {
+          return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'mock-csrf-token' }));
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'mock-csrf-token' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPLint', {
+        action: 'set_formatter_settings',
+        style: 'keywordLower',
+      });
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text);
+      expect(parsed).toEqual({ indentation: false, style: 'keywordLower' });
+
+      const putCall = calls.find((c) => c.method === 'PUT' && c.url.includes('/abapsource/prettyprinter/settings'));
+      expect(putCall).toBeDefined();
+      expect(putCall?.body).toContain('abapformatter:indentation="false"');
+      expect(putCall?.body).toContain('abapformatter:style="keywordLower"');
+    });
+
+    it('set_formatter_settings requires indentation or style', async () => {
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPLint', {
+        action: 'set_formatter_settings',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain(
+        'At least one of "indentation" or "style" is required for set_formatter_settings.',
+      );
     });
 
     it('lint requires source', async () => {

--- a/tests/unit/handlers/schemas.test.ts
+++ b/tests/unit/handlers/schemas.test.ts
@@ -427,6 +427,20 @@ describe('SAPLintSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts formatter actions', () => {
+    expect(SAPLintSchema.safeParse({ action: 'format', source: 'report ztest.' }).success).toBe(true);
+    expect(SAPLintSchema.safeParse({ action: 'get_formatter_settings' }).success).toBe(true);
+    expect(SAPLintSchema.safeParse({ action: 'set_formatter_settings', style: 'keywordLower' }).success).toBe(true);
+  });
+
+  it('coerces indentation for set_formatter_settings', () => {
+    const result = SAPLintSchema.safeParse({ action: 'set_formatter_settings', indentation: 0 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.indentation).toBe(false);
+    }
+  });
+
   it('rejects invalid action', () => {
     const result = SAPLintSchema.safeParse({ action: 'invalid' });
     expect(result.success).toBe(false);

--- a/tests/unit/handlers/tools.test.ts
+++ b/tests/unit/handlers/tools.test.ts
@@ -115,7 +115,7 @@ describe('Tool Definitions', () => {
     expect(names).toContain('SAPQuery');
   });
 
-  it('SAPLint only exposes lint action (atc/syntax moved to SAPDiagnose)', () => {
+  it('SAPLint exposes lint + formatter actions (atc/syntax moved to SAPDiagnose)', () => {
     const tools = getToolDefinitions(DEFAULT_CONFIG);
     const sapLint = tools.find((t) => t.name === 'SAPLint')!;
     const schema = sapLint.inputSchema as Record<string, any>;
@@ -126,7 +126,12 @@ describe('Tool Definitions', () => {
     expect(actionEnum).not.toContain('syntax');
     expect(actionEnum).toContain('lint_and_fix');
     expect(actionEnum).toContain('list_rules');
-    expect(actionEnum).toHaveLength(3);
+    expect(actionEnum).toContain('format');
+    expect(actionEnum).toContain('get_formatter_settings');
+    expect(actionEnum).toContain('set_formatter_settings');
+    expect(actionEnum).toHaveLength(6);
+    expect(schema.properties.indentation).toBeDefined();
+    expect(schema.properties.style).toBeDefined();
   });
 
   it('SAPLint description mentions SAPDiagnose for server-side checks', () => {


### PR DESCRIPTION
## Summary

Adds three new **SAPLint** actions that call SAP's ADT PrettyPrinter API (FEAT-10 from [roadmap.md](docs/roadmap.md)):

- `format` — pretty-print ABAP source via `POST /sap/bc/adt/abapsource/prettyprinter`
- `get_formatter_settings` — read global formatter settings (indentation, keyword style)
- `set_formatter_settings` — update global formatter settings (blocked when `--read-only=true`)

Unlike `lint_and_fix` (which enforces abaplint's opinionated rules locally), `format` uses the SAP system's own global formatter settings — matching whatever the ABAP developer community on that system has agreed on.

Host: **SAPLint**, not a new tool. XS effort — no new scope, no new config flag.

## Endpoints (verified live on A4H)

| Method | Path | Content-Type | Accept |
|--------|------|--------------|--------|
| POST | `/sap/bc/adt/abapsource/prettyprinter` | `text/plain; charset=utf-8` | `text/plain` |
| GET | `/sap/bc/adt/abapsource/prettyprinter/settings` | — | `application/vnd.sap.adt.ppsettings.v2+xml` |
| PUT | `/sap/bc/adt/abapsource/prettyprinter/settings` | `application/vnd.sap.adt.ppsettings.v2+xml` | — |

Safety mapping: `format` and `get_formatter_settings` use `OperationType.Intelligence`/`Read` (allowed in read-only). `set_formatter_settings` uses `OperationType.Update` (blocked in read-only).

## Test plan

- [x] `npm test` — 1900/1900 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Live round-trip against A4H: `format` returns uppercased keywords, `get_formatter_settings` returns `{indentation:true, style:"keywordUpper"}`, `set_formatter_settings` PUT accepted
- [ ] `npm run test:e2e` — requires running MCP server (new smoke tests added in [tests/e2e/smoke.e2e.test.ts](tests/e2e/smoke.e2e.test.ts))

## Docs updated

- [docs/tools.md](docs/tools.md) — SAPLint section (three new actions, response shapes, examples)
- [docs/roadmap.md](docs/roadmap.md) — FEAT-10 moved to Completed
- [compare/00-feature-matrix.md](compare/00-feature-matrix.md) — ARC-1 PrettyPrint row flipped ❌ → ✅
- [README.md](README.md), [CLAUDE.md](CLAUDE.md) — SAPLint row extended
- [docs/plans/completed/prettyprint-adt-formatter.md](docs/plans/completed/prettyprint-adt-formatter.md) — source plan archived

🤖 Generated with [Claude Code](https://claude.com/claude-code)