### PR TITLE
docs: Add skills abapGit and system info

### DIFF
--- a/docs_page/skills.md
+++ b/docs_page/skills.md
@@ -52,6 +52,13 @@ These skills assume:
 | [explain-abap-code](https://github.com/marianfoo/arc-1/blob/main/skills/explain-abap-code.md) | Reads an ABAP object, pulls dependency context, and explains it in structure | Onboarding, debugging, and code comprehension |
 | [migrate-custom-code](https://github.com/marianfoo/arc-1/blob/main/skills/migrate-custom-code.md) | Runs migration-oriented checks and groups findings by priority | S/4HANA migration and ABAP Cloud readiness |
 
+### System Context And Local Workflow
+
+| Skill | What it does | Best for |
+|---|---|---|
+| [bootstrap-system-context](https://github.com/marianfoo/arc-1/blob/main/skills/bootstrap-system-context.md) | Probes the target system and writes a local `system-info.md` with SID, release, installed components, feature flags, and lint preset | First step of a session against an unfamiliar system — grounds later prompts in real constraints |
+| [setup-abap-mirror](https://github.com/marianfoo/arc-1/blob/main/skills/setup-abap-mirror.md) | Creates a local abapGit-style mirror of a package or object list using ARC-1's existing reads | Onboarding a codebase, pre-migration snapshotting, feeding IDE context to tools that cannot call MCP per read |
+
 ### Meta And Quality
 
 | Skill | What it does | Best for |
@@ -60,6 +67,8 @@ These skills assume:
 
 ## Recommended Starting Points
 
+- Run `bootstrap-system-context` first when starting a session against an unfamiliar system — it grounds every later prompt in real constraints.
+- Run `setup-abap-mirror` after bootstrap to pull a package into local abapGit-style files for IDE context and `git diff`.
 - Start with `generate-rap-service` when the goal is speed and the design is straightforward.
 - Start with `generate-rap-service-researched` when writing into transportable packages or when team conventions matter.
 - Use `explain-abap-code` before editing unfamiliar objects.

--- a/docs_page/skills.md
+++ b/docs_page/skills.md
@@ -1,0 +1,75 @@
+# Skills
+
+ARC-1 ships reusable prompt templates in the repository's [`skills/`](https://github.com/marianfoo/arc-1/tree/main/skills) folder.
+
+This page is the published index for those files. The canonical copies stay in `skills/` so users can copy them directly into Claude, Copilot, Cursor, Codex, or another assistant without scraping the docs site.
+
+See the full source catalog in [`skills/README.md`](https://github.com/marianfoo/arc-1/blob/main/skills/README.md).
+
+## What Skills Are
+
+Skills are task-focused prompt files for common SAP development workflows with ARC-1. They are not server features and do not require code changes in ARC-1 itself. They package good tool usage patterns so the assistant starts from a better workflow.
+
+Typical uses:
+
+- create a RAP service stack from a natural-language description
+- implement RAP validations and determinations
+- generate ABAP Unit or CDS unit tests
+- explain unfamiliar ABAP code with dependency context
+- analyze a prior ARC-1 chat session for prompt and tool usage quality
+
+## How To Use Them
+
+Choose the integration style that matches your assistant:
+
+- **Claude Code**: copy a skill file into `~/.claude/commands/` and invoke it as a slash command
+- **GitHub Copilot**: add the file as a prompt or instruction file under `.github/`
+- **Cursor**: place the file under `.cursor/rules/`
+- **OpenAI Codex**: copy the content into a rule file under your Codex rules directory
+- **Generic tools**: paste the markdown into project instructions, system prompt, or reusable templates
+
+These skills assume:
+
+- ARC-1 is connected and working
+- `mcp-sap-docs` is available when the skill asks for SAP documentation research
+
+## Available Skills
+
+### Creating And Generating
+
+| Skill | What it does | Best for |
+|---|---|---|
+| [generate-rap-service](https://github.com/marianfoo/arc-1/blob/main/skills/generate-rap-service.md) | Creates a complete RAP service stack from a natural-language description | Fast prototyping and standard CRUD |
+| [generate-rap-service-researched](https://github.com/marianfoo/arc-1/blob/main/skills/generate-rap-service-researched.md) | Researches the target system first, then plans and creates the RAP stack | Production-quality work in real packages |
+| [generate-rap-logic](https://github.com/marianfoo/arc-1/blob/main/skills/generate-rap-logic.md) | Implements RAP determinations and validations in an existing behavior pool | Filling in business logic after stack creation |
+| [generate-cds-unit-test](https://github.com/marianfoo/arc-1/blob/main/skills/generate-cds-unit-test.md) | Generates CDS unit tests using the CDS Test Double Framework | CDS entities with calculations, joins, filters, or aggregations |
+| [generate-abap-unit-test](https://github.com/marianfoo/arc-1/blob/main/skills/generate-abap-unit-test.md) | Generates ABAP Unit tests with dependency analysis and test doubles | Classes with meaningful business logic |
+
+### Analyzing And Understanding
+
+| Skill | What it does | Best for |
+|---|---|---|
+| [explain-abap-code](https://github.com/marianfoo/arc-1/blob/main/skills/explain-abap-code.md) | Reads an ABAP object, pulls dependency context, and explains it in structure | Onboarding, debugging, and code comprehension |
+| [migrate-custom-code](https://github.com/marianfoo/arc-1/blob/main/skills/migrate-custom-code.md) | Runs migration-oriented checks and groups findings by priority | S/4HANA migration and ABAP Cloud readiness |
+
+### Meta And Quality
+
+| Skill | What it does | Best for |
+|---|---|---|
+| [analyze-chat-session](https://github.com/marianfoo/arc-1/blob/main/skills/analyze-chat-session.md) | Reviews a prior ARC-1 conversation and identifies inefficient tool usage or prompt patterns | Improving team workflows and prompt hygiene |
+
+## Recommended Starting Points
+
+- Start with `generate-rap-service` when the goal is speed and the design is straightforward.
+- Start with `generate-rap-service-researched` when writing into transportable packages or when team conventions matter.
+- Use `explain-abap-code` before editing unfamiliar objects.
+- Use the unit-test skills after generating or modifying non-trivial behavior.
+
+## Why The Files Stay In `skills/`
+
+Keeping canonical skill files in `skills/` has two advantages:
+
+- they stay copyable as plain prompt assets for any assistant
+- docs can explain and link to them without turning the published site into the source of truth
+
+That split keeps the repo practical for both humans and tooling.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
   - Using ARC-1:
       - Tools Reference: tools.md
       - MCP Usage Guide: mcp-usage.md
+      - Skills: skills.md
   - Reference:
       - Architecture: architecture.md
       - Configuration: configuration-reference.md

--- a/skills/README.md
+++ b/skills/README.md
@@ -85,6 +85,13 @@ Both skills produce the same RAP artifact stack. The difference is how they get 
 | [explain-abap-code](explain-abap-code.md) | Reads an ABAP object, fetches all dependencies via SAPContext, and produces a structured explanation | Onboarding to unfamiliar code, investigating bugs, documenting undocumented objects |
 | [migrate-custom-code](migrate-custom-code.md) | Runs ATC readiness checks, groups findings by priority, and generates replacement code | Preparing custom code for S/4HANA migration or ABAP Cloud readiness |
 
+### System Context & Local Workflow
+
+| Skill | What it does | When to use |
+|---|---|---|
+| [bootstrap-system-context](bootstrap-system-context.md) | Probes SID, release, installed components, feature flags, and lint preset; writes a local `system-info.md` | First step of a session against an unfamiliar system — grounds the assistant in real constraints before any code work |
+| [setup-abap-mirror](setup-abap-mirror.md) | Creates a local abapGit-style mirror of a package or object list for IDE context and `git diff` | Onboarding a codebase, pre-migration snapshotting, feeding local context to tools that can't call MCP per-read |
+
 ### Meta / Quality
 
 | Skill | What it does | When to use |
@@ -96,9 +103,19 @@ Both skills produce the same RAP artifact stack. The difference is how they get 
 Skills are designed to chain together. A typical RAP development flow:
 
 ```
-1. generate-rap-service-researched  →  Create the service stack
-2. generate-rap-logic               →  Add business logic (validations, determinations)
-3. generate-abap-unit-test          →  Generate tests for the behavior pool
-4. generate-cds-unit-test           →  Generate tests for the CDS views
-5. analyze-chat-session             →  Review what worked, file improvements
+1. bootstrap-system-context         →  Capture SID, release, features, lint preset
+2. generate-rap-service-researched  →  Create the service stack (uses system-info.md)
+3. generate-rap-logic               →  Add business logic (validations, determinations)
+4. generate-abap-unit-test          →  Generate tests for the behavior pool
+5. generate-cds-unit-test           →  Generate tests for the CDS views
+6. analyze-chat-session             →  Review what worked, file improvements
+```
+
+For codebase onboarding or pre-migration work:
+
+```
+1. bootstrap-system-context  →  Know the system
+2. setup-abap-mirror         →  Pull the target package(s) into abapGit-style files
+3. explain-abap-code         →  Understand key objects with dependency context
+4. migrate-custom-code       →  Run ATC readiness checks and group findings
 ```

--- a/skills/bootstrap-system-context.md
+++ b/skills/bootstrap-system-context.md
@@ -1,0 +1,155 @@
+# Bootstrap System Context
+
+Ground the assistant in the target SAP system before any coding work. Produces a local `system-info.md` file that captures SID, release, installed components, detected features, and ARC-1's active lint preset — so later prompts stop guessing at constraints.
+
+Run this once per session when working against an unfamiliar system, or again after a system upgrade.
+
+## Smart Defaults (apply silently, do NOT ask)
+
+| Setting | Default | Rationale |
+|---|---|---|
+| Output path | `./system-info.md` | Sidecar to the project root |
+| Overwrite | Yes, if file exists | Fresh probe results are authoritative |
+| Probe features | Yes | Feature flags (RAP, UI5, transports) drive downstream decisions |
+| Include lint preset | Yes | Cloud vs on-prem lint rules matter for generated code |
+
+## Input
+
+No input required. Optionally:
+- **Output path** (default: `./system-info.md`)
+- **Skip feature probe** — if the user only wants identity info and the system is slow
+
+## Step 1: Read System Identity
+
+```
+SAPRead(type="SYSTEM")
+```
+
+Returns: SID, system type (`onprem` | `btp`), release, kernel version, current user, client, language.
+
+## Step 2: Read Installed Components
+
+```
+SAPRead(type="COMPONENTS")
+```
+
+Returns an array of `{ name, release, description }`. Capture at minimum: `SAP_BASIS`, `SAP_UI`, `SAP_ABA`, `SAP_GWFND`. These set the safe ABAP syntax ceiling and available APIs.
+
+## Step 3: Probe Feature Availability
+
+```
+SAPManage(action="probe")
+```
+
+Returns feature flags for: `hana`, `abapGit`, `rap`, `amdp`, `ui5`, `ui5repo`, `transport`, `flp`. Each has `available` (bool), `mode`, and a `message`. These drive decisions like "can I generate a RAP stack?" or "is FLP catalog management wired in?"
+
+If the user requested to skip this step, mark features as "not probed" in the output.
+
+## Step 4: Read Lint Preset
+
+```
+SAPLint(action="list_rules")
+```
+
+Returns `{ preset, abapVersion, enabledRules, disabledRules, ... }`. The preset (`cloud` or `onprem`) reflects the system type detection; `abapVersion` is the target ABAP dialect (e.g., `v754`, `cloud`, `standard`). Generated code should stay within this dialect.
+
+## Step 5: Write system-info.md
+
+Create the file at the chosen path. Use exactly this layout:
+
+```markdown
+# System Info: <SID>
+
+_Generated: <ISO timestamp>_ · _Source: ARC-1_
+
+## Identity
+
+| Field | Value |
+|---|---|
+| SID | <SID> |
+| System type | <onprem / btp> |
+| Release | <release> |
+| Kernel | <kernel> |
+| Client | <client> |
+| Language | <lang> |
+| User | <username> |
+
+## Core Components
+
+| Component | Release | Description |
+|---|---|---|
+| SAP_BASIS | <release> | <description> |
+| SAP_UI | <release> | <description> |
+| SAP_ABA | <release> | <description> |
+| SAP_GWFND | <release> | <description> |
+<additional rows for any other captured components>
+
+## Feature Availability
+
+| Feature | Available | Mode | Note |
+|---|---|---|---|
+| RAP / CDS | <yes/no> | <auto/on/off> | <message> |
+| abapGit | <yes/no> | <auto/on/off> | <message> |
+| HANA | <yes/no> | <auto/on/off> | <message> |
+| AMDP | <yes/no> | <auto/on/off> | <message> |
+| UI5 | <yes/no> | <auto/on/off> | <message> |
+| UI5 Repository | <yes/no> | <auto/on/off> | <message> |
+| Transports | <yes/no> | <auto/on/off> | <message> |
+| FLP | <yes/no> | <auto/on/off> | <message> |
+
+## Lint Configuration
+
+- **Preset**: <cloud / onprem>
+- **ABAP dialect**: <abapVersion>
+- **Enabled rules**: <count>
+- **Disabled rules**: <count>
+
+## Coding Guidance
+
+- Target ABAP dialect: **<abapVersion>** — do not use syntax beyond this level without verifying per object.
+- System type is **<onprem / btp>**:
+  - If `btp`: prefer released APIs (check with `SAPRead(type="API_STATE", ...)`); avoid non-cloud object types (PROG, INCL, FUGR).
+  - If `onprem`: full type range available; still prefer released APIs for forward compatibility.
+- Transports <enabled / disabled>: <if disabled, note that writes stay on `$TMP`>.
+- RAP stack <available / not available>: <if not available, skip RAP generation skills>.
+```
+
+## Step 6: Summarize To The User
+
+After writing the file, report in 3-5 lines:
+- Which system was probed (SID, type, release)
+- The ABAP dialect ceiling
+- Which headline features are available (RAP, UI5, transports)
+- File path written
+
+Do not dump the full file contents into chat — the user can open the file.
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| `SAPRead(type="SYSTEM")` fails with auth error | User lacks `S_ADT_RES` for discovery | Continue without identity block; note in output that SID is unknown |
+| `SAPRead(type="COMPONENTS")` empty or 404 | Endpoint unavailable on this system | Note "components endpoint unavailable"; continue with probe + lint |
+| `SAPManage(action="probe")` blocked (read-only mode with no `write` scope) | Safety config | Fall back to `SAPManage(action="features")` for cached results |
+| `SAPLint(action="list_rules")` returns no preset | ARC-1 lint config not yet loaded | Report "lint preset: not configured"; still write the file |
+
+## Notes
+
+### When To Re-Run
+
+- Starting work against a new or unfamiliar system
+- After a support package upgrade (SAP_BASIS release changes)
+- When features added (e.g., abapGit installed, RAP runtime enabled)
+- When migrating from on-prem to BTP (or vice versa)
+
+### What This Skill Does NOT Do
+
+- **No source code is read** — identity/components/features only
+- **No package enumeration** — use `setup-abap-mirror` or `SAPRead(type="DEVC")` for that
+- **No SAP system-level configuration changes** — every call is read-only
+
+### Pairing With Other Skills
+
+- Run **before** `generate-rap-service-researched` — the researcher uses system-info.md to pick the right RAP pattern
+- Run **before** `setup-abap-mirror` — the mirror skill references system-info.md in its header
+- Run **before** `migrate-custom-code` — migration checks depend on knowing the target release

--- a/skills/setup-abap-mirror.md
+++ b/skills/setup-abap-mirror.md
@@ -1,0 +1,210 @@
+# Setup ABAP Mirror
+
+Create a local abapGit-style mirror of an SAP package or object set. Reads are authoritative from the SAP system; local files give you IDE context, `git diff`, and fast searching without round-tripping every time.
+
+This skill works today with ARC-1's existing `SAPRead` + `DEVC` primitives. When dedicated abapGit export tooling lands in ARC-1, the skill can be simplified — the file layout it produces is the target format either way.
+
+## Smart Defaults (apply silently, do NOT ask)
+
+| Setting | Default | Rationale |
+|---|---|---|
+| Mirror root | `./mirror/<SID>/src/<package>/` | Groups by system to support multi-system work |
+| File naming | abapGit conventions | Standard; future-proof |
+| Recurse sub-packages | Yes | Matches abapGit behaviour |
+| Include test classes | Yes | Tests belong with the class |
+| Include metadata XML | Skip for now | ARC-1 does not yet emit abapGit-format XML; source-only is useful and safe |
+
+## Input
+
+One of the following scopes:
+- **Single object** — `name` + `type` (e.g., `ZCL_TRAVEL_HANDLER`, `CLAS`)
+- **Object list** — array of `{ type, name }` pairs
+- **Package** — `package` name; pulls everything inside
+
+Optionally:
+- **Mirror root** (default: `./mirror/<SID>/src/<package>/`)
+- **Skip test classes** (default: include them)
+
+## Prerequisites
+
+Before running, ensure `system-info.md` exists. If it doesn't:
+
+```
+→ Run the bootstrap-system-context skill first
+```
+
+The mirror header references SID, system type, and release from `system-info.md`.
+
+## Step 1: Resolve Scope Into An Object List
+
+### 1a. For a package scope
+
+```
+SAPRead(type="DEVC", name="<PACKAGE>")
+```
+
+Returns `[{ type, name, description, uri }, ...]` where `type` is slash-form (`CLAS/OC`, `DDLS/DF`, `PROG/P`, `DEVC/K`, etc.).
+
+For each `DEVC/K` entry (sub-package): recurse — call `SAPRead(type="DEVC", name=<sub>)` and append its contents.
+
+Normalize slash-form types to the ARC-1 `SAPRead` short codes:
+
+| Slash form | SAPRead type | abapGit extension |
+|---|---|---|
+| `CLAS/OC` | `CLAS` | `.clas.abap` (+ `.clas.testclasses.abap`) |
+| `INTF/OI` | `INTF` | `.intf.abap` |
+| `PROG/P` | `PROG` | `.prog.abap` |
+| `FUGR/F` | `FUGR` | `.fugr.abap` (expanded includes) |
+| `FUNC/FF` | `FUNC` | `.func.abap` |
+| `DDLS/DF` | `DDLS` | `.ddls.asddls` |
+| `DCLS/DL` | `DCLS` | `.dcls.asdcls` |
+| `DDLX/EX` | `DDLX` | `.ddlx.asddlxs` |
+| `BDEF/BO` | `BDEF` | `.bdef.asbdef` |
+| `SRVD/SRV` | `SRVD` | `.srvd.asrvd` |
+| `SRVB/SVB` | `SRVB` | `.srvb.xml` |
+| `TABL/DT` | `TABL` | `.tabl.xml` |
+| `STRU/DS` | `STRU` | `.stru.xml` |
+| `DOMA/DD` | `DOMA` | `.doma.xml` |
+| `DTEL/DE` | `DTEL` | `.dtel.xml` |
+| `MSAG/N` | `MSAG` | `.msag.xml` |
+| `ENHO/EO` | `ENHO` | `.enho.xml` |
+
+Skip types not in this table; log them in a `skipped.md` in the mirror root.
+
+### 1b. For a single object or object list
+
+Skip enumeration; proceed directly with the provided list.
+
+## Step 2: Read Each Object
+
+For every resolved `{ type, name }`:
+
+```
+SAPRead(type="<type>", name="<name>")
+```
+
+For classes, also fetch test classes (unless skipped):
+
+```
+SAPRead(type="CLAS", name="<name>", include="testclasses")
+```
+
+For function groups (on-prem only), expand includes:
+
+```
+SAPRead(type="FUGR", name="<name>", expand_includes=true)
+```
+
+For DDLS, CLAS (structured), DCLS, DDLX — the plain source form is sufficient for mirroring; richer structured forms are for reading, not storage.
+
+Catch and continue on per-object errors — log failures in `skipped.md` with the error class (not-found / forbidden / not-released / connectivity) and move on.
+
+## Step 3: Write Files In abapGit Layout
+
+Directory structure:
+
+```
+mirror/<SID>/
+  README.md               ← written in Step 4
+  system-info.md          ← copied or symlinked from bootstrap-system-context
+  src/
+    <package_lower>/
+      zcl_foo.clas.abap
+      zcl_foo.clas.testclasses.abap
+      zif_foo.intf.abap
+      z_report.prog.abap
+      zi_view.ddls.asddls
+      zi_view_dcl.dcls.asdcls
+      zc_view.ddlx.asddlxs
+      zi_travel.bdef.asbdef
+      ztable.tabl.xml
+      zdomain.doma.xml
+      zdtel.dtel.xml
+    <subpackage_lower>/
+      ...
+  skipped.md              ← per-object errors and unsupported types
+```
+
+Rules:
+- Object names in filenames are **lowercased**.
+- Package names in path segments are lowercased.
+- Source files are written verbatim from SAP — do not reformat.
+- Overwrite existing files without prompting (SAP is the source of truth).
+
+## Step 4: Write mirror/<SID>/README.md
+
+```markdown
+# Mirror: <SID>
+
+_Generated: <ISO timestamp>_ · _Source: ARC-1_
+
+This directory is a **read-only mirror** of selected ABAP objects from **<SID>**. The SAP system is the source of truth — edits here will NOT be pushed back automatically. To deploy local changes, use `SAPWrite` or a dedicated abapGit export/deploy tool.
+
+See [system-info.md](./system-info.md) for system identity and feature availability.
+
+## Scope
+
+- Mode: <single / list / package>
+- <If package: **Package**: ZPKG — recursed into N sub-packages>
+- <If list: **Objects**: M explicit>
+- Objects mirrored: <count by type>
+- Objects skipped: see [skipped.md](./skipped.md)
+
+## Layout
+
+- `src/<package>/` — abapGit-style object files
+- `skipped.md` — objects that failed to read or aren't supported yet
+
+## Refreshing
+
+Re-run the `setup-abap-mirror` skill with the same scope. Files are overwritten.
+```
+
+## Step 5: Summarize To The User
+
+Report in 4-6 lines:
+- SID mirrored, scope (single/list/package)
+- Object counts by type (e.g., `5 CLAS, 12 DDLS, 3 BDEF`)
+- Skipped/failed count with pointer to `skipped.md`
+- Mirror root path
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| DEVC read returns 404 | Package does not exist | Ask user to verify the package name via `SAPSearch` |
+| Per-object read fails | Auth / not-released / not-found | Log in `skipped.md`, continue with the rest |
+| Sub-package recursion loops | Circular reference (rare) | Track visited package names; skip duplicates |
+| FUGR `expand_includes` fails | On-prem feature, endpoint unavailable | Fall back to `expand_includes=false`; log as partial |
+| Source body empty | Generated proxy or inactive object | Write empty file with a comment header; log in `skipped.md` |
+| `system-info.md` missing | Skill dependency | Run `bootstrap-system-context` first, then retry |
+
+## Notes
+
+### What This Skill Does NOT Do
+
+- **No deploy** — local edits are not pushed back. Use `SAPWrite` or a future abapGit deploy action.
+- **No metadata XML in abapGit format** — ARC-1 currently returns source text; XML-based object metadata (TABL definitions, DOMA fixed values, class attributes) is emitted as JSON or XML from SAP's native form, not the abapGit `object.xml` convention. That's enough for reading and `git diff`, not enough for a full abapGit pull-push round trip.
+- **No concurrency** — object reads are sequential to stay within SAP work-process budgets.
+
+### When To Use This Skill
+
+- Onboarding a new team member to an existing codebase
+- Preparing for a migration where you need to grep locally across many objects
+- Snapshotting a system before a support package upgrade
+- Feeding local context into an AI assistant that cannot call MCP tools for every read
+
+### When NOT To Use This Skill
+
+- For single ad-hoc reads — just call `SAPRead` directly
+- When you need a full abapGit round-trip (mirror + deploy back) — wait for native abapGit support
+- On production systems where SAP read load is a concern — large package mirrors issue hundreds of requests
+
+### BTP vs On-Premise
+
+- **BTP**: fewer object types will appear in DEVC listings (no PROG, INCL, FUGR). The normalization table above handles this — unsupported types are just absent.
+- **On-prem**: the full type range applies; legacy types not in the table are logged in `skipped.md` and can be added to ARC-1 over time.
+
+### Future-Proofing
+
+This skill produces abapGit-compatible layout today using existing primitives. When ARC-1 gains a dedicated abapGit export action, the internals change but the output directory remains recognizable to any abapGit-aware tool.


### PR DESCRIPTION
## What changed
- add a published docs page for ARC-1 skills at `docs_page/skills.md`
- add the new page to the MkDocs navigation under "Using ARC-1"
- explain why canonical skill files stay in `skills/` while the docs site provides a discoverable index

## Why
ARC-1 already ships reusable prompt assets in `skills/`, but the docs site had no page that explained what they are, how to use them, or where to find them. This adds a docs entry point without moving the canonical prompt files out of the repository root.

## User impact
- docs readers can now discover shipped skills from the published site
- users still copy the real files directly from `skills/`
- this sets up a clean place to document future skills such as an ABAPGit-oriented workflow

## Validation
- `mkdocs build`
- build succeeded locally
- existing MkDocs warnings about unrelated broken relative links were pre-existing and unchanged
