### PR TITLE
docs: consolidate configuration guidance

### DIFF
--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -52,7 +52,7 @@ Profiles are shortcuts. Individual flags set alongside a profile **override** th
 | Read + named table preview | `ARC1_PROFILE=viewer-data` | Enables `SAPQuery action=table_contents`, still no writes or free SQL |
 | Read + SQL + table preview | `ARC1_PROFILE=viewer-sql` | Enables both `SAPQuery` modes, still no writes or transports |
 | Writes + transports in `$TMP` | `ARC1_PROFILE=developer` | Local development preset without SQL or table preview |
-| Full local development | `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES=*` | Writes + SQL + table preview + transports, unrestricted packages |
+| Full local development | `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES='*'` | Writes + SQL + table preview + transports, unrestricted packages |
 | Power-user operation filter | `SAP_ALLOWED_OPS=RSQ` or `SAP_DISALLOWED_OPS=CDUA` | Exact per-op gating when profiles are too broad |
 
 ### Safety flags

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -52,8 +52,10 @@ Profiles are shortcuts. Individual flags set alongside a profile **override** th
 | Read + named table preview | `ARC1_PROFILE=viewer-data` | Enables `SAPQuery action=table_contents`, still no writes or free SQL |
 | Read + SQL + table preview | `ARC1_PROFILE=viewer-sql` | Enables both `SAPQuery` modes, still no writes or transports |
 | Writes + transports in `$TMP` | `ARC1_PROFILE=developer` | Local development preset without SQL or table preview |
-| Full local development | `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES='*'` | Writes + SQL + table preview + transports, unrestricted packages |
-| Power-user operation filter | `SAP_ALLOWED_OPS=RSQ` or `SAP_DISALLOWED_OPS=CDUA` | Exact per-op gating when profiles are too broad |
+| Full local development | `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES=*` | Writes + SQL + table preview + transports, unrestricted packages |
+| Power-user operation filter | Start from a profile or explicit safety flags, then add `SAP_ALLOWED_OPS` / `SAP_DISALLOWED_OPS` | Fine-grained op gating layered on top of `SAP_READ_ONLY`, `SAP_BLOCK_DATA`, and `SAP_BLOCK_FREE_SQL` |
+
+The recipes above show raw config values. When you pass them through a shell flag such as `-e`, quote shell-sensitive package patterns like `*` or `$TMP`: `-e SAP_ALLOWED_PACKAGES='*'` or `-e SAP_ALLOWED_PACKAGES='Z*,$TMP'`. In JSON, `.env`, and `--env-file`, use the raw value without extra shell quotes.
 
 ### Safety flags
 

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -1,8 +1,26 @@
 # Configuration Reference
 
