### PR TITLE
chore: add .worktreeinclude for Claude Code worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,14 @@
+# Copy gitignored files into Claude Code worktrees.
+# Patterns use .gitignore syntax; only files that are also gitignored get copied.
+
+# Environment files (credentials for SAP, BTP, infrastructure)
+.env
+.env.local
+.env.*
+.env.infrastructure
+
+# BTP deployment config (personal, per-environment values)
+mta.yaml
+
+# arc1 runtime config (may contain credentials)
+.arc1*.json


### PR DESCRIPTION
## Summary
- Adds `.worktreeinclude` so Claude Code copies local-only files into new worktrees automatically
- Covers `.env*`, `mta.yaml`, and `.arc1*.json` — the gitignored files needed for SAP/BTP work

## Test plan
- [ ] Create a new Claude Code worktree and verify `.env`, `.env.infrastructure`, and `mta.yaml` are present
- [ ] Confirm tracked files are not duplicated (only gitignored matches are copied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)