### PR TITLE
docs: add clean-core, dead-code, and object-documenter skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -93,6 +93,14 @@ Both skills produce the same RAP artifact stack. The difference is how they get 
 |---|---|---|
 | [explain-abap-code](explain-abap-code.md) | Reads an ABAP object, fetches all dependencies via SAPContext, and produces a structured explanation | Onboarding to unfamiliar code, investigating bugs, documenting undocumented objects |
 | [migrate-custom-code](migrate-custom-code.md) | Runs ATC readiness checks, groups findings by priority, and generates replacement code | Preparing custom code for S/4HANA migration or ABAP Cloud readiness |
+| [sap-object-documenter](sap-object-documenter.md) | Batch-documents many custom objects at once — purpose, style (Classic/Modern/Mixed), dependencies — as Markdown | Onboarding packages, handoffs, seeding a repo wiki (vs. explain-abap-code which is single-object interactive) |
+
+### Clean Core & Custom Code Retirement
+
+| Skill | What it does | When to use |
+|---|---|---|
+| [sap-clean-core-atc](sap-clean-core-atc.md) | Audits a package of custom code and buckets every Z/Y object into Clean Core Levels A–D using mcp-sap-docs + ATC | Planning an ECC→S/4HANA Cloud or BTP move; quarterly custom-code health check |
+| [sap-unused-code](sap-unused-code.md) | Finds Z/Y objects never called at runtime using SCMON or SUSG, then cross-references static where-used | Scoping a custom-code retirement project; pre-migration dead-code cleanup (requires `SAP_BLOCK_FREE_SQL=false` + `S_TABU_NAM` on `SCMON_*`/`SUSG_*`) |
 
 ### System Context & Local Workflow
 
@@ -128,4 +136,14 @@ For codebase onboarding or pre-migration work:
 2. setup-abap-mirror         →  Pull the target package(s) into abapGit-style files
 3. explain-abap-code         →  Understand key objects with dependency context
 4. migrate-custom-code       →  Run ATC readiness checks and group findings
