### PR TITLE
docs: Refresh RAP workflow skills and docs

### DIFF
--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -2,7 +2,7 @@
 
 A comprehensive comparison of all SAP ADT/MCP projects against ARC-1.
 
-_Last updated: 2026-04-18 (FEAT-22 implemented: `SAPGit` with gCTS + abapGit backend integration and `--enable-git` safety gate; SEC-09 Auth Safety landed 2026-04-17: fixed cookie→PP leak, added `X-SAP-SAML2` opt-in handling, added HTML-login-page detection; FEAT-20 implemented: VERSIONS/VERSION_SOURCE SAPRead support; FEAT-10 implemented: ADT PrettyPrint + formatter settings via SAPLint; FEAT-49 implemented: object → transport reverse lookup via `SAPTransport(action="history")`; FEAT-33 implemented: CDS impact analysis via `SAPContext(action="impact")`; FEAT-43 implemented: AUTH/FTG2/ENHO SAPRead support; PR #134 merged 2026-04-16: SKTD read/write (Knowledge Transfer Documents); COMPAT-01 fixed 2026-04-16: `lockObject()` now guards on `MODIFICATION_SUPPORT=false`; COMPAT-02 fixed 2026-04-16: CSRF HEAD 403 fallback to GET in `http.ts`; COMPAT-03 already fixed 2026-04-15 in PR #130 (`9b0601c`) via V4 SRVB publish endpoint support; fr0ster v6.1.0 and dassian-adt deep analysis updates retained)_
+_Last updated: 2026-04-18 (FEAT-22 implemented: `SAPGit` with gCTS + abapGit backend integration and `--enable-git` safety gate; DOC-04 completed: RAP/common-use-case skill pack refresh now exploits provider-contract guidance plus impact/history/formatter/SKTD/git primitives; SEC-09 Auth Safety landed 2026-04-17: fixed cookie→PP leak, added `X-SAP-SAML2` opt-in handling, added HTML-login-page detection; FEAT-20 implemented: VERSIONS/VERSION_SOURCE SAPRead support; FEAT-10 implemented: ADT PrettyPrint + formatter settings via SAPLint; FEAT-49 implemented: object → transport reverse lookup via `SAPTransport(action="history")`; FEAT-33 implemented: CDS impact analysis via `SAPContext(action="impact")`; FEAT-43 implemented: AUTH/FTG2/ENHO SAPRead support; PR #134 merged 2026-04-16: SKTD read/write (Knowledge Transfer Documents); COMPAT-01 fixed 2026-04-16: `lockObject()` now guards on `MODIFICATION_SUPPORT=false`; COMPAT-02 fixed 2026-04-16: CSRF HEAD 403 fallback to GET in `http.ts`; COMPAT-03 already fixed 2026-04-15 in PR #130 (`9b0601c`) via V4 SRVB publish endpoint support; fr0ster v6.1.0 and dassian-adt deep analysis updates retained)_
 
 ## Legend
 - ✅ = Supported
@@ -297,7 +297,8 @@ The following items were incorrectly marked in the previous version and have sin
 6. **MCP elicitation** — Interactive parameter collection for destructive ops.
 7. **Audit logging** — BTP Audit Log sink for compliance.
 8. **Context compression** — AST-based dependency extraction with depth control.
-9. **npm + Docker + release-please** — Most professional distribution pipeline.
+9. **First-party workflow skills** — researched RAP/common-use-case playbooks can encode provider-contract choices, clean-core guardrails, and recent primitives (`impact`, revisions, formatter settings, SKTD, `SAPGit`) on top of the compact intent-tool surface.
+10. **npm + Docker + release-please** — Most professional distribution pipeline.
 
 ### Biggest Competitive Threats
 1. **vibing-steampunk** (279 stars) — Community favorite. Has Streamable HTTP (v2.38.0), SAML SSO (PR #97). Massive Apr sprint: i18n, gCTS, API release state, version history, code coverage, health analysis, rename preview, dead code analysis, package safety hardening, RecoverFailedCreate primitive. Defaults to hyperfocused mode (1 tool). Open issues: OAuth2 BTP request (#99), recurring lock handle bugs (fix in 22517d4), CSRF HEAD 403 on S/4HANA public cloud (#104), SAProuter support (#103).
@@ -313,9 +314,12 @@ The following items were incorrectly marked in the previous version and have sin
 - ~~RAP completeness~~ → DDLX/SRVB read, DDLS/DDLX/BDEF/SRVD write, batch activation
 - ~~DDIC completeness~~ → STRU, DOMA, DTEL, TRAN read
 - ~~Token efficiency~~ → method-level surgery, hyperfocused mode, context compression
+- ~~Workflow/productization gap~~ → first-party RAP/common-use-case skills now codify provider contracts, draft/auth defaults, impact analysis, revision history, formatter settings, SKTD docs, and SAPGit delivery context.
 
-**Recently merged:**
+**Recently merged / productized:**
 - ~~**SKTD (Knowledge Transfer Documents)**~~ — **✅ Merged PR #134 (2026-04-16)** by lemaiwo. Full read/write for Markdown docs attached to ABAP objects. Unique to ARC-1 among all competitors.
+- **RAP/common-use-case skill refresh (2026-04-18)** — `generate-rap-service-researched`, `generate-rap-service`, and `generate-rap-logic` now explicitly use `SAPContext(action="impact")`, `SAPRead(type="VERSIONS")`, `SAPTransport(action="history")`, `SAPLint(action="format"/"get_formatter_settings")`, `SAPRead/SAPWrite(type="SKTD")`, and `SAPGit`.
+- **Workflow research conclusion** — external steering/skill repos (`sap-abap-base`, `sap-skills`) reinforce that the next differentiation layer is codified workflows, not raw tool-count inflation. ARC-1 is now positioned to ship tighter first-party playbooks on top of its intent-tool model.
 
 **P0 — production blockers:**
 - ~~415/406 content-type auto-retry (SAP version compatibility)~~ — ✅ Implemented. [Deep dive](fr0ster/evaluations/v4.5.0-release-deep-dive.md)
@@ -327,17 +331,18 @@ The following items were incorrectly marked in the previous version and have sin
 - ~~**V4 SRVB publish endpoint bug**~~ — ✅ fixed 2026-04-15 in PR #130 (`9b0601c`). Publish/unpublish now respect resolved service binding type (`odatav2`/`odatav4`). [Eval](fr0ster/evaluations/51781d3-srvd-srvb-activate-variant.md)
 - ~~**BTP transport omission in safeUpdateSource()**~~ — **Likely NOT applicable.** ARC-1's centralized `safeUpdateSource()` already uses `transport ?? (lock.corrNr || undefined)` for all types — fr0ster's bug was per-handler (only `UpdateInterface` was missing it). Verify with BTP INTF update integration test. [Eval](fr0ster/evaluations/c2b8006-dump-simplify-updateintf-fix.md)
 
-**P1 — high-value gaps:**
-- Where-Used analysis, fix proposals
-- ~~DDIC write (DOMA/DTEL)~~, ~~namespace encoding audit~~, error intelligence
-- Type auto-mappings, function group bulk fetch
+**P1 — remaining high-value gaps:**
+- Function group bulk fetch
 - Documentation (Copilot Studio guide, Basis Admin guide)
+- Expand first-party workflow skills beyond RAP into transport review, diagnostics, clean-core checks, and Git-backed change review
 
 **P2+ — future gaps:**
 - System messages (SM02) — AI agent situational awareness. fr0ster v5.0.0 added this.
 - Gateway error log (IWFND) — OData/Gateway debugging with source code + call stack. fr0ster v5.0.0, on-prem only.
-- SQL traces, PrettyPrint, transport contents, source versions
-- Cloud readiness assessment, gCTS/abapGit, enhancement framework
+- Compare/diff on top of FEAT-20 + FEAT-49
+- ABAP documentation / F1 help, table pagination / offset
+- SQL traces, coverage/reporting enhancements
+- Cloud readiness assessment, enhancement framework
 - Multi-system routing, rate limiting
 - Dynpro (screen) metadata — ADT endpoint `/sap/bc/adt/programs/programs/<PROG>/dynpros` (abap-adt-api #44)
 - RecoverFailedCreate — partial-create recovery on 5xx (VSP f00356a)

--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -50,6 +50,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 | ~~—~~ | ~~FEAT-49~~ | ~~Object Transport History (Reverse Lookup)~~ | ~~P1~~ | ~~S~~ | ~~Completed 2026-04-17~~ |
 | 3 | DOC-01 | Copilot Studio Setup Guide | P1 | S | Docs |
 | 4 | DOC-02 | Basis Admin Security Guide | P1 | S | Docs |
+| ~~—~~ | ~~DOC-04~~ | ~~RAP & Common ABAP Workflow Skill Pack Refresh~~ | ~~P1~~ | ~~S~~ | ~~Completed 2026-04-18~~ |
 | 5 | FEAT-24 | CompareSource (Diff) | P2 ↑ | S | Features |
 | 6 | FEAT-32 | Table Pagination / Offset | P2 | XS | Features |
 | 7 | FEAT-21 | ABAP Documentation (F1 Help) | P2 | XS | Features |
@@ -85,6 +86,7 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 
 | ID | Feature | Completed | Category |
 |----|---------|-----------|----------|
+| DOC-04 | RAP & Common ABAP Workflow Skill Pack Refresh | 2026-04-18 | Docs |
 | FEAT-22 | gCTS/abapGit Integration (`SAPGit` tool + `--enable-git` safety gate) | 2026-04-18 | Features |
 | SEC-09 | Auth Safety & Configurability (cookie→PP leak fix, applyAuthHeader guard, fail-fast validation, auth summary log, SAML disable opt-in, HTML login detection) | 2026-04-17 | Security |
 | FEAT-20 | Source Version / Revision History | 2026-04-17 | Features |
@@ -154,6 +156,8 @@ Every other SAP MCP server today runs on the developer's local machine — unman
 > **2026-04-14 priority re-evaluation:** dassian-adt's explosive growth (0→32 stars, 25→53 tools, OAuth/XSUAA, multi-system in 2 weeks) and SAP's confirmed Q2 2026 GA for official ABAP MCP Server increase urgency on fix proposals (FEAT-12↑P1), error intelligence (FEAT-16↑P1), and pretty print (FEAT-10↑P1, completed 2026-04-17). SAP Joule entering the space makes ARC-1's enterprise-grade safety/auth differentiation even more important.
 >
 > **2026-04-16 additions:** Cross-project competitor analysis (VSP, fr0ster, dassian-adt deep dive) identified COMPAT-01..03 plus verify item COMPAT-04. Follow-up confirmed COMPAT-03 had already been fixed in PR #130 (commit `9b0601c`, completed 2026-04-15). COMPAT-01 and COMPAT-02 were fixed in this follow-up (completed 2026-04-16). FR0ster reached v6.1.0 (35 stars). VSP confirmed modificationSupport guard as root cause of recurring 423 lock errors and surfaced S/4HANA Public Cloud CSRF HEAD incompatibility (#104). PR #134 (SKTD) merged 2026-04-16 — ARC-1-unique Knowledge Transfer Document support now live. Enhancement (BAdI) ADT endpoints confirmed from fr0ster analysis. GetProgFullCode confirmed on-prem only via nodestructure API. Added **FEAT-49** (Object Transport History) at P1 — reverse lookup ("which transports contain this object?") is the missing link for transport-scoped code review (fr0ster#30). Enriched **FEAT-20** (revisions) with concrete ADT endpoint details; upgraded **FEAT-24** (diff) rationale — the trio (FEAT-49→FEAT-20→FEAT-24) enables the full code review workflow no competitor has end-to-end. Overview table re-sorted by actual priority (P0→P1→P2→P3).
+>
+> **2026-04-18 additions:** First-party workflow skills became an explicit productization layer. Research across SAP Help / ABAP docs, the `mcp-sap-docs` server, `sap-abap-base` steering docs, and `sap-skills` showed that common success patterns are workflow-level: system bootstrap, provider-contract selection, draft/auth defaults, impact-driven change analysis, revision/history inspection, formatter alignment, documentation capture, and Git/delivery context. ARC-1 now has enough primitives (`impact`, `VERSIONS`, `SAPTransport(action="history")`, `SAPLint` formatting/settings, `SKTD`, `SAPGit`) to encode those workflows directly in first-party RAP/common-use-case skills instead of just adding more raw endpoints.
 
 ### Phase A: Production Blockers (P0)
 1. ~~**FEAT-02** API Release Status / Clean Core (S)~~ — **completed 2026-04-10**
@@ -190,6 +194,7 @@ These bugs affect real-world deployments and were confirmed by cross-project com
 18. ~~**FEAT-49** Object Transport History / Reverse Lookup (S)~~ — **completed 2026-04-17.** Implemented as `SAPTransport(action="history")` using per-object `GET {objectUrl}/transports` endpoint with `transportchecks` fallback for candidate transports.
 19. **DOC-01** Copilot Studio Setup Guide (S) — critical for enterprise adoption
 20. **DOC-02** Basis Admin Security Guide (S) — admin audience needs clear guidance
+21. ~~**DOC-04** RAP & Common ABAP Workflow Skill Pack Refresh (S)~~ — **completed 2026-04-18.** Refreshed first-party RAP skills to use provider-contract guidance, `SAPContext(action="impact")`, revision/history reads, formatter settings, SKTD docs, and `SAPGit`; updated `skills/README.md` and `docs_page/skills.md` to document the new workflow layer.
 
 ### Phase C: ADT Feature Parity (P2) — Quick Wins
 13. **FEAT-32** Table Pagination / Offset (XS) — VSP has this, practical improvement
@@ -246,6 +251,8 @@ SAP confirmed GA of ABAP Cloud Extension for VS Code with built-in agentic AI po
 4. **ARC-1's safety system, multi-client support, and enterprise auth are not in SAP's scope** — the managed gateway model remains unique
 5. **Risk**: SAP's official server may reduce demand for community alternatives for ABAP Cloud customers
 6. **Opportunity**: ARC-1 serves the vast on-premise + RISE customer base that SAP's cloud-only offering won't reach
+7. **Product implication**: raw tool parity is no longer enough; first-party workflow skills for RAP and common ABAP tasks are now a core adoption layer
+8. **Execution consequence**: recent features (`impact`, revisions, transport history, formatter settings, SKTD, `SAPGit`) should be packaged into repeatable playbooks faster than competitors can accumulate more endpoints
 
 ---
 
@@ -1056,6 +1063,30 @@ For FUGR (function groups), the same pattern applies with `objecttype=FUGR/P` an
 
 ---
 
+### DOC-04: RAP & Common ABAP Workflow Skill Pack Refresh
+| Field | Value |
+|-------|-------|
+| **Priority** | P1 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low |
+| **Usefulness** | High — converts raw RAP/tool capability into repeatable workflows |
+| **Status** | Completed (2026-04-18) |
+
+**What:** Refresh first-party skill markdown for RAP service generation, RAP logic implementation, and common ABAP bootstrap flow so the workflow explicitly uses the newest ARC-1 features and up-to-date SAP guidance. This includes:
+- Provider-contract aware service exposure defaults (`odata_v4_ui` vs `odata_v4_webapi`)
+- Draft/auth guidance aligned with current RAP docs (`#MANDATORY` + DCL, total ETag, draft constraints)
+- `SAPContext(action="impact")` and revision/history reads before edits
+- `SAPLint` formatter settings + optional formatting step before writeback
+- `SKTD` read/write for attached knowledge-transfer docs
+- `SAPGit` context for repo-managed packages
+- Stronger `mcp-sap-docs` usage patterns for RAP research prompts
+
+**Why:** SAP's own MCP direction starts with RAP UI service generation. ARC-1 already has the tool primitives; the missing layer was codified workflow guidance that turns those primitives into consistent outcomes for common use cases.
+
+**Outcome (2026-04-18):** Updated `skills/generate-rap-service-researched.md`, `skills/generate-rap-service.md`, `skills/generate-rap-logic.md`, `skills/README.md`, and `docs_page/skills.md`. Research also incorporated ideas from `sap-abap-base` steering docs and `sap-skills`: treat workflow/steering quality as a first-class differentiator instead of chasing tool-count inflation.
+
+---
+
 ### FEAT-37: DCL (Access Control) Read/Write
 | Field | Value |
 |-------|-------|
@@ -1788,7 +1819,7 @@ Based on independent security review against RFC 9700 (reports/2026-04-08-001-oa
 | LLM Search UX | Auto-transliteration, field-name hints, cache indicators |
 | HTTP Client | Native fetch + undici (replaced axios) (#35) |
 | Test Coverage | 1,300+ unit + ~150 integration + ~60 E2E + 28 BTP integration + 5 BTP smoke tests (vitest); coverage telemetry is informational |
-| Documentation | Architecture, auth guides, Docker guide, setup phases, security guide |
+| Documentation | Architecture, auth guides, Docker guide, setup phases, security guide, RAP/common-use-case workflow skills |
 
 ---
 
@@ -1838,8 +1869,8 @@ Based on independent security review against RFC 9700 (reports/2026-04-08-001-oa
 | Competitor | Language | Tools | Auth | Safety | Deployment | Key Advantage |
 |-----------|---------|-------|------|--------|------------|---------------|
 | **ARC-1** | TypeScript | 12 intent-based + hyperfocused | API Key, OIDC, XSUAA, PP | Read-only, pkg filter, op filter, 2D auth (scopes+roles+safety) | Docker, BTP CF, npm | Per-user PP, scope-based tools, 3 auth modes, safety, 1,500+ tests across unit/integration/E2E |
-| **vibing-steampunk** | Go 1.24 | 1-99+ (3 modes) | Basic, Cookie | Op filter, pkg filter, transport guard | Go binary (9 platforms) | 242 stars, **Streamable HTTP (v2.38.0)**, native parser, massive feature sprint (i18n, gCTS, API release state, version history, code coverage) |
-| **fr0ster/mcp-abap-adt** | TypeScript | 287 (4 tiers) | 9 providers (incl. TLS, SAML, Device Flow) | Exposition tiers | npm `@mcp-abap-adt/core` | Most tools, most auth options, embeddable, RFC, multi-system |
+| **vibing-steampunk** | Go 1.24 | 1-99+ (3 modes) | Basic, Cookie | Op filter, pkg filter, transport guard | Go binary (9 platforms) | 279 stars, **Streamable HTTP (v2.38.0)**, native parser, massive feature sprint (i18n, gCTS, API release state, version history, code coverage) |
+| **fr0ster/mcp-abap-adt** | TypeScript | ~320 (4 tiers) | 9 providers (incl. TLS, SAML, Device Flow) | Exposition tiers | npm `@mcp-abap-adt/core` | Most tools, most auth options, embeddable, RFC, multi-system |
 | SAP ABAP Add-on MCP | ABAP | ~10 | SAP native | SAP authorization | Runs inside SAP | No proxy needed, SAP-native auth |
 | lemaiwo/btp-sap-odata-to-mcp-server | TypeScript | ~10 | XSUAA OAuth proxy | XSUAA roles | BTP CF (MTA) | XSUAA OAuth proxy, principal propagation |
 | dassian-adt / abap-mcpb | JavaScript | 25+ | Basic, Browser login | MCP elicitation | Node.js / MCPB | Error intelligence, batch activation, find_definition, edit_method (Apr sprint) |
@@ -1855,14 +1886,15 @@ Based on independent security review against RFC 9700 (reports/2026-04-08-001-oa
 7. **Context compression + method-level surgery** — AST-based 7-30x + 95% method-level reduction
 8. **MCP elicitation** — interactive confirmations for destructive operations
 9. **1,500+ automated tests** with CI on Node 22/24, integration/E2E reliability telemetry, and BTP smoke lane
-10. **npm + Docker + release-please** — most professional distribution pipeline
-11. **RFC 9700 OAuth security** — state + PKCE, loopback binding, audience validation
+10. **First-party workflow skills** — researched RAP/common-use-case playbooks that exploit provider-contract guidance, impact/history/context tools, formatter alignment, SKTD docs, and Git context
+11. **npm + Docker + release-please** — most professional distribution pipeline
+12. **RFC 9700 OAuth security** — state + PKCE, loopback binding, audience validation
 
 **Key competitive threats** (tracked in [`compare/`](../compare/)):
-1. **vibing-steampunk** (242 stars) — community favorite. **Major threat escalation (Apr 2026)**: massive sprint added Streamable HTTP, API release state, i18n (7 tools), gCTS (10 tools), version history, code coverage, dead code analysis, rename preview, health analysis, CDS impact. ARC-1 has now closed the prioritized gCTS/abapGit gap via FEAT-22, but VSP remains strong on breadth and release velocity.
-2. **fr0ster** (v4.8.7, 85+ releases in 5 months) — closest enterprise competitor. 9 auth providers, TLS, RFC, embeddable. Search TSV format optimization. Watch for convergence on enterprise features.
-3. **dassian-adt** — newly active (Apr 2026): batch activation, find_definition, edit_method, BDEF creation. No safety system is a concern but rapid iteration.
-4. **btp-odata-mcp** (119 stars) — different category (OData) but high adoption. Could expand into ADT territory.
+1. **vibing-steampunk** (279 stars) — community favorite. **Major threat escalation (Apr 2026)**: massive sprint added Streamable HTTP, API release state, i18n (7 tools), gCTS (10 tools), version history, code coverage, health analysis, rename preview, dead code analysis, CDS impact, and recovery primitives. ARC-1 has now closed the prioritized gCTS/abapGit gap via FEAT-22, but VSP remains strong on breadth and release velocity.
+2. **fr0ster** (v6.1.0, 100+ releases, 35 stars) — closest enterprise competitor. 9 auth providers, TLS, RFC, embeddable, and broad operational breadth. Watch for convergence on enterprise features.
+3. **dassian-adt / abap-mcpb** (33 stars, 53 tools) — fast April sprint added OAuth/XSUAA, multi-system support, more transport tooling, trace flows, and test/include helpers. No safety system is still a major gap, but the pace is notable.
+4. **btp-odata-mcp** (120 stars) — different category (OData) but high adoption. Could expand into ADT territory.
 
 ---
 

--- a/docs_page/skills.md
+++ b/docs_page/skills.md
@@ -39,9 +39,9 @@ These skills assume:
 
 | Skill | What it does | Best for |
 |---|---|---|
-| [generate-rap-service](https://github.com/marianfoo/arc-1/blob/main/skills/generate-rap-service.md) | Creates a complete RAP service stack from a natural-language description | Fast prototyping and standard CRUD |
-| [generate-rap-service-researched](https://github.com/marianfoo/arc-1/blob/main/skills/generate-rap-service-researched.md) | Researches the target system first, then plans and creates the RAP stack | Production-quality work in real packages |
-| [generate-rap-logic](https://github.com/marianfoo/arc-1/blob/main/skills/generate-rap-logic.md) | Implements RAP determinations and validations in an existing behavior pool | Filling in business logic after stack creation |
+| [generate-rap-service](https://github.com/marianfoo/arc-1/blob/main/skills/generate-rap-service.md) | Creates a complete RAP service stack from a natural-language description, with provider-contract-aware UI/Web API generation | Fast prototyping and standard CRUD |
+| [generate-rap-service-researched](https://github.com/marianfoo/arc-1/blob/main/skills/generate-rap-service-researched.md) | Researches the target system first, then plans and creates the RAP stack using impact analysis, revision history, formatter settings, and SAP docs | Production-quality work in real packages |
+| [generate-rap-logic](https://github.com/marianfoo/arc-1/blob/main/skills/generate-rap-logic.md) | Implements RAP determinations and validations in an existing behavior pool with structured class reads and quickfix-aware validation | Filling in business logic after stack creation |
 | [generate-cds-unit-test](https://github.com/marianfoo/arc-1/blob/main/skills/generate-cds-unit-test.md) | Generates CDS unit tests using the CDS Test Double Framework | CDS entities with calculations, joins, filters, or aggregations |
 | [generate-abap-unit-test](https://github.com/marianfoo/arc-1/blob/main/skills/generate-abap-unit-test.md) | Generates ABAP Unit tests with dependency analysis and test doubles | Classes with meaningful business logic |
 
@@ -73,6 +73,15 @@ These skills assume:
 - Start with `generate-rap-service-researched` when writing into transportable packages or when team conventions matter.
 - Use `explain-abap-code` before editing unfamiliar objects.
 - Use the unit-test skills after generating or modifying non-trivial behavior.
+
+## Recent ARC-1 Features These Skills Exploit
+
+- `SAPContext(action="impact")` for RAP/CDS reuse and dependency analysis
+- `SAPRead(type="VERSIONS")` / `SAPRead(type="VERSION_SOURCE")` for safer edits of existing RAP stacks
+- `SAPTransport(action="history")` for object-to-transport traceability
+- `SAPLint(action="format" | "get_formatter_settings")` for SAP-native formatting
+- `SAPRead` / `SAPWrite` for `SKTD` so RAP artifacts can carry attached Markdown documentation
+- `SAPGit` for abapGit / gCTS-aware package workflows when available
 
 ## Why The Files Stay In `skills/`
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -59,9 +59,9 @@ These skills assume you have:
 
 | Skill | What it does | When to use |
 |---|---|---|
-| [generate-rap-service](generate-rap-service.md) | Creates a complete RAP OData service stack (table, CDS views, BDEF, SRVD, SRVB, class) from a natural language description | Quick prototyping, simple CRUD with standard patterns, user knows exactly what they want |
-| [generate-rap-service-researched](generate-rap-service-researched.md) | Same output as above, but researches the target system first (existing naming conventions, architecture patterns, SAP docs) and builds an approved plan before creating anything | Production-quality services in transportable packages, complex domains, "measure twice, cut once" mode |
-| [generate-rap-logic](generate-rap-logic.md) | Implements determination and validation methods in an existing RAP behavior pool | After creating a RAP service — fills in the empty method stubs with ABAP Cloud logic |
+| [generate-rap-service](generate-rap-service.md) | Creates a complete RAP OData service stack (table, CDS views, BDEF, SRVD, SRVB, class) from a natural language description, with provider-contract-aware service generation | Quick prototyping, simple CRUD, standard UI service generation |
+| [generate-rap-service-researched](generate-rap-service-researched.md) | Same output as above, but researches the target system first (existing naming conventions, architecture patterns, revisions, docs, formatter settings, impact) and builds an approved plan before creating anything | Production-quality services in transportable packages, complex domains, "measure twice, cut once" mode |
+| [generate-rap-logic](generate-rap-logic.md) | Implements determination and validation methods in an existing RAP behavior pool using structured class reads, version-aware edits, and quickfix-aware validation | After creating a RAP service — fills in the empty method stubs with ABAP Cloud logic |
 | [generate-cds-unit-test](generate-cds-unit-test.md) | Generates ABAP Unit tests for CDS entities using the CDS Test Double Framework | When a CDS view has calculations, CASE expressions, WHERE filters, JOINs, or aggregations worth testing |
 | [generate-abap-unit-test](generate-abap-unit-test.md) | Generates ABAP Unit tests for classes with dependency analysis and test doubles | When a class has non-trivial business logic and uses dependency injection |
 
@@ -77,6 +77,15 @@ Both skills produce the same RAP artifact stack. The difference is how they get 
 | **Plan approval** | Shows artifact table, asks to proceed | Full implementation plan with architecture decisions, requires explicit approval |
 | **Best for** | Quick prototyping, proof of concept, simple CRUD | Production services, complex domains, teams with established conventions |
 | **Guardrails** | Managed only, UUID, single entity, standard CRUD | Any scenario — managed/unmanaged, compositions, custom keys |
+
+### Recent ARC-1 Features These Skills Use
+
+- `SAPContext(action="impact")` for RAP/CDS reuse and "what breaks if I change this?" analysis
+- `SAPRead(type="VERSIONS")` and `SAPRead(type="VERSION_SOURCE")` for pattern mining and safer edits of existing RAP stacks
+- `SAPTransport(action="history")` for object-to-transport traceability during later iterations
+- `SAPLint(action="format" | "get_formatter_settings")` for SAP-native keyword case and indentation
+- `SAPRead` / `SAPWrite` for `SKTD` so generated RAP services can carry attached Markdown documentation
+- `SAPGit` when a package is already part of an abapGit or gCTS-backed delivery flow
 
 ### Analyzing & Understanding
 
@@ -108,7 +117,8 @@ Skills are designed to chain together. A typical RAP development flow:
 3. generate-rap-logic               →  Add business logic (validations, determinations)
 4. generate-abap-unit-test          →  Generate tests for the behavior pool
 5. generate-cds-unit-test           →  Generate tests for the CDS views
-6. analyze-chat-session             →  Review what worked, file improvements
+6. optional: attach SKTD docs / inspect revisions / inspect transport history
+7. analyze-chat-session             →  Review what worked, file improvements
 ```
 
 For codebase onboarding or pre-migration work:

--- a/skills/generate-rap-logic.md
+++ b/skills/generate-rap-logic.md
@@ -72,10 +72,25 @@ Understand underlying tables, associations, and related entities. Useful for cro
 Find the behavior pool class name from the BDEF source (`implementation in class <name>`), then:
 
 ```
+SAPRead(type="CLAS", name="<bp_class>", format="structured")
+```
+
+Use the structured read as the default because it returns metadata, includes, and existing test classes in one response. If you need a concise method catalog afterward, add:
+
+```
 SAPRead(type="CLAS", name="<bp_class>", method="*")
 ```
 
-List all methods with their signatures. Identify which methods are empty stubs (body is just comments, `RETURN`, or blank).
+Identify which methods are empty stubs (body is just comments, `RETURN`, or blank).
+
+### 1e. Optional history / documentation context
+
+If this is an existing RAP BO that has already been modified by others, inspect recent changes and any attached documentation before overwriting logic:
+
+```
+SAPRead(type="VERSIONS", name="<bp_class>", objectType="CLAS")
+SAPRead(type="SKTD", name="<bp_class>")
+```
 
 ## Step 2: Identify Target Methods
 
@@ -99,23 +114,29 @@ If the user provided a natural language description, map it to the appropriate m
 
 ## Step 3: Research RAP Patterns
 
-Use mcp-sap-docs to fetch current RAP implementation patterns:
+Use mcp-sap-docs to fetch current RAP implementation patterns. Start with reference-style queries (`includeSamples=false`) and then fetch examples (`includeSamples=true`) only when you need executable patterns:
 
 ```
-search("RAP validation implementation ABAP example")
+search(query="RAP validation implementation ABAP example", includeSamples=true, abapFlavor="<cloud|standard>")
 ```
 
 ```
-search("RAP determination on save trigger")
+search(query="RAP determination on save trigger", includeSamples=false, abapFlavor="<cloud|standard>")
 ```
 
 For specific logic patterns:
 ```
-search("RAP calculate total price determination")
+search(query="RAP calculate total price determination", includeSamples=true, abapFlavor="<cloud|standard>")
 ```
 
 ```
-search("RAP status validation transition")
+search(query="RAP status validation transition", includeSamples=true, abapFlavor="<cloud|standard>")
+```
+
+For backend-driven UI behavior that frequently accompanies logic changes:
+
+```
+search(query="RAP feature control side effects authorization control", includeSamples=false, abapFlavor="<cloud|standard>")
 ```
 
 Use documentation to inform correct ABAP Cloud patterns:
@@ -123,6 +144,7 @@ Use documentation to inform correct ABAP Cloud patterns:
 - `MODIFY ENTITIES OF <entity> IN LOCAL MODE` for updating entity data
 - Proper `FAILED` / `REPORTED` structure handling
 - Correct method signatures for determinations vs validations
+- Feature control checks are **not** evaluated for EML with `IN LOCAL MODE`
 
 ## Step 4: Generate Method Implementation
 
@@ -202,6 +224,12 @@ Before writing, optionally lint-check the generated code to catch issues before 
 SAPLint(action="lint", source="<generated_method_code>", name="<bp_class>")
 ```
 
+If you want the generated method body to follow SAP's formatter settings before it is written back:
+
+```
+SAPLint(action="format", source="<generated_method_code>", name="<bp_class>")
+```
+
 Write each method implementation using method-level surgery:
 
 ```
@@ -244,6 +272,12 @@ Optionally, if a test class exists, run the unit tests:
 
 ```
 SAPDiagnose(action="unittest", type="CLAS", name="<bp_class>")
+```
+
+If ATC is available and the change is non-trivial, run it too:
+
+```
+SAPDiagnose(action="atc", type="CLAS", name="<bp_class>")
 ```
 
 Present a summary:
@@ -468,8 +502,8 @@ ENDMETHOD.
 ### What This Skill Does NOT Do
 
 - **Custom actions**: Only determinations and validations. For custom actions (e.g., `action approve`), implement manually following a similar pattern.
-- **Side effects**: No `side effects` implementation (UI refresh triggers). Add manually if needed.
-- **Feature control**: No dynamic feature control (`instance_features`). Add manually.
+- **Side effects**: No end-to-end `side effects` implementation (UI refresh triggers). Add manually if needed.
+- **Feature control**: No end-to-end dynamic feature control (`instance_features` / `global_features`). Add manually, especially when the UI should disable actions or updates.
 - **Authorization**: No `authorization master` implementation. Add authorization checks manually.
 - **Cross-BO logic**: No inter-business-object operations. Each determination/validation operates within its own BO.
 - **Message class creation**: Uses hardcoded text for messages. For production services, create a message class afterward: `SAPWrite(action="create", type="MSAG", name="Z<MSG_CLASS>", ...)` and replace `new_message_with_text()` with `new_message()` referencing the message class.

--- a/skills/generate-rap-service-researched.md
+++ b/skills/generate-rap-service-researched.md
@@ -12,10 +12,11 @@ This skill produces an implementation plan informed by the target SAP system's a
 | Key strategy | UUID (`sysuuid_x16`), managed numbering | Simplest, no collision risk |
 | Behavior scenario | Managed | Framework handles CRUD, most common |
 | OData version | V4 | Current SAP standard |
-| Draft | Yes on BTP, No on-prem | BTP Fiori Elements expects draft |
-| Strict mode | `strict ( 2 )` | Current RAP best practice |
+| Draft | Prefer for transactional Fiori Elements UI services; verify against system release and BO constraints | Best default for editable FE apps, but not every RAP service needs draft |
+| Strict mode | `strict ( 2 )` unless system patterns or SAP constraints justify otherwise | Current RAP best practice, but not universal |
 | Naming | SAP standard (see reference section) | Overridden by existing system patterns if found |
 | Admin fields | System-appropriate (`syuname`/`timestampl` or `abp_*`) | Detected from system type |
+| Service exposure | OData V4 UI provider contract by default | Best fit for Fiori Elements unless the use case is an API-first service |
 
 These defaults are starting points — research in Phase 1 may override them based on existing system patterns.
 
@@ -61,10 +62,15 @@ Research the target system thoroughly before designing anything. Every finding i
 
 ### 1a. System Capabilities & Version
 
-Detect what the system supports — this determines available RAP features, syntax, and patterns.
+Detect what the system supports — this determines available RAP features, syntax, naming, and safe defaults.
+
+If `./system-info.md` already exists from `bootstrap-system-context`, use it as input. Otherwise, reproduce the critical reads inline:
 
 ```
+SAPRead(type="SYSTEM")
+SAPRead(type="COMPONENTS")
 SAPManage(action="probe")
+SAPLint(action="list_rules")
 ```
 
 **Note:** `rap.available` in the probe response is informational — it indicates whether the DDL source endpoint was detected, but RAP may still be available. Proceed with creation and handle errors if they occur.
@@ -74,8 +80,9 @@ Extract and note:
 - **ABAP language version**: Cloud (strict, released APIs only) vs. Standard (full ABAP)
 - **RAP support level**: Managed, unmanaged, abstract BOs? Draft support? Late numbering? Determination on modify vs. save?
 - **CDS capabilities**: View entities vs. classic views? Table entities? Metadata extensions? Access control?
-- **Available features**: ATC, syntax check, unit test runner, transport management, FLP customization
+- **Available features**: ATC, syntax check, unit test runner, transport management, FLP customization, abapGit/gCTS, version history
 - **FLP support**: If `flp` feature is available, the service can be registered in the Fiori Launchpad after creation
+- **Lint profile**: cloud vs on-prem preset, active ABAP version, formatter style
 
 ### 1b. Existing RAP Projects — Pattern Mining
 
@@ -95,6 +102,10 @@ SAPSearch(query="SRVB Z*", maxResults=20)
 
 ```
 SAPSearch(query="DCLS Z*", maxResults=20)
+```
+
+```
+SAPSearch(query="DDLX Z*", maxResults=20)
 ```
 
 **If NO Z* BDEFs are found**, you MUST still ground yourself in at least one real system example before writing any code. Use this deterministic fallback:
@@ -131,7 +142,19 @@ SAPRead(type="DDLX", name="<found_metadata_ext>")
 ```
 
 ```
-SAPContext(type="DDLS", name="<found_interface_view>")
+SAPRead(type="SRVB", name="<found_service_binding>")
+```
+
+```
+SAPContext(type="DDLS", name="<found_interface_view>", action="impact")
+```
+
+```
+SAPRead(type="VERSIONS", name="<found_interface_view>", objectType="DDLS")
+```
+
+```
+SAPRead(type="SKTD", name="<found_interface_view>")
 ```
 
 From these, extract:
@@ -143,7 +166,24 @@ From these, extract:
 - **Key strategy**: UUID (`sysuuid_x16`)? Semantic keys? Number ranges?
 - **Behavior patterns**: Which determinations/validations are standard? Authorization pattern?
 - **Draft handling**: `with draft` present? Draft table naming? Draft actions included?
-- **OData version**: V2 or V4 bindings?
+- **OData exposure**: UI vs Web API bindings? V2 or V4? Service definition/provider contract style?
+- **Recent evolution**: Did the revision history show stable patterns or an ongoing migration?
+- **Documentation presence**: Are SKTD notes attached to important RAP artifacts?
+
+### 1b2. Optional Git / Delivery Context
+
+If `SAPManage(action="probe")` shows `abapGit` or gCTS support and the target package may already belong to a repo-backed workflow, inspect that context before creating new artifacts:
+
+```
+SAPGit(action="list_repos")
+SAPGit(action="objects", repoId="<repo_id>")
+SAPGit(action="history", repoId="<repo_id>", limit=20)
+```
+
+Use this to learn:
+- Whether the target package is already repo-managed
+- Which naming/branching conventions are active
+- Whether the package is under active delivery and should align with an existing repo layout
 
 ### 1c. Existing Database Tables & Domain Objects
 
@@ -177,10 +217,16 @@ SAPRead(type="API_STATE", name="<found_table_or_view>", objectType="TABL")
 
 If an object is deprecated (C2) or not released, avoid building on it — search for its released successor instead.
 
-To understand what already depends on a found object (reverse dependency):
+To understand what already depends on a found CDS object, use CDS-specific impact instead of generic where-used:
 
 ```
-SAPContext(type="DDLS", name="<found_view>", action="usages")
+SAPContext(type="DDLS", name="<found_view>", action="impact")
+```
+
+Use generic reverse dependencies only for non-DDLS objects:
+
+```
+SAPContext(type="CLAS", name="<found_class>", action="usages")
 ```
 
 ### 1d. Code Guidelines & Quality Standards
@@ -191,29 +237,42 @@ Check if the system has ATC configuration or custom check variants that indicate
 SAPDiagnose(action="atc", type="CLAS", name="<any_existing_class>", variant="DEFAULT")
 ```
 
-If existing RAP classes were found in 1b, run lint on one to understand the baseline:
+If existing RAP classes were found in 1b, read one and run lint + formatter discovery to understand the baseline:
 
 ```
-SAPLint(type="CLAS", name="<found_bp_class>")
+SAPRead(type="CLAS", name="<found_bp_class>")
+SAPLint(action="lint", source="<class_source>", name="<found_bp_class>")
+SAPLint(action="get_formatter_settings")
 ```
 
-This reveals what lint rules and strictness levels are enforced.
+This reveals what lint rules, strictness levels, and keyword/indentation preferences are enforced.
 
 ### 1e. Best Practices Research — SAP Documentation
 
-Use the SAP documentation MCP server to research current RAP best practices relevant to the user's request. The search terms below are **starting suggestions** — adapt them based on the user's specific business requirement and the architecture decisions that need to be made. Craft search queries that target the gaps in your knowledge for this particular service.
+Use the SAP documentation MCP server deliberately, not as a generic keyword dump.
 
-**Example search terms** (adapt to the user's spec):
+1. Start with **official/reference-oriented** queries:
+   - `includeSamples=false`
+   - `abapFlavor="cloud"` on BTP / ABAP Cloud systems
+   - `abapFlavor="standard"` on classic on-prem systems when relevant
+2. Then run **example-oriented** queries:
+   - `includeSamples=true`
+3. Use `fetch(...)` on the top hits you actually rely on.
+4. Use `sap_community_search(...)` only for edge cases, undocumented errors, or workaround hunting after official docs are insufficient.
+
+The search terms below are **starting suggestions** — adapt them based on the user's specific business requirement and the architecture decisions that need to be made. Craft search queries that target the gaps in your knowledge for this particular service.
+
+**Architecture and layering**:
 
 ```
-search("RAP managed business object implementation best practices")
-search("RAP behavior definition managed scenario CDS view entity")
+search(query="RAP projection BO vs RAP BO interface", includeSamples=false, abapFlavor="<cloud|standard>")
+search(query="RAP service definition provider contracts odata_v4_ui odata_v4_webapi", includeSamples=false, abapFlavor="<cloud|standard>")
 ```
 
 **Domain-specific** — tailor to the user's business domain:
 
 ```
-search("<business_domain> RAP example SAP")
+search(query="<business_domain> RAP example SAP", includeSamples=true, abapFlavor="<cloud|standard>")
 ```
 
 For example, if the user wants a travel app: `search("RAP travel booking managed scenario example")`
@@ -221,20 +280,32 @@ For example, if the user wants a travel app: `search("RAP travel booking managed
 **Architecture decisions** — search only for topics relevant to this service:
 
 ```
-search("RAP managed vs unmanaged scenario when to use")
-search("RAP draft handling best practices Fiori Elements")
-search("RAP compositions parent child entity")
+search(query="RAP managed vs unmanaged scenario when to use", includeSamples=false, abapFlavor="<cloud|standard>")
+search(query="RAP draft handling total etag draft-enabled associations", includeSamples=false, abapFlavor="<cloud|standard>")
+search(query="RAP compositions parent child entity", includeSamples=true, abapFlavor="<cloud|standard>")
 ```
 
-**Specific patterns** — search if the requirement suggests them:
+**UI / service behavior** — search if the service is UI-facing:
 
 ```
-search("RAP custom actions determination validation")
-search("RAP value help CDS annotation")
-search("RAP access control authorization")
+search(query="RAP value help metadata extension additional binding OData V4", includeSamples=false, abapFlavor="<cloud|standard>")
+search(query="RAP feature control side effects authorization control", includeSamples=false, abapFlavor="<cloud|standard>")
+search(query="metadata-driven UI metadata extension RAP Fiori Elements", includeSamples=false, abapFlavor="<cloud|standard>")
 ```
 
-**Important:** Don't just run these searches verbatim. Analyze the user's spec and craft targeted queries that fill specific knowledge gaps. If the user asks for something unusual (e.g., integration with a specific SAP module, specific field types, custom numbering), search for those specifics.
+**Clean core / released APIs** — for BTP or released-object reuse:
+
+```
+search(query="ABAP API release RAP business object interface C1 C0", includeSamples=false, abapFlavor="cloud")
+```
+
+**Edge cases / troubleshooting only after official docs fail:**
+
+```
+sap_community_search(query="<exact error text or obscure RAP symptom>")
+```
+
+**Important:** Don't just run these searches verbatim. Analyze the user's spec and craft targeted queries that fill specific knowledge gaps. If the user asks for something unusual (for example, integration with a specific SAP module, specific field types, custom numbering, collaborative draft, or released BO interface consumption), search for those specifics.
 
 No need to research naming conventions at runtime — the official SAP naming schema is documented below in the "SAP Official Naming Conventions" reference section. Use it directly as the default.
 
@@ -255,17 +326,20 @@ Before proceeding, compile a structured research summary. Present this to the us
 - Architecture: [e.g., "All existing BOs use managed with draft, strict(2), UUID keys"]
 - Field Style: [e.g., "CamelCase aliases, abp_ admin field types on BTP"]
 - Annotation Style: [e.g., "Metadata extensions for all UI annotations, facet-based layout"]
+- Service exposure: [e.g., "projection view + OData V4 UI binding, provider contract aligned"]
 - N existing RAP services found: [list names]
 
 ### Domain Research
 - Related existing objects: [tables, views, classes found]
 - SAP standard objects in domain: [relevant standard CDS views, BAPIs]
+- Clean core posture: [released APIs confirmed / successor required / custom tables only]
 - Best practices from docs: [key findings]
 
 ### Quality Baseline
 - ATC variant: [DEFAULT / custom]
 - Lint findings: [clean / N issues on existing code]
 - Strictness: [strict(2) / strict / none]
+- Formatter settings: [keywordUpper / keywordLower / keywordAuto, indentation on/off]
 ```
 
 ---
@@ -314,24 +388,33 @@ For each question, lead with a concrete recommendation based on the user's spec 
 >
 > Which key strategy fits your use case?
 
-**4. OData version & draft**
-> I recommend **OData V4 with draft** because V4 is the current SAP standard for Fiori Elements applications and draft is the default interaction pattern for V4 transactional services.
+**4. Service exposure / provider contract**
+> I recommend **OData V4 UI** if this is a Fiori Elements-facing service, or **OData V4 Web API** if it is primarily for programmatic consumers. The service definition provider contract and the service binding type must match.
 >
-> **Important context on OData V2 vs V4 and draft:**
-> - **V4 + draft** (recommended default): Standard for Fiori Elements List Report / Object Page. Draft is essentially built-in — V4 transactional services expect draft.
-> - **V2 without draft**: Better suited for non-draft transactional apps and SAP UI5 freestyle applications. V2 is more common in the freestyle world and has broader legacy support.
-> - **V4 without draft**: Not a standard pattern — V4 transactional services are designed around draft. Possible for read-only analytical services, but not for CRUD apps.
-> - **V2 with draft**: Supported but less common. Use only if V2 is required and draft is needed.
+> **Important context on service exposure:**
+> - **OData V4 UI**: Best default for Fiori Elements List Report / Object Page apps.
+> - **OData V4 Web API**: Better when the primary consumer is integration code, tests, or external apps.
+> - **OData V2**: Use only if there is a hard legacy/UI client requirement.
 >
-> Unless your requirements specifically suggest a non-draft or freestyle app, V4 with draft is the right choice. Is there any reason to deviate?
+> Which consumer is primary: Fiori UI or API/integration?
 
-**4b. Authorization model**
-> I recommend **enforced CDS access control** (`@AccessControl.authorizationCheck: #CHECK` + `DCLS`) so the service has explicit row-level authorization from day one.
+**4b. Draft model**
+> I recommend **draft** for transactional Fiori Elements applications unless your use case is explicitly non-draft, API-only, or constrained by system/version realities.
+>
+> Important constraints from SAP docs:
+> - Draft requires a dedicated draft table and total ETag.
+> - Every child in a draft-enabled composition hierarchy must be represented in the BDEF.
+> - Some OData/Fiori behaviors differ between V2 and V4.
+>
+> Should this service be draft-enabled?
+
+**4c. Authorization model**
+> I recommend **`@AccessControl.authorizationCheck: #MANDATORY` + DCLS** so the service has explicit row-level authorization from day one. SAP's RAP docs recommend `#MANDATORY` instead of `#CHECK` for RAP BOs.
 >
 > Your options:
 > | Option | Upside | Downside |
 > |--------|--------|----------|
-> | **#CHECK + DCLS** | Correct security baseline, production-ready authorization model | Requires access-control design decisions |
+> | **#MANDATORY + DCLS** | Correct RAP baseline, production-ready authorization model | Requires access-control design decisions |
 > | **#NOT_ALLOWED / #NOT_REQUIRED** | Faster prototyping | Not suitable for production authorization |
 >
 > Should I generate a strict baseline DCLS now (with inheriting conditions) and mark domain-specific rules as follow-up?
@@ -398,6 +481,15 @@ For each question, lead with a concrete recommendation based on the user's spec 
 >
 > If no (freestyle UI5 app or non-UI consumer), we can simplify the annotations.
 
+**9b. Backend-driven UI features**
+> If this is a Fiori Elements app, should I plan any of these from the start?
+> - Field-level read-only / mandatory behavior
+> - Value helps
+> - Side effects
+> - Feature control for actions or updates
+>
+> Note: feature control and side effects are RAP concepts, but they are primarily consumable by Fiori Elements UIs.
+
 **10. Searchable fields**
 > Which fields should be searchable (appear in the search bar)?
 
@@ -438,11 +530,13 @@ Create a comprehensive design table:
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | Scenario | Managed / Unmanaged | [why] |
+| Service exposure | OData V4 UI / OData V4 Web API / OData V2 | [why] |
 | Draft | Yes / No | [why] |
 | Key strategy | UUID / Semantic / NumberRange | [why] |
-| OData version | V4 / V2 | [why] |
+| Provider contract | `odata_v4_ui` / `odata_v4_webapi` / `odata_v2_*` | [why] |
 | Strict mode | strict(2) / strict | [system dependent] |
 | Admin fields | syuname+timestampl / abp_* types | [system dependent] |
+| Authorization | `#MANDATORY + DCLS` / prototype-only | [why] |
 
 ### Entity Model
 | Entity | Role | Key Fields | Business Fields |
@@ -495,8 +589,10 @@ Create a comprehensive design table:
 
 ### Quality Checks Planned
 - Lint validation before each write (automatic via arc-1)
+- PrettyPrint of ABAP sources using SAP formatter settings before CLAS writes
 - Syntax check after each activation
 - ATC check after full stack activation
+- Revision/history readback if iterating on pre-existing artifacts
 - [If behavior logic]: Unit test skeleton
 ```
 
@@ -642,6 +738,8 @@ Use the source code templates from the plan. Adapt them based on research findin
 - **On-Prem systems**: Use `syuname`/`timestampl` types, classic or Cloud syntax depending on what existing code uses
 - **Follow existing patterns**: If existing RAP projects use a specific annotation style or field naming pattern, match it exactly
 - **Draft**: Include draft table, draft actions in interface BDEF, `use draft` in projection BDEF
+- **Service exposure**: Ensure the service definition provider contract matches the planned binding type
+- **ABAP formatting**: Run `SAPLint(action="format", source="<abap_source>", name="<class_name>")` on generated ABAP classes before writing them if you want SAP-native keyword case/indentation
 
 ### 4d. Post-Creation Validation
 
@@ -669,9 +767,11 @@ After all artifacts are created and activated:
    SAPRead(type="SRVD", name="ZSD_<entity>")
    ```
 
-4. **Lint check** the behavior pool:
+5. **Lint + formatter check** the behavior pool:
    ```
-   SAPLint(type="CLAS", name="ZBP_I_<entity>")
+   SAPRead(type="CLAS", name="ZBP_I_<entity>")
+   SAPLint(action="lint", source="<behavior_pool_source>", name="ZBP_I_<entity>")
+   SAPLint(action="get_formatter_settings")
    ```
 
 Fix any issues found. Re-activate if needed.
@@ -703,7 +803,7 @@ Verify the publish status and service URL:
 SAPRead(type="SRVB", name="ZSB_<entity>_V4")
 ```
 
-⚠️ **CHECKPOINT**: Verify the SRVB read shows `published: true` and a service URL. If not published, retry `publish_srvb`.
+⚠️ **CHECKPOINT**: Verify the SRVB read shows `published: true`, the expected binding type, and a service URL. For OData V4 bindings, publish/unpublish applies to the whole binding, not per service version.
 
 ### 4f. Preview the Service
 
@@ -776,6 +876,9 @@ Offer follow-up actions based on the plan:
   - `SAPManage(action="flp_add_tile_to_group", groupId="Z_<ENTITY>_G", catalogId="Z_<ENTITY>_C", tileId="Z_<ENTITY>_T")`
 8. **Create DOMA/DTEL** (if not done in Phase 4) for proper reusable typing
 9. **Release transport** (if transportable package) → use `SAPTransport(action="release_recursive", transport="<TR>")` to release tasks and parent in one step
+10. **Attach generated documentation** (optional) → use `SAPWrite(action="create", type="SKTD", refObjectType="SRVD", name="<service_doc_name>", source="<architecture_summary_markdown>")`
+11. **Review transport + revision context on later iterations** → use `SAPTransport(action="history", objectType="SRVD", objectName="ZSD_<ENTITY>")` and `SAPRead(type="VERSIONS", name="ZSD_<ENTITY>", objectType="SRVD")`
+12. **If the package is repo-managed** → use `SAPGit` (`list_repos`, `objects`, `history`) before changing naming or branch conventions
 ```
 
 ---
@@ -883,7 +986,7 @@ This skill prioritizes **correctness and consistency** over speed. The extra res
 
 ### What This Skill Does NOT Do (yet)
 
-- **Multi-entity compositions** in a single run (plan them, create root entity, suggest Phase 2)
+- **Very large multi-BO landscapes** in a single run — keep one business capability per execution
 - **Unmanaged save** implementation (plan it, implement the managed wrapper, note the save handler as a follow-up)
 - **Custom CDS functions/actions** (plan them, implement standard CRUD, add as follow-up)
 - **Fiori app generation** (generates the OData service; Fiori Elements app is auto-generated from annotations)

--- a/skills/generate-rap-service.md
+++ b/skills/generate-rap-service.md
@@ -14,11 +14,12 @@ This skill replicates SAP Joule's "RAP Service Generation" capability by combini
 | Key strategy | UUID (`sysuuid_x16`), managed numbering | Simplest, no collision risk |
 | Behavior scenario | Managed | Framework handles CRUD |
 | OData version | V4 | Current SAP standard |
-| Draft | Yes on BTP, No on-prem | BTP Fiori Elements expects draft |
+| Draft | Prefer for transactional Fiori Elements UI services; verify against release/constraints | Best default for editable FE apps, but not every RAP service needs draft |
 | Admin fields | `syuname`/`timestampl` (on-prem) or `abp_*` types (BTP) | System-appropriate |
-| Strict mode | `strict ( 2 )` | Current RAP best practice |
+| Strict mode | `strict ( 2 )` unless system patterns or SAP constraints justify otherwise | Current RAP best practice, but not universal |
 | Entity prefix | `Z` + entity name (e.g., `ZTRAVEL`) | SAP standard Z namespace |
 | Naming | SAP standard: `ZI_`, `ZC_`, `ZSD_`, `ZSB_`, `ZBP_I_` | Consistent with SAP docs |
+| Service exposure | OData V4 UI provider contract by default | Best fit for Fiori Elements unless the use case is API-first |
 
 ## Input
 
@@ -39,6 +40,14 @@ Verify the SAP system supports RAP/CDS and detect the system type.
 
 ```
 SAPManage(action="probe")
+```
+
+If you need a firmer baseline for syntax and formatter behavior, also read:
+
+```
+SAPRead(type="SYSTEM")
+SAPLint(action="list_rules")
+SAPLint(action="get_formatter_settings")
 ```
 
 **Note:** `rap.available` in the probe response is informational — it indicates whether the DDL source endpoint was detected, but RAP may still be available. Proceed with creation and handle errors if they occur.
@@ -63,6 +72,12 @@ This checks if a transport is required and returns existing transports for the p
    ```
 
 **If transport is required but unavailable, STOP** — all write operations will fail without a valid transport for non-`$TMP` packages.
+
+If the package does not exist yet and the user wants a new one, create it first:
+
+```
+SAPManage(action="create_package", name="<package>", description="<description>", transport="<transport_if_required>")
+```
 
 ### BTP vs On-Prem Differences
 
@@ -145,21 +160,25 @@ Ask the user: **"Should I proceed with this design? (yes / modify fields / chang
 
 ## Step 3: (Optional) Research RAP Patterns
 
-If mcp-sap-docs is available, fetch current RAP best practices:
+If mcp-sap-docs is available, fetch current RAP best practices. Start with reference-style queries (`includeSamples=false`) and then use examples (`includeSamples=true`) only where needed:
 
 ```
-search("RAP managed business object CDS behavior definition")
-```
-
-```
-search("RAP draft handling total ETag")
+search(query="RAP projection BO vs RAP BO interface", includeSamples=false, abapFlavor="<cloud|standard>")
 ```
 
 ```
-search("CDS annotation Fiori Elements list report")
+search(query="RAP draft handling total etag draft-enabled associations", includeSamples=false, abapFlavor="<cloud|standard>")
 ```
 
-Use the returned documentation to inform correct annotation patterns, draft handling, and behavior definition syntax.
+```
+search(query="service definition provider contracts odata_v4_ui odata_v4_webapi", includeSamples=false, abapFlavor="<cloud|standard>")
+```
+
+```
+search(query="metadata-driven UI metadata extension RAP Fiori Elements", includeSamples=false, abapFlavor="<cloud|standard>")
+```
+
+Use the returned documentation to inform correct annotation patterns, draft handling, provider contracts, and behavior definition syntax.
 
 ## Batch Creation (Preferred)
 
@@ -231,7 +250,7 @@ SAPWrite(action="create", type="DDLS", name="ZI_<entity>", package="<package>", 
 ### Interface View DDL Template
 
 ```cds
-@AccessControl.authorizationCheck: #CHECK
+@AccessControl.authorizationCheck: #MANDATORY
 @EndUserText.label: '<Entity description>'
 define root view entity ZI_<Entity>
   as select from <table_name>
@@ -410,7 +429,7 @@ SAPWrite(action="create", type="DDLS", name="ZC_<entity>", package="<package>", 
 ### Projection View DDL Template
 
 ```cds
-@AccessControl.authorizationCheck: #CHECK
+@AccessControl.authorizationCheck: #MANDATORY
 @EndUserText.label: '<Entity description> - Projection'
 @Metadata.allowExtensions: true
 @Search.searchable: true
@@ -577,7 +596,19 @@ SAPWrite(action="create", type="SRVD", name="ZSD_<entity>", package="<package>",
 
 ```cds
 @EndUserText.label: '<Entity description> Service'
-define service ZSD_<Entity> {
+define service ZSD_<Entity>
+  provider contracts odata_v4_ui
+{
+  expose ZC_<Entity> as <Entity>;
+}
+```
+
+If the primary consumer is an API/integration use case rather than Fiori Elements, switch the provider contract and binding type together:
+
+```cds
+define service ZSD_<Entity>
+  provider contracts odata_v4_webapi
+{
   expose ZC_<Entity> as <Entity>;
 }
 ```
@@ -591,6 +622,12 @@ SAPActivate(type="SRVD", name="ZSD_<entity>")
 ## Step 11: Create Behavior Pool Class
 
 Create the behavior pool class BEFORE batch activation — the interface BDEF references this class via `implementation in class ZBP_I_<Entity>`.
+
+Before writing, optionally run the SAP PrettyPrinter so the class source matches the system's keyword style and indentation:
+
+```
+SAPLint(action="format", source="<class_source>", name="ZBP_I_<entity>")
+```
 
 ```
 SAPWrite(action="create", type="CLAS", name="ZBP_I_<entity>", package="<package>", transport="<transport>", source="<class_source>")
@@ -686,7 +723,7 @@ Verify the publish status and service URL:
 SAPRead(type="SRVB", name="ZSB_<entity>_V4")
 ```
 
-⚠️ **CHECKPOINT**: Verify the SRVB read shows `published: true` and a service URL. If not published, retry `publish_srvb`.
+⚠️ **CHECKPOINT**: Verify the SRVB read shows `published: true`, the expected binding type, and a service URL. For OData V4 bindings, publish/unpublish applies to the whole binding.
 
 ## Step 14: Verify Complete Service
 
@@ -725,6 +762,8 @@ Next steps:
   - Generate unit tests (use generate-abap-unit-test skill)
   - Register in FLP launchpad (use SAPManage flp_create_catalog, flp_create_tile, flp_create_group)
   - Create proper DOMA/DTEL for reusable typing (use SAPWrite with type=DOMA/DTEL)
+  - Attach SKTD documentation to the service or BDEF (optional)
+  - Review later iterations with `SAPTransport(action="history")` + `SAPRead(type="VERSIONS", ...)`
 ```
 
 ## Error Handling
@@ -750,7 +789,7 @@ Next steps:
 
 ### BTP vs On-Prem Summary
 
-- **BTP**: Z*/Y* namespace only, ABAP Cloud syntax enforced, draft tables must be explicitly created (framework manages draft data at runtime), V4 OData preferred, `strict ( 2 )` in BDEF, table entity DDL syntax.
+- **BTP**: Z*/Y* namespace only, ABAP Cloud syntax enforced, draft tables must be explicitly created (framework manages draft data at runtime), V4 OData preferred, `strict ( 2 )` in BDEF, table entity DDL syntax, released SAP APIs only.
 - **On-Prem**: More namespace flexibility, classic ABAP allowed in behavior pool (not recommended), explicit draft table creation may be needed, V2 or V4, `strict` level depends on release.
 
 ### What This Skill Does NOT Do (v1)
@@ -759,6 +798,7 @@ Next steps:
 - **Custom actions**: No `action` declarations beyond draft actions. Use generate-rap-logic skill after.
 - **Determinations / validations**: No business logic. Use generate-rap-logic skill to add these after.
 - **Value helps**: No `@Consumption.valueHelpDefinition` annotations. Add manually.
+- **Feature control / side effects**: No backend-driven UI behavior beyond standard CRUD. Add manually when the UI needs dynamic enablement or recalculation hints.
 - **Unmanaged / abstract BOs**: Only managed scenario with UUID keys.
 - **DOMA/DTEL creation**: Uses inline types. For production services, create proper domains and data elements afterward using `SAPWrite(type="DOMA"/"DTEL")`.
 - **FLP registration**: Does not auto-register in Fiori Launchpad. Use `SAPManage` FLP actions afterward.


### PR DESCRIPTION
## Summary
- refresh the RAP skill pack to use current RAP guidance and recent ARC-1 capabilities
- update the skills docs to explain the newer workflow layer and the features those skills now exploit
- realign the feature matrix and roadmap with the current shipped feature set and first-party workflow positioning

## Why
Recent ARC-1 features materially improved RAP-oriented workflows (`SAPContext(action="impact")`, revision history, transport history, formatter settings, SKTD, and `SAPGit`), but the skill markdown and supporting docs were still describing an older capability picture. The result was that the first-party RAP workflows were underusing the product and the roadmap/matrix still framed some shipped capabilities as open gaps.

## User impact
Users invoking the RAP skills now get better defaults and stronger research guidance around:
- provider contracts and service exposure (`odata_v4_ui` vs `odata_v4_webapi`)
- draft and authorization choices aligned with current RAP guidance
- impact/history checks before editing existing RAP artifacts
- SAP-native formatter settings, attached SKTD docs, and optional Git delivery context

The roadmap and matrix now also make the product strategy clearer: workflow skills are part of ARC-1's differentiation layer, not just the raw tool inventory.

## Validation
- `npm run lint`