### PR TITLE
fix: filter empty SAP_ALLOWED_PACKAGES entries and clarify docker docs

### DIFF
--- a/docs_page/authorization.md
+++ b/docs_page/authorization.md
@@ -155,7 +155,7 @@ Independent of scopes, the server administrator can set a global safety configur
 | Block free SQL | `--block-free-sql` / `SAP_BLOCK_FREE_SQL` | **`true`** | Blocks freestyle SQL queries |
 | Allowed operations | `--allowed-ops` / `SAP_ALLOWED_OPS` | (all) | Whitelist of operation type codes |
 | Disallowed operations | `--disallowed-ops` / `SAP_DISALLOWED_OPS` | (none) | Blacklist of operation type codes |
-| Allowed packages | `--allowed-packages` / `SAP_ALLOWED_PACKAGES` | `$TMP` | Restrict to specific ABAP packages (supports wildcards). Defaults to `$TMP` (local objects only). Set to `"*"` for unrestricted or `"Z*,$TMP"` for custom packages. |
+| Allowed packages | `--allowed-packages` / `SAP_ALLOWED_PACKAGES` | `$TMP` | Restrict to specific ABAP packages (supports wildcards). Defaults to `$TMP` (local objects only). Set to `'*'` for unrestricted or `'Z*,$TMP'` for custom packages (single quotes in shell so `$TMP` isn't expanded). |
 | Enable transports | `--enable-transports` / `SAP_ENABLE_TRANSPORTS` | `false` | Allow transport management |
 
 ### How Safety and Scopes Interact

--- a/docs_page/cli-guide.md
+++ b/docs_page/cli-guide.md
@@ -108,7 +108,8 @@ arc1 --block-free-sql=false      # Enable free SQL
 arc1 --block-data=false          # Enable table preview
 
 # Restrict write operations to specific packages (reads are not restricted by package)
-arc1 --allowed-packages "ZPROD*,$TMP"
+# Use single quotes — bash expands $TMP inside double quotes.
+arc1 --allowed-packages 'ZPROD*,$TMP'
 
 # Whitelist operations
 arc1 --allowed-ops "RSQ"

--- a/docs_page/docker.md
+++ b/docs_page/docker.md
@@ -452,14 +452,19 @@ Restrict all write operations to specific packages. Supports wildcards:
 
 ```bash
 # Only allow writes to custom packages and $TMP
--e SAP_ALLOWED_PACKAGES="Z*,$TMP"
+-e SAP_ALLOWED_PACKAGES='Z*,$TMP'
 
 # Only one specific package
--e SAP_ALLOWED_PACKAGES="\$ZRAY_DEV"
+-e SAP_ALLOWED_PACKAGES='$ZRAY_DEV'
 
 # Multiple packages (comma-separated)
--e SAP_ALLOWED_PACKAGES="ZMYAPP,ZMYAPP_TEST,\$TMP"
+-e SAP_ALLOWED_PACKAGES='ZMYAPP,ZMYAPP_TEST,$TMP'
 ```
+
+> **Use single quotes.** Double quotes let bash expand `$TMP` to the shell's
+> `$TMP` variable (often empty), turning your allowlist into `,,`. Single quotes
+> pass the value literally. If your shell parser requires double quotes, escape
+> the `$`: `"Z*,\$TMP"`.
 
 Read operations (`R`, `S`) are not restricted by this filter — the AI can still
 read objects from any package; it just cannot modify objects outside the
@@ -696,7 +701,7 @@ docker run -i --rm \
   -e SAP_USER=developer \
   -e SAP_PASSWORD=secret \
   -e SAP_READ_ONLY=false \
-  -e SAP_ALLOWED_PACKAGES="Z*,\$TMP" \
+  -e SAP_ALLOWED_PACKAGES='Z*,$TMP' \
   -e SAP_DISALLOWED_OPS=D \
   ghcr.io/marianfoo/arc-1:latest
 ```

--- a/docs_page/index.md
+++ b/docs_page/index.md
@@ -171,7 +171,7 @@ arc1 --profile developer
 
 # Fine-grained individual flags
 arc1 --read-only=false                        # writes only (still $TMP)
-arc1 --read-only=false --allowed-packages "ZPROD*,$TMP"
+arc1 --read-only=false --allowed-packages 'ZPROD*,$TMP'   # single quotes: bash expands $TMP inside "..."
 arc1 --block-free-sql=false                   # free SQL only
 arc1 --block-data=false                       # table preview only
 arc1 --enable-transports=true                 # SAPTransport (all actions)

--- a/docs_page/tools.md
+++ b/docs_page/tools.md
@@ -250,7 +250,7 @@ SAPWrite(action="create", type="SRVB", name="ZSB_TRAVEL_O4", package="$TMP",
   - If a transport IS required but none was provided, ARC-1 returns an actionable error message listing existing transports and guiding the caller to use `SAPTransport(action="list")` or `SAPTransport(action="create")` first.
   - If the pre-flight check fails (older system, permissions), ARC-1 proceeds and lets SAP handle the error.
 
-**Note:** Not available by default (read-only mode). Enable with `--read-only=false` or `--profile developer`. When enabled, write access is restricted to package `$TMP` (local objects). To write to other packages, configure `--allowed-packages` (e.g., `"Z*,$TMP"`).
+**Note:** Not available by default (read-only mode). Enable with `--read-only=false` or `--profile developer`. When enabled, write access is restricted to package `$TMP` (local objects). To write to other packages, configure `--allowed-packages` (e.g., `'Z*,$TMP'` — use single quotes in shell so `$TMP` isn't expanded).
 
 ---
 

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -8,6 +8,7 @@
  * for drop-in compatibility with existing deployments and documentation.
  */
 
+import { logger } from './logger.js';
 import type { FeatureToggle, ServerConfig, TransportType } from './types.js';
 import { DEFAULT_CONFIG } from './types.js';
 
@@ -204,7 +205,17 @@ export function parseArgs(args: string[]): ServerConfig {
   config.allowedOps = resolve('allowed-ops', 'SAP_ALLOWED_OPS', '');
   config.disallowedOps = resolve('disallowed-ops', 'SAP_DISALLOWED_OPS', '');
   const pkgs = getFlag('allowed-packages') ?? process.env.SAP_ALLOWED_PACKAGES;
-  if (pkgs) config.allowedPackages = pkgs.split(',').map((p) => p.trim());
+  if (pkgs) {
+    const raw = pkgs.split(',').map((p) => p.trim());
+    const filtered = raw.filter((p) => p.length > 0);
+    if (raw.length !== filtered.length) {
+      logger.warn(
+        "SAP_ALLOWED_PACKAGES contained empty entries — likely shell expansion of unset $VARs. Use single quotes: SAP_ALLOWED_PACKAGES='$TMP,Z*'",
+        { raw: pkgs, parsed: filtered },
+      );
+    }
+    config.allowedPackages = filtered;
+  }
   const enableTransportsExplicit = getFlag('enable-transports') ?? process.env.SAP_ENABLE_TRANSPORTS;
   if (enableTransportsExplicit !== undefined)
     config.enableTransports = enableTransportsExplicit === 'true' || enableTransportsExplicit === '1';

--- a/tests/unit/server/config.test.ts
+++ b/tests/unit/server/config.test.ts
@@ -149,6 +149,19 @@ describe('parseArgs', () => {
     expect(config.allowedPackages).toEqual(['Z*', '$TMP']);
   });
 
+  it('filters out empty entries from SAP_ALLOWED_PACKAGES (e.g. shell-expanded unset $VARs)', () => {
+    // Simulates `SAP_ALLOWED_PACKAGES=$tmp,$locals,$*` with unset shell vars → ",,"
+    process.env.SAP_ALLOWED_PACKAGES = ',,';
+    const config = parseArgs([]);
+    expect(config.allowedPackages).toEqual([]);
+  });
+
+  it('filters empty entries but keeps valid ones', () => {
+    process.env.SAP_ALLOWED_PACKAGES = 'Z*,,$TMP,';
+    const config = parseArgs([]);
+    expect(config.allowedPackages).toEqual(['Z*', '$TMP']);
+  });
+
   it('parses cookie auth options', () => {
     const config = parseArgs(['--cookie-file', '/path/cookies.txt', '--cookie-string', 'a=b; c=d']);
     expect(config.cookieFile).toBe('/path/cookies.txt');


### PR DESCRIPTION
## Summary

Reported by @se38: writes failed on a perfectly reasonable-looking docker config. The error message was `allowed: ["","",""]` — three empty strings in the allowlist — which made root cause almost impossible to see.

Cause: the user ran

```bash
-e SAP_ALLOWED_PACKAGES=$tmp,$locals,$*
```

unquoted. Bash expanded `$tmp`, `$locals`, `$*` to empty (unset vars), so docker received `SAP_ALLOWED_PACKAGES=,,`. The parser split this into `["", "", ""]` and dutifully matched nothing.

Two fixes:

1. **Parser — defensive** ([src/server/config.ts](src/server/config.ts)): filter empty entries and warn once with the actionable fix (single-quote the value). Correct input is unchanged.
2. **Docker docs — preventive** ([docs_page/docker.md](docs_page/docker.md)): switch `SAP_ALLOWED_PACKAGES` examples from `"..."` to `'...'` and add a short note explaining why double quotes don't protect `$VAR` in bash. Other docs using single quotes (deployment.md) or non-shell contexts (quickstart.md JSON, local-development.md `.env`) are already correct.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run tests/unit/server/config.test.ts` — 87 tests pass, including two new tests:
  - `SAP_ALLOWED_PACKAGES=,,` → `[]` (simulates shell-expanded unset `$VARs`)
  - `SAP_ALLOWED_PACKAGES=Z*,,$TMP,` → `['Z*', '$TMP']` (valid entries preserved)
- [x] Warning emits with the offending raw value and the correct remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)