+```
+
+For clean-core / custom-code retirement planning:
+
+```
+1. bootstrap-system-context  →  Know the system
+2. sap-unused-code           →  Scope the retirement (what even runs?)
+3. sap-clean-core-atc        →  Classify the USED code into Levels A–D
+4. sap-object-documenter     →  Document the keepers before rewriting
+5. migrate-custom-code       →  Fix the Level B/C/D findings one at a time
 ```

--- a/skills/sap-clean-core-atc.md
+++ b/skills/sap-clean-core-atc.md
@@ -1,0 +1,189 @@
+# SAP Clean Core ATC Classification
+
+Inventory a package of custom code and bucket every Z/Y object into **Clean Core Levels A–D** based on the SAP APIs it uses — the "is this cloud-ready?" audit.
+
+This is different from [migrate-custom-code](migrate-custom-code.md): that skill fixes one object's ATC findings; this one **produces a package-wide classification report** with per-object levels, used to plan a clean-core / BTP migration. It combines ARC-1 (ATC + source access) with mcp-sap-docs (released-API classification data from `SAP/abap-atc-cr-cv-s4hc`).
+
+## Clean Core Levels (what they mean)
+
+| Level | Meaning | Cloud-ready? |
+|---|---|---|
+| **A** | Uses only released SAP APIs | ✅ Yes — move as-is to ABAP Cloud / BTP |
+| **B** | Uses classic APIs (on-premise-only, documented) | 🟡 Works on on-prem S/4HANA; needs rewrite for cloud |
+| **C** | Uses internal/stable SAP objects (not customer-released) | 🔴 Supported today but no API guarantee |
+| **D** | Uses objects with no API status (deep internals, undocumented) | 🔴 High migration risk, may break on upgrade |
+
+Source: [SAP/abap-atc-cr-cv-s4hc](https://github.com/SAP/abap-atc-cr-cv-s4hc) — SAP's official machine-readable release state list.
+
+## Smart Defaults (apply silently, do NOT ask)
+
+| Setting | Default | Rationale |
+|---|---|---|
+| Target system type | `public_cloud` | Clean-core audits almost always target cloud readiness |
+| ATC variant | `ABAP_CLOUD_READINESS` if available, else system default | Cloud readiness is the point of the exercise |
+| Include in scope | Z*, Y*, plus any `/namespace/*` the user names | Customer code only; skip SAP-shipped |
+| Report detail | Summary table + level-breakdown + top violations | Actionable overview; drill-down on request |
+
+## Input
+
+The user provides a **package** (preferred) or a comma-separated object list, plus optional target system type.
+
+- **Package** (e.g., `Z_FI_CUSTOM`): audit every custom object in it
+- **Object list** (e.g., `ZCL_POSTING, ZR_SALES_REPORT`): audit only the named ones
+- **Target system type**: `public_cloud` (default) | `btp` | `private_cloud` | `on_premise`
+
+If neither package nor object list is given, ask which to use. Do NOT audit "everything" — that's never what the user wants.
+
+## Step 1: Enumerate Custom Objects
+
+### 1a. Package path
+
+```
+SAPRead(type="DEVC", name="<package>")
+```
+
+Filter results to keep only `PROG | CLAS | INTF | FUGR | FUNC | DDLS | BDEF | SRVD | TABL` with names starting `Z`, `Y`, or a customer namespace. Skip subpackages (audit them separately) unless the user says "recursive".
+
+### 1b. Object-list path
+
+For each name, resolve the type:
+
+```
+SAPSearch(query="<name>")
+```
+
+Use the first exact match.
+
+## Step 2: Extract SAP API References per Object
+
+For each custom object, collect the list of SAP-shipped objects it references.
+
+### 2a. Use SAPContext for dependency extraction
+
+```
+SAPContext(type="<type>", name="<object_name>", depth=1)
+```
+
+SAPContext returns a dependency list. Keep only dependencies whose names do NOT start with Z/Y/customer-namespace — those are SAP references. Record each as `(objectType, objectName)`.
+
+`SAPContext` supports CLAS, INTF, PROG, FUNC, DDLS (on-prem) and CLAS, INTF, DDLS (BTP). For other types (FUGR, BDEF, SRVD, TABL), fall back to reading the source with `SAPRead` and extracting SAP class / interface / function references with a regex scan over lines (e.g., `CL_*`, `IF_*`, `SAP*`, `CALL FUNCTION '...'`). Mark these references as "static-scan" in the report so the user knows confidence is lower than AST-derived deps.
+
+### 2b. Also run ATC for cloud readiness
+
+```
+SAPDiagnose(action="atc", type="<type>", name="<object_name>", variant="ABAP_CLOUD_READINESS")
+```
+
+If `ABAP_CLOUD_READINESS` doesn't exist on the system, use the system default and note this in the report. ATC findings complement the API classification — a released API can still be used incorrectly.
+
+## Step 3: Classify Each SAP Reference via mcp-sap-docs
+
+For each unique SAP object the custom code references:
+
+```
+sap_get_object_details(object_type="<type>", object_name="<name>", system_type="<target>", target_clean_core_level="A")
+```
+
+This returns:
+- `cleanCoreLevel` — A, B, C, or D
+- `state` — released | deprecated | classicAPI | stable | notToBeReleased | noAPI
+- `complianceStatus` — `compliant` | `non_compliant` vs. the target level
+- `successorObjects` — replacement recommendations if deprecated
+
+Cache results by `(object_type, object_name)` — the same SAP class is often referenced from many Z-objects.
+
+If an object isn't found in the dataset (`found: false`), classify as **D (unknown / no API)** and flag it as requiring manual review.
+
+## Step 4: Roll Up to Per-Object Level
+
+Each custom object's level is **the highest (worst) level among its SAP references**:
+
+| If any reference is … | Object level |
+|---|---|
+| D | D |
+| C (and no D) | C |
+| B (and no C/D) | B |
+| All A | A |
+
+Record per object:
+- Object level (A/B/C/D)
+- Reference breakdown (counts per level)
+- Top 3 worst references with their successors (if any)
+- ATC cloud-readiness findings count (Priority 1/2/3)
+
+## Step 5: Emit the Report
+
+### 5a. Headline summary
+
+```
+Clean Core Audit — <package_or_list>
+Target system: <target>   ATC variant: <variant>
+
+Objects audited:  42
+  Level A:  12  (29%)  — ready for ABAP Cloud as-is
+  Level B:  18  (43%)  — on-prem only; rewrite for cloud
+  Level C:   8  (19%)  — uses internal APIs; plan replacement
+  Level D:   4   (9%)  — high risk; manual review required
+```
+
+### 5b. Per-level tables
+
+For each level (start with D, work down — worst first):
+
+```
+Level D — High Risk (4 objects)
+
+Object                    Non-compliant refs  Top violation           ATC P1
+ZCL_MIGRATION_HELPER      8                   CL_SALV_TREE_WRAPPER    3
+ZR_OLD_POSTING           12                   SAPLSMTR_NAVIGATION     5
+...
+```
+
+### 5c. Replacement suggestions (Level B/C/D only)
+
+For the top 10 most-referenced deprecated APIs, show `{deprecated → successor}` pairs with counts:
+
+```
+CL_GUI_ALV_GRID  (used in 18 Z-objects)  →  CL_SALV_TABLE  (A)
+CL_IXML          (used in 12 Z-objects)  →  XML transformations (A)
+...
+```
+
+### 5d. Follow-up Options
+
+Offer next steps:
+- "Want per-object detail for Level D objects?" (drill into the 4 riskiest)
+- "Want to migrate one of these objects now?" (→ [migrate-custom-code](migrate-custom-code.md))
+- "Want to see which Z-objects are even USED?" (→ [sap-unused-code](sap-unused-code.md) — no point migrating dead code)
+- "Want to document the Level A objects as reference examples?" (→ [sap-object-documenter](sap-object-documenter.md))
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| `sap_get_object_details` returns `found: false` | SAP object not in the release state dataset | Classify as D, flag for manual review; dataset covers S/4HANA only |
+| `ABAP_CLOUD_READINESS` variant not found | System doesn't have it configured | Fall back to default variant; note in report that finding is less cloud-specific |
+| SAPContext unsupported for object type | E.g., dynamic programs, generated code | Fall back to regex scan of source for `CL_*`, `IF_*`, `SAP*` patterns |
+| Empty package | Typo or package is only a structure package | Verify via SAPSearch; ask user to pick a child package |
+| mcp-sap-docs not connected | Missing MCP server | Skill degrades to ATC-only classification; warn user |
+
+## Caveats
+
+### What this skill is NOT
+
+- **Not a migration tool** — it classifies risk; use [migrate-custom-code](migrate-custom-code.md) to actually fix.
+- **Not a replacement for SAP's Custom Code Migration app** — that tool has more depth (runtime usage analysis, simplification DB, transport impact). This skill is a fast, LLM-friendly approximation.
+- **Accuracy depends on mcp-sap-docs dataset freshness** — the SAP/abap-atc-cr-cv-s4hc repo is updated per S/4HANA release.
+
+### BTP vs On-Premise
+
+- **BTP audit (`system_type=btp`)**: Level B becomes non-compliant — BTP only accepts Level A. Stricter than public_cloud.
+- **On-premise audit (`system_type=on_premise`)**: Level A+B are both compliant. Use this when the goal is "does my custom code survive the next S/4HANA upgrade?" rather than "can I run this in the cloud?".
+
+### When to Use This Skill
+
+- Planning a move from ECC → S/4HANA Cloud
+- Planning a move from ECC → ABAP Cloud on BTP
+- Quarterly custom-code health check
+- Before a major release upgrade (to flag high-risk objects early)
+- Scoping a custom-code retirement project (combine with [sap-unused-code](sap-unused-code.md))

--- a/skills/sap-object-documenter.md
+++ b/skills/sap-object-documenter.md
@@ -1,0 +1,222 @@
+# SAP Object Documenter
+
+Produce stable, package-scoped documentation for custom ABAP objects — classifies each by style (Classic / Modern / Mixed), summarizes purpose and dependencies, and outputs Markdown suitable for a repo wiki or onboarding doc.
+
+This skill complements [explain-abap-code](explain-abap-code.md) which targets a single object interactively. Use this one when you want **written docs for many objects at once** — e.g., to seed a `docs/` folder during onboarding, or to generate knowledge-transfer material before a team handoff.
+
+## Smart Defaults (apply silently, do NOT ask)
+
+| Setting | Default | Rationale |
+|---|---|---|
+| Include | Z*, Y*, customer-namespace | Customer code only |
+| Depth | 1 (direct dependencies only) | Keep docs readable; don't drown in transitive graph |
+| Style classification | Yes | Free signal — just ask SAPLint |
+| Per-object section length | ~30–60 lines Markdown | Enough to be useful, not so long it's unread |
+| Output format | Markdown file(s) | Portable, fits any wiki |
+
+## Input
+
+The user provides **one of**:
+
+- **Package** (e.g., `Z_SALES_EXTENSIONS`) — document every custom object in it
+- **Object list** — comma-separated (e.g., `ZCL_SALES_HANDLER, ZR_POSTING_JOB`)
+- **Type + prefix** — e.g., "document all Z* classes" → runs `SAPSearch(query="Z*", objectType="CLAS")`
+
+And optionally:
+- **Output path** — default: `docs/custom-code/<package_or_group>.md`
+- **One file or one-per-object** — default: one file with per-object sections, unless >30 objects in which case one-per-object
+
+If the scope would produce >100 objects, stop and ask the user to narrow it — documentation nobody reads is worse than no documentation.
+
+## Step 1: Enumerate Scope
+
+### 1a. Package path
+
+```
+SAPRead(type="DEVC", name="<package>")
+```
+
+### 1b. Object-list path
+
+Resolve each:
+
+```
+SAPSearch(query="<name>")
+```
+
+Filter to document-worthy types: `CLAS, INTF, FUGR, PROG, DDLS, BDEF, SRVD, TABL`. Skip generated proxies, transport objects, and test include classes.
+
+## Step 2: For Each Object — Read Source + Metadata
+
+Run these in parallel for each object:
+
+```
+SAPRead(type="<type>", name="<name>")             # Source
+SAPContext(type="<type>", name="<name>", depth=1) # Dependencies (CLAS/INTF/PROG/FUNC/DDLS only; BTP: CLAS/INTF/DDLS)
+```
+
+For object types SAPContext doesn't support (FUGR, BDEF, SRVD, TABL, DOMA, DTEL), skip the dependency call and list the "obvious" callers/dependencies by regex-scanning the source for `CL_*`, `IF_*`, `SAP*` and `CALL FUNCTION '...'`. Note the degraded confidence in the "Dependencies" section.
+
+For classes, also:
+
+```
+SAPRead(type="CLAS", name="<name>", method="*")   # Method listing with signatures
+```
+
+For CDS views, also:
+
+```
+SAPRead(type="DDLS", name="<name>", include="elements")  # Field list
+```
+
+## Step 3: Classify ABAP Style (Classes + Programs only)
+
+```
+SAPLint(action="lint", name="<name>")
+```
+
+(Pass `source=<source>` instead of `name` if you already have the source in memory — avoids a second fetch.)
+
+Interpret the lint findings:
+
+| Signals of **Modern** ABAP | Signals of **Classic** ABAP |
+|---|---|
+| Uses CDS, RAP, inline declarations, `NEW`, `REDUCE`, `CORRESPONDING` | Uses `FORM/ENDFORM`, `TABLES` statements, `OCCURS` |
+| No `SELECT *`, has `ORDER BY`, bulk operations | Line-by-line `SELECT SINGLE` in loops, `SELECT *` |
+| Classes with test classes, uses interfaces for DI | Function modules with global state |
+| No `MOVE-CORRESPONDING`, uses `CORRESPONDING OF` | Heavy `PERFORM` chains |
+
+Classify as:
+- **Modern** — mostly modern patterns, cloud-ready style
+- **Classic** — mostly classic patterns, pre-7.40 feel
+- **Mixed** — both present (often: modern wrapper around classic guts)
+
+If SAPLint fails or object isn't lintable (e.g., CDS view, table), skip this section.
+
+## Step 4: (Optional) Business-Context Lookup via mcp-sap-docs
+
+For objects whose name or structure references an SAP app component (FI, SD, MM, etc.), enrich with component context:
+
+```
+search("<component_code> application component")
+```
+
+Example: `ZCL_FI_GL_POSTING` → search `"FI-GL general ledger"` to get the SAP application-component description for the doc header.
+
+Skip this step if the object name gives no hint.
+
+## Step 5: Write the Markdown
+
+### 5a. One-file structure (≤30 objects)
+
+```markdown
+# <Package or group name> — Custom Code Documentation
+
+_Generated <date> via sap-object-documenter skill on system <SID>._
+
+## Overview
+
+| Object | Type | Style | Purpose (1 line) |
+|---|---|---|---|
+| ZCL_SALES_HANDLER | CLAS | Modern | Behavior implementation for sales order RAP service |
+| ZR_OLD_POSTING | PROG | Classic | Nightly batch for legacy FI posting |
+| ...
+
+## Objects
+
+### ZCL_SALES_HANDLER
+
+- **Type:** CLAS
+- **Package:** Z_SALES_EXTENSIONS
+- **Style:** Modern (uses RAP, inline decls, no SELECT *)
+- **Purpose:** Handle validations and determinations for the Sales Order RAP business object.
+
+**Public API**
+- `validate_credit_limit( i_order )` — checks customer credit limit before save
+- `determine_currency( c_order )` — defaults currency from sales org
+
+**Dependencies**
+- ZI_SALESORDER (CDS — root entity)
+- CL_SALV_TABLE (A — released ALV class)
+- ZCL_CREDIT_SERVICE (Z — custom credit service wrapper)
+
+**Notes**
+- No direct DB access; routes everything through the RAP entity.
+- Tests: `ZCL_SALES_HANDLER_UT` (present, 8 test methods).
+
+---
+
+### ZR_OLD_POSTING
+...
+```
+
+### 5b. One-file-per-object structure (>30 objects)
+
+Create `docs/custom-code/<package>/README.md` with the overview table (linking to each file) plus one `<object_name>.md` per object with the same sections as above.
+
+### 5c. Header per object (canonical fields)
+
+```markdown
+- **Type:** <TADIR type>
+- **Package:** <package>
+- **Style:** Modern | Classic | Mixed | n/a
+- **Purpose:** <one-sentence summary>
+- **Last change:** <SAPRead VERSIONS — most recent timestamp + user>
+- **Transports:** <SAPTransport action="history" — last 3 TR numbers>
+```
+
+The "Last change" + "Transports" lines come for free from ARC-1's version/transport APIs and anchor the doc in time.
+
+## Step 6: Write to Disk + Report
+
+Use the local file system (Write tool) to emit the Markdown file(s). Return a short summary:
+
+```
+Wrote 42 object docs to docs/custom-code/Z_SALES_EXTENSIONS/
+  12 Modern | 18 Classic | 8 Mixed | 4 n/a (CDS/tables)
+
+Longest objects (may need deeper docs):
+  ZCL_SALES_HANDLER   (847 lines, 14 methods)
+  ZR_OLD_POSTING      (1,204 lines)
+  ...
+```
+
+### Follow-up Options
+
+- "Want to expand any of these into deeper explanations?" (→ [explain-abap-code](explain-abap-code.md))
+- "Want to check clean-core readiness for this package?" (→ [sap-clean-core-atc](sap-clean-core-atc.md))
+- "Want to prune the dead ones first?" (→ [sap-unused-code](sap-unused-code.md))
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| Object not found | Wrong name or deleted | Log and skip; continue with rest |
+| SAPContext fails | Unsupported type | Manually list imports via regex scan of source |
+| SAPLint fails | No source (table, CDS), unsupported syntax | Skip style classification for that object |
+| Source is empty | Generated proxy or stub | Note "no source available" in doc, still emit other metadata |
+| Output path exists | File collision | Add timestamp suffix or ask user |
+| >100 objects in scope | Doc would be unreadable | Stop and ask user to narrow scope |
+
+## Caveats
+
+### What this skill does NOT do
+
+- **No code generation** — pure read + summarize.
+- **No English translation of business logic** — the "Purpose" line is derived from naming, class header comments, and test-class names. If those are missing, it says so.
+- **Not a substitute for good code comments** — the output is only as good as the source naming.
+- **No cross-object consolidation** — each object is documented independently. Package-level architecture description is out of scope.
+
+### When to Use This Skill
+
+- Onboarding new developers to a custom-code package
+- Before a consulting handoff — capture institutional knowledge as docs
+- Pre-migration documentation (snapshot what exists before rewriting)
+- Compliance / audit trail (some orgs require per-object documentation)
+- Seeding a knowledge base / repo wiki
+
+### When NOT to Use This Skill
+
+- For a single object — use [explain-abap-code](explain-abap-code.md), faster and interactive.
+- For SAP-shipped code — this is Z/Y-only; for SAP objects, use mcp-sap-docs directly.
+- When code quality analysis is the goal — use [migrate-custom-code](migrate-custom-code.md).

--- a/skills/sap-unused-code.md
+++ b/skills/sap-unused-code.md
@@ -1,0 +1,289 @@
+# SAP Unused Code Discovery
+
+Find Z/Y custom objects that are **never called at runtime** — the prerequisite for any credible custom-code retirement project. Combines runtime usage data from SAP's call monitor (SCMON) with static where-used analysis to classify each object as **UNUSED / LIKELY_UNUSED / USED / INDETERMINATE**.
+
+## ⚠ Required: scope and intent
+
+**This skill refuses to run without a filter.** A "list all unused code" report across an ECC system returns tens of thousands of rows and is useless. The user must provide at least one of:
+
+- **Package** (e.g., `Z_FI_CUSTOM`) — analyze only objects in this package
+- **Namespace prefix** (e.g., `Z_SALES_*`, `/ACME/*`) — only objects matching the pattern
+- **Object list** — comma-separated names to check
+- **Intent statement** — e.g., "find Z reports in FI-GL that haven't run in 90 days" — narrow by purpose
+
+If none is given, ask. Example clarifying questions:
+
+> Which package or namespace do you want to audit? E.g., "the Z_REPORTING package", "all Z* starting with Z_FI_", or "these 15 reports I'm planning to delete".
+
+## Why this is harder than it looks (read before proposing a plan)
+
+SAP has two relevant monitoring systems. Understand which you're working with:
+
+| System | What it is | Where data lives | Latency | Data lifetime |
+|---|---|---|---|---|
+| **SCMON** (ABAP Call Monitor) | Raw per-call counters | `SCMON_DATA` + `SCMON_PROG` + `SCMON_SUB` + `SCMON_RDATA` tables | Real-time while active | ~7 days rolling |
+| **SUSG** (Usage Statistics Generator) | Daily aggregation over SCMON | `SUSG_DATA` + `SUSG_PROG` + `SUSG_RDATA` + `SUSG_SUB` + `SUSG_ADMIN` tables (or CDS views `SUSG_I_DATA`, `SUSG_I_RDATA`, `SUSG_I_ODATA`) | Depends on batch schedule (default ~02:30 daily) | Months/years |
+
+**Key constraint:** SCMON auto-deactivates when record threshold is hit (`SCMON_CONF_SET_MAX_NUM_SLICES`). SUSG refuses to aggregate if SCMON was inactive during the window. On dev/test systems this breaks the pipeline constantly.
+
+## Three Options (pick based on system state)
+
+### Option A (preferred) — Direct SCMON table join via ARC-1
+
+Works immediately on any system where SCMON has ever been active, regardless of whether SUSG aggregation ran.
+
+```sql
+-- "Which programs actually ran?"
+SELECT p~PROGNAME, p~OBJECT, p~OBJ_NAME, SUM( d~COUNTER ) AS EXECS
+FROM SCMON_DATA AS d INNER JOIN SCMON_PROG AS p ON d~TRIGID = p~PROGID
+WHERE <filter>
+GROUP BY p~PROGNAME, p~OBJECT, p~OBJ_NAME
+ORDER BY EXECS DESCENDING
+```
+
+```sql
+-- "Which transactions/reports triggered anything?"
+SELECT s~ROOTNAME, s~ROOTTYPE, SUM( d~COUNTER ) AS EXECS
+FROM SCMON_DATA AS d INNER JOIN SCMON_SUB AS s ON d~SUBID = s~SUBID
+GROUP BY s~ROOTNAME, s~ROOTTYPE
+```
+
+**Column caveat (SAP naming is inverted):**
+- `SCMON_DATA.TRIGID` → `SCMON_PROG.PROGID` (the *executed program*, despite the name)
+- `SCMON_DATA.SUBID` → `SCMON_SUB.SUBID` (the *trigger root*, transaction/report that initiated)
+
+**Pros:** No batch wait, no slice rotation dance, runs today.
+**Cons:** Limited retention window (~7 days); useless for "has this run in the last 6 months" questions.
+
+### Option B — Aggregated SUSG via CDS views
+
+Use when the customer has SUSG properly scheduled (production systems usually do).
+
+```sql
+-- Same question, longer window
+SELECT PROGNAME, OBJ_TYPE, OBJ_NAME, SUM( COUNTER ) AS EXECS, MAX( LAST_USED ) AS LAST_SEEN
+FROM SUSG_I_DATA
+WHERE <filter>
+GROUP BY PROGNAME, OBJ_TYPE, OBJ_NAME
+```
+
+Pre-joined CDS view: `SUSG_I_DATA`, `SUSG_I_RDATA`, `SUSG_I_ODATA`. All have `@AccessControl.authorizationCheck: #NOT_REQUIRED`.
+
+**Pros:** Longer history (months), pre-joined (simpler SQL), officially supported data.
+**Cons:** Requires SUSG batch to have run (0 rows in SUSG until it does); nothing works if SCMON was deactivated during the window.
+
+### Option C — Manual SUSG XML export (fallback only)
+
+If the customer has already run transaction SUSG and exported the 5 XML files (`ADMIN0001.xml`, `PROG0001.xml`, `DATA*.xml`, `RDATA*.xml`, `SUB0001.xml`), the skill can parse those locally. **This is the Kiro path and should be the last resort** — it requires human action in SAP GUI and offline file handoff.
+
+This skill does not bundle an XML parser. If the user insists on Option C, tell them to use [Kiro's parse-susg.py](https://github.com/aws-solutions-library-samples/guidance-for-accelerating-sap-clean-core-journey-using-kiro-agents) or write a local Python script; ARC-1 won't do it.
+
+## Smart Defaults (apply silently, do NOT ask)
+
+| Setting | Default | Rationale |
+|---|---|---|
+| Option selection | Probe SCMON activity first; use A if live data exists, else B | Most systems have one or the other |
+| Output classification | UNUSED / LIKELY_UNUSED / USED / INDETERMINATE | Kiro's 4-way classification; useful for prioritization |
+| Where-used check | Yes, for non-runtime-seen objects | Static references are a real signal |
+| Reporting granularity | Per-object with counts; top-20 + summary | Full list available on request |
+
+## Prerequisites
+
+Check these up front. If missing, stop and tell the user.
+
+1. **`SAP_BLOCK_FREE_SQL=false`** on the ARC-1 server (otherwise `SAPQuery` is blocked — it runs FreeSQL). Ask admin if needed.
+2. **User has `S_TABU_NAM` authorization** on `SCMON_DATA`, `SCMON_PROG`, `SCMON_SUB`, `SCMON_RDATA` (or the SUSG equivalents for Option B).
+3. **SCMON has been active at some point** (Option A) OR **SUSG aggregation has run** (Option B). Probe with:
+
+```
+SAPQuery(sql="SELECT COUNT(*) AS CNT FROM SCMON_DATA")
+SAPQuery(sql="SELECT COUNT(*) AS CNT FROM SUSG_I_DATA")
+```
+
+Zero rows in both → data collection hasn't happened. Point the user to the next section and stop.
+
+### If the customer has no SCMON/SUSG data yet
+
+Tell them:
+
+1. SAP GUI: transaction `SCMON` → activate the monitor → let it run for N days (7 is a common minimum)
+2. Transaction `SCMONL` shows slice state; `SCMOND` shows raw data
+3. For permanent data: schedule `SCMON_COLLECT` as a daily job, then `SUSG_COLLECT_FROM_SCMON` after it
+4. Re-run this skill once data is flowing
+
+## Step 1: Probe which option to use
+
+Run the two COUNT queries above. Decision table:
+
+| SCMON_DATA count | SUSG_I_DATA count | Use |
+|---|---|---|
+| > 0 | > 0 | **A** (fresher data, real-time) — but mention B is also available for longer history |
+| > 0 | 0 | **A** (SUSG hasn't aggregated yet) |
+| 0 | > 0 | **B** (SCMON expired; SUSG has history) |
+| 0 | 0 | **Stop.** Tell user to activate SCMON; don't guess. |
+
+## Step 2: Enumerate the scope
+
+Based on user's filter input:
+
+### 2a. Package
+
+```
+SAPRead(type="DEVC", name="<package>")
+```
+
+Keep only objects of runtime types (PROG, CLAS, FUGR, FUNC) with Z/Y prefix. (Tables, CDS views, interfaces aren't "called at runtime" in a way SCMON/SUSG captures directly.)
+
+### 2b. Namespace / prefix
+
+`SAPSearch` takes a single `objectType` filter — call it once per runtime type and union the results:
+
+```
+SAPSearch(query="<prefix>*", objectType="PROG")
+SAPSearch(query="<prefix>*", objectType="CLAS")
+SAPSearch(query="<prefix>*", objectType="FUGR")
+```
+
+### 2c. Object list
+
+Use names as given.
+
+Call this **set S** (the candidate list).
+
+## Step 3: Query runtime usage
+
+### Option A (SCMON direct join)
+
+Build a WHERE clause from set S. SAP FreeSQL has query length limits, so chunk if |S| > 100.
+
+```sql
+SELECT p~PROGNAME, p~OBJECT, p~OBJ_NAME, SUM( d~COUNTER ) AS EXECS
+FROM SCMON_DATA AS d INNER JOIN SCMON_PROG AS p ON d~TRIGID = p~PROGID
+WHERE p~OBJ_NAME IN ( 'ZCL_FOO', 'ZR_BAR', ... )   -- or  p~OBJ_NAME LIKE 'Z_FI_%'
+GROUP BY p~PROGNAME, p~OBJECT, p~OBJ_NAME
+```
+
+Also check trigger-side (some Z-objects run only as transactions/RFCs, never as inner callees):
+
+```sql
+SELECT s~ROOTNAME, s~ROOTTYPE, SUM( d~COUNTER ) AS EXECS
+FROM SCMON_DATA AS d INNER JOIN SCMON_SUB AS s ON d~SUBID = s~SUBID
+WHERE s~ROOTNAME IN ( ... )
+```
+
+Union the results. Build **set U** (runtime-used objects with counts).
+
+### Option B (SUSG)
+
+```sql
+SELECT PROGNAME, OBJ_TYPE, OBJ_NAME, SUM( COUNTER ) AS EXECS, MAX( LAST_USED ) AS LAST_SEEN
+FROM SUSG_I_DATA
+WHERE <scope filter>
+GROUP BY PROGNAME, OBJ_TYPE, OBJ_NAME
+```
+
+Build **set U** with additional `LAST_SEEN` timestamp.
+
+## Step 4: Static where-used for objects not in U
+
+For each object in S but not in U:
+
+```
+SAPNavigate(action="references", type="<type>", name="<name>")
+```
+
+(`references` is ARC-1's where-used action — it calls SAP's where-used scope API under the hood.)
+
+Build **set W** (statically referenced objects — someone calls them in source, even if no one ran them in the observed window).
+
+## Step 5: Classify
+
+Apply first-match-wins:
+
+| Object in … | Classification | Meaning |
+|---|---|---|
+| U (runtime executed ≥ 1 time) | **USED** | Runs in production; keep |
+| W (referenced in source, not in U) | **LIKELY_UNUSED** | Static callers exist but nothing exercised it in the observed window |
+| Neither U nor W | **UNUSED** | Strong deletion candidate |
+| S but object doesn't exist on system (e.g., SAPSearch couldn't resolve it) | **INDETERMINATE** | Manual review |
+
+## Step 6: Emit the report
+
+### 6a. Headline
+
+```
+Unused Code Audit — <scope>
+Data source: SCMON (2,843 rows, window: 2026-04-12 → 2026-04-19)   ← Option A
+  — or —
+Data source: SUSG (Aggregated 2026-01-01 → 2026-04-19, 128 days)    ← Option B
+
+Scope:         42 objects
+  USED:          18  (43%)  — safe to keep
+  LIKELY_UNUSED: 12  (29%)  — still has static callers; investigate
+  UNUSED:        10  (24%)  — deletion candidates
+  INDETERMINATE:  2   (5%)  — manual review
+```
+
+### 6b. UNUSED table (the deletion candidates)
+
+```
+Object                  Type  Package           Last change (TR)
+ZR_OLD_FI_POSTING       PROG  Z_FI_CUSTOM       2024-02-15 (MARIAN / A4HK900042)
+ZCL_LEGACY_HELPER       CLAS  Z_FI_CUSTOM       2023-11-03 (MARIAN / A4HK900031)
+...
+```
+
+"Last change" comes from `SAPRead(type="VERSIONS")`. Old + unused = safest to delete.
+
+### 6c. LIKELY_UNUSED table with caller hints
+
+For each LIKELY_UNUSED object, show who references it:
+
+```
+ZCL_OLD_SALES_UTILS  (CLAS)
+  Called by:  ZR_SALES_JOB (PROG — also UNUSED — cascade delete)
+              ZCL_ACTIVE_HANDLER (CLAS — USED at runtime) ← blocks deletion
+```
+
+A LIKELY_UNUSED object whose callers are all UNUSED is transitively deletable. One active caller blocks deletion.
+
+### 6d. Follow-up options
+
+- "Want to see the static reference graph as a tree?" (→ chained `SAPNavigate where-used`)
+- "Want to clean-core-check the USED objects before worrying about unused ones?" (→ [sap-clean-core-atc](sap-clean-core-atc.md))
+- "Want documentation for the USED objects?" (→ [sap-object-documenter](sap-object-documenter.md))
+- "Want to start deleting UNUSED objects?" → Manual: this skill **does not delete anything**; the user does it via `SAPWrite` or a transport
+
+## Error Handling
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| `SCMON_DATA` count = 0, `SUSG_I_DATA` count = 0 | Monitoring never activated | Stop; instruct user to activate SCMON (Step above) |
+| SCMON has data but all `SLICEID=1` and SUSG is 0 | Slice hasn't rotated; SUSG can't aggregate open slices | Use Option A (direct), skip SUSG; or run `SCMON_COLLECT_ALL` via SA38 then `SUSG_COLLECT_FROM_SCMON` |
+| `SUSG_LOG` shows "SCMON not active" | SCMON auto-deactivated (record threshold hit) | Raise threshold via `SCMON_CONF_SET_MAX_NUM_SLICES`, reactivate SCMON, accept you lost one aggregation cycle |
+| `SAP_BLOCK_FREE_SQL=true` | Admin policy | Either get it relaxed, or fall back to `SAPRead(type="TABLE_CONTENTS", name="SCMON_DATA", maxRows=…)` (also blocked by `SAP_BLOCK_DATA=true`; no joins either way) — badly degrades the report |
+| 403 on `SCMON_*` / `SUSG_*` tables | Missing `S_TABU_NAM` auth | User needs auth assignment; document tables in request |
+| Scope returns > 500 candidates | User's filter too broad | Refuse; ask user to narrow (a 500-object deletion list is not actionable) |
+
+## Caveats
+
+### What runtime data does NOT tell you
+
+- **Coverage gap**: a report that runs every year-end won't appear in a week's worth of SCMON data. Always consider the observation window vs. the object's expected frequency.
+- **Dead-code-detection ≠ code elimination**: an UNUSED object may be emergency/DR code, exam-period-only, or called by a scheduled job not active during the window. Cross-check with business owners before deletion.
+- **Dynamic calls**: `CALL FUNCTION IN BACKGROUND`, `SUBMIT` with dynamic program names, or CALL METHOD via RTTI may not attribute to the right PROGNAME in SCMON. Some false UNUSEDs are unavoidable.
+
+### What this skill does NOT do
+
+- **No deletion.** Report only. Deletion must be a human decision, ideally via transport and CTS.
+- **No cross-system consolidation** (DEV + QAS + PRD usage). That requires exports from each system; this skill reads one system at a time.
+- **No replacement suggestions** for deprecated-but-used code. For that, use [sap-clean-core-atc](sap-clean-core-atc.md).
+- **No XML import** (Option C). If the customer has SUSG XML dumps and nothing else, they need an offline parser.
+
+### When to Use This Skill
+
+- Scoping a custom-code retirement project
+- Before a migration — don't migrate what you don't use
+- Post-project cleanup — removing code written for a feature that was rolled back
+- License/compliance reviews requiring a dead-code inventory
+- **Combine with [sap-clean-core-atc](sap-clean-core-atc.md):** migrate USED Level-A code, audit USED Level-C/D code, delete UNUSED code entirely


### PR DESCRIPTION
## Summary

Three new skills for custom-code retirement and clean-core planning, plus a retirement-planning workflow example in the skills README.

- **[sap-clean-core-atc](skills/sap-clean-core-atc.md)** — package-wide Clean Core A/B/C/D classification. Combines `SAPContext` (dependency extraction) with mcp-sap-docs `sap_get_object_details` (release-state lookup) and rolls up to per-object worst-reference level.
- **[sap-object-documenter](skills/sap-object-documenter.md)** — batch Markdown documentation for custom objects. Uses `SAPRead`, `SAPContext`, and `SAPLint(action="lint")` to produce per-object sections with Modern/Classic/Mixed style classification.
- **[sap-unused-code](skills/sap-unused-code.md)** — runtime-usage audit. Two paths: Option A (direct `SCMON_DATA` ⋈ `SCMON_PROG` via `SAPQuery`) for real-time data, Option B (`SUSG_I_DATA` CDS views) for longer history. Requires explicit scope (package / namespace / object list / intent) — refuses to run without a filter.

All tool signatures verified against `src/handlers/schemas.ts` (Zod) and mcp-sap-docs tool definitions.

## Test plan

- [ ] Review skill Markdown for readability in the GitHub UI
- [ ] Drop one skill into `~/.claude/commands/` and run against a Z-package on an on-prem S/4 system
- [ ] Confirm `sap-unused-code` correctly refuses without a scope argument
- [ ] Confirm `sap-clean-core-atc` degrades gracefully when a SAP reference is not in the `abap-atc-cr-cv-s4hc` dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)