-Every flag, env var, and default. Precedence: **CLI flag > env var > `.env` file > default**.
+Every flag, env var, and default in one place.
+
+Global precedence: **CLI flag > env var > `.env` file > built-in default**. Within the safety layer, **profiles apply first and explicit safety flags override the profile's values**.
 
 For the grouped template with inline commentary, see [`.env.example`](https://github.com/marianfoo/arc-1/blob/main/.env.example).
+
+---
+
+## Mental model
+
+ARC-1 has three independent gates:
+
+1. **Server safety config = ceiling.** `SAP_READ_ONLY`, `SAP_ALLOWED_PACKAGES`, `SAP_ENABLE_TRANSPORTS`, and related flags define the maximum power this process will expose.
+2. **Profiles and MCP auth scopes = gate beneath that ceiling.** Use `ARC1_PROFILE` first for local development. API-key profiles and JWT scopes can only restrict further; they never widen the server ceiling.
+3. **SAP authorization = final per-user check.** Even if ARC-1 allows an action, SAP can still reject it based on the SAP user's own permissions.
+
+These gates combine with **AND**, not OR.
+
+**Precedence example:** `ARC1_PROFILE=developer` + `SAP_READ_ONLY=true` stays read-only. The profile enables writes and transports first, then the explicit flag overrides that part of the profile again.
+
+**Transport note:** `SAP_ENABLE_TRANSPORTS` is still explicit. Today it turns on only via a developer profile or `SAP_ENABLE_TRANSPORTS=true`; it is not auto-derived from `SAP_ALLOWED_PACKAGES`.
 
 ---
 
@@ -112,21 +130,9 @@ Full reference: [xsuaa-setup.md](xsuaa-setup.md).
 
 ## Safety / scopes / profiles
 
-**Every gate below defaults to the restrictive setting.** ARC-1 starts read-only: no writes, no free SQL, no named table preview, no transport actions, writes confined to `$TMP`. Flip flags or set a profile to enable specific capabilities.
+**Every gate below defaults to the restrictive setting.** ARC-1 starts read-only: no writes, no free SQL, no named table preview, no transport actions, writes confined to `$TMP`.
 
-| Flag | Env Var | Default | What it blocks when enabled |
-|---|---|---|---|
-| `--read-only` | `SAP_READ_ONLY` | `true` | `SAPWrite` (create/update/delete/edit_method), `SAPActivate`, FLP workflow actions — i.e. ops `C`, `U`, `D`, `A`, `W` |
-| `--block-data` | `SAP_BLOCK_DATA` | `true` | `SAPQuery action=table_contents` (op `Q`) |
-| `--block-free-sql` | `SAP_BLOCK_FREE_SQL` | `true` | `SAPQuery action=run_query` (op `F`) |
-| `--enable-transports` | `SAP_ENABLE_TRANSPORTS` | `false` | When `false`, **all** `SAPTransport` actions are blocked — list, get, create, release, delete, reassign |
-| `--allowed-packages` | `SAP_ALLOWED_PACKAGES` | `$TMP` | Writes targeting packages outside this list fail. Comma-separated, trailing `*` wildcard only (`Z*,Y*,$TMP`). `*` alone = unrestricted. **Reads are never package-filtered.** |
-| `--allowed-ops` | `SAP_ALLOWED_OPS` | — | Whitelist operation codes (e.g. `RSQ`) — anything not listed is blocked |
-| `--disallowed-ops` | `SAP_DISALLOWED_OPS` | — | Blacklist operation codes — listed codes are blocked, rest allowed |
-| `--profile` | `ARC1_PROFILE` | — | Preset — expands to multiple flags, see [profile expansions](#profile-expansions) below |
-| `--tool-mode` | `ARC1_TOOL_MODE` | `standard` | `standard` (11 tools) / `hyperfocused` (1 tool, ~200 tokens) |
-| `--abaplint-config` | `SAP_ABAPLINT_CONFIG` | — | Path to custom abaplint.jsonc |
-| `--lint-before-write` | `SAP_LINT_BEFORE_WRITE` | `true` | Pre-write lint validation |
+Profiles are the primary knob. Pick the closest preset first, then use individual flags only when you need a custom mix.
 
 ### Profile expansions
 
@@ -142,7 +148,30 @@ Profiles are shortcuts. Individual flags set alongside a profile **override** th
 | `developer-data` | `false` | `false` | `true` | `true` | `$TMP` |
 | `developer-sql` | `false` | `false` | `false` | `true` | `$TMP` |
 
-**"Enable everything" recipe:** `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES=*`.
+### Common recipes
+
+| Use case | Set | Result |
+|---|---|---|
+| Read/search only | nothing, or `ARC1_PROFILE=viewer` | Safe default: no writes, no SQL, no table preview, no transports |
+| Read + named table preview | `ARC1_PROFILE=viewer-data` | Enables `SAPQuery action=table_contents`, still no writes or free SQL |
+| Read + SQL + table preview | `ARC1_PROFILE=viewer-sql` | Enables both `SAPQuery` modes, still no writes or transports |
+| Writes + transports in `$TMP` | `ARC1_PROFILE=developer` | Local development preset without SQL or table preview |
+| Full local development | `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES=*` | Writes + SQL + table preview + transports, unrestricted packages |
+| Power-user operation filter | `SAP_ALLOWED_OPS=RSQ` or `SAP_DISALLOWED_OPS=CDUA` | Exact per-op gating when profiles are too broad |
+
+| Flag | Env Var | Default | What it blocks when enabled |
+|---|---|---|---|
+| `--read-only` | `SAP_READ_ONLY` | `true` | `SAPWrite` (create/update/delete/edit_method), `SAPActivate`, FLP workflow actions — i.e. ops `C`, `U`, `D`, `A`, `W` |
+| `--block-data` | `SAP_BLOCK_DATA` | `true` | `SAPQuery action=table_contents` (op `Q`) |
+| `--block-free-sql` | `SAP_BLOCK_FREE_SQL` | `true` | `SAPQuery action=run_query` (op `F`) |
+| `--enable-transports` | `SAP_ENABLE_TRANSPORTS` | `false` | When `false`, **all** `SAPTransport` actions are blocked — list, get, create, release, delete, reassign. Current behavior: stays off unless a developer profile or this flag enables it |
+| `--allowed-packages` | `SAP_ALLOWED_PACKAGES` | `$TMP` | Writes targeting packages outside this list fail. Comma-separated, trailing `*` wildcard only (`Z*,Y*,$TMP`). `*` alone = unrestricted. **Reads are never package-filtered.** |
+| `--allowed-ops` | `SAP_ALLOWED_OPS` | — | Whitelist operation codes (e.g. `RSQ`) — anything not listed is blocked. Power-user knob when profiles are too coarse |
+| `--disallowed-ops` | `SAP_DISALLOWED_OPS` | — | Blacklist operation codes — listed codes are blocked, rest allowed |
+| `--profile` | `ARC1_PROFILE` | — | Preset — expands to multiple flags, see [profile expansions](#profile-expansions) below |
+| `--tool-mode` | `ARC1_TOOL_MODE` | `standard` | `standard` (11 tools) / `hyperfocused` (1 tool, ~200 tokens) |
+| `--abaplint-config` | `SAP_ABAPLINT_CONFIG` | — | Path to custom abaplint.jsonc |
+| `--lint-before-write` | `SAP_LINT_BEFORE_WRITE` | `true` | Pre-write lint validation |
 
 ### Operation-type codes
 

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -24,6 +24,68 @@ These gates combine with **AND**, not OR.
 
 ---
 
+## Safety / scopes / profiles
+
+**Every gate below defaults to the restrictive setting.** ARC-1 starts read-only: no writes, no free SQL, no named table preview, no transport actions, writes confined to `$TMP`.
+
+Profiles are the primary knob. Pick the closest preset first, then use individual flags only when you need a custom mix.
+
+### Profile expansions
+
+Profiles are shortcuts. Individual flags set alongside a profile **override** the profile's values.
+
+| Profile | `readOnly` | `blockData` | `blockFreeSQL` | `enableTransports` | `allowedPackages` |
+|---|:---:|:---:|:---:|:---:|---|
+| *(none)* | `true` | `true` | `true` | `false` | `$TMP` |
+| `viewer` | `true` | `true` | `true` | `false` | (default) |
+| `viewer-data` | `true` | `false` | `true` | `false` | (default) |
+| `viewer-sql` | `true` | `false` | `false` | `false` | (default) |
+| `developer` | `false` | `true` | `true` | `true` | `$TMP` |
+| `developer-data` | `false` | `false` | `true` | `true` | `$TMP` |
+| `developer-sql` | `false` | `false` | `false` | `true` | `$TMP` |
+
+### Common recipes
+
+| Use case | Set | Result |
+|---|---|---|
+| Read/search only | nothing, or `ARC1_PROFILE=viewer` | Safe default: no writes, no SQL, no table preview, no transports |
+| Read + named table preview | `ARC1_PROFILE=viewer-data` | Enables `SAPQuery action=table_contents`, still no writes or free SQL |
+| Read + SQL + table preview | `ARC1_PROFILE=viewer-sql` | Enables both `SAPQuery` modes, still no writes or transports |
+| Writes + transports in `$TMP` | `ARC1_PROFILE=developer` | Local development preset without SQL or table preview |
+| Full local development | `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES=*` | Writes + SQL + table preview + transports, unrestricted packages |
+| Power-user operation filter | `SAP_ALLOWED_OPS=RSQ` or `SAP_DISALLOWED_OPS=CDUA` | Exact per-op gating when profiles are too broad |
+
+### Safety flags
+
+| Flag | Env Var | Default | What it blocks when enabled |
+|---|---|---|---|
+| `--read-only` | `SAP_READ_ONLY` | `true` | `SAPWrite` (create/update/delete/edit_method), `SAPActivate`, FLP workflow actions — i.e. ops `C`, `U`, `D`, `A`, `W` |
+| `--block-data` | `SAP_BLOCK_DATA` | `true` | `SAPQuery action=table_contents` (op `Q`) |
+| `--block-free-sql` | `SAP_BLOCK_FREE_SQL` | `true` | `SAPQuery action=run_query` (op `F`) |
+| `--enable-transports` | `SAP_ENABLE_TRANSPORTS` | `false` | When `false`, **all** `SAPTransport` actions are blocked — list, get, create, release, delete, reassign. Current behavior: stays off unless a developer profile or this flag enables it |
+| `--allowed-packages` | `SAP_ALLOWED_PACKAGES` | `$TMP` | Writes targeting packages outside this list fail. Comma-separated, trailing `*` wildcard only (`Z*,Y*,$TMP`). `*` alone = unrestricted. **Reads are never package-filtered.** |
+| `--allowed-ops` | `SAP_ALLOWED_OPS` | — | Whitelist operation codes (e.g. `RSQ`) — anything not listed is blocked. Power-user knob when profiles are too coarse |
+| `--disallowed-ops` | `SAP_DISALLOWED_OPS` | — | Blacklist operation codes — listed codes are blocked, rest allowed |
+| `--profile` | `ARC1_PROFILE` | — | Preset — expands to multiple flags, see [profile expansions](#profile-expansions) above |
+| `--tool-mode` | `ARC1_TOOL_MODE` | `standard` | `standard` (11 tools) / `hyperfocused` (1 tool, ~200 tokens) |
+| `--abaplint-config` | `SAP_ABAPLINT_CONFIG` | — | Path to custom abaplint.jsonc |
+| `--lint-before-write` | `SAP_LINT_BEFORE_WRITE` | `true` | Pre-write lint validation |
+
+### Operation-type codes
+
+Used in `--allowed-ops` / `--disallowed-ops`:
+
+```
+Reads:  R = Read       S = Search     I = Intelligence (findRef, whereUsed, completion)
+        Q = Query (table preview)     F = FreeSQL
+Writes: C = Create     U = Update     D = Delete     A = Activate     W = Workflow (FLP)
+Other:  T = Test (unit)   L = Lock   X = Transport
+```
+
+Write operations `C`, `D`, `U`, `A`, `W` are all blocked when `readOnly=true`, regardless of the op filter.
+
+---
+
 ## SAP connection
 
 | Flag | Env Var | Default | Description |
@@ -125,66 +187,6 @@ Full reference: [oauth-jwt-setup.md](oauth-jwt-setup.md).
 | `--xsuaa-auth` | `SAP_XSUAA_AUTH` | `false` | Enable XSUAA token validation |
 
 Full reference: [xsuaa-setup.md](xsuaa-setup.md).
-
----
-
-## Safety / scopes / profiles
-
-**Every gate below defaults to the restrictive setting.** ARC-1 starts read-only: no writes, no free SQL, no named table preview, no transport actions, writes confined to `$TMP`.
-
-Profiles are the primary knob. Pick the closest preset first, then use individual flags only when you need a custom mix.
-
-### Profile expansions
-
-Profiles are shortcuts. Individual flags set alongside a profile **override** the profile's values.
-
-| Profile | `readOnly` | `blockData` | `blockFreeSQL` | `enableTransports` | `allowedPackages` |
-|---|:---:|:---:|:---:|:---:|---|
-| *(none)* | `true` | `true` | `true` | `false` | `$TMP` |
-| `viewer` | `true` | `true` | `true` | `false` | (default) |
-| `viewer-data` | `true` | `false` | `true` | `false` | (default) |
-| `viewer-sql` | `true` | `false` | `false` | `false` | (default) |
-| `developer` | `false` | `true` | `true` | `true` | `$TMP` |
-| `developer-data` | `false` | `false` | `true` | `true` | `$TMP` |
-| `developer-sql` | `false` | `false` | `false` | `true` | `$TMP` |
-
-### Common recipes
-
-| Use case | Set | Result |
-|---|---|---|
-| Read/search only | nothing, or `ARC1_PROFILE=viewer` | Safe default: no writes, no SQL, no table preview, no transports |
-| Read + named table preview | `ARC1_PROFILE=viewer-data` | Enables `SAPQuery action=table_contents`, still no writes or free SQL |
-| Read + SQL + table preview | `ARC1_PROFILE=viewer-sql` | Enables both `SAPQuery` modes, still no writes or transports |
-| Writes + transports in `$TMP` | `ARC1_PROFILE=developer` | Local development preset without SQL or table preview |
-| Full local development | `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES=*` | Writes + SQL + table preview + transports, unrestricted packages |
-| Power-user operation filter | `SAP_ALLOWED_OPS=RSQ` or `SAP_DISALLOWED_OPS=CDUA` | Exact per-op gating when profiles are too broad |
-
-| Flag | Env Var | Default | What it blocks when enabled |
-|---|---|---|---|
-| `--read-only` | `SAP_READ_ONLY` | `true` | `SAPWrite` (create/update/delete/edit_method), `SAPActivate`, FLP workflow actions — i.e. ops `C`, `U`, `D`, `A`, `W` |
-| `--block-data` | `SAP_BLOCK_DATA` | `true` | `SAPQuery action=table_contents` (op `Q`) |
-| `--block-free-sql` | `SAP_BLOCK_FREE_SQL` | `true` | `SAPQuery action=run_query` (op `F`) |
-| `--enable-transports` | `SAP_ENABLE_TRANSPORTS` | `false` | When `false`, **all** `SAPTransport` actions are blocked — list, get, create, release, delete, reassign. Current behavior: stays off unless a developer profile or this flag enables it |
-| `--allowed-packages` | `SAP_ALLOWED_PACKAGES` | `$TMP` | Writes targeting packages outside this list fail. Comma-separated, trailing `*` wildcard only (`Z*,Y*,$TMP`). `*` alone = unrestricted. **Reads are never package-filtered.** |
-| `--allowed-ops` | `SAP_ALLOWED_OPS` | — | Whitelist operation codes (e.g. `RSQ`) — anything not listed is blocked. Power-user knob when profiles are too coarse |
-| `--disallowed-ops` | `SAP_DISALLOWED_OPS` | — | Blacklist operation codes — listed codes are blocked, rest allowed |
-| `--profile` | `ARC1_PROFILE` | — | Preset — expands to multiple flags, see [profile expansions](#profile-expansions) below |
-| `--tool-mode` | `ARC1_TOOL_MODE` | `standard` | `standard` (11 tools) / `hyperfocused` (1 tool, ~200 tokens) |
-| `--abaplint-config` | `SAP_ABAPLINT_CONFIG` | — | Path to custom abaplint.jsonc |
-| `--lint-before-write` | `SAP_LINT_BEFORE_WRITE` | `true` | Pre-write lint validation |
-
-### Operation-type codes
-
-Used in `--allowed-ops` / `--disallowed-ops`:
-
-```
-Reads:  R = Read       S = Search     I = Intelligence (findRef, whereUsed, completion)
-        Q = Query (table preview)     F = FreeSQL
-Writes: C = Create     U = Update     D = Delete     A = Activate     W = Workflow (FLP)
-Other:  T = Test (unit)   L = Lock   X = Transport
-```
-
-Write operations `C`, `D`, `U`, `A`, `W` are all blocked when `readOnly=true`, regardless of the op filter.
 
 ---
 

--- a/docs_page/deployment.md
+++ b/docs_page/deployment.md
@@ -64,9 +64,20 @@ docker run -d --name arc1 -p 8080:8080 \
   -e SAP_URL=https://your-sap-host:44300 \
   -e SAP_USER=SVC_ARC1 -e SAP_PASSWORD=... \
   -e SAP_OIDC_ISSUER=https://login.microsoftonline.com/{tenant}/v2.0 \
-  -e SAP_OIDC_AUDIENCE=api://arc1 \
+  -e SAP_OIDC_AUDIENCE={client-id-guid} \
   ghcr.io/marianfoo/arc-1:latest
 ```
+
+This example only turns on OIDC validation for the MCP endpoint. It does **not** widen the server's safety ceiling: ARC-1 still defaults to read-only, no SQL, no named table preview, no transports, and writes restricted to `$TMP` unless you set a profile or explicit safety flags.
+
+If this shared server should allow development work, add these flags to the same `docker run` command:
+
+```bash
+-e ARC1_PROFILE=developer \
+-e SAP_ALLOWED_PACKAGES='Z*,$TMP'
+```
+
+JWT scopes and profiles sit **beneath** that server ceiling. A token with `write` or `sql` scopes still cannot bypass `SAP_READ_ONLY=true` or other stricter server flags. Full matrix: [configuration-reference.md](configuration-reference.md). Scope model and ceiling interaction: [authorization.md](authorization.md#how-safety-and-scopes-interact).
 
 ARC-1 audit logs show the real MCP user; SAP audit logs show the shared service account. Trade-off — good compromise when you can't use PP.
 

--- a/docs_page/docker.md
+++ b/docs_page/docker.md
@@ -270,9 +270,9 @@ docker run -d --rm \
 
 Keep credentials and stable connection settings in `.env`; layer temporary overrides with `-e`.
 
-For what `ARC1_PROFILE`, `SAP_ENABLE_TRANSPORTS`, `SAP_ALLOWED_OPS`, `SAP_ALLOWED_PACKAGES`, and the rest actually do, use [configuration-reference.md](configuration-reference.md). Ready-made read-only, sandboxed, and developer recipes live in [configuration-reference.md → Common recipes](configuration-reference.md#common-recipes) — translate each `ENV=value` into `-e ENV=value` or add it to your `--env-file`.
+For what `ARC1_PROFILE`, `SAP_ENABLE_TRANSPORTS`, `SAP_ALLOWED_OPS`, `SAP_ALLOWED_PACKAGES`, and the rest actually do, use [configuration-reference.md](configuration-reference.md). Ready-made read-only, sandboxed, and developer recipes live in [configuration-reference.md → Common recipes](configuration-reference.md#common-recipes). That page shows raw `ENV=value` values: use them as-is in `.env` and `--env-file`, but quote shell-sensitive package patterns when you pass them via `-e`.
 
-If you pass `$TMP` in `SAP_ALLOWED_PACKAGES`, use single quotes so the shell does not expand it: `-e SAP_ALLOWED_PACKAGES='Z*,$TMP'`.
+If you pass package patterns like `*` or `$TMP` through `-e SAP_ALLOWED_PACKAGES=...`, use single quotes so the shell does not expand them: `-e SAP_ALLOWED_PACKAGES='*'` or `-e SAP_ALLOWED_PACKAGES='Z*,$TMP'`.
 
 ### Cookie files inside the container
 

--- a/docs_page/docker.md
+++ b/docs_page/docker.md
@@ -270,7 +270,7 @@ docker run -d --rm \
 
 Keep credentials and stable connection settings in `.env`; layer temporary overrides with `-e`.
 
-For what `ARC1_PROFILE`, `SAP_ENABLE_TRANSPORTS`, `SAP_ALLOWED_OPS`, `SAP_ALLOWED_PACKAGES`, and the rest actually do, use [configuration-reference.md](configuration-reference.md).
+For what `ARC1_PROFILE`, `SAP_ENABLE_TRANSPORTS`, `SAP_ALLOWED_OPS`, `SAP_ALLOWED_PACKAGES`, and the rest actually do, use [configuration-reference.md](configuration-reference.md). Ready-made read-only, sandboxed, and developer recipes live in [configuration-reference.md → Common recipes](configuration-reference.md#common-recipes) — translate each `ENV=value` into `-e ENV=value` or add it to your `--env-file`.
 
 If you pass `$TMP` in `SAP_ALLOWED_PACKAGES`, use single quotes so the shell does not expand it: `-e SAP_ALLOWED_PACKAGES='Z*,$TMP'`.
 

--- a/docs_page/docker.md
+++ b/docs_page/docker.md
@@ -16,25 +16,16 @@ without spawning a new process per session.
 2. [Pre-Built Images (GHCR)](#pre-built-images-ghcr)
 3. [Building the Image](#building-the-image)
 4. [How arc1 Runs in Docker](#how-arc1-runs-in-docker)
-5. [Configuration Reference](#configuration-reference)
-   - [Connection](#connection)
-   - [Authentication](#authentication)
-   - [Safety / Read-Only](#safety--read-only)
-   - [Transport Management](#transport-management)
-   - [Feature Flags](#feature-flags)
-   - [Debugger](#debugger)
-   - [Network / TLS](#network--tls)
+5. [Passing Configuration into Docker](#passing-configuration-into-docker)
+   - [Env vars and env files](#env-vars-and-env-files)
+   - [Cookie files inside the container](#cookie-files-inside-the-container)
+   - [Proxy, TLS, and networking](#proxy-tls-and-networking)
 6. [MCP Client Integration](#mcp-client-integration)
    - [Claude Desktop](#claude-desktop)
    - [Gemini CLI / Other Agents](#gemini-cli--other-agents)
-7. [Common Configurations](#common-configurations)
-   - [Read-Only for Production Review](#read-only-for-production-review)
-   - [Sandboxed AI (Z* packages only)](#sandboxed-ai-z-packages-only)
-   - [Cookie Authentication](#cookie-authentication)
-   - [Corporate Proxy](#corporate-proxy)
-8. [Updating the Image](#updating-the-image)
-9. [Security Notes](#security-notes)
-10. [Troubleshooting](#troubleshooting)
+7. [Updating the Image](#updating-the-image)
+8. [Security Notes](#security-notes)
+9. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -249,277 +240,56 @@ MCP Client
 
 ---
 
-## Configuration Reference
+## Passing Configuration into Docker
 
-All configuration is done through **environment variables** with the `SAP_`
-prefix. CLI flags map 1:1 to env vars:
+All ARC-1 env vars, CLI flags, profiles, and safety recipes live in [configuration-reference.md](configuration-reference.md). This page only covers the Docker-specific part: how to pass that config into a container.
 
-| CLI flag | Env variable | Default |
-|---|---|---|
-| `--url` | `SAP_URL` | *(required)* |
-| `--user` | `SAP_USER` | |
-| `--password` | `SAP_PASSWORD` | |
-| `--client` | `SAP_CLIENT` | `100` |
-| `--language` | `SAP_LANGUAGE` | `EN` |
-| `--insecure` | `SAP_INSECURE` | `false` |
-| `--read-only` | `SAP_READ_ONLY` | `true` |
-| `--block-free-sql` | `SAP_BLOCK_FREE_SQL` | `true` |
-| `--allowed-ops` | `SAP_ALLOWED_OPS` | |
-| `--disallowed-ops` | `SAP_DISALLOWED_OPS` | |
-| `--allowed-packages` | `SAP_ALLOWED_PACKAGES` | `$TMP` |
-| `--enable-transports` | `SAP_ENABLE_TRANSPORTS` | `false` |
-| `--feature-abapgit` | `SAP_FEATURE_ABAPGIT` | `auto` |
-| `--feature-rap` | `SAP_FEATURE_RAP` | `auto` |
-| `--feature-amdp` | `SAP_FEATURE_AMDP` | `auto` |
-| `--feature-ui5` | `SAP_FEATURE_UI5` | `auto` |
-| `--feature-transport` | `SAP_FEATURE_TRANSPORT` | `auto` |
-| `--feature-hana` | `SAP_FEATURE_HANA` | `auto` |
-| `--feature-ui5repo` | `SAP_FEATURE_UI5REPO` | `auto` |
-| `--feature-flp` | `SAP_FEATURE_FLP` | `auto` |
-| `--transport` | `SAP_TRANSPORT` | `http-streamable` *(image default)* |
-| `--http-addr` | `SAP_HTTP_ADDR` | `0.0.0.0:8080` *(image default)* |
-| `--verbose` | `SAP_VERBOSE` | `false` |
-| **MCP Client Auth** | | |
-| `--api-key` | `ARC1_API_KEY` | |
-| `--api-keys` | `ARC1_API_KEYS` | |
-| `--oidc-issuer` | `SAP_OIDC_ISSUER` | |
-| `--oidc-audience` | `SAP_OIDC_AUDIENCE` | |
-| `--xsuaa-auth` | `SAP_XSUAA_AUTH` | `false` |
-| `--pp-enabled` | `SAP_PP_ENABLED` | `false` |
-| `--pp-strict` | `SAP_PP_STRICT` | `false` |
-| `--profile` | `ARC1_PROFILE` | |
-| *(BTP destination)* | `SAP_BTP_DESTINATION` | |
-| *(BTP PP destination)* | `SAP_BTP_PP_DESTINATION` | |
+### Env vars and env files
 
----
-
-### Connection
+Use `-e` for short examples and `--env-file` when the list gets long:
 
 ```bash
-SAP_URL=https://host:44300    # Required. Include scheme and port.
-SAP_CLIENT=001                # SAP client number (3 digits)
-SAP_LANGUAGE=EN               # ABAP session language (2-char ISO)
+# Keep connection/auth settings in .env, add a profile at runtime
+docker run -d --rm \
+  -p 8080:8080 \
+  --env-file .env \
+  -e ARC1_PROFILE=developer \
+  ghcr.io/marianfoo/arc-1:latest
 ```
 
----
-
-### Authentication
-
-arc1 supports multiple auth methods for connecting to SAP, plus optional MCP client authentication.
-
-#### MCP Client Authentication (Hop 1: Client → arc1)
-
-When running arc1 as a shared server, protect it with API key or OAuth:
+For the "everything on" local-dev path:
 
 ```bash
-# API Key (simplest)
--e ARC1_API_KEY='your-secret-key'
-
-# OAuth/OIDC JWT validation (enterprise)
--e SAP_OIDC_ISSUER='https://login.microsoftonline.com/{tenant}/v2.0' \
--e SAP_OIDC_AUDIENCE='<expected-aud-claim>'
-
-# Principal Propagation (BTP Destination + Cloud Connector path)
--e SAP_BTP_DESTINATION=SAP_TRIAL \
--e SAP_BTP_PP_DESTINATION=SAP_TRIAL_PP \
--e SAP_PP_ENABLED=true
+docker run -d --rm \
+  -p 8080:8080 \
+  --env-file .env \
+  -e ARC1_PROFILE=developer-sql \
+  -e SAP_ALLOWED_PACKAGES='*' \
+  ghcr.io/marianfoo/arc-1:latest
 ```
 
-See the [Authentication guides](enterprise-auth.md) for detailed setup.
+Keep credentials and stable connection settings in `.env`; layer temporary overrides with `-e`.
 
-#### SAP Authentication (Hop 2: arc1 → SAP)
+For what `ARC1_PROFILE`, `SAP_ENABLE_TRANSPORTS`, `SAP_ALLOWED_OPS`, `SAP_ALLOWED_PACKAGES`, and the rest actually do, use [configuration-reference.md](configuration-reference.md).
 
-arc1 supports these mutually exclusive SAP auth methods. Use exactly one.
+If you pass `$TMP` in `SAP_ALLOWED_PACKAGES`, use single quotes so the shell does not expand it: `-e SAP_ALLOWED_PACKAGES='Z*,$TMP'`.
 
-#### Basic auth (username + password)
+### Cookie files inside the container
 
-```bash
--e SAP_USER=myuser -e SAP_PASSWORD=mypassword
-```
-
-#### Cookie file (Netscape format)
-
-Mount a cookie file into the container and reference it:
+Mount a Netscape-format cookie file into the container and reference it with `SAP_COOKIE_FILE`:
 
 ```bash
 docker run -i --rm \
   -e SAP_URL=https://host:44300 \
   -e SAP_COOKIE_FILE=/cookies/cookies.txt \
   -v /path/to/local/cookies.txt:/cookies/cookies.txt:ro \
-  arc1
+  ghcr.io/marianfoo/arc-1:latest
 ```
 
-The cookie file must use the Netscape format exported by browser extensions like
-*Edit This Cookie* or *Cookie-Editor*.
+The cookie file must use the Netscape format exported by browser extensions like *Edit This Cookie* or *Cookie-Editor*.
 
-#### Cookie string
-
-```bash
--e SAP_COOKIE_STRING="sap-usercontext=sap-client=001; SAP_SESSIONID_ABC=xyz"
-```
-
-> **Never bake credentials into the image** with `ENV` in a downstream
-> Dockerfile. Always pass them at runtime via `-e` or `--env-file`.
-
-#### Using `--env-file`
-
-Keep credentials in a local `.env` file (never committed to git):
-
-```bash
-# .env
-SAP_URL=https://host:44300
-SAP_USER=developer
-SAP_PASSWORD=s3cr3t
-```
-
-```bash
-docker run -i --rm --env-file .env arc1
-```
-
----
-
-### Safety / Read-Only
-
-ARC-1 is safe by default — read-only, no free SQL, no table preview, no transports. Use profiles or explicit flags to enable capabilities.
-
-#### Default (safest)
-
-Out of the box, all write operations, free SQL, and table preview are blocked. No additional flags needed for read-only access.
-
-#### Enable developer access
-
-Use a profile to enable writes and transports:
-
-```bash
--e ARC1_PROFILE=developer
-```
-
-#### Enable free SQL
-
-To allow arbitrary SELECT statements via `RunQuery`:
-
-```bash
--e SAP_BLOCK_FREE_SQL=false
-```
-
-#### Operation allowlist
-
-Only permit specific operation types. The operation codes are:
-
-| Code | Meaning |
-|---|---|
-| `R` | Read (GetSource, GetObject, etc.) |
-| `S` | Search (SearchObjects, GrepSource, etc.) |
-| `I` | Intelligence (findRef, whereUsed, completion) |
-| `Q` | Query (named table preview) |
-| `F` | Free SQL (`RunQuery`) |
-| `C` | Create |
-| `U` | Update (EditSource, WriteSource) |
-| `D` | Delete |
-| `A` | Activate |
-| `W` | Workflow (FLP actions) |
-| `T` | Test (unit tests) |
-| `L` | Lock |
-| `X` | Transport |
-
-Example — allow only read and search (equivalent to read-only but explicit):
-
-```bash
--e SAP_ALLOWED_OPS=RS
-```
-
-Example — allow read, search, and query but no writes:
-
-```bash
--e SAP_ALLOWED_OPS=RSQ
-```
-
-#### Operation blocklist
-
-Block specific operation types while allowing everything else:
-
-```bash
-# Block create, delete, update, activate (but allow read/search/query)
--e SAP_DISALLOWED_OPS=CDUA
-```
-
-> `SAP_ALLOWED_OPS` and `SAP_DISALLOWED_OPS` are mutually exclusive. Use one or
-> the other, not both.
-
-#### Package restriction
-
-Restrict all write operations to specific packages. Supports wildcards:
-
-```bash
-# Only allow writes to custom packages and $TMP
--e SAP_ALLOWED_PACKAGES='Z*,$TMP'
-
-# Only one specific package
--e SAP_ALLOWED_PACKAGES='$ZRAY_DEV'
-
-# Multiple packages (comma-separated)
--e SAP_ALLOWED_PACKAGES='ZMYAPP,ZMYAPP_TEST,$TMP'
-```
-
-> **Use single quotes.** Double quotes let bash expand `$TMP` to the shell's
-> `$TMP` variable (often empty), turning your allowlist into `,,`. Single quotes
-> pass the value literally. If your shell parser requires double quotes, escape
-> the `$`: `"Z*,\$TMP"`.
-
-Read operations (`R`, `S`) are not restricted by this filter — the AI can still
-read objects from any package; it just cannot modify objects outside the
-allowlist. Use `"*"` for unrestricted write access.
-
----
-
-### Transport Management
-
-CTS transport tools are **disabled by default** to prevent accidental releases.
-
-```bash
-# Enable transport tools
--e SAP_ENABLE_TRANSPORTS=true
-```
-
----
-
-### Feature Flags
-
-Feature flags control whether optional SAP features are enabled. The default
-`auto` mode probes the SAP system on startup and enables a feature only if the
-corresponding ABAP components are installed.
-
-Use `on` or `off` to skip the probe and force the behavior:
-
-| Variable | Feature | Notes |
-|---|---|---|
-| `SAP_FEATURE_RAP` | RAP/OData development | BDEF, SRVD, SRVB tools |
-| `SAP_FEATURE_AMDP` | AMDP/HANA debugger | Expert mode only |
-| `SAP_FEATURE_UI5` | UI5/Fiori BSP | BSP app management |
-| `SAP_FEATURE_TRANSPORT` | CTS transport | Superset of `--enable-transports` |
-| `SAP_FEATURE_HANA` | HANA detection | AMDP, HANA SQL tools |
-| `SAP_FEATURE_UI5REPO` | UI5 ABAP Repository OData | BSP deploy metadata reads |
-| `SAP_FEATURE_FLP` | FLP PAGE_BUILDER_CUST OData | SAPManage FLP catalog/group/tile actions |
-
-```bash
-# Force all features off — fastest startup, smallest tool surface
--e SAP_FEATURE_ABAPGIT=off \
--e SAP_FEATURE_RAP=off \
--e SAP_FEATURE_AMDP=off \
--e SAP_FEATURE_UI5=off \
--e SAP_FEATURE_TRANSPORT=off \
--e SAP_FEATURE_HANA=off
-
-# Force abapGit on without probing
--e SAP_FEATURE_ABAPGIT=on
-```
-
-Setting features to `off` reduces the number of registered MCP tools, which
-keeps the AI's tool list shorter and lowers token usage.
-
----
-
-### Network / TLS
+> **Never bake credentials into the image** with `ENV` in a downstream Dockerfile. Always pass them at runtime via `-e` or `--env-file`.
+### Proxy, TLS, and networking
 
 #### Self-signed or internal CA certificates
 
@@ -672,62 +442,6 @@ Clients that support HTTP MCP can connect to `http://localhost:8080/mcp` directl
 once the container is running. For stdio-only clients use `docker run -i` with
 `-e SAP_TRANSPORT=stdio`. See [local-development.md → MCP client configuration](local-development.md#mcp-client-configuration) for agent-specific
 configuration examples.
-
----
-
-## Common Configurations
-
-### Read-Only for Production Review
-
-Default configuration is already read-only — safe for production:
-
-```bash
-docker run -d --rm \
-  -p 8080:8080 \
-  -e SAP_URL=https://prod:44300 \
-  -e SAP_USER=s_ai_viewer \
-  -e SAP_PASSWORD=secret \
-  -e SAP_VERBOSE=true \
-  ghcr.io/marianfoo/arc-1:latest
-```
-
-### Sandboxed AI (Z* packages only)
-
-AI can read anything but only write to custom development packages:
-
-```bash
-docker run -i --rm \
-  -e SAP_URL=https://dev:44300 \
-  -e SAP_USER=developer \
-  -e SAP_PASSWORD=secret \
-  -e SAP_READ_ONLY=false \
-  -e SAP_ALLOWED_PACKAGES='Z*,$TMP' \
-  -e SAP_DISALLOWED_OPS=D \
-  ghcr.io/marianfoo/arc-1:latest
-```
-
-This setup lets the AI read system objects, write only to custom packages, and
-prevents deletions. Free SQL and table preview remain blocked (defaults).
-
-### Cookie Authentication
-
-```bash
-docker run -i --rm \
-  -e SAP_URL=https://host:44300 \
-  -e SAP_COOKIE_FILE=/cookies/cookies.txt \
-  -v "${HOME}/.sap-cookies/my-system.txt:/cookies/cookies.txt:ro" \
-  ghcr.io/marianfoo/arc-1:latest
-```
-
-### Corporate Proxy
-
-```bash
-docker run -i --rm \
-  --env-file .env \
-  -e HTTPS_PROXY=http://proxy.corp.example:3128 \
-  -e NO_PROXY=localhost,127.0.0.1 \
-  ghcr.io/marianfoo/arc-1:latest
-```
 
 ---
 

--- a/docs_page/index.md
+++ b/docs_page/index.md
@@ -164,7 +164,7 @@ Safe by default — read-only, no SQL, no data preview, no transports. Writes ar
 
 - `ARC1_PROFILE=viewer` or nothing: read/search only.
 - `ARC1_PROFILE=developer`: writes + transports in `$TMP`, still no SQL or named table preview.
-- `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES=*`: full local development access.
+- `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES='*'`: full local development access. (Quote the `*` in shell so it isn't globbed to filenames.)
 
 Profiles never widen a stricter server flag. Example: `ARC1_PROFILE=developer` + `SAP_READ_ONLY=true` is still read-only.
 

--- a/docs_page/index.md
+++ b/docs_page/index.md
@@ -95,7 +95,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 }
 ```
 
-For fine-grained control, see [Admin Controls (Safety)](#admin-controls-safety) below or [local-development.md → Safety profiles](local-development.md#safety-profiles).
+Profiles are the main local-dev knob. Start with `ARC1_PROFILE=viewer` or `ARC1_PROFILE=developer-sql`, then use [configuration-reference.md](configuration-reference.md) for the full matrix and individual flags.
 
 ### Claude Code
 
@@ -160,25 +160,15 @@ Full reference: **[tools.md](tools.md)**
 
 ## Admin Controls (Safety)
 
-Safe by default — read-only, no SQL, no data preview, no transports. Writes are restricted to `$TMP`. Enable capabilities explicitly:
+Safe by default — read-only, no SQL, no data preview, no transports. Writes are restricted to `$TMP`.
 
-```bash
-# Enable everything (writes + transports + SQL + data, all packages)
-arc1 --profile developer-sql --allowed-packages "*"
+- `ARC1_PROFILE=viewer` or nothing: read/search only.
+- `ARC1_PROFILE=developer`: writes + transports in `$TMP`, still no SQL or named table preview.
+- `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES=*`: full local development access.
 
-# Writes + transports, no SQL/data (default developer preset)
-arc1 --profile developer
+Profiles never widen a stricter server flag. Example: `ARC1_PROFILE=developer` + `SAP_READ_ONLY=true` is still read-only.
 
-# Fine-grained individual flags
-arc1 --read-only=false                        # writes only (still $TMP)
-arc1 --read-only=false --allowed-packages 'ZPROD*,$TMP'   # single quotes: bash expands $TMP inside "..."
-arc1 --block-free-sql=false                   # free SQL only
-arc1 --block-data=false                       # table preview only
-arc1 --enable-transports=true                 # SAPTransport (all actions)
-arc1 --allowed-ops "RSQ"                      # whitelist operation codes
-```
-
-Full recipe reference: [local-development.md → Safety profiles](local-development.md#safety-profiles). Profile expansions: [configuration-reference.md → Profile expansions](configuration-reference.md#profile-expansions).
+Full env/CLI reference, profile expansions, and recipes: [configuration-reference.md](configuration-reference.md).
 
 ## Documentation
 

--- a/docs_page/local-development.md
+++ b/docs_page/local-development.md
@@ -143,9 +143,9 @@ Same pattern: spawn `npx -y arc-1@latest` with the same `env` block. All stdio c
 
 ## Safety profiles
 
-> **ARC-1 ships read-only.** Writes, free SQL, named table preview, and transport actions are all blocked by default. Nothing the AI can do here will modify your SAP system until you flip a flag.
+> **ARC-1 ships read-only.** For local development, start with a profile first and reach for individual flags only when you need a custom mix.
 
-### What's blocked by default, and by which flag
+### What's blocked by default
 
 | Capability | Default | Flag that blocks it | Tools/actions disabled when blocked |
 |---|---|---|---|
@@ -155,75 +155,15 @@ Same pattern: spawn `npx -y arc-1@latest` with the same `env` block. All stdio c
 | Transports | **off** | `SAP_ENABLE_TRANSPORTS=false` | **all** `SAPTransport` actions — including list/get |
 | Package scope for writes | `$TMP` only | `SAP_ALLOWED_PACKAGES` | Writes to packages outside the allowlist fail. **Reads are never restricted by package.** |
 
-### Profiles (shortcuts)
+### Common local starting points
 
-A profile sets several flags at once. Pick the closest, then widen specifics with individual flags.
+- `ARC1_PROFILE=viewer` or nothing: read/search only, same safe default.
+- `ARC1_PROFILE=developer`: writes + transports in `$TMP`, still no SQL or named table preview.
+- `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES=*`: full local development access.
 
-| Profile | Writes | SQL | Data preview | Transports | Packages |
-|---|---|---|---|---|---|
-| *(none set)* | ❌ | ❌ | ❌ | ❌ | `$TMP` |
-| `viewer` | ❌ | ❌ | ❌ | ❌ | `$TMP` |
-| `viewer-data` | ❌ | ❌ | ✅ | ❌ | `$TMP` |
-| `viewer-sql` | ❌ | ✅ | ✅ | ❌ | `$TMP` |
-| `developer` | ✅ | ❌ | ❌ | ✅ | `$TMP` |
-| `developer-data` | ✅ | ❌ | ✅ | ✅ | `$TMP` |
-| `developer-sql` | ✅ | ✅ | ✅ | ✅ | `$TMP` |
+Need something in between? The full profile matrix and recipes live in [configuration-reference.md](configuration-reference.md#common-recipes).
 
-### Recipes — enable exactly what you need
-
-Put these in the `env` block of your MCP client config (or in `.env` / CLI flags). Individual flags override profile values, so you can combine them.
-
-**Enable writes (stay in `$TMP`):**
-
-```bash
-SAP_READ_ONLY=false
-```
-
-**Enable writes to Z-packages as well:**
-
-```bash
-SAP_READ_ONLY=false
-SAP_ALLOWED_PACKAGES=Z*,$TMP            # trailing * wildcard, comma-separated
-```
-
-**Enable free SQL (`SAPQuery run_query`):**
-
-```bash
-SAP_BLOCK_FREE_SQL=false
-```
-
-**Enable named table preview (`SAPQuery table_contents`):**
-
-```bash
-SAP_BLOCK_DATA=false
-```
-
-**Enable transport management (`SAPTransport` list/create/release/delete):**
-
-```bash
-SAP_ENABLE_TRANSPORTS=true
-```
-
-**Enable everything — writes, transports, SQL, data, unrestricted packages:**
-
-```bash
-ARC1_PROFILE=developer-sql
-SAP_ALLOWED_PACKAGES=*
-```
-
-**Developer defaults (writes + transports, no SQL/data, `$TMP` only):**
-
-```bash
-ARC1_PROFILE=developer
-```
-
-### Package allowlist rules
-
-- Comma-separated; trailing `*` wildcard only. `Z*,Y*,$TMP` matches `ZTEST`, `YFOO`, `$TMP`. Case-insensitive.
-- `*` alone means unrestricted.
-- Applies to **writes only** — `SAPRead`, `SAPSearch`, `SAPContext`, `SAPNavigate` are never package-filtered.
-
-Full flag table: [configuration-reference.md](configuration-reference.md#safety-scopes-profiles). Production hardening recommendations: [security-guide.md](security-guide.md).
+For surgical policies, `SAP_ALLOWED_OPS` and `SAP_DISALLOWED_OPS` are real power-user knobs. Use one or the other when profiles are too broad. Full flag table: [configuration-reference.md](configuration-reference.md). Production hardening recommendations: [security-guide.md](security-guide.md).
 
 ---
 

--- a/docs_page/local-development.md
+++ b/docs_page/local-development.md
@@ -159,7 +159,7 @@ Same pattern: spawn `npx -y arc-1@latest` with the same `env` block. All stdio c
 
 - `ARC1_PROFILE=viewer` or nothing: read/search only, same safe default.
 - `ARC1_PROFILE=developer`: writes + transports in `$TMP`, still no SQL or named table preview.
-- `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES=*`: full local development access.
+- `ARC1_PROFILE=developer-sql` + `SAP_ALLOWED_PACKAGES='*'`: full local development access. (In shell, quote the `*` — otherwise the shell expands it to filenames before ARC-1 sees it.)
 
 Need something in between? The full profile matrix and recipes live in [configuration-reference.md](configuration-reference.md#common-recipes).
 

--- a/docs_page/oauth-jwt-setup.md
+++ b/docs_page/oauth-jwt-setup.md
@@ -124,6 +124,37 @@ export SAP_OIDC_CLOCK_TOLERANCE='5'                  # seconds, optional (defaul
 
 > **Note:** `SAP_OIDC_AUDIENCE` must match the exact `aud` claim in your tokens. For Entra ID v2 access tokens, this is typically the raw client ID GUID. Validate with a real token from your tenant.
 
+### How ARC-1 permissions are derived
+
+OIDC answers **who the MCP caller is**. It does not, by itself, grant write access or override ARC-1 safety settings.
+
+ARC-1 combines three things on each request:
+
+1. The user's JWT scopes from the `scope` or `scp` claim. For ARC-1 these should be `read`, `write`, `data`, and `sql`.
+2. The server's safety/profile configuration such as `ARC1_PROFILE`, `SAP_READ_ONLY`, `SAP_BLOCK_DATA`, `SAP_BLOCK_FREE_SQL`, `SAP_ENABLE_TRANSPORTS`, and `SAP_ALLOWED_PACKAGES`.
+3. The SAP user's own authorization, which still runs after ARC-1 allows the request.
+
+These gates combine with **AND**, not OR:
+
+- If the token has `write` but the server runs with `SAP_READ_ONLY=true`, writes are still blocked.
+- If the token has `sql` but the server keeps `SAP_BLOCK_FREE_SQL=true`, free SQL is still blocked.
+- If the token has no `scope` or `scp` claim at all, ARC-1 falls back to read-only access and logs a warning.
+
+For a shared development server, a common setup is:
+
+```bash
+export ARC1_PROFILE=developer
+export SAP_ALLOWED_PACKAGES='Z*,$TMP'
+```
+
+Then let your IdP assign JWT scopes per user:
+
+- `read` for reviewers
+- `read write` for developers
+- `read write data sql` only for users who should access SAP data through ARC-1
+
+Full flag/profile reference: [configuration-reference.md](configuration-reference.md). Full scope and role model: [authorization.md](authorization.md).
+
 ## Client Configuration
 
 ### VS Code (with OAuth)

--- a/docs_page/quickstart.md
+++ b/docs_page/quickstart.md
@@ -40,14 +40,7 @@ Hit `Ctrl+C` to stop. If this failed, check TLS (`--insecure` for self-signed de
 
 ## 2. Wire it into Claude Desktop
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
-
-Use the same `command` and `args` either way:
-
-- `command`: `npx`
-- `args`: `["-y", "arc-1@latest"]`
-
-Then pick one `env` block for local development.
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows) and pick one of the two paths below.
 
 ### Path A — read and search only
 
@@ -55,11 +48,19 @@ Then pick one `env` block for local development.
 
 ```json
 {
-  "SAP_URL": "https://your-sap-host:44300",
-  "SAP_USER": "YOUR_USER",
-  "SAP_PASSWORD": "YOUR_PASS",
-  "SAP_CLIENT": "100",
-  "ARC1_PROFILE": "viewer"
+  "mcpServers": {
+    "sap": {
+      "command": "npx",
+      "args": ["-y", "arc-1@latest"],
+      "env": {
+        "SAP_URL": "https://your-sap-host:44300",
+        "SAP_USER": "YOUR_USER",
+        "SAP_PASSWORD": "YOUR_PASS",
+        "SAP_CLIENT": "100",
+        "ARC1_PROFILE": "viewer"
+      }
+    }
+  }
 }
 ```
 
@@ -75,16 +76,24 @@ Then pick one `env` block for local development.
 
 ### Path B — full local development
 
-Use this only on a dev or sandbox system you are comfortable modifying.
+Same structure as Path A — only the `env` block changes. Use this only on a dev or sandbox system you are comfortable modifying.
 
 ```json
 {
-  "SAP_URL": "https://your-sap-host:44300",
-  "SAP_USER": "YOUR_USER",
-  "SAP_PASSWORD": "YOUR_PASS",
-  "SAP_CLIENT": "100",
-  "ARC1_PROFILE": "developer-sql",
-  "SAP_ALLOWED_PACKAGES": "*"
+  "mcpServers": {
+    "sap": {
+      "command": "npx",
+      "args": ["-y", "arc-1@latest"],
+      "env": {
+        "SAP_URL": "https://your-sap-host:44300",
+        "SAP_USER": "YOUR_USER",
+        "SAP_PASSWORD": "YOUR_PASS",
+        "SAP_CLIENT": "100",
+        "ARC1_PROFILE": "developer-sql",
+        "SAP_ALLOWED_PACKAGES": "*"
+      }
+    }
+  }
 }
 ```
 

--- a/docs_page/quickstart.md
+++ b/docs_page/quickstart.md
@@ -42,24 +42,65 @@ Hit `Ctrl+C` to stop. If this failed, check TLS (`--insecure` for self-signed de
 
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
+Use the same `command` and `args` either way:
+
+- `command`: `npx`
+- `args`: `["-y", "arc-1@latest"]`
+
+Then pick one `env` block for local development.
+
+### Path A — read and search only
+
+`viewer` is the same as the built-in default, but keeping it explicit makes the intent obvious in local configs.
+
 ```json
 {
-  "mcpServers": {
-    "sap": {
-      "command": "npx",
-      "args": ["-y", "arc-1@latest"],
-      "env": {
-        "SAP_URL": "https://your-sap-host:44300",
-        "SAP_USER": "YOUR_USER",
-        "SAP_PASSWORD": "YOUR_PASS",
-        "SAP_CLIENT": "100"
-      }
-    }
-  }
+  "SAP_URL": "https://your-sap-host:44300",
+  "SAP_USER": "YOUR_USER",
+  "SAP_PASSWORD": "YOUR_PASS",
+  "SAP_CLIENT": "100",
+  "ARC1_PROFILE": "viewer"
 }
 ```
 
-Restart Claude Desktop. The SAP tools (`SAPRead`, `SAPSearch`, etc.) should appear in the tool picker.
+#### What you just got — read-only by default
+
+| Capability | Result |
+|---|---|
+| Writes | Off |
+| Free SQL | Off |
+| Named table preview | Off |
+| Transports | Off |
+| Package scope | `$TMP` if you later enable writes |
+
+### Path B — full local development
+
+Use this only on a dev or sandbox system you are comfortable modifying.
+
+```json
+{
+  "SAP_URL": "https://your-sap-host:44300",
+  "SAP_USER": "YOUR_USER",
+  "SAP_PASSWORD": "YOUR_PASS",
+  "SAP_CLIENT": "100",
+  "ARC1_PROFILE": "developer-sql",
+  "SAP_ALLOWED_PACKAGES": "*"
+}
+```
+
+#### What you just got — writes, SQL, data, and transports
+
+| Capability | Result |
+|---|---|
+| Writes | On |
+| Free SQL | On |
+| Named table preview | On |
+| Transports | On |
+| Package scope | `*` (all packages) |
+
+Need something in between? Start from `ARC1_PROFILE=developer` for writes in `$TMP`, or pick a narrower recipe in [configuration-reference.md → Common recipes](configuration-reference.md#common-recipes).
+
+Restart Claude Desktop after updating the config. The SAP tools (`SAPRead`, `SAPSearch`, etc.) should appear in the tool picker.
 
 Other MCP clients (Claude Code, Cursor, VS Code Copilot, Gemini CLI, Goose): same shape, see [local-development.md](local-development.md#mcp-client-configuration).
 
@@ -75,46 +116,8 @@ Claude should call `SAPRead` and return the ABAP source.
 
 ---
 
-## What you just got — read-only by default
-
-Out of the box every destructive or data-exposing capability is blocked:
-
-| Blocked by default | What it disables |
-|---|---|
-| `SAP_READ_ONLY=true` | `SAPWrite` (create/update/delete), `SAPActivate`, FLP workflow actions |
-| `SAP_BLOCK_FREE_SQL=true` | `SAPQuery action=run_query` (free-form SELECT) |
-| `SAP_BLOCK_DATA=true` | `SAPQuery action=table_contents` (named table preview) |
-| `SAP_ENABLE_TRANSPORTS=false` | **all** `SAPTransport` actions — including list/get |
-| `SAP_ALLOWED_PACKAGES=$TMP` | Writes go to `$TMP` only (reads are **never** restricted by package) |
-
-Auth is Basic Auth as YOUR_USER — SAP's audit log shows your actual username.
-
-## Enable more capabilities
-
-Pick the smallest thing that unblocks your task. All three examples go in the same `env` block as the SAP credentials above.
-
-**Writes only (CLAS/INTF/PROG create/update/delete in `$TMP`):**
-
-```json
-"env": { "SAP_READ_ONLY": "false" }
-```
-
-**Writes to custom Z-packages too:**
-
-```json
-"env": { "SAP_READ_ONLY": "false", "SAP_ALLOWED_PACKAGES": "Z*,$TMP" }
-```
-
-**Everything on (writes + transports + SQL + table preview, all packages):**
-
-```json
-"env": { "ARC1_PROFILE": "developer-sql", "SAP_ALLOWED_PACKAGES": "*" }
-```
-
-Profiles are shortcuts — `developer-sql` expands to `readOnly=false`, `blockData=false`, `blockFreeSQL=false`, `enableTransports=true`, and keeps `allowedPackages=$TMP` (widen it with `SAP_ALLOWED_PACKAGES`). Full matrix and per-capability recipes: [local-development.md → Safety profiles](local-development.md#safety-profiles).
-
 ## Next steps
 
 - **Your SAP uses SSO (SAML / SPNEGO / X.509)?** Basic Auth won't work. See [local-development.md → SSO-only on-prem](local-development.md#sso-only-on-prem-cookie-extractor).
 - **Running on BTP or deploying for a team?** → [deployment.md](deployment.md).
-- **Full flag reference** → [configuration-reference.md](configuration-reference.md).
+- **Full flag and profile reference** → [configuration-reference.md](configuration-reference.md).


### PR DESCRIPTION
## Summary
- make `configuration-reference.md` the canonical source for profiles, safety layers, and common recipes
- rewrite `quickstart.md` around the two main local-dev paths: explicit read-only and full local development
- trim duplicated safety/config sections from `docker.md`, `local-development.md`, and `index.md`, keeping only environment-specific guidance

## Verification
- `git diff --check`

## Notes
- docs-only change; no code or test files changed