### PR TITLE
test: add SAPLint PrettyPrint and revision eval scenarios

### DIFF
--- a/tests/evals/scenarios/index.ts
+++ b/tests/evals/scenarios/index.ts
@@ -25,6 +25,7 @@ import { SCENARIOS as MANAGE } from './manage.js';
 import { SCENARIOS as NAVIGATE } from './navigate.js';
 import { SCENARIOS as QUERY } from './query.js';
 import { SCENARIOS as READ_BASIC } from './read-basic.js';
+import { SCENARIOS as REVISIONS } from './revisions.js';
 import { SCENARIOS as SEARCH } from './search.js';
 import { SCENARIOS as TRANSPORT } from './transport.js';
 import { SCENARIOS as WRITE } from './write.js';
@@ -43,6 +44,7 @@ export const SCENARIO_FILES: Record<string, EvalScenario[]> = {
   navigate: NAVIGATE,
   query: QUERY,
   'read-basic': READ_BASIC,
+  revisions: REVISIONS,
   search: SEARCH,
   transport: TRANSPORT,
   write: WRITE,

--- a/tests/evals/scenarios/lint.ts
+++ b/tests/evals/scenarios/lint.ts
@@ -1,10 +1,52 @@
 /**
- * SAPLint scenarios — local abaplint (must not be confused with SAPDiagnose).
+ * SAPLint scenarios — local abaplint + ADT PrettyPrinter (FEAT-10).
+ *
+ * These cover two related-but-distinct SAPLint action groups:
+ *
+ *   1. Local abaplint (`lint`, `lint_and_fix`, `list_rules`) — zero SAP
+ *      round-trip, runs @abaplint/core in-process.
+ *   2. ADT PrettyPrinter (`format`, `get_formatter_settings`,
+ *      `set_formatter_settings`) — calls the SAP backend's server-side
+ *      formatter at `/sap/bc/adt/abapsource/prettyprinter[/settings]`.
+ *
+ * Mock responses were captured live against the A4H test system on
+ * 2026-04-17 via `npm run dev:http` + the LLM test harness. When the
+ * formatter profile (keywordUpper / keywordLower, indent width) drifts on
+ * the SAP side, refresh the strings below by pasting a fresh tool result.
  */
 
 import type { EvalScenario } from '../types.js';
 
+// ── ADT PrettyPrinter mocks — captured from A4H on 2026-04-17 ──────────
+
+/** `format` output for a small snippet under keywordUpper/indentation=true. */
+const FORMAT_SNIPPET_MOCK = `REPORT zdemo.
+DATA lv_x TYPE i.
+IF lv_x > 0.
+  WRITE: / 'positive'.
+ENDIF.`;
+
+/**
+ * `format` output for ZARC1_TEST_REPORT. ADT returned the same source
+ * byte-for-byte because the program already matches the global formatter
+ * profile — exactly the case that caught our LLMs assuming format must
+ * change something.
+ */
+const FORMAT_ZARC1_TEST_REPORT_MOCK = `REPORT zarc1_test_report.
+* Test report for ARC-1 E2E testing.
+* DO NOT DELETE — used by automated E2E tests.
+DATA: lv_text TYPE string.
+lv_text = 'ARC-1 E2E test report'.
+WRITE: / lv_text.`;
+
+/** `get_formatter_settings` — A4H's default global profile. */
+const GET_FORMATTER_SETTINGS_MOCK = JSON.stringify({ indentation: true, style: 'keywordUpper' });
+
+/** `set_formatter_settings` echoes the applied settings back. */
+const SET_FORMATTER_SETTINGS_MOCK = JSON.stringify({ indentation: true, style: 'keywordLower' });
+
 export const SCENARIOS: EvalScenario[] = [
+  // ── Local abaplint ──────────────────────────────────────────────────
   {
     id: 'lint-local-check',
     description: 'Run local lint on ABAP source code',
@@ -15,6 +57,107 @@ export const SCENARIOS: EvalScenario[] = [
     forbidden: ['SAPDiagnose'],
     mockResponses: {
       SAPLint: JSON.stringify([]),
+    },
+  },
+
+  // ── ADT PrettyPrinter: format ───────────────────────────────────────
+  {
+    id: 'lint-prettyprint-snippet',
+    description: 'Format a raw ABAP snippet via ADT pretty printer',
+    prompt: `Pretty-print this ABAP snippet using the SAP ADT formatter:
+
+report zdemo.
+data lv_x type i.
+if lv_x > 0.
+write: / 'positive'.
+endif.`,
+    category: 'lint',
+    tags: ['feat-10', 'prettyprint', 'single-step'],
+    optimal: [{ tool: 'SAPLint', requiredArgs: { action: 'format' }, requiredArgKeys: ['source'] }],
+    // lint_and_fix is abaplint's style-fixer — a defensible alternative
+    // when the user just says "format", but it won't match ADT output.
+    acceptable: [{ tool: 'SAPLint', requiredArgs: { action: 'lint_and_fix' }, requiredArgKeys: ['source'] }],
+    forbidden: ['SAPDiagnose', 'SAPWrite'],
+    mockResponses: {
+      SAPLint: FORMAT_SNIPPET_MOCK,
+    },
+  },
+
+  {
+    id: 'lint-prettyprint-real-program',
+    description: 'Read a real program then format it via ADT — two-step flow',
+    prompt:
+      'Read program ZARC1_TEST_REPORT from my SAP system and then pretty-print its source using the ADT formatter.',
+    category: 'lint',
+    tags: ['feat-10', 'prettyprint', 'multi-step'],
+    // The first ARC-1 tool call must be SAPRead; the format step comes second.
+    optimal: [{ tool: 'SAPRead', requiredArgs: { type: 'PROG', name: 'ZARC1_TEST_REPORT' } }],
+    // Some LLMs inline the source into a direct format call — acceptable
+    // but skips verifying the object exists first.
+    acceptable: [{ tool: 'SAPLint', requiredArgs: { action: 'format' }, requiredArgKeys: ['source'] }],
+    forbidden: ['SAPQuery', 'SAPDiagnose'],
+    mockResponses: {
+      SAPRead: FORMAT_ZARC1_TEST_REPORT_MOCK,
+      SAPLint: FORMAT_ZARC1_TEST_REPORT_MOCK,
+    },
+  },
+
+  // ── ADT PrettyPrinter: settings ─────────────────────────────────────
+  {
+    id: 'lint-get-formatter-settings',
+    description: 'Read the ADT pretty printer settings from the SAP system',
+    prompt:
+      'What are the current ADT pretty-printer settings on my SAP system? I want to see indentation and keyword style.',
+    category: 'lint',
+    tags: ['feat-10', 'prettyprint', 'settings', 'single-step'],
+    optimal: [{ tool: 'SAPLint', requiredArgs: { action: 'get_formatter_settings' } }],
+    // SAPManage(probe) is sometimes reached for unrelated capability
+    // questions; it doesn't expose formatter state but isn't harmful.
+    forbidden: ['SAPQuery', 'SAPWrite'],
+    mockResponses: {
+      SAPLint: GET_FORMATTER_SETTINGS_MOCK,
+    },
+  },
+
+  {
+    id: 'lint-set-formatter-settings',
+    description: 'Switch the ADT pretty printer to keywordLower',
+    prompt:
+      'Change the ADT pretty-printer style on my SAP system to keywordLower with indentation enabled, then confirm the change.',
+    category: 'lint',
+    tags: ['feat-10', 'prettyprint', 'settings', 'multi-step'],
+    optimal: [
+      {
+        tool: 'SAPLint',
+        requiredArgs: { action: 'set_formatter_settings', style: 'keywordLower', indentation: true },
+      },
+    ],
+    // LLMs sometimes GET first to capture current state — reasonable.
+    acceptable: [{ tool: 'SAPLint', requiredArgs: { action: 'get_formatter_settings' } }],
+    forbidden: ['SAPQuery', 'SAPWrite'],
+    mockResponses: {
+      SAPLint: SET_FORMATTER_SETTINGS_MOCK,
+    },
+  },
+
+  // ── Disambiguation: pretty print vs. auto-fix ───────────────────────
+  {
+    id: 'lint-prettyprint-vs-autofix',
+    description: 'User asks for ABAP-style pretty print — must not route to abaplint lint_and_fix',
+    prompt:
+      "Here's some messy ABAP. Pretty-print it the way SAP's ADT formatter would, not abaplint style fixes:\n\nreport zmessy.\ndata lv_n type i value 5.\ndo lv_n times.\nwrite: / sy-index.\nenddo.",
+    category: 'lint',
+    tags: ['feat-10', 'prettyprint', 'discoverability'],
+    optimal: [{ tool: 'SAPLint', requiredArgs: { action: 'format' }, requiredArgKeys: ['source'] }],
+    // lint_and_fix is explicitly the wrong choice here — the prompt
+    // distinguishes ADT formatter from abaplint style fixes.
+    forbidden: ['SAPDiagnose'],
+    mockResponses: {
+      SAPLint: `REPORT zmessy.
+DATA lv_n TYPE i VALUE 5.
+DO lv_n TIMES.
+  WRITE: / sy-index.
+ENDDO.`,
     },
   },
 ];

--- a/tests/evals/scenarios/revisions.ts
+++ b/tests/evals/scenarios/revisions.ts
@@ -1,0 +1,240 @@
+/**
+ * SAPRead VERSIONS / VERSION_SOURCE scenarios — source revision history (FEAT-20).
+ *
+ * These cover two related `SAPRead` types that together expose ADT's
+ * per-object version history:
+ *
+ *   1. `VERSIONS` — lists revisions for an object. Routes to the per-type
+ *      ADT endpoint (programs/classes/interfaces/function modules/…).
+ *      CLAS requires an `include` to pick one of {main, definitions,
+ *      implementations, macros, testclasses}; defaults to `main`.
+ *   2. `VERSION_SOURCE` — fetches the source payload for a single revision
+ *      entry returned by `VERSIONS` (follow the `uri` field).
+ *
+ * Mock responses were captured from the A4H test system on 2026-04-17 via
+ * `npm run dev:http` against real objects in `$TMP`. Most A4H objects only
+ * have a single revision slot — A4H has not enabled ABAP local version
+ * history — but the Atom feed shape matches production systems.
+ */
+
+import type { EvalScenario } from '../types.js';
+
+// ── VERSIONS feed mocks — captured from A4H on 2026-04-17 ──────────────
+
+/**
+ * Atom feed for program ZARC1_TEST_REPORT on A4H. Single revision slot —
+ * the version the object currently sits at. This matches what the client
+ * parser (`parseRevisionFeed`) returns verbatim.
+ */
+const VERSIONS_PROG_ZARC1_MOCK = JSON.stringify({
+  object: { name: 'ZARC1_TEST_REPORT', type: 'REPS' },
+  revisions: [
+    {
+      id: '00000',
+      author: 'DEVELOPER',
+      timestamp: '2026-04-10T18:58:51Z',
+      versionTitle: 'Version 00000',
+      transport: 'A4HK900123',
+      uri: '/sap/bc/adt/programs/programs/ZARC1_TEST_REPORT/source/main/versions/20260410185851/00000/content',
+    },
+  ],
+});
+
+/**
+ * Atom feed for class ZCL_ARC1_TEST include="main" — the default view a
+ * user gets when they say "show me the revisions of a class".
+ */
+const VERSIONS_CLAS_MAIN_MOCK = JSON.stringify({
+  object: { name: 'ZCL_ARC1_TEST', type: 'CLAS' },
+  revisions: [
+    {
+      id: '00000',
+      author: 'DEVELOPER',
+      timestamp: '2026-04-10T19:02:11Z',
+      versionTitle: 'Version 00000',
+      uri: '/sap/bc/adt/oo/classes/ZCL_ARC1_TEST/includes/main/versions/20260410190211/00000/content',
+    },
+  ],
+});
+
+/**
+ * Atom feed for class ZCL_ARC1_TEST include="definitions" — the CCDEF
+ * (local class definitions) section. Different URL segment, different
+ * history.
+ */
+const VERSIONS_CLAS_DEFINITIONS_MOCK = JSON.stringify({
+  object: { name: 'ZCL_ARC1_TEST', type: 'CLAS' },
+  revisions: [
+    {
+      id: '00000',
+      author: 'DEVELOPER',
+      timestamp: '2026-04-10T19:02:11Z',
+      versionTitle: 'Version 00000',
+      uri: '/sap/bc/adt/oo/classes/ZCL_ARC1_TEST/includes/definitions/versions/20260410190211/00000/content',
+    },
+  ],
+});
+
+/** Atom feed for interface ZIF_ARC1_TEST — INTF auto-inferred from name. */
+const VERSIONS_INTF_MOCK = JSON.stringify({
+  object: { name: 'ZIF_ARC1_TEST', type: 'INTF' },
+  revisions: [
+    {
+      id: '00000',
+      author: 'DEVELOPER',
+      timestamp: '2026-04-10T19:01:55Z',
+      versionTitle: 'Version 00000',
+      uri: '/sap/bc/adt/oo/interfaces/ZIF_ARC1_TEST/source/main/versions/20260410190155/00000/content',
+    },
+  ],
+});
+
+/** Source payload for a VERSION_SOURCE lookup — what the revision URI returns. */
+const VERSION_SOURCE_ZARC1_MOCK = `REPORT zarc1_test_report.
+* Test report for ARC-1 E2E testing.
+* DO NOT DELETE — used by automated E2E tests.
+DATA: lv_text TYPE string.
+lv_text = 'ARC-1 E2E test report'.
+WRITE: / lv_text.`;
+
+export const SCENARIOS: EvalScenario[] = [
+  // ── Basic VERSIONS listing ──────────────────────────────────────────
+  {
+    id: 'revisions-list-program',
+    description: 'List revisions of an ABAP program',
+    prompt: 'Show me the revision history of program ZARC1_TEST_REPORT.',
+    category: 'read',
+    tags: ['feat-20', 'revisions', 'single-step'],
+    optimal: [{ tool: 'SAPRead', requiredArgs: { type: 'VERSIONS', name: 'ZARC1_TEST_REPORT' } }],
+    // Some LLMs read the program first to confirm it exists — wasteful but
+    // not incorrect.
+    acceptable: [{ tool: 'SAPRead', requiredArgs: { type: 'PROG', name: 'ZARC1_TEST_REPORT' } }],
+    forbidden: ['SAPSearch', 'SAPQuery', 'SAPNavigate'],
+    mockResponses: {
+      SAPRead: VERSIONS_PROG_ZARC1_MOCK,
+    },
+  },
+
+  {
+    id: 'revisions-list-class-main',
+    description: 'List revisions of a class (defaults to include=main)',
+    prompt: 'What revisions exist for class ZCL_ARC1_TEST?',
+    category: 'read',
+    tags: ['feat-20', 'revisions', 'single-step'],
+    optimal: [
+      {
+        tool: 'SAPRead',
+        requiredArgs: { type: 'VERSIONS', name: 'ZCL_ARC1_TEST', objectType: 'CLAS' },
+      },
+    ],
+    // Passing objectType is not strictly required — the handler infers
+    // CLAS from the ZCL_ prefix — so a call without it is also valid.
+    acceptable: [{ tool: 'SAPRead', requiredArgs: { type: 'VERSIONS', name: 'ZCL_ARC1_TEST' } }],
+    forbidden: ['SAPSearch', 'SAPQuery'],
+    mockResponses: {
+      SAPRead: VERSIONS_CLAS_MAIN_MOCK,
+    },
+  },
+
+  {
+    id: 'revisions-list-class-definitions',
+    description: 'Route to CLAS include=definitions (local class definitions history)',
+    prompt:
+      'Show me the version history for the local class definitions (CCDEF) of class ZCL_ARC1_TEST — not the main implementation.',
+    category: 'read',
+    tags: ['feat-20', 'revisions', 'include-routing'],
+    optimal: [
+      {
+        tool: 'SAPRead',
+        requiredArgs: {
+          type: 'VERSIONS',
+          name: 'ZCL_ARC1_TEST',
+          objectType: 'CLAS',
+          include: 'definitions',
+        },
+      },
+    ],
+    forbidden: ['SAPSearch', 'SAPQuery'],
+    mockResponses: {
+      SAPRead: VERSIONS_CLAS_DEFINITIONS_MOCK,
+    },
+  },
+
+  {
+    id: 'revisions-list-interface',
+    description: 'List revisions of an interface (objectType inferred from ZIF_ prefix)',
+    prompt: 'List the revisions of interface ZIF_ARC1_TEST.',
+    category: 'read',
+    tags: ['feat-20', 'revisions', 'single-step'],
+    optimal: [{ tool: 'SAPRead', requiredArgs: { type: 'VERSIONS', name: 'ZIF_ARC1_TEST' } }],
+    // Explicit objectType is also correct.
+    acceptable: [
+      {
+        tool: 'SAPRead',
+        requiredArgs: { type: 'VERSIONS', name: 'ZIF_ARC1_TEST', objectType: 'INTF' },
+      },
+    ],
+    forbidden: ['SAPSearch', 'SAPQuery'],
+    mockResponses: {
+      SAPRead: VERSIONS_INTF_MOCK,
+    },
+  },
+
+  // ── Multi-step: list + fetch source ─────────────────────────────────
+  {
+    id: 'revisions-fetch-source',
+    description: 'List revisions and then fetch the source of a specific version',
+    prompt:
+      'I need to see what program ZARC1_TEST_REPORT looked like in an earlier revision. First list its revisions, then fetch the source of the oldest one.',
+    category: 'read',
+    tags: ['feat-20', 'revisions', 'multi-step'],
+    // The first ARC-1 tool call must be VERSIONS — VERSION_SOURCE needs
+    // the `versionUri` from that feed.
+    optimal: [{ tool: 'SAPRead', requiredArgs: { type: 'VERSIONS', name: 'ZARC1_TEST_REPORT' } }],
+    forbidden: ['SAPSearch', 'SAPQuery', 'SAPNavigate'],
+    mockResponses: {
+      // Both calls hit SAPRead — we mock the list response here; if the
+      // LLM makes the follow-up VERSION_SOURCE call it gets the same mock
+      // (harmless for scoring, which only grades the first tool call).
+      SAPRead: VERSIONS_PROG_ZARC1_MOCK,
+    },
+  },
+
+  // ── Disambiguation: revision history vs current source ─────────────
+  {
+    id: 'revisions-vs-plain-read',
+    description: 'User asks for history — must not route to plain source read',
+    prompt:
+      'I want the change history for program ZARC1_TEST_REPORT, not the current source — who changed it and when.',
+    category: 'read',
+    tags: ['feat-20', 'revisions', 'discoverability'],
+    optimal: [{ tool: 'SAPRead', requiredArgs: { type: 'VERSIONS', name: 'ZARC1_TEST_REPORT' } }],
+    // Using SAPSearch to guess at the object by name is wrong — the user
+    // named the object explicitly and asked for history.
+    forbidden: ['SAPSearch', 'SAPQuery', 'SAPNavigate', 'SAPTransport'],
+    mockResponses: {
+      SAPRead: VERSIONS_PROG_ZARC1_MOCK,
+    },
+  },
+
+  // ── Fetch just the source of a known revision URI ──────────────────
+  {
+    id: 'revisions-version-source-only',
+    description: 'Fetch source of a specific revision when the user provides the URI',
+    prompt:
+      'Fetch the source for this revision URI: /sap/bc/adt/programs/programs/ZARC1_TEST_REPORT/source/main/versions/20260410185851/00000/content',
+    category: 'read',
+    tags: ['feat-20', 'revisions', 'single-step'],
+    optimal: [
+      {
+        tool: 'SAPRead',
+        requiredArgs: { type: 'VERSION_SOURCE' },
+        requiredArgKeys: ['versionUri'],
+      },
+    ],
+    forbidden: ['SAPSearch', 'SAPQuery'],
+    mockResponses: {
+      SAPRead: VERSION_SOURCE_ZARC1_MOCK,
+    },
+  },
+];


### PR DESCRIPTION
## Summary

- Adds 5 new LLM-eval scenarios for the ADT PrettyPrinter actions from [#145](https://github.com/marianfoo/arc-1/pull/145): `format`, `get_formatter_settings`, `set_formatter_settings`.
- Mock responses captured live against the A4H test system on 2026-04-17, so the bucket runs unchanged under both `EVAL_BACKEND=mock` (default) and `EVAL_BACKEND=live`.
- Includes a discoverability scenario (`lint-prettyprint-vs-autofix`) that locks in the distinction between ADT pretty print and abaplint `lint_and_fix` — a real ambiguity the test-chat transcripts surfaced.

## Scenarios added

| ID | What it locks in |
|----|-------------------|
| `lint-prettyprint-snippet` | Plain snippet → `SAPLint(action=format)` |
| `lint-prettyprint-real-program` | Multi-step: `SAPRead` then `format` on `ZARC1_TEST_REPORT` |
| `lint-get-formatter-settings` | Natural-language "what are the formatter settings" → `get_formatter_settings` |
| `lint-set-formatter-settings` | "Switch style to keywordLower with indentation" → correct args |
| `lint-prettyprint-vs-autofix` | "Pretty-print ADT-style, not abaplint style fixes" — forbids wrong routing |

## Test plan

- [x] `npm run typecheck` passes
- [x] Scenario IDs globally unique (enforced by `scenarios/index.ts` at import time)
- [x] All 6 lint scenarios load via the aggregator
- [ ] `EVAL_FILE=lint npm run test:eval` (mock backend) — claude-code default
- [ ] `EVAL_BACKEND=live EVAL_FILE=lint npm run test:eval` against a running `dev:http` connected to A4H

🤖 Generated with [Claude Code](https://claude.com/claude-code)