### PR TITLE
feat: close RAP on-prem authoring gaps with preflight and handler scaffolding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,8 @@ src/
 │   ├── gcts.ts                 # gCTS Git backend client (/sap/bc/cts_abapvcs/*, JSON)
 │   ├── abapgit.ts              # abapGit ADT bridge client (/sap/bc/adt/abapgit/*, XML/HATEOAS)
 │   ├── cds-impact.ts           # CDS downstream impact classifier (RAP-oriented buckets)
+│   ├── rap-preflight.ts        # Deterministic RAP static-rule validator (TABL/BDEF/DDLX/DDLS)
+│   ├── rap-handlers.ts         # RAP handler signature extraction/matching/injection helpers
 │   ├── ui5-repository.ts       # UI5 ABAP Repository OData client
 │   ├── flp.ts                  # FLP PAGE_BUILDER_CUST OData client
 │   └── transport.ts            # CTS transport management
@@ -188,6 +190,8 @@ tests/
 | Add package create/delete/move (DEVC) | `src/handlers/intent.ts` (`handleSAPManage`), `src/handlers/tools.ts`, `src/handlers/schemas.ts`, `src/adt/ddic-xml.ts`, `src/adt/refactoring.ts` |
 | Add object transport history (reverse lookup) | `src/adt/transport.ts` (`getObjectTransports`), `src/adt/types.ts` (`ObjectTransportHistory`), `src/handlers/intent.ts` (`handleSAPTransport` case `history`), `src/handlers/schemas.ts`, `src/handlers/tools.ts` |
 | Add gCTS / abapGit operation | `src/adt/gcts.ts` or `src/adt/abapgit.ts`, `src/handlers/intent.ts` (`handleSAPGit`), `src/handlers/tools.ts`, `src/handlers/schemas.ts` |
+| Add RAP deterministic preflight checks | `src/adt/rap-preflight.ts`, `src/handlers/intent.ts` (`runRapPreflightValidation`), `src/handlers/tools.ts`, `src/handlers/schemas.ts`, `tests/unit/adt/rap-preflight.test.ts` |
+| Add RAP behavior handler scaffolding logic | `src/adt/rap-handlers.ts`, `src/handlers/intent.ts` (`SAPWrite action=scaffold_rap_handlers`), `src/handlers/tools.ts`, `src/handlers/schemas.ts`, `tests/unit/adt/rap-handlers.test.ts` |
 | Add new tool type | `src/handlers/tools.ts`, `src/handlers/schemas.ts`, `src/handlers/intent.ts` |
 | Add/modify tool input schema | `src/handlers/schemas.ts`, `src/handlers/tools.ts` |
 | Add DDIC domain/data element write | `src/adt/ddic-xml.ts`, `src/adt/crud.ts`, `src/handlers/intent.ts` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ src/
 │   ├── abapgit.ts              # abapGit ADT bridge client (/sap/bc/adt/abapgit/*, XML/HATEOAS)
 │   ├── cds-impact.ts           # CDS downstream impact classifier (RAP-oriented buckets)
 │   ├── rap-preflight.ts        # Deterministic RAP static-rule validator (TABL/BDEF/DDLX/DDLS)
-│   ├── rap-handlers.ts         # RAP handler signature extraction/matching/injection helpers
+│   ├── rap-handlers.ts         # RAP handler signature/stub extraction, matching, and injection helpers
 │   ├── ui5-repository.ts       # UI5 ABAP Repository OData client
 │   ├── flp.ts                  # FLP PAGE_BUILDER_CUST OData client
 │   └── transport.ts            # CTS transport management

--- a/docs/plans/completed/rap-onprem-agent-gap-closure.md
+++ b/docs/plans/completed/rap-onprem-agent-gap-closure.md
@@ -82,12 +82,12 @@ Use one consolidated implementation stream with three technical tracks executed 
 
 Create a deterministic preflight validator for high-frequency RAP static-rule failures so the user gets actionable diagnostics before activation round-trips.
 
-- [ ] Implement `validateRapSource(type, source, context)` in `src/adt/rap-preflight.ts` with typed findings (`severity`, `ruleId`, `message`, `line?`, `column?`, `suggestion?`).
-- [ ] Cover initial deterministic rules from session feedback: TABL currency/unit semantics, forbidden TABL types for on-prem 7.5x, BDEF enum/header misuse, projection BDEF header misuse, DDLX duplicate annotation and scope misuse checks.
-- [ ] Add a guarded call in `handleSAPWrite` pre-write flow to include preflight findings in write-time response/hints (blocking only on clearly invalid syntax/state; warnings otherwise).
-- [ ] Expose a per-call escape hatch (`preflightBeforeWrite: false`) in schema/tool docs, mirroring existing lint override behavior.
-- [ ] Add unit tests (~20) for parser/validator rules and intent-level integration of findings.
-- [ ] Run `npm test` — all tests must pass.
+- [x] Implement `validateRapSource(type, source, context)` in `src/adt/rap-preflight.ts` with typed findings (`severity`, `ruleId`, `message`, `line?`, `column?`, `suggestion?`).
+- [x] Cover initial deterministic rules from session feedback: TABL currency/unit semantics, forbidden TABL types for on-prem 7.5x, BDEF enum/header misuse, projection BDEF header misuse, DDLX duplicate annotation and scope misuse checks.
+- [x] Add a guarded call in `handleSAPWrite` pre-write flow to include preflight findings in write-time response/hints (blocking only on clearly invalid syntax/state; warnings otherwise).
+- [x] Expose a per-call escape hatch (`preflightBeforeWrite: false`) in schema/tool docs, mirroring existing lint override behavior.
+- [x] Add unit tests (~20) for parser/validator rules and intent-level integration of findings.
+- [x] Run `npm test` — all tests must pass.
 
 ### Task 2: Automate RAP Behavior Handler Scaffolding And Quick-Fix Flow
 
@@ -103,12 +103,12 @@ Create a deterministic preflight validator for high-frequency RAP static-rule fa
 
 Provide an MCP-native path to generate/apply RAP handler signatures and reduce dependency on manual ADT editor quick-fixes.
 
-- [ ] Add a RAP-oriented helper action (under existing tool families) that maps BDEF declarations to required behavior-pool method signatures and returns missing signatures with exact insertion targets.
-- [ ] Implement optional auto-apply mode that uses existing quickfix/apply_quickfix ADT plumbing where possible, and falls back to safe method-level patching when full-class update is unstable.
-- [ ] Ensure create/update flows detect behavior-pool signature mismatch failures and return explicit guidance referencing the new helper action.
-- [ ] Add unit tests (~15) for signature extraction/matching, helper responses, and fallback logic.
-- [ ] Add integration tests (~4) against live SAP test system for end-to-end handler-signature scaffolding on a scratch RAP object set.
-- [ ] Run `npm test` and targeted integration tests — all must pass.
+- [x] Add a RAP-oriented helper action (under existing tool families) that maps BDEF declarations to required behavior-pool method signatures and returns missing signatures with exact insertion targets.
+- [x] Implement optional auto-apply mode that uses existing quickfix/apply_quickfix ADT plumbing where possible, and falls back to safe method-level patching when full-class update is unstable.
+- [x] Ensure create/update flows detect behavior-pool signature mismatch failures and return explicit guidance referencing the new helper action.
+- [x] Add unit tests (~15) for signature extraction/matching, helper responses, and fallback logic.
+- [x] Add integration tests (~4) against live SAP test system for end-to-end handler-signature scaffolding on a scratch RAP object set.
+- [x] Run `npm test` and targeted integration tests — all must pass.
 
 ### Task 3: Improve Error And Activation Ergonomics For RAP Authoring
 
@@ -121,11 +121,11 @@ Provide an MCP-native path to generate/apply RAP handler signatures and reduce d
 
 Improve high-frequency friction points that still cause unnecessary retries.
 
-- [ ] Add explicit create-collision recovery hint for `Resource X does already exist` to recommend `action="update"` with full source payload.
-- [ ] Extend batch activation response formatting to always include per-object status and message arrays when mixed success/failure occurs.
-- [ ] Add targeted classification/hint for behavior-pool full-class save failures (`[?/011]`) with clear remediation path.
-- [ ] Add unit tests (~10) covering new hint conditions and batch activation response shape.
-- [ ] Run `npm test` — all tests must pass.
+- [x] Add explicit create-collision recovery hint for `Resource X does already exist` to recommend `action="update"` with full source payload.
+- [x] Extend batch activation response formatting to always include per-object status and message arrays when mixed success/failure occurs.
+- [x] Add targeted classification/hint for behavior-pool full-class save failures (`[?/011]`) with clear remediation path.
+- [x] Add unit tests (~10) covering new hint conditions and batch activation response shape.
+- [x] Run `npm test` — all tests must pass.
 
 ### Task 4: Skill And Documentation Alignment
 
@@ -141,11 +141,11 @@ Improve high-frequency friction points that still cause unnecessary retries.
 
 Align skill workflows and public docs with the new RAP capabilities and operationally-proven fallback strategy.
 
-- [ ] Update RAP generation skills to call out deterministic preflight behavior, reduced activation churn, and the behavior-handler scaffolding action.
-- [ ] Update bootstrap skill to record RAP-relevant constraints block (including known on-prem 7.5x pitfalls and feature flags).
-- [ ] Update chat-analysis skill to produce a mandatory triage section: `Quick Wins In-Session` vs `Needs Planned Implementation`.
-- [ ] Update tool docs/roadmap/CLAUDE references for any new or changed RAP actions/parameters.
-- [ ] Run `npm run lint` and `npm run typecheck` — no errors.
+- [x] Update RAP generation skills to call out deterministic preflight behavior, reduced activation churn, and the behavior-handler scaffolding action.
+- [x] Update bootstrap skill to record RAP-relevant constraints block (including known on-prem 7.5x pitfalls and feature flags).
+- [x] Update chat-analysis skill to produce a mandatory triage section: `Quick Wins In-Session` vs `Needs Planned Implementation`.
+- [x] Update tool docs/roadmap/CLAUDE references for any new or changed RAP actions/parameters.
+- [x] Run `npm run lint` and `npm run typecheck` — no errors.
 
 ### Task 5: Final Verification
 
@@ -156,8 +156,14 @@ Align skill workflows and public docs with the new RAP capabilities and operatio
 - Read: `skills/generate-rap-service-researched.md`
 - Read: `docs_page/tools.md`
 
-- [ ] Run full test suite: `npm test` — all tests pass.
-- [ ] Run typecheck: `npm run typecheck` — no errors.
-- [ ] Run lint: `npm run lint` — no errors.
-- [ ] Run RAP-focused integration tests against SAP test system with configured credentials and capture pass/fail evidence.
-- [ ] Move this plan to `docs/plans/completed/` once implementation is fully complete.
+- [x] Run full test suite: `npm test` — all tests pass.
+- [x] Run typecheck: `npm run typecheck` — no errors.
+- [x] Run lint: `npm run lint` — no errors.
+- [x] Run RAP-focused integration tests against SAP test system with configured credentials and capture pass/fail evidence.
+- [x] Move this plan to `docs/plans/completed/` once implementation is fully complete.
+
+### Verification Notes (2026-04-21)
+
+- RAP integration coverage was validated during implementation with SAP credentials:
+  `npm run test:integration -- --run tests/integration/adt.integration.test.ts -t "RAP handler scaffolding helpers"` → `3 passed, 76 skipped`.
+- A subsequent rerun in a clean shell failed setup due missing `TEST_SAP_*`/`SAP_*` credentials, while unit/typecheck/lint remained green.

--- a/docs/plans/completed/rap-onprem-agent-gap-closure.md
+++ b/docs/plans/completed/rap-onprem-agent-gap-closure.md
@@ -104,6 +104,7 @@ Create a deterministic preflight validator for high-frequency RAP static-rule fa
 Provide an MCP-native path to generate/apply RAP handler signatures and reduce dependency on manual ADT editor quick-fixes.
 
 - [x] Add a RAP-oriented helper action (under existing tool families) that maps BDEF declarations to required behavior-pool method signatures and returns missing signatures with exact insertion targets.
+- [x] Auto-apply also creates empty implementation stubs when matching local handler implementation blocks are available, so `SAPWrite(action="edit_method")` can patch method bodies immediately after scaffolding.
 - [x] Implement optional auto-apply mode that uses existing quickfix/apply_quickfix ADT plumbing where possible, and falls back to safe method-level patching when full-class update is unstable.
 - [x] Ensure create/update flows detect behavior-pool signature mismatch failures and return explicit guidance referencing the new helper action.
 - [x] Add unit tests (~15) for signature extraction/matching, helper responses, and fallback logic.

--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -115,6 +115,7 @@ SORT RULES for this table — DO NOT BREAK when adding rows:
 |----|---------|-----------|----------|
 | [FEAT-57](#feat-57) | SAPContext Impact — Sibling DDLS/DDLX Consistency Check (PR #177) | 2026-04-22 | Features |
 | [FEAT-55](#feat-55) | System Messages (SM02) + Gateway Error Log (IWFND) in SAPDiagnose (PR #174) | 2026-04-21 | Features |
+| — | RAP authoring hardening (`SAPWrite` deterministic RAP preflight, `scaffold_rap_handlers`, per-object batch activation statuses) | 2026-04-21 | Features |
 | [FEAT-56](#feat-56) | ADT Type-Availability Probe (diagnostic) (PR #163) | 2026-04-20 | Features |
 | [FEAT-58](#feat-58) | DTEL v2→v1 Content-Type Fallback + SICF-aware Error Hints (PR #169) | 2026-04-20 | Features |
 | — | SAPManage Scope Split + Data Preview Diagnostics (PR #171) | 2026-04-19 | Security |

--- a/docs_page/tools.md
+++ b/docs_page/tools.md
@@ -157,14 +157,19 @@ Create or update ABAP source code. Handles lock/modify/unlock automatically.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | string | Yes | `create`, `update`, `delete`, `edit_method`, or `batch_create` |
+| `action` | string | Yes | `create`, `update`, `delete`, `edit_method`, `batch_create`, or `scaffold_rap_handlers` |
 | `type` | string | No | `PROG`, `CLAS`, `INTF`, `FUNC`, `INCL`, `DDLS`, `DCLS`, `DDLX`, `BDEF`, `SRVD`, `SRVB`, `TABL`, `DOMA`, `DTEL`, `MSAG` (for single object actions). Slash/case aliases are auto-normalized (e.g., `CLAS/OC` or `clas` → `CLAS`). |
 | `name` | string | No | Object name (for single object actions) |
 | `source` | string | No | ABAP source code (for create/update/edit_method) |
 | `method` | string | No | For `edit_method`: method name to replace (e.g., `"get_name"`) |
+| `bdefName` | string | No | For `scaffold_rap_handlers`: interface BDEF name used to derive required handler signatures |
+| `autoApply` | boolean | No | For `scaffold_rap_handlers`: when `true`, inject missing signatures into behavior pool class declarations and write back |
+| `targetAlias` | string | No | For `scaffold_rap_handlers`: optional RAP entity alias filter (scaffold only one alias/handler class) |
 | `description` | string | No | Object description for `create` (defaults to name if omitted, max 60 chars) |
 | `package` | string | No | Package for new objects (default `$TMP`) |
 | `transport` | string | No | Transport request number. For `update` and `delete`, if omitted ARC-1 auto-uses the correction number returned by the SAP lock (if any). Explicit value takes precedence. |
+| `lintBeforeWrite` | boolean | No | Override server lint setting for this call (`false` to bypass pre-write lint) |
+| `preflightBeforeWrite` | boolean | No | Override deterministic RAP preflight checks for this call (`false` to bypass TABL/BDEF/DDLX/DDLS static checks) |
 | `dataType` | string | No | DOMA/DTEL: ABAP data type (`CHAR`, `NUMC`, `DEC`, ...) |
 | `length` | number | No | DOMA/DTEL: data type length |
 | `decimals` | number | No | DOMA/DTEL: decimal places |
@@ -213,11 +218,26 @@ This helps pinpoint the exact failing field/annotation instead of retrying blind
 - **Reserved keyword warnings:** CDS field names like `position`, `value`, `type`, `data` etc. may be CDS reserved keywords that cause silent DDL save failures. ARC-1 detects these and includes an advisory warning (non-blocking) suggesting renamed alternatives.
 - **Empty DDLS source:** When reading a DDLS that exists but has no stored source, ARC-1 returns an explicit warning instead of silent empty content.
 
+**RAP deterministic preflight validation:**
+
+- Runs before `create`/`update`/`batch_create` for RAP-prone source types (`TABL`, `BDEF`, `DDLX`, `DDLS`).
+- Blocks writes on deterministic rule errors (for example: missing `@Semantics.amount.currencyCode` for `abap.curr`, invalid `authorization master ( none )`, unsupported DDLX scope annotations on on-prem 7.5x).
+- Emits warning-only findings for non-fatal patterns (for example: explicit client in DDLS select list).
+- Per-call override: `preflightBeforeWrite=false`.
+
 **Batch creation:**
 
 `batch_create` creates and activates multiple objects in sequence via a single tool call. Objects are processed in array order — put dependencies first (e.g., domain before data element, TABL before DDLS, DCLS after DDLS, BDEF after CDS views). Each object in the array has: `type` (string, required), `name` (string, required), `source` (string, optional), `description` (string, optional), plus optional DOMA/DTEL metadata fields.
 
 If any object fails, processing stops and the response reports which objects succeeded and which failed. AFF metadata validation runs automatically for supported types (CLAS, INTF, PROG, DDLS, BDEF, SRVD, SRVB) — invalid metadata is rejected before hitting SAP.
+
+**RAP handler scaffolding:**
+
+`scaffold_rap_handlers` derives required behavior-pool `METHODS ... FOR ...` signatures from an interface BDEF, computes missing signatures, and can optionally inject declarations into the behavior pool class:
+
+- Scans class sections from `source/main`, `includes/definitions`, and `includes/implementations`
+- Supports dry-run listing (`autoApply=false`, default) and write-back mode (`autoApply=true`)
+- Helps recover from generic behavior-pool save errors by generating exact signatures for actions/determinations/validations/authorization handlers
 
 ```
 SAPWrite(action="batch_create", package="ZDEV", transport="K900123", objects=[
@@ -243,6 +263,9 @@ SAPWrite(action="create", type="DTEL", name="ZSTATUS", package="$TMP",
 
 SAPWrite(action="create", type="SRVB", name="ZSB_TRAVEL_O4", package="$TMP",
   serviceDefinition="ZSD_TRAVEL", category="0")
+
+SAPWrite(action="scaffold_rap_handlers", type="CLAS", name="ZBP_I_TRAVELREQ",
+  bdefName="ZI_TRAVELREQ", autoApply=true)
 ```
 
 **Transport behavior:**
@@ -271,7 +294,7 @@ Activate (publish) ABAP objects. Supports single object or batch activation.
 | `preaudit` | boolean | No | Request pre-activation audit from SAP (default: `true`). Set `false` to skip pre-audit for faster activation. |
 | `objects` | array | No | For batch: array of `{type, name}` objects to activate together |
 
-Use batch activation for RAP stacks where objects depend on each other (DDLS, BDEF, SRVD, DDLX, SRVB must be activated together).
+Use batch activation for RAP stacks where objects depend on each other (DDLS, BDEF, SRVD, DDLX, SRVB must be activated together). Batch responses include per-object status (`active`, `warning`, `error`) with attached messages, so failed members can be retried selectively.
 
 **Examples:**
 ```

--- a/docs_page/tools.md
+++ b/docs_page/tools.md
@@ -163,7 +163,7 @@ Create or update ABAP source code. Handles lock/modify/unlock automatically.
 | `source` | string | No | ABAP source code (for create/update/edit_method) |
 | `method` | string | No | For `edit_method`: method name to replace (e.g., `"get_name"`) |
 | `bdefName` | string | No | For `scaffold_rap_handlers`: interface BDEF name used to derive required handler signatures |
-| `autoApply` | boolean | No | For `scaffold_rap_handlers`: when `true`, inject missing signatures into behavior pool class declarations and write back |
+| `autoApply` | boolean | No | For `scaffold_rap_handlers`: when `true`, inject missing signatures plus empty method stubs into the behavior pool and write back |
 | `targetAlias` | string | No | For `scaffold_rap_handlers`: optional RAP entity alias filter (scaffold only one alias/handler class) |
 | `description` | string | No | Object description for `create` (defaults to name if omitted, max 60 chars) |
 | `package` | string | No | Package for new objects (default `$TMP`) |
@@ -233,7 +233,7 @@ If any object fails, processing stops and the response reports which objects suc
 
 **RAP handler scaffolding:**
 
-`scaffold_rap_handlers` derives required behavior-pool `METHODS ... FOR ...` signatures from an interface BDEF, computes missing signatures, and can optionally inject declarations into the behavior pool class:
+`scaffold_rap_handlers` derives required behavior-pool `METHODS ... FOR ...` signatures from an interface BDEF, computes missing signatures, and can optionally inject declarations plus empty `METHOD ... ENDMETHOD` stubs into the behavior pool class:
 
 - Scans class sections from `source/main`, `includes/definitions`, and `includes/implementations`
 - Supports dry-run listing (`autoApply=false`, default) and write-back mode (`autoApply=true`)

--- a/skills/analyze-chat-session.md
+++ b/skills/analyze-chat-session.md
@@ -174,6 +174,8 @@ Output two lists:
 1. **Quick wins to execute now** (ordered by leverage)
 2. **Planned items** (grouped into the minimum number of implementation plans)
 
+This triage section is mandatory in `issue` and `internal` outputs.
+
 ---
 
 ## Phase 4: Produce the Report

--- a/skills/bootstrap-system-context.md
+++ b/skills/bootstrap-system-context.md
@@ -54,6 +54,7 @@ Include at minimum:
 - Is RAP creation likely viable (`rap.available`, plus whether DDLS/BDEF reads work)
 - On-prem 7.5x guardrails (TABL typing pitfalls, projection BDEF header limits, DDLX annotation scope caveats)
 - Whether pre-write lint likely covers DDLS only vs broader RAP artifacts
+- Whether ARC-1 RAP preflight/scaffolding helpers should be the default path (`preflightBeforeWrite`, `scaffold_rap_handlers`)
 - Whether draft should default to deferred/two-pass for safety
 
 ## Step 4: Read Lint Preset
@@ -123,6 +124,7 @@ _Generated: <ISO timestamp>_ · _Source: ARC-1_
 - **Known projection BDEF caveat**: <e.g., use `projection;` header only on 7.5x>
 - **Known DDLX scope caveat**: <e.g., headerInfo/search/objectmodel placement limits>
 - **Lint coverage hint**: <ABAP+DDLS only / broader>
+- **RAP helper path**: <`scaffold_rap_handlers` available / use quick-fix fallback>
 
 ## Coding Guidance
 

--- a/skills/generate-rap-logic.md
+++ b/skills/generate-rap-logic.md
@@ -117,7 +117,7 @@ If the user provided a natural language description, map it to the appropriate m
 If the BDEF declares action/determination/validation handlers that do not exist in the class definition:
 
 1. Run `SAPWrite(action="scaffold_rap_handlers", type="CLAS", name="<bp_class>", bdefName="<bdef_name>")` to list missing signatures.
-2. If signatures are missing, rerun with `autoApply=true` to inject declarations into class sections when possible.
+2. If signatures are missing, rerun with `autoApply=true` to inject declarations plus empty method stubs into class sections when possible.
 3. If unresolved, try MCP quick-fix flow:
    - `SAPDiagnose(action="quickfix", ...)`
    - `SAPDiagnose(action="apply_quickfix", ...)`

--- a/skills/generate-rap-logic.md
+++ b/skills/generate-rap-logic.md
@@ -116,11 +116,13 @@ If the user provided a natural language description, map it to the appropriate m
 
 If the BDEF declares action/determination/validation handlers that do not exist in the class definition:
 
-1. Try MCP quick-fix flow first:
+1. Run `SAPWrite(action="scaffold_rap_handlers", type="CLAS", name="<bp_class>", bdefName="<bdef_name>")` to list missing signatures.
+2. If signatures are missing, rerun with `autoApply=true` to inject declarations into class sections when possible.
+3. If unresolved, try MCP quick-fix flow:
    - `SAPDiagnose(action="quickfix", ...)`
    - `SAPDiagnose(action="apply_quickfix", ...)`
-2. If no suitable proposal is available, use ADT quick-fix to generate the missing `METHODS ... FOR ...` signature.
-3. Re-read method list with `SAPRead(type="CLAS", name="<bp_class>", method="*")` before writing bodies.
+4. If still unresolved, use ADT quick-fix to generate the missing `METHODS ... FOR ...` signature.
+5. Re-read method list with `SAPRead(type="CLAS", name="<bp_class>", method="*")` before writing bodies.
 
 ## Step 3: Research RAP Patterns
 
@@ -268,7 +270,7 @@ If you want the generated method body to follow SAP's formatter settings before 
 SAPLint(action="format", source="<generated_method_code>", name="<bp_class>")
 ```
 
-Before calling `edit_method`, confirm the target method exists in `SAPRead(..., method="*")`. If it does not exist yet, generate the signature first via quick-fix flow (`quickfix` + `apply_quickfix`) or ADT quick-fix fallback.
+Before calling `edit_method`, confirm the target method exists in `SAPRead(..., method="*")`. If it does not exist yet, run `scaffold_rap_handlers` first, then quick-fix flow (`quickfix` + `apply_quickfix`) or ADT quick-fix fallback.
 
 Write each method implementation using method-level surgery:
 
@@ -523,7 +525,7 @@ ENDMETHOD.
 |---|---|---|
 | 415 Unsupported Media Type on DDLS/BDEF | RAP/CDS endpoint not responding as expected | Check `SAPManage(action="probe")` for system info. Verify ICF service activation. Try creating the object in ADT to confirm system capability. |
 | Method not found in behavior pool | Class name in BDEF doesn't match actual class | Check `implementation in class` in BDEF source, verify class exists |
-| Missing `METHODS ... FOR ...` handler signature | BDEF declaration exists but class signature not generated yet | Run `SAPDiagnose(action="quickfix")` + `apply_quickfix` when available, or use ADT quick-fix, then retry `edit_method` |
+| Missing `METHODS ... FOR ...` handler signature | BDEF declaration exists but class signature not generated yet | Run `SAPWrite(action="scaffold_rap_handlers", ...)` first (optionally `autoApply=true`), then `SAPDiagnose(action="quickfix")` + `apply_quickfix` or ADT quick-fix, then retry `edit_method` |
 | Syntax error: `<entity>` unknown in `READ ENTITIES` | Wrong entity name or alias | Use the exact alias from the BDEF `define behavior for ... alias <Alias>` |
 | Syntax error: field `<Field>` unknown | Field alias doesn't match CDS view | Check CDS view field aliases — BDEF uses CDS aliases, not table field names |
 | Activation fails | BDEF and class are incompatible | Activate BDEF and class together: `SAPActivate(objects=[...])` |
@@ -531,7 +533,7 @@ ENDMETHOD.
 | `IN LOCAL MODE` missing | Missing clause causes authorization check | Always use `IN LOCAL MODE` for internal reads/writes within the behavior pool |
 | `%tky` not available | Method signature doesn't provide transactional key | Check method signature — determinations use `keys`, validations use `keys` |
 | Runtime error on `MODIFY ENTITIES` | Trying to modify read-only fields | Don't modify fields marked `field ( readonly )` in BDEF |
-| Generic save error `[?/011]` on full class write | Behavior-pool full-class update path is unstable on some systems | Keep class signature generated via quickfix, then patch method bodies via `edit_method` only |
+| Generic save error `[?/011]` on full class write | Behavior-pool full-class update path is unstable on some systems | Use `scaffold_rap_handlers` + quickfix path for signatures, then patch method bodies via `edit_method` only |
 
 ## Notes
 

--- a/skills/generate-rap-service-researched.md
+++ b/skills/generate-rap-service-researched.md
@@ -725,7 +725,7 @@ At this point the service is previewable and stable.
 9. Add actions/determinations/validations to interface BDEF and activate.
 10. Generate missing behavior handler signatures:
    - First preference: `SAPWrite(action="scaffold_rap_handlers", type="CLAS", name="ZBP_I_<entity>", bdefName="ZI_<entity>")` to list missing signatures.
-   - Then rerun with `autoApply=true` to inject declarations into class sections (`main`, `definitions`, `implementations`) when possible.
+   - Then rerun with `autoApply=true` to inject declarations plus empty implementation stubs into class sections (`main`, `definitions`, `implementations`) when possible.
    - Next fallback: `SAPDiagnose(action="quickfix", ...)` + `SAPDiagnose(action="apply_quickfix", ...)` if proposals are available.
    - Fallback: ADT quick-fix in editor if no MCP quick-fix proposal is exposed.
 11. Implement method bodies with `SAPWrite(action="edit_method", ...)` (avoid full-class rewrites when behavior pools are unstable).

--- a/skills/generate-rap-service-researched.md
+++ b/skills/generate-rap-service-researched.md
@@ -724,7 +724,9 @@ At this point the service is previewable and stable.
 
 9. Add actions/determinations/validations to interface BDEF and activate.
 10. Generate missing behavior handler signatures:
-   - First preference: `SAPDiagnose(action="quickfix", ...)` + `SAPDiagnose(action="apply_quickfix", ...)` if proposals are available.
+   - First preference: `SAPWrite(action="scaffold_rap_handlers", type="CLAS", name="ZBP_I_<entity>", bdefName="ZI_<entity>")` to list missing signatures.
+   - Then rerun with `autoApply=true` to inject declarations into class sections (`main`, `definitions`, `implementations`) when possible.
+   - Next fallback: `SAPDiagnose(action="quickfix", ...)` + `SAPDiagnose(action="apply_quickfix", ...)` if proposals are available.
    - Fallback: ADT quick-fix in editor if no MCP quick-fix proposal is exposed.
 11. Implement method bodies with `SAPWrite(action="edit_method", ...)` (avoid full-class rewrites when behavior pools are unstable).
 12. Add `strict ( 2 )` and authorization handlers only after signatures and method bodies are active.
@@ -950,7 +952,7 @@ Activate the **child view entity first**, then the root. The root's `composition
 
 ### Lint and non-ABAP types
 
-Pre-write lint runs by default for ABAP sources and DDLS. BDEF/SRVD/SRVB/DDLX/TABL/DOMA/DTEL still need activation or preflight validation for most semantic checks. If lint blocks a known-valid case, use `lintBeforeWrite: false` for that specific write and keep the override local.
+Pre-write lint runs by default for ABAP sources and DDLS. BDEF/SRVD/SRVB/DDLX/TABL/DOMA/DTEL still need activation or RAP preflight validation for most semantic checks. Keep RAP preflight enabled by default; only use `preflightBeforeWrite: false` for narrowly-scoped recovery when you understand the specific rule being bypassed. If lint blocks a known-valid case, use `lintBeforeWrite: false` for that specific write and keep the override local.
 
 ---
 
@@ -993,7 +995,7 @@ Fall back to sequential creation (Phase 4b). Report which objects succeeded and 
 | `not a suitable draft persistency ... there is no "X" field` | Hand-written draft table column naming mismatch | Generate draft table via quick-fix (preferred), or follow CDS-name derivation exactly. |
 | `Annotation 'UI.headerInfo.X' used at wrong position` in DDLX | Unsupported annotation scope in DDLX on 7.5x | Move `@UI.headerInfo`, `@Search.searchable`, `@ObjectModel.*` to projection DDLS source. |
 | `Multiple entries with same name 'X' not allowed` in DDLX | Duplicate annotation blocks on same field | Consolidate field annotations into one block. |
-| `[?/011]` while updating behavior pool class | Full-class behavior-pool write path unstable for `METHODS ... FOR ...` | Keep class minimal, generate signatures via quick-fix, then patch bodies with `SAPWrite(action="edit_method", ...)`. |
+| `[?/011]` while updating behavior pool class | Full-class behavior-pool write path unstable for `METHODS ... FOR ...` | Use `SAPWrite(action="scaffold_rap_handlers", ...)` first (optionally `autoApply=true`), then quick-fix fallback, then patch bodies with `SAPWrite(action="edit_method", ...)`. |
 
 ---
 

--- a/skills/generate-rap-service.md
+++ b/skills/generate-rap-service.md
@@ -96,7 +96,8 @@ SAPManage(action="create_package", name="<package>", description="<description>"
 - Use `abap.char(1)` for boolean-like flags in TABL (not `abap.boolean`).
 - Every `abap.curr(...)` field needs `@Semantics.amount.currencyCode` above it.
 - Keep projection BDEF header as `projection;` (do not add `use etag` header lines).
-- If behavior-pool full-class writes fail with generic save errors, use quickfix-generated signatures + `SAPWrite(action="edit_method")` for method bodies.
+- Keep RAP preflight checks enabled (default) so deterministic TABL/BDEF/DDLX issues are blocked before activation churn. Only use `preflightBeforeWrite=false` as a local escape hatch.
+- If behavior-pool full-class writes fail with generic save errors, use `SAPWrite(action="scaffold_rap_handlers", ...)` first to derive/apply signatures, then use quickfix fallback + `SAPWrite(action="edit_method")` for method bodies.
 
 ## Step 2: Design the Data Model
 
@@ -699,7 +700,9 @@ If batch activation fails, activate sequentially in dependency order:
 9. Service definition
 
 If behavior pool activation fails because `METHODS ... FOR ...` signatures are missing:
-- Use `SAPDiagnose(action="quickfix", ...)` and `SAPDiagnose(action="apply_quickfix", ...)` when proposals are available.
+- Use `SAPWrite(action="scaffold_rap_handlers", type="CLAS", name="<bp_class>", bdefName="ZI_<entity>")` to list missing signatures.
+- If needed, rerun with `autoApply=true` to inject signatures into class declarations.
+- If signatures are still unresolved, use `SAPDiagnose(action="quickfix", ...)` and `SAPDiagnose(action="apply_quickfix", ...)` when proposals are available.
 - Fallback to ADT editor quick-fix generation, then patch method bodies with `SAPWrite(action="edit_method", ...)`.
 
 For any failing object, run syntax check to identify the issue:

--- a/skills/generate-rap-service.md
+++ b/skills/generate-rap-service.md
@@ -701,7 +701,7 @@ If batch activation fails, activate sequentially in dependency order:
 
 If behavior pool activation fails because `METHODS ... FOR ...` signatures are missing:
 - Use `SAPWrite(action="scaffold_rap_handlers", type="CLAS", name="<bp_class>", bdefName="ZI_<entity>")` to list missing signatures.
-- If needed, rerun with `autoApply=true` to inject signatures into class declarations.
+- If needed, rerun with `autoApply=true` to inject signatures into class declarations plus empty method stubs.
 - If signatures are still unresolved, use `SAPDiagnose(action="quickfix", ...)` and `SAPDiagnose(action="apply_quickfix", ...)` when proposals are available.
 - Fallback to ADT editor quick-fix generation, then patch method bodies with `SAPWrite(action="edit_method", ...)`.
 

--- a/src/adt/errors.ts
+++ b/src/adt/errors.ts
@@ -394,7 +394,7 @@ export function classifySapDomainError(statusCode: number, responseBody?: string
   if ((typeId === 'ExceptionResourceCreationFailure' || resourceExistsPattern) && objectExistsPattern) {
     return {
       category: 'object-exists',
-      hint: 'An object with this name already exists. Use SAPRead to inspect the existing object, or choose a different name.',
+      hint: 'An object with this name already exists. Recovery path: rerun the same payload with SAPWrite(action="update") to overwrite source/content, instead of retrying create.',
       details: typeId ? { exceptionType: typeId } : undefined,
     };
   }

--- a/src/adt/rap-handlers.ts
+++ b/src/adt/rap-handlers.ts
@@ -1,0 +1,405 @@
+export type RapHandlerKind =
+  | 'action'
+  | 'determination'
+  | 'validation'
+  | 'instance_authorization'
+  | 'global_authorization';
+
+export interface RapHandlerRequirement {
+  kind: RapHandlerKind;
+  methodName: string;
+  entityName: string;
+  entityAlias: string;
+  targetHandlerClass: string;
+  declarationLine: number;
+  signature: string;
+}
+
+export interface RapHandlerApplySkipped {
+  requirement: RapHandlerRequirement;
+  reason: string;
+}
+
+export interface RapHandlerApplyResult {
+  updatedSource: string;
+  inserted: RapHandlerRequirement[];
+  skipped: RapHandlerApplySkipped[];
+  changed: boolean;
+}
+
+interface RapBehaviorBlock {
+  entityName: string;
+  alias: string;
+  startLine: number;
+  lines: string[];
+}
+
+interface ClassDefinitionRange {
+  name: string;
+  start: number;
+  end: number;
+  privateSection?: number;
+}
+
+function countChar(value: string, char: string): number {
+  return value.split(char).length - 1;
+}
+
+function normalizeMethodName(name: string): string {
+  return name.replace(/\.$/, '').trim().toLowerCase();
+}
+
+function deriveAlias(entityName: string): string {
+  const noNamespace = entityName.split('/').at(-1) ?? entityName;
+  const noPrefix = noNamespace.replace(/^[A-Z]{1,4}_/, '');
+  const normalized = (noPrefix || noNamespace).replace(/[^A-Za-z0-9_]/g, '');
+  return normalized || 'Entity';
+}
+
+function parseBehaviorBlocks(source: string): RapBehaviorBlock[] {
+  const blocks: RapBehaviorBlock[] = [];
+  const lines = source.split('\n');
+
+  let current:
+    | {
+        entityName: string;
+        alias: string;
+        startLine: number;
+        lines: string[];
+        depth: number;
+        seenOpening: boolean;
+      }
+    | undefined;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+
+    if (!current) {
+      const defineMatch = line.match(/^\s*define\s+behavior\s+for\s+([^\s{]+)(?:\s+alias\s+([A-Za-z_]\w*))?/i);
+      if (!defineMatch) continue;
+
+      const entityName = defineMatch[1] ?? '';
+      const alias = defineMatch[2] ?? deriveAlias(entityName);
+      current = {
+        entityName,
+        alias,
+        startLine: i + 1,
+        lines: [],
+        depth: 0,
+        seenOpening: false,
+      };
+    }
+
+    current.lines.push(line);
+    if (line.includes('{')) current.seenOpening = true;
+    current.depth += countChar(line, '{') - countChar(line, '}');
+
+    if (current.seenOpening && current.depth <= 0) {
+      blocks.push({
+        entityName: current.entityName,
+        alias: current.alias,
+        startLine: current.startLine,
+        lines: current.lines,
+      });
+      current = undefined;
+    }
+  }
+
+  return blocks;
+}
+
+function pushRequirement(out: RapHandlerRequirement[], requirement: RapHandlerRequirement, seen: Set<string>): void {
+  const key = [
+    requirement.targetHandlerClass.toLowerCase(),
+    requirement.kind,
+    normalizeMethodName(requirement.methodName),
+    requirement.entityAlias.toLowerCase(),
+  ].join('|');
+  if (seen.has(key)) return;
+  seen.add(key);
+  out.push(requirement);
+}
+
+/**
+ * Extract RAP behavior-pool handler method requirements from interface BDEF source.
+ */
+export function extractRapHandlerRequirements(bdefSource: string): RapHandlerRequirement[] {
+  const requirements: RapHandlerRequirement[] = [];
+  const seen = new Set<string>();
+  const blocks = parseBehaviorBlocks(bdefSource);
+
+  for (const block of blocks) {
+    const alias = block.alias;
+    const targetHandlerClass = `lhc_${alias.toLowerCase()}`;
+    const body = block.lines.join('\n');
+
+    for (let idx = 0; idx < block.lines.length; idx += 1) {
+      const line = block.lines[idx] ?? '';
+      const declarationLine = block.startLine + idx;
+
+      const actionMatch = line.match(/^\s*(?:internal\s+)?action(?:\s*\([^)]*\))?\s+([A-Za-z_]\w*)\b/i);
+      if (actionMatch?.[1]) {
+        const actionName = actionMatch[1];
+        const methodName = normalizeMethodName(actionName);
+        pushRequirement(
+          requirements,
+          {
+            kind: 'action',
+            methodName,
+            entityName: block.entityName,
+            entityAlias: alias,
+            targetHandlerClass,
+            declarationLine,
+            signature:
+              `METHODS ${methodName} FOR MODIFY\n` +
+              `  IMPORTING keys FOR ACTION ${alias}~${actionName} RESULT result.`,
+          },
+          seen,
+        );
+      }
+
+      const determinationMatch = line.match(/^\s*determination\s+([A-Za-z_]\w*)\s+on\s+(modify|save)\b/i);
+      if (determinationMatch?.[1] && determinationMatch[2]) {
+        const determinationName = determinationMatch[1];
+        const event = determinationMatch[2].toUpperCase();
+        const methodName = normalizeMethodName(determinationName);
+        pushRequirement(
+          requirements,
+          {
+            kind: 'determination',
+            methodName,
+            entityName: block.entityName,
+            entityAlias: alias,
+            targetHandlerClass,
+            declarationLine,
+            signature:
+              `METHODS ${methodName} FOR DETERMINE ON ${event}\n` +
+              `  IMPORTING keys FOR ${alias}~${determinationName}.`,
+          },
+          seen,
+        );
+      }
+
+      const validationMatch = line.match(/^\s*validation\s+([A-Za-z_]\w*)\s+on\s+(modify|save)\b/i);
+      if (validationMatch?.[1] && validationMatch[2]) {
+        const validationName = validationMatch[1];
+        const event = validationMatch[2].toUpperCase();
+        const methodName = normalizeMethodName(validationName);
+        pushRequirement(
+          requirements,
+          {
+            kind: 'validation',
+            methodName,
+            entityName: block.entityName,
+            entityAlias: alias,
+            targetHandlerClass,
+            declarationLine,
+            signature:
+              `METHODS ${methodName} FOR VALIDATE ON ${event}\n` + `  IMPORTING keys FOR ${alias}~${validationName}.`,
+          },
+          seen,
+        );
+      }
+    }
+
+    const instanceAuthMatch = body.match(/\bauthorization\s+master\s*\(\s*instance\s*\)/i);
+    if (instanceAuthMatch) {
+      pushRequirement(
+        requirements,
+        {
+          kind: 'instance_authorization',
+          methodName: 'get_instance_authorizations',
+          entityName: block.entityName,
+          entityAlias: alias,
+          targetHandlerClass,
+          declarationLine: block.startLine,
+          signature:
+            'METHODS get_instance_authorizations FOR INSTANCE AUTHORIZATION\n' +
+            `  IMPORTING keys REQUEST requested_authorizations FOR ${alias} RESULT result.`,
+        },
+        seen,
+      );
+    }
+
+    const globalAuthMatch = body.match(/\bauthorization\s+master\s*\(\s*global\s*\)/i);
+    if (globalAuthMatch) {
+      pushRequirement(
+        requirements,
+        {
+          kind: 'global_authorization',
+          methodName: 'get_global_authorizations',
+          entityName: block.entityName,
+          entityAlias: alias,
+          targetHandlerClass,
+          declarationLine: block.startLine,
+          signature:
+            'METHODS get_global_authorizations FOR GLOBAL AUTHORIZATION\n' +
+            `  IMPORTING REQUEST requested_authorizations FOR ${alias} RESULT result.`,
+        },
+        seen,
+      );
+    }
+  }
+
+  return requirements;
+}
+
+function parseClassDefinitionRanges(source: string): ClassDefinitionRange[] {
+  const lines = source.split('\n');
+  const ranges: ClassDefinitionRange[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    const startMatch = line.match(/^\s*CLASS\s+([A-Za-z_][\w$]*)\s+DEFINITION\b/i);
+    if (!startMatch?.[1]) continue;
+
+    const name = startMatch[1];
+    const isDeferred = /\bDEFINITION\b.*\bDEFERRED\b/i.test(line);
+    if (isDeferred) {
+      // Deferred declarations are single-line declarations without ENDCLASS.
+      ranges.push({ name, start: i, end: i });
+      continue;
+    }
+
+    let end = i;
+    let privateSection: number | undefined;
+    for (let j = i + 1; j < lines.length; j += 1) {
+      const inner = lines[j] ?? '';
+      if (privateSection === undefined && /^\s*PRIVATE\s+SECTION\./i.test(inner)) {
+        privateSection = j;
+      }
+      if (/^\s*ENDCLASS\./i.test(inner)) {
+        end = j;
+        break;
+      }
+    }
+
+    ranges.push({ name, start: i, end, privateSection });
+    i = end;
+  }
+
+  return ranges;
+}
+
+/**
+ * Parse method declarations (`METHODS ...`) per class definition.
+ */
+export function parseClassDefinitionMethods(source: string): Map<string, Set<string>> {
+  const lines = source.split('\n');
+  const ranges = parseClassDefinitionRanges(source);
+  const out = new Map<string, Set<string>>();
+
+  for (const range of ranges) {
+    const key = range.name.toLowerCase();
+    const methods = out.get(key) ?? new Set<string>();
+
+    for (let i = range.start; i <= range.end; i += 1) {
+      const line = lines[i] ?? '';
+      const match = line.match(/^\s*(?:CLASS-)?METHODS\s+([A-Za-z_~][\w~]*)/i);
+      if (!match?.[1]) continue;
+      methods.add(normalizeMethodName(match[1]));
+    }
+
+    out.set(key, methods);
+  }
+
+  return out;
+}
+
+/**
+ * Determine which RAP handler requirements are missing from class definitions.
+ */
+export function findMissingRapHandlerRequirements(
+  requirements: RapHandlerRequirement[],
+  classSource: string,
+): RapHandlerRequirement[] {
+  const classMethods = parseClassDefinitionMethods(classSource);
+
+  return requirements.filter((req) => {
+    const methods = classMethods.get(req.targetHandlerClass.toLowerCase());
+    if (!methods) return true;
+    return !methods.has(normalizeMethodName(req.methodName));
+  });
+}
+
+/**
+ * Insert missing RAP handler signatures into matching `lhc_*` class definitions.
+ * This modifies declaration sections only; no method implementations are created.
+ */
+export function applyRapHandlerSignatures(
+  classSource: string,
+  requirements: RapHandlerRequirement[],
+): RapHandlerApplyResult {
+  if (requirements.length === 0) {
+    return { updatedSource: classSource, inserted: [], skipped: [], changed: false };
+  }
+
+  const lines = classSource.split('\n');
+  const ranges = parseClassDefinitionRanges(classSource);
+  const methodsByClass = parseClassDefinitionMethods(classSource);
+  const grouped = new Map<string, RapHandlerRequirement[]>();
+
+  for (const req of requirements) {
+    const key = req.targetHandlerClass.toLowerCase();
+    const list = grouped.get(key) ?? [];
+    list.push(req);
+    grouped.set(key, list);
+  }
+
+  type Edit = { index: number; lines: string[] };
+  const edits: Edit[] = [];
+  const inserted: RapHandlerRequirement[] = [];
+  const skipped: RapHandlerApplySkipped[] = [];
+
+  for (const [targetClassName, classRequirements] of grouped.entries()) {
+    const range = ranges.find((r) => r.name.toLowerCase() === targetClassName);
+    if (!range) {
+      for (const req of classRequirements) {
+        skipped.push({
+          requirement: req,
+          reason: `Handler class ${req.targetHandlerClass} not found in behavior pool.`,
+        });
+      }
+      continue;
+    }
+
+    const existingMethods = methodsByClass.get(targetClassName) ?? new Set<string>();
+    const toInsert = classRequirements.filter((req) => !existingMethods.has(normalizeMethodName(req.methodName)));
+    if (toInsert.length === 0) continue;
+
+    const signatureLines: string[] = [];
+    for (let i = 0; i < toInsert.length; i += 1) {
+      const req = toInsert[i]!;
+      signatureLines.push(...req.signature.split('\n').map((line) => `    ${line}`));
+      if (i < toInsert.length - 1) signatureLines.push('');
+      inserted.push(req);
+    }
+
+    if (range.privateSection === undefined) {
+      const block = ['  PRIVATE SECTION.', ...signatureLines, ''];
+      edits.push({ index: range.end, lines: block });
+      continue;
+    }
+
+    edits.push({
+      index: range.privateSection + 1,
+      lines: [...signatureLines, ''],
+    });
+  }
+
+  if (edits.length === 0) {
+    return { updatedSource: classSource, inserted, skipped, changed: false };
+  }
+
+  const sorted = edits.sort((a, b) => b.index - a.index);
+  for (const edit of sorted) {
+    lines.splice(edit.index, 0, ...edit.lines);
+  }
+
+  return {
+    updatedSource: lines.join('\n'),
+    inserted,
+    skipped,
+    changed: inserted.length > 0,
+  };
+}

--- a/src/adt/rap-handlers.ts
+++ b/src/adt/rap-handlers.ts
@@ -16,6 +16,7 @@
  *   2. findMissingRapHandlerRequirements — diff required vs. present in class
  *   3. applyRapHandlerSignatures         — insert the missing METHODS lines
  *   4. applyRapHandlerImplementationStubs — insert empty METHOD stubs
+ *   5. applyRapHandlerScaffold           — plan multi-include auto-apply
  *
  * The scaffolder writes declarations plus empty implementations only.
  * Business logic remains the developer's responsibility and can be filled
@@ -56,6 +57,31 @@ export interface RapHandlerApplyResult {
   changed: boolean;
 }
 
+export type RapHandlerSectionName = 'main' | 'definitions' | 'implementations';
+
+export interface RapHandlerSourceSections {
+  main: string;
+  definitions?: string;
+  implementations?: string;
+}
+
+export interface RapHandlerSectionApplyResults {
+  main: RapHandlerApplyResult;
+  definitions?: RapHandlerApplyResult;
+  implementations?: RapHandlerApplyResult;
+}
+
+export interface RapHandlerScaffoldPlan {
+  sections: RapHandlerSourceSections;
+  signatures: RapHandlerSectionApplyResults;
+  implementationStubs: RapHandlerSectionApplyResults;
+  unresolved: RapHandlerRequirement[];
+  changed: Record<RapHandlerSectionName, boolean>;
+  changedSections: RapHandlerSectionName[];
+  insertedSignatureCount: number;
+  insertedImplementationStubCount: number;
+}
+
 interface RapBehaviorBlock {
   entityName: string;
   alias: string;
@@ -76,22 +102,12 @@ interface ClassImplementationRange {
   end: number;
 }
 
-function requirementKey(
-  targetHandlerClass: string,
-  kind: RapHandlerKind,
-  methodName: string,
-  entityAlias: string,
-): string {
+function bindingKey(targetHandlerClass: string, kind: RapHandlerKind, methodName: string, entityAlias: string): string {
   return [targetHandlerClass.toLowerCase(), kind, normalizeMethodName(methodName), entityAlias.toLowerCase()].join('|');
 }
 
-function keyForRequirement(requirement: RapHandlerRequirement): string {
-  return requirementKey(
-    requirement.targetHandlerClass,
-    requirement.kind,
-    requirement.methodName,
-    requirement.entityAlias,
-  );
+export function rapHandlerRequirementKey(requirement: RapHandlerRequirement): string {
+  return bindingKey(requirement.targetHandlerClass, requirement.kind, requirement.methodName, requirement.entityAlias);
 }
 
 function countChar(value: string, char: string): number {
@@ -120,6 +136,25 @@ function collectStatement(lines: string[], startIdx: number): string {
     statement += ` ${next}`;
     if (next.includes(';')) break;
     if (j - startIdx > 20) break;
+  }
+  return statement;
+}
+
+/**
+ * Collect a multi-line ABAP statement terminated by `.`.
+ *
+ * Behavior handler declarations are often split across lines:
+ *   METHODS set_status_accepted FOR MODIFY
+ *     IMPORTING keys FOR ACTION travel~acceptTravel RESULT result.
+ * Binding parsing needs the continuation lines; otherwise semantic method
+ * names cannot be mapped back to the BDEF action/determination/validation.
+ */
+function collectAbapStatement(lines: string[], startIdx: number, endIdx: number, maxContinuation = 10): string {
+  let statement = lines[startIdx] ?? '';
+  for (let j = startIdx + 1; j <= endIdx && j < startIdx + maxContinuation; j += 1) {
+    const cont = lines[j] ?? '';
+    statement += ` ${cont}`;
+    if (/\.\s*$/.test(cont.trim())) break;
   }
   return statement;
 }
@@ -222,7 +257,7 @@ function parseBehaviorBlocks(source: string): RapBehaviorBlock[] {
 }
 
 function pushRequirement(out: RapHandlerRequirement[], requirement: RapHandlerRequirement, seen: Set<string>): void {
-  const key = keyForRequirement(requirement);
+  const key = rapHandlerRequirementKey(requirement);
   if (seen.has(key)) return;
   seen.add(key);
   out.push(requirement);
@@ -487,6 +522,47 @@ function parseClassImplementationMethods(source: string): Map<string, Set<string
   return out;
 }
 
+function parseHandlerDeclarationBinding(
+  statement: string,
+): { kind: RapHandlerKind; methodName: string; entityAlias: string } | undefined {
+  const actionBinding = statement.match(/\bFOR\s+ACTION\s+([A-Za-z_]\w*)\s*~\s*([A-Za-z_]\w*)/i);
+  if (actionBinding?.[1] && actionBinding[2]) {
+    return { kind: 'action', entityAlias: actionBinding[1], methodName: actionBinding[2] };
+  }
+
+  const entityBinding = statement.match(
+    /\bFOR\s+(?!ACTION\b|MODIFY\b|READ\b|VALIDATE\b|DETERMINE\b|INSTANCE\b|GLOBAL\b)([A-Za-z_]\w*)\s*~\s*([A-Za-z_]\w*)/i,
+  );
+  if (entityBinding?.[1] && entityBinding[2]) {
+    if (/\bFOR\s+DETERMINE\s+ON\b/i.test(statement)) {
+      return { kind: 'determination', entityAlias: entityBinding[1], methodName: entityBinding[2] };
+    }
+    if (/\bFOR\s+VALIDATE\s+ON\b/i.test(statement)) {
+      return { kind: 'validation', entityAlias: entityBinding[1], methodName: entityBinding[2] };
+    }
+  }
+
+  const authBinding = statement.match(/\bAUTHORIZATION\b.*\bFOR\s+([A-Za-z_]\w*)\s+RESULT\b/i);
+  if (authBinding?.[1]) {
+    if (/\bFOR\s+INSTANCE\s+AUTHORIZATION\b/i.test(statement)) {
+      return {
+        kind: 'instance_authorization',
+        entityAlias: authBinding[1],
+        methodName: 'get_instance_authorizations',
+      };
+    }
+    if (/\bFOR\s+GLOBAL\s+AUTHORIZATION\b/i.test(statement)) {
+      return {
+        kind: 'global_authorization',
+        entityAlias: authBinding[1],
+        methodName: 'get_global_authorizations',
+      };
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Map BDEF requirement keys to the concrete ABAP method name used in the
  * handler declaration.
@@ -510,52 +586,14 @@ function parseClassDefinitionHandlerBindings(source: string): Map<string, string
       const match = line.match(/^\s*(?:CLASS-)?METHODS\s+([A-Za-z_~][\w~]*)/i);
       if (!match?.[1]) continue;
       const declaredMethodName = normalizeMethodName(match[1]);
+      const statement = collectAbapStatement(lines, i, range.end);
 
-      let statement = line;
-      for (let j = i + 1; j <= range.end && j < i + 10; j += 1) {
-        const cont = lines[j] ?? '';
-        statement += ` ${cont}`;
-        if (/\.\s*$/.test(cont.trim())) break;
-      }
-
-      const actionBinding = statement.match(/\bFOR\s+ACTION\s+([A-Za-z_]\w*)\s*~\s*([A-Za-z_]\w*)/i);
-      if (actionBinding?.[1] && actionBinding[2]) {
-        out.set(requirementKey(targetHandlerClass, 'action', actionBinding[2], actionBinding[1]), declaredMethodName);
-        continue;
-      }
-
-      const entityBinding = statement.match(
-        /\bFOR\s+(?!ACTION\b|MODIFY\b|READ\b|VALIDATE\b|DETERMINE\b|INSTANCE\b|GLOBAL\b)([A-Za-z_]\w*)\s*~\s*([A-Za-z_]\w*)/i,
-      );
-      if (entityBinding?.[1] && entityBinding[2]) {
-        if (/\bFOR\s+DETERMINE\s+ON\b/i.test(statement)) {
-          out.set(
-            requirementKey(targetHandlerClass, 'determination', entityBinding[2], entityBinding[1]),
-            declaredMethodName,
-          );
-        } else if (/\bFOR\s+VALIDATE\s+ON\b/i.test(statement)) {
-          out.set(
-            requirementKey(targetHandlerClass, 'validation', entityBinding[2], entityBinding[1]),
-            declaredMethodName,
-          );
-        }
-        continue;
-      }
-
-      const authBinding = statement.match(/\bAUTHORIZATION\b.*\bFOR\s+([A-Za-z_]\w*)\s+RESULT\b/i);
-      if (authBinding?.[1]) {
-        if (/\bFOR\s+INSTANCE\s+AUTHORIZATION\b/i.test(statement)) {
-          out.set(
-            requirementKey(targetHandlerClass, 'instance_authorization', 'get_instance_authorizations', authBinding[1]),
-            declaredMethodName,
-          );
-        } else if (/\bFOR\s+GLOBAL\s+AUTHORIZATION\b/i.test(statement)) {
-          out.set(
-            requirementKey(targetHandlerClass, 'global_authorization', 'get_global_authorizations', authBinding[1]),
-            declaredMethodName,
-          );
-        }
-      }
+      const binding = parseHandlerDeclarationBinding(statement);
+      if (binding)
+        out.set(
+          bindingKey(targetHandlerClass, binding.kind, binding.methodName, binding.entityAlias),
+          declaredMethodName,
+        );
     }
   }
 
@@ -602,28 +640,13 @@ export function parseClassDefinitionMethods(source: string): Map<string, Set<str
 
       // Collect the full multi-line METHODS statement so FOR-clause patterns
       // (which usually sit on a continuation line) are visible to the regex.
-      let statement = line;
-      for (let j = i + 1; j <= range.end && j < i + 10; j += 1) {
-        const cont = lines[j] ?? '';
-        statement += ` ${cont}`;
-        if (/\.\s*$/.test(cont.trim())) break;
-      }
+      const statement = collectAbapStatement(lines, i, range.end);
 
-      // `FOR ACTION alias~name` — action bindings.
-      const actionBinding = statement.match(/\bFOR\s+ACTION\s+[A-Za-z_]\w*\s*~\s*([A-Za-z_]\w*)/i);
-      if (actionBinding?.[1]) methods.add(normalizeMethodName(actionBinding[1]));
-
-      // `FOR alias~name` (no ACTION keyword) — determinations/validations.
-      // Exclude the ACTION case (handled above) and FOR MODIFY / FOR READ etc.
-      const entityBinding = statement.match(
-        /\bFOR\s+(?!ACTION\b|MODIFY\b|READ\b|VALIDATE\b|DETERMINE\b|INSTANCE\b|GLOBAL\b)[A-Za-z_]\w*\s*~\s*([A-Za-z_]\w*)/i,
-      );
-      if (entityBinding?.[1]) methods.add(normalizeMethodName(entityBinding[1]));
-
-      // Authorization handlers have no alias~name binding — the BDEF side
-      // uses the fixed method names get_instance_authorizations /
-      // get_global_authorizations, so a literal method-name match already
-      // covers them (added at the top of this loop).
+      // Also index the BDEF-side binding key. This is different from the
+      // ABAP method name when developers use semantic names such as
+      // `set_status_accepted FOR ACTION travel~acceptTravel`.
+      const binding = parseHandlerDeclarationBinding(statement);
+      if (binding) methods.add(normalizeMethodName(binding.methodName));
     }
 
     out.set(key, methods);
@@ -668,7 +691,7 @@ export function findMissingRapHandlerImplementationStubs(
     const methods = classMethods.get(req.targetHandlerClass.toLowerCase());
     if (!methods) return true;
     const implementationMethodName =
-      declaredMethodByRequirement.get(keyForRequirement(req)) ?? normalizeMethodName(req.methodName);
+      declaredMethodByRequirement.get(rapHandlerRequirementKey(req)) ?? normalizeMethodName(req.methodName);
     return !methods.has(implementationMethodName);
   });
 }
@@ -804,7 +827,7 @@ export function applyRapHandlerImplementationStubs(
     const toInsert: Array<{ requirement: RapHandlerRequirement; implementationMethodName: string }> = [];
     for (const req of classRequirements) {
       const implementationMethodName =
-        declaredMethodByRequirement.get(keyForRequirement(req)) ?? normalizeMethodName(req.methodName);
+        declaredMethodByRequirement.get(rapHandlerRequirementKey(req)) ?? normalizeMethodName(req.methodName);
       if (seenMethods.has(implementationMethodName)) continue;
       seenMethods.add(implementationMethodName);
       toInsert.push({ requirement: req, implementationMethodName });
@@ -857,5 +880,122 @@ export function applyRapHandlerImplementationStubs(
     inserted,
     skipped,
     changed: inserted.length > 0,
+  };
+}
+
+function countInserted(results: RapHandlerSectionApplyResults): number {
+  return (
+    results.main.inserted.length +
+    (results.definitions?.inserted.length ?? 0) +
+    (results.implementations?.inserted.length ?? 0)
+  );
+}
+
+/**
+ * Build the complete auto-apply plan for a behavior pool without doing I/O.
+ *
+ * This is intentionally pure: the MCP handler owns safety checks, locks,
+ * linting, and ADT writes; this helper owns the RAP-specific sequencing:
+ *   1. insert missing METHODS declarations into whichever include contains
+ *      the matching `lhc_<alias> DEFINITION`
+ *   2. skip stubs whose declarations still could not be placed
+ *   3. insert empty METHOD stubs using the concrete ABAP method name from
+ *      existing/new declarations, including semantic names bound via
+ *      `FOR ACTION alias~ActionName`
+ *
+ * Keeping this plan here prevents `intent.ts` from duplicating RAP parser
+ * invariants such as "deferred classes are not editable" and "stub method
+ * names come from declarations, not necessarily from BDEF action names".
+ */
+export function applyRapHandlerScaffold(
+  sections: RapHandlerSourceSections,
+  missingSignatures: RapHandlerRequirement[],
+  missingImplementationStubs: RapHandlerRequirement[],
+): RapHandlerScaffoldPlan {
+  const applyMain = applyRapHandlerSignatures(sections.main, missingSignatures);
+  let pending = applyMain.skipped.map((entry) => entry.requirement);
+
+  let applyDefinitions: RapHandlerApplyResult | undefined;
+  if (pending.length > 0 && sections.definitions) {
+    applyDefinitions = applyRapHandlerSignatures(sections.definitions, pending);
+    pending = applyDefinitions.skipped.map((entry) => entry.requirement);
+  }
+
+  let applyImplementations: RapHandlerApplyResult | undefined;
+  if (pending.length > 0 && sections.implementations) {
+    applyImplementations = applyRapHandlerSignatures(sections.implementations, pending);
+    pending = applyImplementations.skipped.map((entry) => entry.requirement);
+  }
+
+  // A METHOD stub is only useful after its declaration exists. If the target
+  // `lhc_*` class was not found anywhere, suppress the stub for that unresolved
+  // declaration rather than creating an implementation block with no matching
+  // RAP handler signature.
+  const unresolvedDeclarationKeys = new Set(pending.map(rapHandlerRequirementKey));
+  const stubRequirements = missingImplementationStubs.filter(
+    (req) => !unresolvedDeclarationKeys.has(rapHandlerRequirementKey(req)),
+  );
+  const definitionLookupSource = [
+    applyMain.updatedSource,
+    applyDefinitions?.updatedSource ?? sections.definitions,
+    applyImplementations?.updatedSource ?? sections.implementations,
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+
+  const stubMain = applyRapHandlerImplementationStubs(applyMain.updatedSource, stubRequirements, {
+    createImplementationBlocks: true,
+    definitionSource: definitionLookupSource,
+  });
+  const stubDefinitions = sections.definitions
+    ? applyRapHandlerImplementationStubs(applyDefinitions?.updatedSource ?? sections.definitions, stubRequirements, {
+        definitionSource: definitionLookupSource,
+      })
+    : undefined;
+  const stubImplementations = sections.implementations
+    ? applyRapHandlerImplementationStubs(
+        applyImplementations?.updatedSource ?? sections.implementations,
+        stubRequirements,
+        { createImplementationBlocks: true, definitionSource: definitionLookupSource },
+      )
+    : undefined;
+
+  const changed = {
+    main: applyMain.changed || stubMain.changed,
+    definitions: (applyDefinitions?.changed ?? false) || (stubDefinitions?.changed ?? false),
+    implementations: (applyImplementations?.changed ?? false) || (stubImplementations?.changed ?? false),
+  };
+  const changedSections = (Object.keys(changed) as RapHandlerSectionName[]).filter((section) => changed[section]);
+
+  return {
+    sections: {
+      main: stubMain.updatedSource,
+      definitions: stubDefinitions?.updatedSource ?? applyDefinitions?.updatedSource ?? sections.definitions,
+      implementations:
+        stubImplementations?.updatedSource ?? applyImplementations?.updatedSource ?? sections.implementations,
+    },
+    signatures: {
+      main: applyMain,
+      definitions: applyDefinitions,
+      implementations: applyImplementations,
+    },
+    implementationStubs: {
+      main: stubMain,
+      definitions: stubDefinitions,
+      implementations: stubImplementations,
+    },
+    unresolved: pending,
+    changed,
+    changedSections,
+    insertedSignatureCount: countInserted({
+      main: applyMain,
+      definitions: applyDefinitions,
+      implementations: applyImplementations,
+    }),
+    insertedImplementationStubCount: countInserted({
+      main: stubMain,
+      definitions: stubDefinitions,
+      implementations: stubImplementations,
+    }),
   };
 }

--- a/src/adt/rap-handlers.ts
+++ b/src/adt/rap-handlers.ts
@@ -45,6 +45,19 @@ function countChar(value: string, char: string): number {
   return value.split(char).length - 1;
 }
 
+function collectStatement(lines: string[], startIdx: number): string {
+  let statement = lines[startIdx] ?? '';
+  if (statement.includes(';')) return statement;
+  for (let j = startIdx + 1; j < lines.length; j += 1) {
+    const next = lines[j] ?? '';
+    statement += ` ${next}`;
+    if (next.includes(';')) break;
+    // Safety cutoff: behavior blocks shouldn't have single statements > 20 lines.
+    if (j - startIdx > 20) break;
+  }
+  return statement;
+}
+
 function normalizeMethodName(name: string): string {
   return name.replace(/\.$/, '').trim().toLowerCase();
 }
@@ -137,10 +150,18 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
       const line = block.lines[idx] ?? '';
       const declarationLine = block.startLine + idx;
 
-      const actionMatch = line.match(/^\s*(?:internal\s+)?action(?:\s*\([^)]*\))?\s+([A-Za-z_]\w*)\b/i);
+      // Match: [static] [factory|internal] action [(features...)] <name>
+      // Examples: "action Foo", "internal action Foo", "factory action Foo",
+      //           "static factory action Foo", "action ( features: instance ) Foo".
+      const actionMatch = line.match(
+        /^\s*(?:static\s+)?(?:(?:internal|factory)\s+)*action(?:\s*\([^)]*\))?\s+([A-Za-z_]\w*)\b/i,
+      );
       if (actionMatch?.[1]) {
         const actionName = actionMatch[1];
         const methodName = normalizeMethodName(actionName);
+        const actionDecl = collectStatement(block.lines, idx);
+        const hasResult = /\bresult\b/i.test(actionDecl);
+        const resultPart = hasResult ? ' RESULT result' : '';
         pushRequirement(
           requirements,
           {
@@ -151,8 +172,7 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
             targetHandlerClass,
             declarationLine,
             signature:
-              `METHODS ${methodName} FOR MODIFY\n` +
-              `  IMPORTING keys FOR ACTION ${alias}~${actionName} RESULT result.`,
+              `METHODS ${methodName} FOR MODIFY\n` + `  IMPORTING keys FOR ACTION ${alias}~${actionName}${resultPart}.`,
           },
           seen,
         );

--- a/src/adt/rap-handlers.ts
+++ b/src/adt/rap-handlers.ts
@@ -76,6 +76,24 @@ interface ClassImplementationRange {
   end: number;
 }
 
+function requirementKey(
+  targetHandlerClass: string,
+  kind: RapHandlerKind,
+  methodName: string,
+  entityAlias: string,
+): string {
+  return [targetHandlerClass.toLowerCase(), kind, normalizeMethodName(methodName), entityAlias.toLowerCase()].join('|');
+}
+
+function keyForRequirement(requirement: RapHandlerRequirement): string {
+  return requirementKey(
+    requirement.targetHandlerClass,
+    requirement.kind,
+    requirement.methodName,
+    requirement.entityAlias,
+  );
+}
+
 function countChar(value: string, char: string): number {
   return value.split(char).length - 1;
 }
@@ -204,12 +222,7 @@ function parseBehaviorBlocks(source: string): RapBehaviorBlock[] {
 }
 
 function pushRequirement(out: RapHandlerRequirement[], requirement: RapHandlerRequirement, seen: Set<string>): void {
-  const key = [
-    requirement.targetHandlerClass.toLowerCase(),
-    requirement.kind,
-    normalizeMethodName(requirement.methodName),
-    requirement.entityAlias.toLowerCase(),
-  ].join('|');
+  const key = keyForRequirement(requirement);
   if (seen.has(key)) return;
   seen.add(key);
   out.push(requirement);
@@ -475,6 +488,81 @@ function parseClassImplementationMethods(source: string): Map<string, Set<string
 }
 
 /**
+ * Map BDEF requirement keys to the concrete ABAP method name used in the
+ * handler declaration.
+ *
+ * The generated method name for a BDEF action `acceptTravel` is `accepttravel`,
+ * but real behavior pools often declare semantic method names such as
+ * `set_status_accepted FOR ACTION travel~acceptTravel`. Stub detection and
+ * stub generation must use the declared ABAP method name, otherwise a pool
+ * that is already implemented under semantic names is reported as missing.
+ */
+function parseClassDefinitionHandlerBindings(source: string): Map<string, string> {
+  const lines = source.split('\n');
+  const ranges = parseClassDefinitionRanges(source);
+  const out = new Map<string, string>();
+
+  for (const range of ranges) {
+    const targetHandlerClass = range.name;
+
+    for (let i = range.start; i <= range.end; i += 1) {
+      const line = lines[i] ?? '';
+      const match = line.match(/^\s*(?:CLASS-)?METHODS\s+([A-Za-z_~][\w~]*)/i);
+      if (!match?.[1]) continue;
+      const declaredMethodName = normalizeMethodName(match[1]);
+
+      let statement = line;
+      for (let j = i + 1; j <= range.end && j < i + 10; j += 1) {
+        const cont = lines[j] ?? '';
+        statement += ` ${cont}`;
+        if (/\.\s*$/.test(cont.trim())) break;
+      }
+
+      const actionBinding = statement.match(/\bFOR\s+ACTION\s+([A-Za-z_]\w*)\s*~\s*([A-Za-z_]\w*)/i);
+      if (actionBinding?.[1] && actionBinding[2]) {
+        out.set(requirementKey(targetHandlerClass, 'action', actionBinding[2], actionBinding[1]), declaredMethodName);
+        continue;
+      }
+
+      const entityBinding = statement.match(
+        /\bFOR\s+(?!ACTION\b|MODIFY\b|READ\b|VALIDATE\b|DETERMINE\b|INSTANCE\b|GLOBAL\b)([A-Za-z_]\w*)\s*~\s*([A-Za-z_]\w*)/i,
+      );
+      if (entityBinding?.[1] && entityBinding[2]) {
+        if (/\bFOR\s+DETERMINE\s+ON\b/i.test(statement)) {
+          out.set(
+            requirementKey(targetHandlerClass, 'determination', entityBinding[2], entityBinding[1]),
+            declaredMethodName,
+          );
+        } else if (/\bFOR\s+VALIDATE\s+ON\b/i.test(statement)) {
+          out.set(
+            requirementKey(targetHandlerClass, 'validation', entityBinding[2], entityBinding[1]),
+            declaredMethodName,
+          );
+        }
+        continue;
+      }
+
+      const authBinding = statement.match(/\bAUTHORIZATION\b.*\bFOR\s+([A-Za-z_]\w*)\s+RESULT\b/i);
+      if (authBinding?.[1]) {
+        if (/\bFOR\s+INSTANCE\s+AUTHORIZATION\b/i.test(statement)) {
+          out.set(
+            requirementKey(targetHandlerClass, 'instance_authorization', 'get_instance_authorizations', authBinding[1]),
+            declaredMethodName,
+          );
+        } else if (/\bFOR\s+GLOBAL\s+AUTHORIZATION\b/i.test(statement)) {
+          out.set(
+            requirementKey(targetHandlerClass, 'global_authorization', 'get_global_authorizations', authBinding[1]),
+            declaredMethodName,
+          );
+        }
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
  * Parse method declarations (`METHODS ...`) per class definition.
  *
  * The returned Set contains BOTH:
@@ -574,11 +662,14 @@ export function findMissingRapHandlerImplementationStubs(
   classSource: string,
 ): RapHandlerRequirement[] {
   const classMethods = parseClassImplementationMethods(classSource);
+  const declaredMethodByRequirement = parseClassDefinitionHandlerBindings(classSource);
 
   return requirements.filter((req) => {
     const methods = classMethods.get(req.targetHandlerClass.toLowerCase());
     if (!methods) return true;
-    return !methods.has(normalizeMethodName(req.methodName));
+    const implementationMethodName =
+      declaredMethodByRequirement.get(keyForRequirement(req)) ?? normalizeMethodName(req.methodName);
+    return !methods.has(implementationMethodName);
   });
 }
 
@@ -681,7 +772,7 @@ export function applyRapHandlerSignatures(
 export function applyRapHandlerImplementationStubs(
   classSource: string,
   requirements: RapHandlerRequirement[],
-  options: { createImplementationBlocks?: boolean } = {},
+  options: { createImplementationBlocks?: boolean; definitionSource?: string } = {},
 ): RapHandlerApplyResult {
   if (requirements.length === 0) {
     return { updatedSource: classSource, inserted: [], skipped: [], changed: false };
@@ -691,6 +782,8 @@ export function applyRapHandlerImplementationStubs(
   const definitionRanges = parseClassDefinitionRanges(classSource);
   const implementationRanges = parseClassImplementationRanges(classSource);
   const methodsByClass = parseClassImplementationMethods(classSource);
+  const definitionLookupSource = options.definitionSource ? `${options.definitionSource}\n${classSource}` : classSource;
+  const declaredMethodByRequirement = parseClassDefinitionHandlerBindings(definitionLookupSource);
   const grouped = new Map<string, RapHandlerRequirement[]>();
 
   for (const req of requirements) {
@@ -707,15 +800,23 @@ export function applyRapHandlerImplementationStubs(
 
   for (const [targetClassName, classRequirements] of grouped.entries()) {
     const existingMethods = methodsByClass.get(targetClassName) ?? new Set<string>();
-    const toInsert = classRequirements.filter((req) => !existingMethods.has(normalizeMethodName(req.methodName)));
+    const seenMethods = new Set(existingMethods);
+    const toInsert: Array<{ requirement: RapHandlerRequirement; implementationMethodName: string }> = [];
+    for (const req of classRequirements) {
+      const implementationMethodName =
+        declaredMethodByRequirement.get(keyForRequirement(req)) ?? normalizeMethodName(req.methodName);
+      if (seenMethods.has(implementationMethodName)) continue;
+      seenMethods.add(implementationMethodName);
+      toInsert.push({ requirement: req, implementationMethodName });
+    }
     if (toInsert.length === 0) continue;
 
     const stubLines: string[] = [];
     for (let i = 0; i < toInsert.length; i += 1) {
-      const req = toInsert[i]!;
-      stubLines.push(`  METHOD ${normalizeMethodName(req.methodName)}.`, '  ENDMETHOD.');
+      const { requirement, implementationMethodName } = toInsert[i]!;
+      stubLines.push(`  METHOD ${implementationMethodName}.`, '  ENDMETHOD.');
       if (i < toInsert.length - 1) stubLines.push('');
-      inserted.push(req);
+      inserted.push(requirement);
     }
 
     const implementationRange = implementationRanges.find((r) => r.name.toLowerCase() === targetClassName);
@@ -733,10 +834,10 @@ export function applyRapHandlerImplementationStubs(
       continue;
     }
 
-    for (const req of toInsert) {
+    for (const { requirement } of toInsert) {
       skipped.push({
-        requirement: req,
-        reason: `Implementation class ${req.targetHandlerClass} not found in behavior pool.`,
+        requirement,
+        reason: `Implementation class ${requirement.targetHandlerClass} not found in behavior pool.`,
       });
     }
     inserted.splice(inserted.length - toInsert.length, toInsert.length);

--- a/src/adt/rap-handlers.ts
+++ b/src/adt/rap-handlers.ts
@@ -82,6 +82,18 @@ export interface RapHandlerScaffoldPlan {
   insertedImplementationStubCount: number;
 }
 
+interface RapHandlerDeclarationBinding {
+  kind: RapHandlerKind;
+  methodName: string;
+  entityAlias: string;
+}
+
+interface SignatureFallthroughPlan {
+  signatures: RapHandlerSectionApplyResults;
+  updatedSections: RapHandlerSourceSections;
+  unresolved: RapHandlerRequirement[];
+}
+
 interface RapBehaviorBlock {
   entityName: string;
   alias: string;
@@ -101,6 +113,36 @@ interface ClassImplementationRange {
   start: number;
   end: number;
 }
+
+// AI-maintenance guide:
+// If SAP adds or changes RAP handler syntax, update these parser patterns first,
+// then add one fixture-style test in tests/unit/adt/rap-handlers.test.ts. Keeping
+// the grammar fragments here avoids subtly divergent regexes in detection,
+// missing-checks, and auto-apply.
+const BDEF_DEFINE_BEHAVIOR_RE = /^\s*define\s+behavior\s+for\s+([^\s{]+)(?:\s+alias\s+([A-Za-z_]\w*))?/i;
+const BDEF_ACTION_DECLARATION_RE =
+  /^\s*(?:static\s+)?(?:(?:internal|factory)\s+)*action(?:\s*\([^)]*\))?\s+([A-Za-z_]\w*)\b/i;
+const BDEF_DETERMINATION_DECLARATION_RE = /^\s*determination\s+([A-Za-z_]\w*)\s+on\s+(modify|save)\b/i;
+const BDEF_VALIDATION_DECLARATION_RE = /^\s*validation\s+([A-Za-z_]\w*)\s+on\s+(modify|save)\b/i;
+const BDEF_INSTANCE_AUTH_RE = /\bauthorization\s+master\s*\(\s*instance\s*\)/i;
+const BDEF_GLOBAL_AUTH_RE = /\bauthorization\s+master\s*\(\s*global\s*\)/i;
+
+const CLASS_DEFINITION_START_RE = /^\s*CLASS\s+([A-Za-z_][\w$]*)\s+DEFINITION\b/i;
+const CLASS_DEFINITION_DEFERRED_RE = /\bDEFINITION\b.*\bDEFERRED\b/i;
+const CLASS_IMPLEMENTATION_START_RE = /^\s*CLASS\s+([A-Za-z_][\w$]*)\s+IMPLEMENTATION\s*\./i;
+const PRIVATE_SECTION_RE = /^\s*PRIVATE\s+SECTION\./i;
+const ENDCLASS_RE = /^\s*ENDCLASS\./i;
+const METHOD_DECLARATION_RE = /^\s*(?:CLASS-)?METHODS\s+([A-Za-z_~][\w~]*)/i;
+const METHOD_IMPLEMENTATION_RE = /^\s*METHOD\s+([A-Za-z_~][\w~]*)\s*\./i;
+
+const HANDLER_ACTION_BINDING_RE = /\bFOR\s+ACTION\s+([A-Za-z_]\w*)\s*~\s*([A-Za-z_]\w*)/i;
+const HANDLER_ENTITY_BINDING_RE =
+  /\bFOR\s+(?!ACTION\b|MODIFY\b|READ\b|VALIDATE\b|DETERMINE\b|INSTANCE\b|GLOBAL\b)([A-Za-z_]\w*)\s*~\s*([A-Za-z_]\w*)/i;
+const HANDLER_AUTH_BINDING_RE = /\bAUTHORIZATION\b.*\bFOR\s+([A-Za-z_]\w*)\s+RESULT\b/i;
+const HANDLER_DETERMINE_STATEMENT_RE = /\bFOR\s+DETERMINE\s+ON\b/i;
+const HANDLER_VALIDATE_STATEMENT_RE = /\bFOR\s+VALIDATE\s+ON\b/i;
+const HANDLER_INSTANCE_AUTH_STATEMENT_RE = /\bFOR\s+INSTANCE\s+AUTHORIZATION\b/i;
+const HANDLER_GLOBAL_AUTH_STATEMENT_RE = /\bFOR\s+GLOBAL\s+AUTHORIZATION\b/i;
 
 function bindingKey(targetHandlerClass: string, kind: RapHandlerKind, methodName: string, entityAlias: string): string {
   return [targetHandlerClass.toLowerCase(), kind, normalizeMethodName(methodName), entityAlias.toLowerCase()].join('|');
@@ -223,7 +265,7 @@ function parseBehaviorBlocks(source: string): RapBehaviorBlock[] {
     const line = lines[i] ?? '';
 
     if (!current) {
-      const defineMatch = line.match(/^\s*define\s+behavior\s+for\s+([^\s{]+)(?:\s+alias\s+([A-Za-z_]\w*))?/i);
+      const defineMatch = line.match(BDEF_DEFINE_BEHAVIOR_RE);
       if (!defineMatch) continue;
 
       const entityName = defineMatch[1] ?? '';
@@ -261,6 +303,21 @@ function pushRequirement(out: RapHandlerRequirement[], requirement: RapHandlerRe
   if (seen.has(key)) return;
   seen.add(key);
   out.push(requirement);
+}
+
+function groupRequirementsByTargetClass(requirements: RapHandlerRequirement[]): Map<string, RapHandlerRequirement[]> {
+  const grouped = new Map<string, RapHandlerRequirement[]>();
+  for (const req of requirements) {
+    const key = req.targetHandlerClass.toLowerCase();
+    const list = grouped.get(key) ?? [];
+    list.push(req);
+    grouped.set(key, list);
+  }
+  return grouped;
+}
+
+function hasActionResultClause(actionDeclaration: string): boolean {
+  return /\bresult\b/i.test(actionDeclaration);
 }
 
 /**
@@ -303,9 +360,7 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
       //     `action` and the action name — `action ( features: instance ) Foo`
       // Missing any of these prefixes used to silently drop the requirement,
       // which was the original bug on live /DMO/BP_TRAVEL_M samples.
-      const actionMatch = line.match(
-        /^\s*(?:static\s+)?(?:(?:internal|factory)\s+)*action(?:\s*\([^)]*\))?\s+([A-Za-z_]\w*)\b/i,
-      );
+      const actionMatch = line.match(BDEF_ACTION_DECLARATION_RE);
       if (actionMatch?.[1]) {
         const actionName = actionMatch[1];
         const methodName = normalizeMethodName(actionName);
@@ -317,7 +372,7 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
         // carry RESULT in the handler signature — the activation check is strict
         // and rejects mismatched signatures with a cryptic "method signature
         // does not match BDL declaration" error.
-        const hasResult = /\bresult\b/i.test(actionDecl);
+        const hasResult = hasActionResultClause(actionDecl);
         const resultPart = hasResult ? ' RESULT result' : '';
         pushRequirement(
           requirements,
@@ -335,7 +390,7 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
         );
       }
 
-      const determinationMatch = line.match(/^\s*determination\s+([A-Za-z_]\w*)\s+on\s+(modify|save)\b/i);
+      const determinationMatch = line.match(BDEF_DETERMINATION_DECLARATION_RE);
       if (determinationMatch?.[1] && determinationMatch[2]) {
         const determinationName = determinationMatch[1];
         const event = determinationMatch[2].toUpperCase();
@@ -357,7 +412,7 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
         );
       }
 
-      const validationMatch = line.match(/^\s*validation\s+([A-Za-z_]\w*)\s+on\s+(modify|save)\b/i);
+      const validationMatch = line.match(BDEF_VALIDATION_DECLARATION_RE);
       if (validationMatch?.[1] && validationMatch[2]) {
         const validationName = validationMatch[1];
         const event = validationMatch[2].toUpperCase();
@@ -382,7 +437,7 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
     // `authorization master ( instance )` → the pool must implement
     // get_instance_authorizations (per-instance row-level checks, imports
     // keys so the handler can evaluate each row individually).
-    const instanceAuthMatch = body.match(/\bauthorization\s+master\s*\(\s*instance\s*\)/i);
+    const instanceAuthMatch = body.match(BDEF_INSTANCE_AUTH_RE);
     if (instanceAuthMatch) {
       pushRequirement(
         requirements,
@@ -404,7 +459,7 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
     // `authorization master ( global )` → the pool must implement
     // get_global_authorizations (a single, stateless check for the whole
     // entity; no keys parameter because the decision is not per-row).
-    const globalAuthMatch = body.match(/\bauthorization\s+master\s*\(\s*global\s*\)/i);
+    const globalAuthMatch = body.match(BDEF_GLOBAL_AUTH_RE);
     if (globalAuthMatch) {
       pushRequirement(
         requirements,
@@ -448,21 +503,21 @@ function parseClassDefinitionRanges(source: string): ClassDefinitionRange[] {
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? '';
-    const startMatch = line.match(/^\s*CLASS\s+([A-Za-z_][\w$]*)\s+DEFINITION\b/i);
+    const startMatch = line.match(CLASS_DEFINITION_START_RE);
     if (!startMatch?.[1]) continue;
 
     const name = startMatch[1];
-    const isDeferred = /\bDEFINITION\b.*\bDEFERRED\b/i.test(line);
+    const isDeferred = CLASS_DEFINITION_DEFERRED_RE.test(line);
     if (isDeferred) continue;
 
     let end = i;
     let privateSection: number | undefined;
     for (let j = i + 1; j < lines.length; j += 1) {
       const inner = lines[j] ?? '';
-      if (privateSection === undefined && /^\s*PRIVATE\s+SECTION\./i.test(inner)) {
+      if (privateSection === undefined && PRIVATE_SECTION_RE.test(inner)) {
         privateSection = j;
       }
-      if (/^\s*ENDCLASS\./i.test(inner)) {
+      if (ENDCLASS_RE.test(inner)) {
         end = j;
         break;
       }
@@ -481,14 +536,14 @@ function parseClassImplementationRanges(source: string): ClassImplementationRang
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? '';
-    const startMatch = line.match(/^\s*CLASS\s+([A-Za-z_][\w$]*)\s+IMPLEMENTATION\s*\./i);
+    const startMatch = line.match(CLASS_IMPLEMENTATION_START_RE);
     if (!startMatch?.[1]) continue;
 
     const name = startMatch[1];
     let end = i;
     for (let j = i + 1; j < lines.length; j += 1) {
       const inner = lines[j] ?? '';
-      if (/^\s*ENDCLASS\./i.test(inner)) {
+      if (ENDCLASS_RE.test(inner)) {
         end = j;
         break;
       }
@@ -512,7 +567,7 @@ function parseClassImplementationMethods(source: string): Map<string, Set<string
 
     for (let i = range.start; i <= range.end; i += 1) {
       const line = lines[i] ?? '';
-      const match = line.match(/^\s*METHOD\s+([A-Za-z_~][\w~]*)\s*\./i);
+      const match = line.match(METHOD_IMPLEMENTATION_RE);
       if (match?.[1]) methods.add(normalizeMethodName(match[1]));
     }
 
@@ -522,36 +577,32 @@ function parseClassImplementationMethods(source: string): Map<string, Set<string
   return out;
 }
 
-function parseHandlerDeclarationBinding(
-  statement: string,
-): { kind: RapHandlerKind; methodName: string; entityAlias: string } | undefined {
-  const actionBinding = statement.match(/\bFOR\s+ACTION\s+([A-Za-z_]\w*)\s*~\s*([A-Za-z_]\w*)/i);
+function parseHandlerDeclarationBinding(statement: string): RapHandlerDeclarationBinding | undefined {
+  const actionBinding = statement.match(HANDLER_ACTION_BINDING_RE);
   if (actionBinding?.[1] && actionBinding[2]) {
     return { kind: 'action', entityAlias: actionBinding[1], methodName: actionBinding[2] };
   }
 
-  const entityBinding = statement.match(
-    /\bFOR\s+(?!ACTION\b|MODIFY\b|READ\b|VALIDATE\b|DETERMINE\b|INSTANCE\b|GLOBAL\b)([A-Za-z_]\w*)\s*~\s*([A-Za-z_]\w*)/i,
-  );
+  const entityBinding = statement.match(HANDLER_ENTITY_BINDING_RE);
   if (entityBinding?.[1] && entityBinding[2]) {
-    if (/\bFOR\s+DETERMINE\s+ON\b/i.test(statement)) {
+    if (HANDLER_DETERMINE_STATEMENT_RE.test(statement)) {
       return { kind: 'determination', entityAlias: entityBinding[1], methodName: entityBinding[2] };
     }
-    if (/\bFOR\s+VALIDATE\s+ON\b/i.test(statement)) {
+    if (HANDLER_VALIDATE_STATEMENT_RE.test(statement)) {
       return { kind: 'validation', entityAlias: entityBinding[1], methodName: entityBinding[2] };
     }
   }
 
-  const authBinding = statement.match(/\bAUTHORIZATION\b.*\bFOR\s+([A-Za-z_]\w*)\s+RESULT\b/i);
+  const authBinding = statement.match(HANDLER_AUTH_BINDING_RE);
   if (authBinding?.[1]) {
-    if (/\bFOR\s+INSTANCE\s+AUTHORIZATION\b/i.test(statement)) {
+    if (HANDLER_INSTANCE_AUTH_STATEMENT_RE.test(statement)) {
       return {
         kind: 'instance_authorization',
         entityAlias: authBinding[1],
         methodName: 'get_instance_authorizations',
       };
     }
-    if (/\bFOR\s+GLOBAL\s+AUTHORIZATION\b/i.test(statement)) {
+    if (HANDLER_GLOBAL_AUTH_STATEMENT_RE.test(statement)) {
       return {
         kind: 'global_authorization',
         entityAlias: authBinding[1],
@@ -583,7 +634,7 @@ function parseClassDefinitionHandlerBindings(source: string): Map<string, string
 
     for (let i = range.start; i <= range.end; i += 1) {
       const line = lines[i] ?? '';
-      const match = line.match(/^\s*(?:CLASS-)?METHODS\s+([A-Za-z_~][\w~]*)/i);
+      const match = line.match(METHOD_DECLARATION_RE);
       if (!match?.[1]) continue;
       const declaredMethodName = normalizeMethodName(match[1]);
       const statement = collectAbapStatement(lines, i, range.end);
@@ -634,7 +685,7 @@ export function parseClassDefinitionMethods(source: string): Map<string, Set<str
 
     for (let i = range.start; i <= range.end; i += 1) {
       const line = lines[i] ?? '';
-      const match = line.match(/^\s*(?:CLASS-)?METHODS\s+([A-Za-z_~][\w~]*)/i);
+      const match = line.match(METHOD_DECLARATION_RE);
       if (!match?.[1]) continue;
       methods.add(normalizeMethodName(match[1]));
 
@@ -725,14 +776,7 @@ export function applyRapHandlerSignatures(
   const lines = classSource.split('\n');
   const ranges = parseClassDefinitionRanges(classSource);
   const methodsByClass = parseClassDefinitionMethods(classSource);
-  const grouped = new Map<string, RapHandlerRequirement[]>();
-
-  for (const req of requirements) {
-    const key = req.targetHandlerClass.toLowerCase();
-    const list = grouped.get(key) ?? [];
-    list.push(req);
-    grouped.set(key, list);
-  }
+  const grouped = groupRequirementsByTargetClass(requirements);
 
   type Edit = { index: number; lines: string[] };
   const edits: Edit[] = [];
@@ -807,14 +851,7 @@ export function applyRapHandlerImplementationStubs(
   const methodsByClass = parseClassImplementationMethods(classSource);
   const definitionLookupSource = options.definitionSource ? `${options.definitionSource}\n${classSource}` : classSource;
   const declaredMethodByRequirement = parseClassDefinitionHandlerBindings(definitionLookupSource);
-  const grouped = new Map<string, RapHandlerRequirement[]>();
-
-  for (const req of requirements) {
-    const key = req.targetHandlerClass.toLowerCase();
-    const list = grouped.get(key) ?? [];
-    list.push(req);
-    grouped.set(key, list);
-  }
+  const grouped = groupRequirementsByTargetClass(requirements);
 
   type Edit = { index: number; lines: string[] };
   const edits: Edit[] = [];
@@ -891,6 +928,69 @@ function countInserted(results: RapHandlerSectionApplyResults): number {
   );
 }
 
+function changedSectionsFrom(changed: Record<RapHandlerSectionName, boolean>): RapHandlerSectionName[] {
+  return (Object.keys(changed) as RapHandlerSectionName[]).filter((section) => changed[section]);
+}
+
+/**
+ * Build the source used to resolve semantic method names while creating stubs.
+ *
+ * The declaration (`METHODS set_status_accepted FOR ACTION travel~acceptTravel`)
+ * and implementation (`METHOD set_status_accepted.`) can live in different ADT
+ * includes. Stub generation therefore needs the post-signature sources for all
+ * sections, not only the include currently being edited.
+ */
+function buildDefinitionLookupSource(
+  originalSections: RapHandlerSourceSections,
+  signaturePlan: SignatureFallthroughPlan,
+): string {
+  return [
+    signaturePlan.updatedSections.main,
+    signaturePlan.updatedSections.definitions ?? originalSections.definitions,
+    signaturePlan.updatedSections.implementations ?? originalSections.implementations,
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+/**
+ * Try signature insertion in ADT include order: main → definitions → implementations.
+ *
+ * A handler class can legally exist in any of these includes depending on how
+ * ADT generated the behavior pool. The unresolved list is deliberately carried
+ * forward between sections so a requirement is inserted exactly once, in the
+ * first include that contains its concrete `lhc_<alias> DEFINITION`.
+ */
+function applySignaturesAcrossSections(
+  sections: RapHandlerSourceSections,
+  missingSignatures: RapHandlerRequirement[],
+): SignatureFallthroughPlan {
+  const main = applyRapHandlerSignatures(sections.main, missingSignatures);
+  let unresolved = main.skipped.map((entry) => entry.requirement);
+
+  let definitions: RapHandlerApplyResult | undefined;
+  if (unresolved.length > 0 && sections.definitions) {
+    definitions = applyRapHandlerSignatures(sections.definitions, unresolved);
+    unresolved = definitions.skipped.map((entry) => entry.requirement);
+  }
+
+  let implementations: RapHandlerApplyResult | undefined;
+  if (unresolved.length > 0 && sections.implementations) {
+    implementations = applyRapHandlerSignatures(sections.implementations, unresolved);
+    unresolved = implementations.skipped.map((entry) => entry.requirement);
+  }
+
+  return {
+    signatures: { main, definitions, implementations },
+    updatedSections: {
+      main: main.updatedSource,
+      definitions: definitions?.updatedSource ?? sections.definitions,
+      implementations: implementations?.updatedSource ?? sections.implementations,
+    },
+    unresolved,
+  };
+}
+
 /**
  * Build the complete auto-apply plan for a behavior pool without doing I/O.
  *
@@ -912,86 +1012,63 @@ export function applyRapHandlerScaffold(
   missingSignatures: RapHandlerRequirement[],
   missingImplementationStubs: RapHandlerRequirement[],
 ): RapHandlerScaffoldPlan {
-  const applyMain = applyRapHandlerSignatures(sections.main, missingSignatures);
-  let pending = applyMain.skipped.map((entry) => entry.requirement);
-
-  let applyDefinitions: RapHandlerApplyResult | undefined;
-  if (pending.length > 0 && sections.definitions) {
-    applyDefinitions = applyRapHandlerSignatures(sections.definitions, pending);
-    pending = applyDefinitions.skipped.map((entry) => entry.requirement);
-  }
-
-  let applyImplementations: RapHandlerApplyResult | undefined;
-  if (pending.length > 0 && sections.implementations) {
-    applyImplementations = applyRapHandlerSignatures(sections.implementations, pending);
-    pending = applyImplementations.skipped.map((entry) => entry.requirement);
-  }
+  const signaturePlan = applySignaturesAcrossSections(sections, missingSignatures);
 
   // A METHOD stub is only useful after its declaration exists. If the target
   // `lhc_*` class was not found anywhere, suppress the stub for that unresolved
   // declaration rather than creating an implementation block with no matching
   // RAP handler signature.
-  const unresolvedDeclarationKeys = new Set(pending.map(rapHandlerRequirementKey));
+  const unresolvedDeclarationKeys = new Set(signaturePlan.unresolved.map(rapHandlerRequirementKey));
   const stubRequirements = missingImplementationStubs.filter(
     (req) => !unresolvedDeclarationKeys.has(rapHandlerRequirementKey(req)),
   );
-  const definitionLookupSource = [
-    applyMain.updatedSource,
-    applyDefinitions?.updatedSource ?? sections.definitions,
-    applyImplementations?.updatedSource ?? sections.implementations,
-  ]
-    .filter(Boolean)
-    .join('\n\n');
+  const definitionLookupSource = buildDefinitionLookupSource(sections, signaturePlan);
 
-  const stubMain = applyRapHandlerImplementationStubs(applyMain.updatedSource, stubRequirements, {
+  const stubMain = applyRapHandlerImplementationStubs(signaturePlan.updatedSections.main, stubRequirements, {
     createImplementationBlocks: true,
     definitionSource: definitionLookupSource,
   });
   const stubDefinitions = sections.definitions
-    ? applyRapHandlerImplementationStubs(applyDefinitions?.updatedSource ?? sections.definitions, stubRequirements, {
-        definitionSource: definitionLookupSource,
-      })
+    ? applyRapHandlerImplementationStubs(
+        signaturePlan.updatedSections.definitions ?? sections.definitions,
+        stubRequirements,
+        {
+          definitionSource: definitionLookupSource,
+        },
+      )
     : undefined;
   const stubImplementations = sections.implementations
     ? applyRapHandlerImplementationStubs(
-        applyImplementations?.updatedSource ?? sections.implementations,
+        signaturePlan.updatedSections.implementations ?? sections.implementations,
         stubRequirements,
         { createImplementationBlocks: true, definitionSource: definitionLookupSource },
       )
     : undefined;
 
   const changed = {
-    main: applyMain.changed || stubMain.changed,
-    definitions: (applyDefinitions?.changed ?? false) || (stubDefinitions?.changed ?? false),
-    implementations: (applyImplementations?.changed ?? false) || (stubImplementations?.changed ?? false),
+    main: signaturePlan.signatures.main.changed || stubMain.changed,
+    definitions: (signaturePlan.signatures.definitions?.changed ?? false) || (stubDefinitions?.changed ?? false),
+    implementations:
+      (signaturePlan.signatures.implementations?.changed ?? false) || (stubImplementations?.changed ?? false),
   };
-  const changedSections = (Object.keys(changed) as RapHandlerSectionName[]).filter((section) => changed[section]);
+  const changedSections = changedSectionsFrom(changed);
 
   return {
     sections: {
       main: stubMain.updatedSource,
-      definitions: stubDefinitions?.updatedSource ?? applyDefinitions?.updatedSource ?? sections.definitions,
-      implementations:
-        stubImplementations?.updatedSource ?? applyImplementations?.updatedSource ?? sections.implementations,
+      definitions: stubDefinitions?.updatedSource ?? signaturePlan.updatedSections.definitions,
+      implementations: stubImplementations?.updatedSource ?? signaturePlan.updatedSections.implementations,
     },
-    signatures: {
-      main: applyMain,
-      definitions: applyDefinitions,
-      implementations: applyImplementations,
-    },
+    signatures: signaturePlan.signatures,
     implementationStubs: {
       main: stubMain,
       definitions: stubDefinitions,
       implementations: stubImplementations,
     },
-    unresolved: pending,
+    unresolved: signaturePlan.unresolved,
     changed,
     changedSections,
-    insertedSignatureCount: countInserted({
-      main: applyMain,
-      definitions: applyDefinitions,
-      implementations: applyImplementations,
-    }),
+    insertedSignatureCount: countInserted(signaturePlan.signatures),
     insertedImplementationStubCount: countInserted({
       main: stubMain,
       definitions: stubDefinitions,

--- a/src/adt/rap-handlers.ts
+++ b/src/adt/rap-handlers.ts
@@ -1,3 +1,30 @@
+/**
+ * RAP behavior-pool handler scaffolding.
+ *
+ * Context — this module exists because on-prem RAP development has a tight
+ * contract between a BDEF (behavior definition source) and its behavior pool
+ * (the ABAP global class named in `managed implementation in class ZBP_...`).
+ * Every `action` / `determination` / `validation` / `authorization master`
+ * declared in the BDEF requires a matching METHOD signature inside a local
+ * handler class (`lhc_<alias>`). If any signature is missing, the class will
+ * not activate and the error reported by ADT doesn't tell the developer
+ * which signatures are missing — they see a generic "behavior pool does not
+ * implement the required method for ..." message.
+ *
+ * The three exported helpers cooperate:
+ *   1. extractRapHandlerRequirements     — parse BDEF → list of required methods
+ *   2. findMissingRapHandlerRequirements — diff required vs. present in class
+ *   3. applyRapHandlerSignatures         — insert the missing METHODS lines
+ *
+ * The scaffolder never writes implementations — it only declares signatures.
+ * That keeps the scaffold deterministic and safe to run on existing pools.
+ *
+ * Naming convention: handler classes use the prefix `lhc_` (local handler
+ * class) followed by the lowercased alias from the BDEF. This is the RAP
+ * convention SAP's own templates use (see cl_abap_behavior_handler examples
+ * in /DMO/* and the "Create Behavior Implementation Class" wizard in ADT).
+ */
+
 export type RapHandlerKind =
   | 'action'
   | 'determination'
@@ -45,6 +72,20 @@ function countChar(value: string, char: string): number {
   return value.split(char).length - 1;
 }
 
+/**
+ * Collect a BDEF statement that may span multiple lines.
+ *
+ * RAP behavior definitions are terminated by `;`, but developers routinely
+ * split long declarations across lines for readability, e.g.:
+ *     action acceptTravel
+ *       result [1] $self;
+ * We must join the continuation lines before deciding whether a `result`
+ * clause is present — otherwise we'd emit `FOR ACTION ... RESULT result` for
+ * actions that don't return anything, producing an invalid handler signature.
+ *
+ * The 20-line safety cutoff guards against runaway scans when the BDEF is
+ * malformed or truncated; real declarations rarely exceed 5-6 lines.
+ */
 function collectStatement(lines: string[], startIdx: number): string {
   let statement = lines[startIdx] ?? '';
   if (statement.includes(';')) return statement;
@@ -52,16 +93,34 @@ function collectStatement(lines: string[], startIdx: number): string {
     const next = lines[j] ?? '';
     statement += ` ${next}`;
     if (next.includes(';')) break;
-    // Safety cutoff: behavior blocks shouldn't have single statements > 20 lines.
     if (j - startIdx > 20) break;
   }
   return statement;
 }
 
+/**
+ * Lowercase a BDEF identifier for use as an ABAP METHOD name.
+ *
+ * BDEF is case-insensitive for identifier matching but ABAP source code is
+ * rendered in lowercase by SAP's pretty printer. We emit lowercase here so
+ * the scaffolded METHODS lines match both the `lhc_<alias>` class name and
+ * SAP's default code-style. The trailing period (from a terminating `.` or
+ * `;` accidentally included by the regex match) is stripped defensively.
+ */
 function normalizeMethodName(name: string): string {
   return name.replace(/\.$/, '').trim().toLowerCase();
 }
 
+/**
+ * Derive an alias from an entity name when the BDEF author omits `alias X`.
+ *
+ * RAP aliases are optional; if absent, SAP falls back to the entity name
+ * itself for handler-class derivation. We emulate that by stripping namespace
+ * prefixes (`/DMO/ZI_TRAVEL` → `ZI_TRAVEL`) and a short leading prefix like
+ * `ZI_` or `I_` (→ `TRAVEL`), then sanitizing any leftover non-identifier
+ * characters. Final fallback is `Entity` so the generated `lhc_entity`
+ * remains a valid ABAP identifier.
+ */
 function deriveAlias(entityName: string): string {
   const noNamespace = entityName.split('/').at(-1) ?? entityName;
   const noPrefix = noNamespace.replace(/^[A-Z]{1,4}_/, '');
@@ -69,6 +128,21 @@ function deriveAlias(entityName: string): string {
   return normalized || 'Entity';
 }
 
+/**
+ * Split a BDEF into per-entity blocks bounded by `define behavior for ... { ... }`.
+ *
+ * A single interface BDEF can declare behavior for multiple entities
+ * (root + compositions), and each block has its own alias, its own actions,
+ * and produces its own `lhc_<alias>` handler class. We need the block
+ * boundaries so that an action declared under entity A isn't attributed to
+ * entity B's handler class.
+ *
+ * We track brace depth rather than simply splitting on `define behavior` so
+ * nested `{ ... }` inside features/draft/etag clauses doesn't close the block
+ * prematurely. `seenOpening` avoids closing a block before the first `{` is
+ * consumed — `define behavior for X` and the opening brace may be on
+ * separate lines.
+ */
 function parseBehaviorBlocks(source: string): RapBehaviorBlock[] {
   const blocks: RapBehaviorBlock[] = [];
   const lines = source.split('\n');
@@ -135,6 +209,17 @@ function pushRequirement(out: RapHandlerRequirement[], requirement: RapHandlerRe
 
 /**
  * Extract RAP behavior-pool handler method requirements from interface BDEF source.
+ *
+ * For every behavior block (one per entity in the BDEF), this produces the
+ * exact METHOD signatures that the behavior pool's `lhc_<alias>` class must
+ * declare for the class to activate. The output is used by:
+ *   - findMissingRapHandlerRequirements: to diff against an existing class
+ *   - applyRapHandlerSignatures: to synthesize the missing METHODS lines
+ *
+ * The emitted signatures mirror what SAP's "Create Behavior Implementation"
+ * wizard would generate — same FOR MODIFY/FOR DETERMINE ON/FOR VALIDATE ON
+ * syntax, same `alias~method` entity reference, same RESULT clause only when
+ * the BDEF declares a `result` cardinality.
  */
 export function extractRapHandlerRequirements(bdefSource: string): RapHandlerRequirement[] {
   const requirements: RapHandlerRequirement[] = [];
@@ -143,6 +228,9 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
 
   for (const block of blocks) {
     const alias = block.alias;
+    // RAP convention: one handler class per entity, named lhc_<alias>.
+    // This matches SAP's own templates and the ADT "Create Behavior
+    // Implementation Class" wizard — see /DMO/BP_TRAVEL_M and similar.
     const targetHandlerClass = `lhc_${alias.toLowerCase()}`;
     const body = block.lines.join('\n');
 
@@ -150,16 +238,29 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
       const line = block.lines[idx] ?? '';
       const declarationLine = block.startLine + idx;
 
-      // Match: [static] [factory|internal] action [(features...)] <name>
-      // Examples: "action Foo", "internal action Foo", "factory action Foo",
-      //           "static factory action Foo", "action ( features: instance ) Foo".
+      // Match all BDEF action variants. Order of the optional prefixes matters:
+      //   - `static` can appear alone or before `factory`: `static action`,
+      //     `static factory action`
+      //   - `internal` and `factory` are mutually exclusive but each may
+      //     appear after `static`: `internal action`, `factory action`
+      //   - the optional `( features: ... )` clause sits between the keyword
+      //     `action` and the action name — `action ( features: instance ) Foo`
+      // Missing any of these prefixes used to silently drop the requirement,
+      // which was the original bug on live /DMO/BP_TRAVEL_M samples.
       const actionMatch = line.match(
         /^\s*(?:static\s+)?(?:(?:internal|factory)\s+)*action(?:\s*\([^)]*\))?\s+([A-Za-z_]\w*)\b/i,
       );
       if (actionMatch?.[1]) {
         const actionName = actionMatch[1];
         const methodName = normalizeMethodName(actionName);
+        // Collapse continuation lines so the `result` clause is visible even
+        // when the author split the declaration across multiple lines.
         const actionDecl = collectStatement(block.lines, idx);
+        // Emit `RESULT result` only when the BDEF declares a result cardinality.
+        // Factory/internal/static actions without a result clause must NOT
+        // carry RESULT in the handler signature — the activation check is strict
+        // and rejects mismatched signatures with a cryptic "method signature
+        // does not match BDL declaration" error.
         const hasResult = /\bresult\b/i.test(actionDecl);
         const resultPart = hasResult ? ' RESULT result' : '';
         pushRequirement(
@@ -222,6 +323,9 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
       }
     }
 
+    // `authorization master ( instance )` → the pool must implement
+    // get_instance_authorizations (per-instance row-level checks, imports
+    // keys so the handler can evaluate each row individually).
     const instanceAuthMatch = body.match(/\bauthorization\s+master\s*\(\s*instance\s*\)/i);
     if (instanceAuthMatch) {
       pushRequirement(
@@ -241,6 +345,9 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
       );
     }
 
+    // `authorization master ( global )` → the pool must implement
+    // get_global_authorizations (a single, stateless check for the whole
+    // entity; no keys parameter because the decision is not per-row).
     const globalAuthMatch = body.match(/\bauthorization\s+master\s*\(\s*global\s*\)/i);
     if (globalAuthMatch) {
       pushRequirement(
@@ -264,6 +371,21 @@ export function extractRapHandlerRequirements(bdefSource: string): RapHandlerReq
   return requirements;
 }
 
+/**
+ * Find every `CLASS ... DEFINITION` block in an ABAP source, returning the
+ * line index range and — if present — the line index of PRIVATE SECTION.
+ *
+ * Behavior pool sources frequently contain:
+ *   - multiple concrete handler classes (`lhc_travel`, `lhc_booking`, ...)
+ *   - deferred declarations (`CLASS lhc_travel DEFINITION DEFERRED.`) used
+ *     to satisfy forward references in the implementation section; these
+ *     have no matching ENDCLASS and must not be confused with the real
+ *     definition that follows later in the same file
+ *
+ * The `i = end` advance at the bottom skips past the ENDCLASS of the class
+ * we just processed, so the outer loop doesn't re-enter the same class and
+ * double-register ranges.
+ */
 function parseClassDefinitionRanges(source: string): ClassDefinitionRange[] {
   const lines = source.split('\n');
   const ranges: ClassDefinitionRange[] = [];
@@ -277,6 +399,8 @@ function parseClassDefinitionRanges(source: string): ClassDefinitionRange[] {
     const isDeferred = /\bDEFINITION\b.*\bDEFERRED\b/i.test(line);
     if (isDeferred) {
       // Deferred declarations are single-line declarations without ENDCLASS.
+      // Record the range at the same index so a later concrete definition of
+      // the same class gets its own entry and isn't shadowed here.
       ranges.push({ name, start: i, end: i });
       continue;
     }
@@ -303,6 +427,26 @@ function parseClassDefinitionRanges(source: string): ClassDefinitionRange[] {
 
 /**
  * Parse method declarations (`METHODS ...`) per class definition.
+ *
+ * The returned Set contains BOTH:
+ *   1. Every declared METHOD name in the class (e.g. `submitforapproval`,
+ *      `set_status_accepted`, `validate_customer`)
+ *   2. Every RAP binding-key those methods are bound to (the action /
+ *      determination / validation / authorization referenced in the
+ *      `FOR ACTION <alias>~<name>` / `FOR <alias>~<name>` /
+ *      `FOR INSTANCE AUTHORIZATION ... FOR <alias>` clauses)
+ *
+ * Why both? Hand-crafted behavior pools (like SAP's own /DMO/BP_TRAVEL_M)
+ * routinely use semantic method names that differ from the BDEF action
+ * names — e.g. BDEF `action acceptTravel` bound to METHOD
+ * `set_status_accepted` via `FOR ACTION travel~acceptTravel`. The
+ * scaffolder's missing-requirement check compares by BDEF identifier, so if
+ * we only indexed method names, it would incorrectly report
+ * `accepttravel` as missing and try to inject a duplicate METHOD line.
+ *
+ * METHOD declarations can span multiple lines (one line for the name +
+ * continuation lines for FOR / IMPORTING / RESULT), so we join the
+ * statement up to its terminating `.` before pattern-matching the binding.
  */
 export function parseClassDefinitionMethods(source: string): Map<string, Set<string>> {
   const lines = source.split('\n');
@@ -318,6 +462,31 @@ export function parseClassDefinitionMethods(source: string): Map<string, Set<str
       const match = line.match(/^\s*(?:CLASS-)?METHODS\s+([A-Za-z_~][\w~]*)/i);
       if (!match?.[1]) continue;
       methods.add(normalizeMethodName(match[1]));
+
+      // Collect the full multi-line METHODS statement so FOR-clause patterns
+      // (which usually sit on a continuation line) are visible to the regex.
+      let statement = line;
+      for (let j = i + 1; j <= range.end && j < i + 10; j += 1) {
+        const cont = lines[j] ?? '';
+        statement += ` ${cont}`;
+        if (/\.\s*$/.test(cont.trim())) break;
+      }
+
+      // `FOR ACTION alias~name` — action bindings.
+      const actionBinding = statement.match(/\bFOR\s+ACTION\s+[A-Za-z_]\w*\s*~\s*([A-Za-z_]\w*)/i);
+      if (actionBinding?.[1]) methods.add(normalizeMethodName(actionBinding[1]));
+
+      // `FOR alias~name` (no ACTION keyword) — determinations/validations.
+      // Exclude the ACTION case (handled above) and FOR MODIFY / FOR READ etc.
+      const entityBinding = statement.match(
+        /\bFOR\s+(?!ACTION\b|MODIFY\b|READ\b|VALIDATE\b|DETERMINE\b|INSTANCE\b|GLOBAL\b)[A-Za-z_]\w*\s*~\s*([A-Za-z_]\w*)/i,
+      );
+      if (entityBinding?.[1]) methods.add(normalizeMethodName(entityBinding[1]));
+
+      // Authorization handlers have no alias~name binding — the BDEF side
+      // uses the fixed method names get_instance_authorizations /
+      // get_global_authorizations, so a literal method-name match already
+      // covers them (added at the top of this loop).
     }
 
     out.set(key, methods);
@@ -328,6 +497,15 @@ export function parseClassDefinitionMethods(source: string): Map<string, Set<str
 
 /**
  * Determine which RAP handler requirements are missing from class definitions.
+ *
+ * If the target handler class (`lhc_<alias>`) doesn't exist in the source at
+ * all, every requirement for that class is reported missing so the caller
+ * can decide whether to create the class or fall through to another include
+ * (the scaffold flow searches `main` → `definitions` → `implementations`).
+ *
+ * Method-name comparison is case-insensitive because ABAP identifiers
+ * are — we normalize on both sides so `METHODS SubmitForApproval ...`
+ * matches a BDEF `action SubmitForApproval`.
  */
 export function findMissingRapHandlerRequirements(
   requirements: RapHandlerRequirement[],
@@ -344,7 +522,21 @@ export function findMissingRapHandlerRequirements(
 
 /**
  * Insert missing RAP handler signatures into matching `lhc_*` class definitions.
- * This modifies declaration sections only; no method implementations are created.
+ *
+ * Scope and contract:
+ *  - Only DEFINITION sections are modified. METHOD implementations are the
+ *    developer's responsibility — scaffolding them with a RETURN placeholder
+ *    would mask activation errors and ship misleading handler logic.
+ *  - Requirements whose target class (`lhc_<alias>`) is not present in this
+ *    source are returned in `skipped`, not silently dropped. The caller can
+ *    then try another include (definitions/implementations) or surface a
+ *    clear error to the user.
+ *  - Edits are applied bottom-up (highest line index first) so that earlier
+ *    splice operations don't shift the indices of later ones.
+ *  - When a target class exists but has no PRIVATE SECTION at all, the
+ *    entire PRIVATE SECTION with the signatures is inserted just before
+ *    ENDCLASS — this covers freshly-generated behavior pools where ADT
+ *    produced a skeleton without method declarations.
  */
 export function applyRapHandlerSignatures(
   classSource: string,

--- a/src/adt/rap-handlers.ts
+++ b/src/adt/rap-handlers.ts
@@ -11,13 +11,15 @@
  * which signatures are missing — they see a generic "behavior pool does not
  * implement the required method for ..." message.
  *
- * The three exported helpers cooperate:
+ * The exported helpers cooperate:
  *   1. extractRapHandlerRequirements     — parse BDEF → list of required methods
  *   2. findMissingRapHandlerRequirements — diff required vs. present in class
  *   3. applyRapHandlerSignatures         — insert the missing METHODS lines
+ *   4. applyRapHandlerImplementationStubs — insert empty METHOD stubs
  *
- * The scaffolder never writes implementations — it only declares signatures.
- * That keeps the scaffold deterministic and safe to run on existing pools.
+ * The scaffolder writes declarations plus empty implementations only.
+ * Business logic remains the developer's responsibility and can be filled
+ * with edit_method.
  *
  * Naming convention: handler classes use the prefix `lhc_` (local handler
  * class) followed by the lowercased alias from the BDEF. This is the RAP
@@ -66,6 +68,12 @@ interface ClassDefinitionRange {
   start: number;
   end: number;
   privateSection?: number;
+}
+
+interface ClassImplementationRange {
+  name: string;
+  start: number;
+  end: number;
 }
 
 function countChar(value: string, char: string): number {
@@ -397,13 +405,7 @@ function parseClassDefinitionRanges(source: string): ClassDefinitionRange[] {
 
     const name = startMatch[1];
     const isDeferred = /\bDEFINITION\b.*\bDEFERRED\b/i.test(line);
-    if (isDeferred) {
-      // Deferred declarations are single-line declarations without ENDCLASS.
-      // Record the range at the same index so a later concrete definition of
-      // the same class gets its own entry and isn't shadowed here.
-      ranges.push({ name, start: i, end: i });
-      continue;
-    }
+    if (isDeferred) continue;
 
     let end = i;
     let privateSection: number | undefined;
@@ -423,6 +425,53 @@ function parseClassDefinitionRanges(source: string): ClassDefinitionRange[] {
   }
 
   return ranges;
+}
+
+function parseClassImplementationRanges(source: string): ClassImplementationRange[] {
+  const lines = source.split('\n');
+  const ranges: ClassImplementationRange[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    const startMatch = line.match(/^\s*CLASS\s+([A-Za-z_][\w$]*)\s+IMPLEMENTATION\s*\./i);
+    if (!startMatch?.[1]) continue;
+
+    const name = startMatch[1];
+    let end = i;
+    for (let j = i + 1; j < lines.length; j += 1) {
+      const inner = lines[j] ?? '';
+      if (/^\s*ENDCLASS\./i.test(inner)) {
+        end = j;
+        break;
+      }
+    }
+
+    ranges.push({ name, start: i, end });
+    i = end;
+  }
+
+  return ranges;
+}
+
+function parseClassImplementationMethods(source: string): Map<string, Set<string>> {
+  const lines = source.split('\n');
+  const ranges = parseClassImplementationRanges(source);
+  const out = new Map<string, Set<string>>();
+
+  for (const range of ranges) {
+    const key = range.name.toLowerCase();
+    const methods = out.get(key) ?? new Set<string>();
+
+    for (let i = range.start; i <= range.end; i += 1) {
+      const line = lines[i] ?? '';
+      const match = line.match(/^\s*METHOD\s+([A-Za-z_~][\w~]*)\s*\./i);
+      if (match?.[1]) methods.add(normalizeMethodName(match[1]));
+    }
+
+    out.set(key, methods);
+  }
+
+  return out;
 }
 
 /**
@@ -520,13 +569,26 @@ export function findMissingRapHandlerRequirements(
   });
 }
 
+export function findMissingRapHandlerImplementationStubs(
+  requirements: RapHandlerRequirement[],
+  classSource: string,
+): RapHandlerRequirement[] {
+  const classMethods = parseClassImplementationMethods(classSource);
+
+  return requirements.filter((req) => {
+    const methods = classMethods.get(req.targetHandlerClass.toLowerCase());
+    if (!methods) return true;
+    return !methods.has(normalizeMethodName(req.methodName));
+  });
+}
+
 /**
  * Insert missing RAP handler signatures into matching `lhc_*` class definitions.
  *
  * Scope and contract:
- *  - Only DEFINITION sections are modified. METHOD implementations are the
- *    developer's responsibility — scaffolding them with a RETURN placeholder
- *    would mask activation errors and ship misleading handler logic.
+ *  - Only DEFINITION sections are modified. Use
+ *    applyRapHandlerImplementationStubs after this step when the scaffold
+ *    should be immediately patchable with edit_method.
  *  - Requirements whose target class (`lhc_<alias>`) is not present in this
  *    source are returned in `skipped`, not silently dropped. The caller can
  *    then try another include (definitions/implementations) or surface a
@@ -597,6 +659,87 @@ export function applyRapHandlerSignatures(
       index: range.privateSection + 1,
       lines: [...signatureLines, ''],
     });
+  }
+
+  if (edits.length === 0) {
+    return { updatedSource: classSource, inserted, skipped, changed: false };
+  }
+
+  const sorted = edits.sort((a, b) => b.index - a.index);
+  for (const edit of sorted) {
+    lines.splice(edit.index, 0, ...edit.lines);
+  }
+
+  return {
+    updatedSource: lines.join('\n'),
+    inserted,
+    skipped,
+    changed: inserted.length > 0,
+  };
+}
+
+export function applyRapHandlerImplementationStubs(
+  classSource: string,
+  requirements: RapHandlerRequirement[],
+  options: { createImplementationBlocks?: boolean } = {},
+): RapHandlerApplyResult {
+  if (requirements.length === 0) {
+    return { updatedSource: classSource, inserted: [], skipped: [], changed: false };
+  }
+
+  const lines = classSource.split('\n');
+  const definitionRanges = parseClassDefinitionRanges(classSource);
+  const implementationRanges = parseClassImplementationRanges(classSource);
+  const methodsByClass = parseClassImplementationMethods(classSource);
+  const grouped = new Map<string, RapHandlerRequirement[]>();
+
+  for (const req of requirements) {
+    const key = req.targetHandlerClass.toLowerCase();
+    const list = grouped.get(key) ?? [];
+    list.push(req);
+    grouped.set(key, list);
+  }
+
+  type Edit = { index: number; lines: string[] };
+  const edits: Edit[] = [];
+  const inserted: RapHandlerRequirement[] = [];
+  const skipped: RapHandlerApplySkipped[] = [];
+
+  for (const [targetClassName, classRequirements] of grouped.entries()) {
+    const existingMethods = methodsByClass.get(targetClassName) ?? new Set<string>();
+    const toInsert = classRequirements.filter((req) => !existingMethods.has(normalizeMethodName(req.methodName)));
+    if (toInsert.length === 0) continue;
+
+    const stubLines: string[] = [];
+    for (let i = 0; i < toInsert.length; i += 1) {
+      const req = toInsert[i]!;
+      stubLines.push(`  METHOD ${normalizeMethodName(req.methodName)}.`, '  ENDMETHOD.');
+      if (i < toInsert.length - 1) stubLines.push('');
+      inserted.push(req);
+    }
+
+    const implementationRange = implementationRanges.find((r) => r.name.toLowerCase() === targetClassName);
+    if (implementationRange) {
+      edits.push({ index: implementationRange.end, lines: [...stubLines, ''] });
+      continue;
+    }
+
+    const hasDefinition = definitionRanges.some((r) => r.name.toLowerCase() === targetClassName);
+    if (options.createImplementationBlocks && hasDefinition) {
+      edits.push({
+        index: lines.length,
+        lines: ['', `CLASS ${classRequirements[0]!.targetHandlerClass} IMPLEMENTATION.`, ...stubLines, 'ENDCLASS.'],
+      });
+      continue;
+    }
+
+    for (const req of toInsert) {
+      skipped.push({
+        requirement: req,
+        reason: `Implementation class ${req.targetHandlerClass} not found in behavior pool.`,
+      });
+    }
+    inserted.splice(inserted.length - toInsert.length, toInsert.length);
   }
 
   if (edits.length === 0) {

--- a/src/adt/rap-preflight.ts
+++ b/src/adt/rap-preflight.ts
@@ -226,11 +226,13 @@ function validateBdef(source: string, context: RapPreflightContext, findings: Ra
       const preamble = firstBehaviorIdx >= 0 ? source.slice(0, firstBehaviorIdx) : source;
       // Header-level form is terminated by a semicolon (or end-of-preamble);
       // the per-entity form never has a terminating `;` directly after etag.
-      if (/\buse\s+etag\s*;/i.test(preamble)) {
+      const headerUseEtagMatch = /\buse\s+etag\s*;/i.exec(preamble);
+      if (headerUseEtagMatch) {
         findings.push({
           severity: 'error',
           ruleId: 'BDEF_PROJECTION_USE_ETAG_UNSUPPORTED',
           message: 'Projection BDEF contains "use etag" as a header statement, which is not supported on on-prem 7.5x.',
+          line: source.slice(0, headerUseEtagMatch.index).split(/\r?\n/).length,
           suggestion:
             'Move "use etag" into each "define behavior for X alias Y use etag { ... }" block instead of declaring it at the projection header level.',
         });

--- a/src/adt/rap-preflight.ts
+++ b/src/adt/rap-preflight.ts
@@ -27,7 +27,21 @@ export interface RapPreflightResult {
  * Deterministic RAP pre-write checks for artifact types where activation-time
  * round-trips are expensive and common failure patterns are known.
  *
- * This validator intentionally focuses on static checks with high signal.
+ * Why deterministic static rules instead of letting SAP tell us?
+ *   Every failed activation is a full lock → PUT → activate → unlock cycle
+ *   against the ABAP backend. On a slow / loaded system that's 5-15 seconds
+ *   per retry, and the error messages are often cryptic ("activation error:
+ *   see error log"). Catching well-known patterns before the write keeps the
+ *   LLM-driven agent loop tight and turns error output into actionable
+ *   suggestions the model can act on immediately.
+ *
+ * This validator intentionally focuses on static checks with high signal —
+ * every rule maps to a concrete, reproducible failure observed on a real
+ * SAP system. We deliberately don't attempt full semantic validation (that's
+ * what activation is for); we just catch the traps that waste round-trips.
+ *
+ * Rules are tagged `error` only when the pattern is guaranteed to fail
+ * activation; anything ambiguous (heuristic, release-dependent) is a warning.
  */
 export function validateRapSource(type: string, source: string, context: RapPreflightContext = {}): RapPreflightResult {
   const normalizedType = type.toUpperCase();
@@ -75,13 +89,32 @@ export function formatRapPreflightFindings(findings: RapPreflightFinding[]): str
     .join('\n');
 }
 
+/**
+ * TABL (database table) pre-write checks.
+ *
+ * Targets two categories of failure:
+ *  1. Missing currency/quantity metadata (universal — any release):
+ *     RAP requires every `abap.curr` field to be paired with a
+ *     `@Semantics.amount.currencyCode` annotation referencing a currency key
+ *     field (`abap.cuky`). Without it, activation fails with "amount field
+ *     requires currency code reference". Same pattern applies to `abap.quan`
+ *     + `@Semantics.quantity.unitOfMeasure` + `abap.unit`.
+ *
+ *  2. Forbidden built-in types on on-prem 7.5x:
+ *     SAP_BASIS 750-759 does not accept `abap.uname`, `abap.utclong`, or
+ *     `abap.boolean` in TABL source (released builtin types matrix differs
+ *     between on-prem NW and S/4HANA 2020+). These are the three most
+ *     common migration stumbles when a developer copies a cloud CDS-TABL
+ *     from help.sap.com into an older system.
+ */
 function validateTabl(source: string, context: RapPreflightContext, findings: RapPreflightFinding[]): void {
   const lines = source.split('\n');
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? '';
 
-    // curr requires @Semantics.amount.currencyCode directly above the field.
+    // Amount field: must carry @Semantics.amount.currencyCode on a line
+    // within 5 lines above the field (annotations may be stacked).
     if (/\babap\.curr\s*\(/i.test(line) && !hasNearbyAnnotation(lines, i, /@Semantics\.amount\.currencyCode\b/i)) {
       findings.push({
         severity: 'error',
@@ -92,7 +125,8 @@ function validateTabl(source: string, context: RapPreflightContext, findings: Ra
       });
     }
 
-    // quan requires @Semantics.quantity.unitOfMeasure directly above the field.
+    // Quantity field: symmetrical rule — must carry
+    // @Semantics.quantity.unitOfMeasure pointing at an abap.unit key field.
     if (/\babap\.quan\s*\(/i.test(line) && !hasNearbyAnnotation(lines, i, /@Semantics\.quantity\.unitOfMeasure\b/i)) {
       findings.push({
         severity: 'error',
@@ -104,6 +138,8 @@ function validateTabl(source: string, context: RapPreflightContext, findings: Ra
       });
     }
 
+    // On-prem 7.5x only — these built-in types exist in modern systems but
+    // the TABL activator on older releases rejects them.
     if (isOnPrem75x(context)) {
       if (/\babap\.uname\b/i.test(line)) {
         findings.push({
@@ -136,6 +172,31 @@ function validateTabl(source: string, context: RapPreflightContext, findings: Ra
   }
 }
 
+/**
+ * BDEF (behavior definition) pre-write checks.
+ *
+ * Rules in order of severity:
+ *
+ *  1. `authorization master ( none )` — error, all releases.
+ *     This is a frequent copy-paste mistake: developers see `authorization
+ *     master ( global )` in one template and `authorization master ( instance )`
+ *     in another and guess that `none` is a valid "turn off auth" option.
+ *     It isn't. The BDL parser rejects it outright. The right escape hatch
+ *     is to omit the clause entirely until the handler class exists.
+ *
+ *  2. Projection BDEF + `use etag` — error on on-prem 7.5x only.
+ *     Modern S/4 supports etag overrides in projection headers; on-prem 7.5x
+ *     only accepts `projection;` as the entire projection header and
+ *     requires etag semantics to be inherited from the interface BDEF. The
+ *     activator error for this is particularly opaque ("syntax error in
+ *     behavior definition header").
+ *
+ *  3. Duplicate `etag master <field>` — warning, all releases.
+ *     Reusing the same field name across root + composition is *sometimes*
+ *     intentional, but far more often it's a mistake where the developer
+ *     copy-pasted a composition block and forgot to retarget the etag
+ *     field. Surface it as a warning so the dev can confirm.
+ */
 function validateBdef(source: string, context: RapPreflightContext, findings: RapPreflightFinding[]): void {
   const lines = source.split('\n');
 
@@ -155,28 +216,71 @@ function validateBdef(source: string, context: RapPreflightContext, findings: Ra
   }
 
   if (isOnPrem75x(context)) {
-    if (/\bprojection\s*;/i.test(source) && /\buse\s+etag\b/i.test(source)) {
-      findings.push({
-        severity: 'error',
-        ruleId: 'BDEF_PROJECTION_USE_ETAG_UNSUPPORTED',
-        message: 'Projection BDEF contains "use etag", which is not supported as a header construct on on-prem 7.5x.',
-        suggestion: 'Keep projection BDEF header as "projection;" and inherit etag behavior from interface BDEF.',
-      });
+    // Target ONLY header-level `use etag` — i.e. `use etag;` in the preamble
+    // between `projection;` and the first `define behavior` block. The
+    // per-entity form `define behavior for X alias Y use etag { ... }`
+    // (which SAP's own /DMO/C_TRAVEL_PROCESSOR_M uses, verified on-system)
+    // is valid on all modern releases and MUST NOT be flagged.
+    if (/\bprojection\s*;/i.test(source)) {
+      const firstBehaviorIdx = source.search(/\bdefine\s+behavior\b/i);
+      const preamble = firstBehaviorIdx >= 0 ? source.slice(0, firstBehaviorIdx) : source;
+      // Header-level form is terminated by a semicolon (or end-of-preamble);
+      // the per-entity form never has a terminating `;` directly after etag.
+      if (/\buse\s+etag\s*;/i.test(preamble)) {
+        findings.push({
+          severity: 'error',
+          ruleId: 'BDEF_PROJECTION_USE_ETAG_UNSUPPORTED',
+          message: 'Projection BDEF contains "use etag" as a header statement, which is not supported on on-prem 7.5x.',
+          suggestion:
+            'Move "use etag" into each "define behavior for X alias Y use etag { ... }" block instead of declaring it at the projection header level.',
+        });
+      }
     }
   }
 
+  // Same field name used as etag master across multiple entities. SAP's own
+  // /DMO/I_TRAVEL_M does this (both root and booking use last_changed_at) and
+  // activates fine — so this is NOT a guaranteed failure. But when the fields
+  // actually belong to different tables and have no semantic connection, etag
+  // comparisons can behave unexpectedly on draft/update round-trips. We surface
+  // it as a warning so the developer confirms the intent.
   const etagNames = Array.from(source.matchAll(/\betag\s+master\s+([A-Za-z_]\w*)/gi), (m) => m[1]?.toLowerCase() ?? '');
   const duplicate = firstDuplicate(etagNames);
   if (duplicate) {
     findings.push({
       severity: 'warning',
       ruleId: 'BDEF_DUPLICATE_ETAG_MASTER_NAME',
-      message: `Multiple etag master declarations reuse "${duplicate}". This commonly fails for root/dependent entities.`,
-      suggestion: 'Use distinct etag master field names across root and dependent entities.',
+      message: `Multiple etag master declarations reuse "${duplicate}". Verify each entity's etag master refers to its own timestamp field.`,
+      suggestion:
+        'Reusing the same identifier across root and dependent entities works when both tables contain a column of that name (SAP /DMO/* does this). Double-check the fields are actually present and semantically represent last-changed on each entity.',
     });
   }
 }
 
+/**
+ * DDLX (metadata extension) pre-write checks.
+ *
+ * Two distinct rule families here:
+ *
+ *  1. On-prem 7.5x only — DDLX_ANNOTATION_SCOPE_ONPREM_75X.
+ *     The DDLX annotation scope was narrowed on older releases: headerInfo,
+ *     searchable, and objectModel belong in the projection DDLS source
+ *     instead. Modern S/4 relaxes this, which is why the rule is gated on
+ *     `isOnPrem75x(context)`. The error rendered at activation is "unknown
+ *     annotation in this scope" — doesn't tell the developer that the fix is
+ *     to move the annotation to a different artifact.
+ *
+ *  2. All releases — DDLX_DUPLICATE_UI_ANNOTATION.
+ *     Developers sometimes stack multiple @UI.lineItem / @UI.fieldGroup /
+ *     @UI.selectionField blocks above the same field, expecting them to
+ *     merge. They don't — activation rejects it as a duplicate.
+ *
+ * The duplicate-detection walker is state-machine-like: blank lines and
+ * non-UI annotation lines don't reset the `pendingKinds` buffer (stacking
+ * annotations on consecutive lines is idiomatic), but once a field
+ * declaration ends a block, we record what kinds were seen for that field
+ * and clear the buffer for the next field.
+ */
 function validateDdlx(source: string, context: RapPreflightContext, findings: RapPreflightFinding[]): void {
   const lines = source.split('\n');
 
@@ -196,6 +300,9 @@ function validateDdlx(source: string, context: RapPreflightContext, findings: Ra
     }
   }
 
+  // Track which UI annotation "kinds" (lineItem / fieldGroup / selectionField)
+  // have been applied per field. A second @UI.lineItem entry on the same
+  // field is a duplicate regardless of qualifier.
   const perFieldSeen = new Map<string, Set<string>>();
   let pendingKinds: string[] = [];
 
@@ -211,6 +318,7 @@ function validateDdlx(source: string, context: RapPreflightContext, findings: Ra
     }
 
     if (line.startsWith('@')) {
+      // Non-targeted annotation — keep buffering UI kinds for the next field.
       continue;
     }
 
@@ -241,10 +349,29 @@ function validateDdlx(source: string, context: RapPreflightContext, findings: Ra
       continue;
     }
 
+    // Anything that's neither an annotation nor a field declaration ends the
+    // annotation-buffering window (e.g. `extend view entity ... with { ... }`).
     pendingKinds = [];
   }
 }
 
+/**
+ * DDLS (CDS view entity) pre-write checks.
+ *
+ * Warning-only: explicit `client` field in the select list.
+ *
+ * For CDS view entities (the RAP-era successor to DDIC views), SAP handles
+ * client filtering implicitly and including `client` in the select list
+ * either triggers an activation warning or a hard error depending on
+ * release. The safest guidance is to omit it entirely; existing customer
+ * sources may be intentional, hence warning-only.
+ *
+ * Regex limitation (intentional): the pattern matches one flat `{ ... }`
+ * select block and will miss `client` inside a nested association block
+ * like `{ key c, _Assoc.{ client } }`. Upgrading this to a full CDS parser
+ * isn't worth the complexity for a single warning — we accept the false
+ * negative.
+ */
 function validateDdls(source: string, _context: RapPreflightContext, findings: RapPreflightFinding[]): void {
   const match = source.match(/\bselect\s+from\s+\w+\s*{\s*[^}]*\bclient\b[^}]*}/is);
   if (match) {
@@ -257,6 +384,16 @@ function validateDdls(source: string, _context: RapPreflightContext, findings: R
   }
 }
 
+/**
+ * True if the given line is within 5 lines of an annotation matching the
+ * given pattern (stopping at the first non-annotation, non-blank line).
+ *
+ * Scope is kept small intentionally — TABL semantic annotations like
+ * `@Semantics.amount.currencyCode` are conventionally written on the
+ * immediately preceding line (or stacked with one or two other annotations
+ * above the field). Widening the scan would produce false negatives when an
+ * unrelated annotation block further up references the same currency key.
+ */
 function hasNearbyAnnotation(lines: string[], lineIndex: number, annotationPattern: RegExp): boolean {
   for (let i = lineIndex - 1; i >= 0 && i >= lineIndex - 5; i -= 1) {
     const candidate = (lines[i] ?? '').trim();
@@ -278,6 +415,19 @@ function firstDuplicate(values: string[]): string | undefined {
   return undefined;
 }
 
+/**
+ * True if the system is on-prem NetWeaver 7.5x (SAP_BASIS 750-759).
+ *
+ * Conservative by design — when we don't know the system type (e.g. feature
+ * detection hasn't run, or the system is an unknown self-hosted variant),
+ * we return false so on-prem-75x-only rules don't fire against modern
+ * systems as false positives. BTP never qualifies.
+ *
+ * If systemType is 'onprem' but we couldn't parse the release, assume the
+ * most common on-prem scenario (7.5x); customers on S/4 2020+ should always
+ * have an abapRelease, so the undefined-release case realistically means
+ * we're on older NW.
+ */
 function isOnPrem75x(context: RapPreflightContext): boolean {
   if (context.systemType === 'btp') return false;
   if (context.systemType !== 'onprem') return false;
@@ -287,6 +437,11 @@ function isOnPrem75x(context: RapPreflightContext): boolean {
   return release >= 750 && release <= 759;
 }
 
+/**
+ * Extract the numeric SAP_BASIS release from release strings like "754",
+ * "7.54", "754 SP3". Strips non-digits and parses — imperfect but adequate
+ * for the 75x / 75z comparison this module needs.
+ */
 function parseAbapRelease(value: string | undefined): number | undefined {
   if (!value) return undefined;
   const parsed = Number.parseInt(value.replace(/\D/g, ''), 10);

--- a/src/adt/rap-preflight.ts
+++ b/src/adt/rap-preflight.ts
@@ -1,0 +1,295 @@
+import type { SystemType } from './types.js';
+
+export type RapPreflightSeverity = 'error' | 'warning';
+
+export interface RapPreflightFinding {
+  severity: RapPreflightSeverity;
+  ruleId: string;
+  message: string;
+  line?: number;
+  column?: number;
+  suggestion?: string;
+}
+
+export interface RapPreflightContext {
+  systemType?: SystemType;
+  abapRelease?: string;
+}
+
+export interface RapPreflightResult {
+  findings: RapPreflightFinding[];
+  errors: RapPreflightFinding[];
+  warnings: RapPreflightFinding[];
+  blocked: boolean;
+}
+
+/**
+ * Deterministic RAP pre-write checks for artifact types where activation-time
+ * round-trips are expensive and common failure patterns are known.
+ *
+ * This validator intentionally focuses on static checks with high signal.
+ */
+export function validateRapSource(type: string, source: string, context: RapPreflightContext = {}): RapPreflightResult {
+  const normalizedType = type.toUpperCase();
+  const findings: RapPreflightFinding[] = [];
+
+  if (!source.trim()) {
+    return { findings, errors: [], warnings: [], blocked: false };
+  }
+
+  switch (normalizedType) {
+    case 'TABL':
+      validateTabl(source, context, findings);
+      break;
+    case 'BDEF':
+      validateBdef(source, context, findings);
+      break;
+    case 'DDLX':
+      validateDdlx(source, context, findings);
+      break;
+    case 'DDLS':
+      validateDdls(source, context, findings);
+      break;
+    default:
+      break;
+  }
+
+  const errors = findings.filter((f) => f.severity === 'error');
+  const warnings = findings.filter((f) => f.severity === 'warning');
+  return {
+    findings,
+    errors,
+    warnings,
+    blocked: errors.length > 0,
+  };
+}
+
+export function formatRapPreflightFindings(findings: RapPreflightFinding[]): string {
+  if (findings.length === 0) return '';
+  return findings
+    .map((f) => {
+      const loc = f.line ? ` (line ${f.line}${f.column ? `:${f.column}` : ''})` : '';
+      const suggestion = f.suggestion ? `\n    Suggestion: ${f.suggestion}` : '';
+      return `  - [${f.ruleId}] ${f.message}${loc}${suggestion}`;
+    })
+    .join('\n');
+}
+
+function validateTabl(source: string, context: RapPreflightContext, findings: RapPreflightFinding[]): void {
+  const lines = source.split('\n');
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+
+    // curr requires @Semantics.amount.currencyCode directly above the field.
+    if (/\babap\.curr\s*\(/i.test(line) && !hasNearbyAnnotation(lines, i, /@Semantics\.amount\.currencyCode\b/i)) {
+      findings.push({
+        severity: 'error',
+        ruleId: 'TABL_CURR_REQUIRES_CURRENCY_CODE',
+        message: 'abap.curr field is missing @Semantics.amount.currencyCode.',
+        line: i + 1,
+        suggestion: 'Add @Semantics.amount.currencyCode above the amount field and pair it with an abap.cuky field.',
+      });
+    }
+
+    // quan requires @Semantics.quantity.unitOfMeasure directly above the field.
+    if (/\babap\.quan\s*\(/i.test(line) && !hasNearbyAnnotation(lines, i, /@Semantics\.quantity\.unitOfMeasure\b/i)) {
+      findings.push({
+        severity: 'error',
+        ruleId: 'TABL_QUAN_REQUIRES_UNIT',
+        message: 'abap.quan field is missing @Semantics.quantity.unitOfMeasure.',
+        line: i + 1,
+        suggestion:
+          'Add @Semantics.quantity.unitOfMeasure above the quantity field and pair it with an abap.unit field.',
+      });
+    }
+
+    if (isOnPrem75x(context)) {
+      if (/\babap\.uname\b/i.test(line)) {
+        findings.push({
+          severity: 'error',
+          ruleId: 'TABL_FORBIDDEN_ABAP_UNAME',
+          message: 'abap.uname is not accepted in TABL source on on-prem 7.5x.',
+          line: i + 1,
+          suggestion: 'Use syuname for user fields.',
+        });
+      }
+      if (/\babap\.utclong\b/i.test(line)) {
+        findings.push({
+          severity: 'error',
+          ruleId: 'TABL_FORBIDDEN_ABAP_UTCLONG',
+          message: 'abap.utclong is not accepted in TABL source on on-prem 7.5x.',
+          line: i + 1,
+          suggestion: 'Use timestampl for timestamp fields.',
+        });
+      }
+      if (/\babap\.boolean\b/i.test(line)) {
+        findings.push({
+          severity: 'error',
+          ruleId: 'TABL_FORBIDDEN_ABAP_BOOLEAN',
+          message: 'abap.boolean is not accepted in TABL source on on-prem 7.5x.',
+          line: i + 1,
+          suggestion: 'Use abap.char(1) with X/space semantics for boolean-like fields.',
+        });
+      }
+    }
+  }
+}
+
+function validateBdef(source: string, context: RapPreflightContext, findings: RapPreflightFinding[]): void {
+  const lines = source.split('\n');
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+
+    if (/\bauthorization\s+master\s*\(\s*none\s*\)/i.test(line)) {
+      findings.push({
+        severity: 'error',
+        ruleId: 'BDEF_INVALID_AUTH_MASTER_NONE',
+        message: 'authorization master ( none ) is invalid. Only global or instance are allowed.',
+        line: i + 1,
+        suggestion:
+          'Use authorization master ( global ) or authorization master ( instance ), or omit until handlers exist.',
+      });
+    }
+  }
+
+  if (isOnPrem75x(context)) {
+    if (/\bprojection\s*;/i.test(source) && /\buse\s+etag\b/i.test(source)) {
+      findings.push({
+        severity: 'error',
+        ruleId: 'BDEF_PROJECTION_USE_ETAG_UNSUPPORTED',
+        message: 'Projection BDEF contains "use etag", which is not supported as a header construct on on-prem 7.5x.',
+        suggestion: 'Keep projection BDEF header as "projection;" and inherit etag behavior from interface BDEF.',
+      });
+    }
+  }
+
+  const etagNames = Array.from(source.matchAll(/\betag\s+master\s+([A-Za-z_]\w*)/gi), (m) => m[1]?.toLowerCase() ?? '');
+  const duplicate = firstDuplicate(etagNames);
+  if (duplicate) {
+    findings.push({
+      severity: 'warning',
+      ruleId: 'BDEF_DUPLICATE_ETAG_MASTER_NAME',
+      message: `Multiple etag master declarations reuse "${duplicate}". This commonly fails for root/dependent entities.`,
+      suggestion: 'Use distinct etag master field names across root and dependent entities.',
+    });
+  }
+}
+
+function validateDdlx(source: string, context: RapPreflightContext, findings: RapPreflightFinding[]): void {
+  const lines = source.split('\n');
+
+  if (isOnPrem75x(context)) {
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i] ?? '';
+      if (/@UI\.headerInfo\b/i.test(line) || /@Search\.searchable\b/i.test(line) || /@ObjectModel\./i.test(line)) {
+        findings.push({
+          severity: 'error',
+          ruleId: 'DDLX_ANNOTATION_SCOPE_ONPREM_75X',
+          message: 'Annotation scope is unsupported in DDLX on on-prem 7.5x (headerInfo/searchable/objectmodel).',
+          line: i + 1,
+          suggestion:
+            'Move these annotations to the projection DDLS source and keep DDLX to UI facet/lineItem/fieldGroup style annotations.',
+        });
+      }
+    }
+  }
+
+  const perFieldSeen = new Map<string, Set<string>>();
+  let pendingKinds: string[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const raw = lines[i] ?? '';
+    const line = raw.trim();
+    if (!line) continue;
+
+    const annMatch = line.match(/^@UI\.(lineItem|fieldGroup|selectionField)\b/i);
+    if (annMatch) {
+      pendingKinds.push(`@UI.${annMatch[1].toLowerCase()}`);
+      continue;
+    }
+
+    if (line.startsWith('@')) {
+      continue;
+    }
+
+    const fieldMatch = line.match(/^([A-Za-z_]\w*)\s*;/);
+    if (fieldMatch) {
+      const field = fieldMatch[1]!.toLowerCase();
+      const seenForField = perFieldSeen.get(field) ?? new Set<string>();
+      const seenInCurrentBlock = new Set<string>();
+
+      for (const kind of pendingKinds) {
+        if (seenInCurrentBlock.has(kind) || seenForField.has(kind)) {
+          findings.push({
+            severity: 'error',
+            ruleId: 'DDLX_DUPLICATE_UI_ANNOTATION',
+            message: `Field "${field}" has duplicate ${kind} annotation entries.`,
+            line: i + 1,
+            suggestion: 'Consolidate each UI annotation type into one block per field.',
+          });
+        }
+        seenInCurrentBlock.add(kind);
+      }
+
+      for (const kind of seenInCurrentBlock) {
+        seenForField.add(kind);
+      }
+      perFieldSeen.set(field, seenForField);
+      pendingKinds = [];
+      continue;
+    }
+
+    pendingKinds = [];
+  }
+}
+
+function validateDdls(source: string, _context: RapPreflightContext, findings: RapPreflightFinding[]): void {
+  const match = source.match(/\bselect\s+from\s+\w+\s*{\s*[^}]*\bclient\b[^}]*}/is);
+  if (match) {
+    findings.push({
+      severity: 'warning',
+      ruleId: 'DDLS_CLIENT_FIELD_IN_SELECT_LIST',
+      message: 'CDS view entity select list appears to include client explicitly.',
+      suggestion: 'For view entities, omit client from the select list and let SAP handle implicit client filtering.',
+    });
+  }
+}
+
+function hasNearbyAnnotation(lines: string[], lineIndex: number, annotationPattern: RegExp): boolean {
+  for (let i = lineIndex - 1; i >= 0 && i >= lineIndex - 5; i -= 1) {
+    const candidate = (lines[i] ?? '').trim();
+    if (!candidate) continue;
+    if (annotationPattern.test(candidate)) return true;
+    if (candidate.startsWith('@')) continue;
+    break;
+  }
+  return false;
+}
+
+function firstDuplicate(values: string[]): string | undefined {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (!value) continue;
+    if (seen.has(value)) return value;
+    seen.add(value);
+  }
+  return undefined;
+}
+
+function isOnPrem75x(context: RapPreflightContext): boolean {
+  if (context.systemType === 'btp') return false;
+  if (context.systemType !== 'onprem') return false;
+
+  const release = parseAbapRelease(context.abapRelease);
+  if (release === undefined) return true;
+  return release >= 750 && release <= 759;
+}
+
+function parseAbapRelease(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value.replace(/\D/g, ''), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}

--- a/src/authz/policy.ts
+++ b/src/authz/policy.ts
@@ -50,6 +50,13 @@ export const ACTION_POLICY: Record<string, ActionPolicy> = {
   'SAPWrite.delete': { scope: 'write', opType: OperationType.Delete },
   'SAPWrite.edit_method': { scope: 'write', opType: OperationType.Update },
   'SAPWrite.batch_create': { scope: 'write', opType: OperationType.Create },
+  // scaffold_rap_handlers updates an existing behavior-pool CLAS (writes method
+  // declarations into one or more includes). It is a RAP-feature-specific
+  // action — explicit entry lets admins target it with SAP_DENY_ACTIONS
+  // (e.g. "SAPWrite.scaffold_rap_handlers") to block it while still allowing
+  // plain create/update. The featureGate tag also keeps this action aligned
+  // with the SAPTransport/SAPGit/FLP pattern for future enforcement.
+  'SAPWrite.scaffold_rap_handlers': { scope: 'write', opType: OperationType.Update, featureGate: 'rap' },
 
   // ── SAPActivate ──────────────────────────────────────────────────
   SAPActivate: { scope: 'write', opType: OperationType.Activate },

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -125,8 +125,10 @@ import {
   switchBranch as gctsSwitchBranch,
 } from '../adt/gcts.js';
 import {
+  applyRapHandlerImplementationStubs,
   applyRapHandlerSignatures,
   extractRapHandlerRequirements,
+  findMissingRapHandlerImplementationStubs,
   findMissingRapHandlerRequirements,
 } from '../adt/rap-handlers.js';
 import { formatRapPreflightFindings, validateRapSource } from '../adt/rap-preflight.js';
@@ -2627,6 +2629,7 @@ async function handleSAPWrite(
       }
 
       const missing = findMissingRapHandlerRequirements(requirements, classCombinedSource);
+      const missingImplementationStubs = findMissingRapHandlerImplementationStubs(requirements, classCombinedSource);
       const summary = {
         className: name,
         bdefName,
@@ -2639,9 +2642,11 @@ async function handleSAPWrite(
         requiredCount: requirements.length,
         missingCount: missing.length,
         missing,
+        missingImplementationStubCount: missingImplementationStubs.length,
+        missingImplementationStubs,
       };
 
-      if (!autoApply || missing.length === 0) {
+      if (!autoApply || (missing.length === 0 && missingImplementationStubs.length === 0)) {
         return textResult(JSON.stringify({ ...summary, applied: false }, null, 2));
       }
 
@@ -2682,9 +2687,43 @@ async function handleSAPWrite(
         pending = applyImplementations.skipped.map((entry) => entry.requirement);
       }
 
-      const changedMain = applyMain.changed;
-      const changedDefinitions = applyDefinitions?.changed ?? false;
-      const changedImplementations = applyImplementations?.changed ?? false;
+      const unresolvedDeclarationKeys = new Set(
+        pending.map(
+          (req) =>
+            `${req.targetHandlerClass.toLowerCase()}|${req.kind}|${req.methodName.toLowerCase()}|${req.entityAlias.toLowerCase()}`,
+        ),
+      );
+      const stubRequirements = missingImplementationStubs.filter(
+        (req) =>
+          !unresolvedDeclarationKeys.has(
+            `${req.targetHandlerClass.toLowerCase()}|${req.kind}|${req.methodName.toLowerCase()}|${req.entityAlias.toLowerCase()}`,
+          ),
+      );
+
+      const stubMain = applyRapHandlerImplementationStubs(applyMain.updatedSource, stubRequirements, {
+        createImplementationBlocks: true,
+      });
+      const stubDefinitions = classDefinitionsSource
+        ? applyRapHandlerImplementationStubs(
+            applyDefinitions?.updatedSource ?? classDefinitionsSource,
+            stubRequirements,
+          )
+        : undefined;
+      const stubImplementations = classImplementationsSource
+        ? applyRapHandlerImplementationStubs(
+            applyImplementations?.updatedSource ?? classImplementationsSource,
+            stubRequirements,
+            { createImplementationBlocks: true },
+          )
+        : undefined;
+
+      const finalMainSource = stubMain.updatedSource;
+      const finalDefinitionsSource = stubDefinitions?.updatedSource ?? applyDefinitions?.updatedSource;
+      const finalImplementationsSource = stubImplementations?.updatedSource ?? applyImplementations?.updatedSource;
+      const changedMain = applyMain.changed || stubMain.changed;
+      const changedDefinitions = (applyDefinitions?.changed ?? false) || (stubDefinitions?.changed ?? false);
+      const changedImplementations =
+        (applyImplementations?.changed ?? false) || (stubImplementations?.changed ?? false);
       if (!changedMain && !changedDefinitions && !changedImplementations) {
         return textResult(
           JSON.stringify(
@@ -2695,6 +2734,11 @@ async function handleSAPWrite(
                 main: applyMain,
                 definitions: applyDefinitions,
                 implementations: applyImplementations,
+                implementationStubs: {
+                  main: stubMain,
+                  definitions: stubDefinitions,
+                  implementations: stubImplementations,
+                },
                 unresolved: pending,
               },
             },
@@ -2707,23 +2751,17 @@ async function handleSAPWrite(
       // Run lint for every section we are about to update; block before any write to avoid partial state.
       let lintWarningsMain: PreWriteLintResult | undefined;
       if (changedMain) {
-        lintWarningsMain = runPreWriteLint(applyMain.updatedSource, type, name, config, lintOverride);
+        lintWarningsMain = runPreWriteLint(finalMainSource, type, name, config, lintOverride);
         if (lintWarningsMain.blocked) return lintWarningsMain.result!;
       }
       let lintWarningsDefinitions: PreWriteLintResult | undefined;
-      if (changedDefinitions && applyDefinitions) {
-        lintWarningsDefinitions = runPreWriteLint(applyDefinitions.updatedSource, type, name, config, lintOverride);
+      if (changedDefinitions && finalDefinitionsSource) {
+        lintWarningsDefinitions = runPreWriteLint(finalDefinitionsSource, type, name, config, lintOverride);
         if (lintWarningsDefinitions.blocked) return lintWarningsDefinitions.result!;
       }
       let lintWarningsImplementations: PreWriteLintResult | undefined;
-      if (changedImplementations && applyImplementations) {
-        lintWarningsImplementations = runPreWriteLint(
-          applyImplementations.updatedSource,
-          type,
-          name,
-          config,
-          lintOverride,
-        );
+      if (changedImplementations && finalImplementationsSource) {
+        lintWarningsImplementations = runPreWriteLint(finalImplementationsSource, type, name, config, lintOverride);
         if (lintWarningsImplementations.blocked) return lintWarningsImplementations.result!;
       }
 
@@ -2737,31 +2775,24 @@ async function handleSAPWrite(
         const effectiveTransport = transport ?? (lock.corrNr || undefined);
         try {
           if (changedMain) {
-            await updateSource(
-              session,
-              client.safety,
-              srcUrl,
-              applyMain.updatedSource,
-              lock.lockHandle,
-              effectiveTransport,
-            );
+            await updateSource(session, client.safety, srcUrl, finalMainSource, lock.lockHandle, effectiveTransport);
           }
-          if (changedDefinitions && applyDefinitions) {
+          if (changedDefinitions && finalDefinitionsSource) {
             await updateSource(
               session,
               client.safety,
               classIncludeUrl(name, 'definitions'),
-              applyDefinitions.updatedSource,
+              finalDefinitionsSource,
               lock.lockHandle,
               effectiveTransport,
             );
           }
-          if (changedImplementations && applyImplementations) {
+          if (changedImplementations && finalImplementationsSource) {
             await updateSource(
               session,
               client.safety,
               classIncludeUrl(name, 'implementations'),
-              applyImplementations.updatedSource,
+              finalImplementationsSource,
               lock.lockHandle,
               effectiveTransport,
             );
@@ -2783,13 +2814,17 @@ async function handleSAPWrite(
         applyMain.inserted.length +
         (applyDefinitions?.inserted.length ?? 0) +
         (applyImplementations?.inserted.length ?? 0);
+      const implementationStubCount =
+        stubMain.inserted.length +
+        (stubDefinitions?.inserted.length ?? 0) +
+        (stubImplementations?.inserted.length ?? 0);
       const updatedSections = [
         changedMain ? 'main' : undefined,
         changedDefinitions ? 'definitions' : undefined,
         changedImplementations ? 'implementations' : undefined,
       ].filter(Boolean);
       const msg =
-        `Scaffolded ${insertedCount} RAP handler signature(s) in ${type} ${name} from BDEF ${bdefName}. ` +
+        `Scaffolded ${insertedCount} RAP handler signature(s) and ${implementationStubCount} implementation stub(s) in ${type} ${name} from BDEF ${bdefName}. ` +
         `Updated section(s): ${updatedSections.join(', ')}.`;
       const warnings = mergePreWriteWarnings(
         lintWarningsMain?.warnings,
@@ -2804,6 +2839,11 @@ async function handleSAPWrite(
             main: applyMain,
             definitions: applyDefinitions,
             implementations: applyImplementations,
+            implementationStubs: {
+              main: stubMain,
+              definitions: stubDefinitions,
+              implementations: stubImplementations,
+            },
             unresolved: pending,
           },
         },

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -2662,11 +2662,19 @@ async function handleSAPWrite(
       );
 
       if (scaffoldPlan.changedSections.length === 0) {
+        const unresolvedHandlerClasses = Array.from(
+          new Set(scaffoldPlan.unresolved.map((req) => req.targetHandlerClass)),
+        );
+        const unresolvedHint =
+          unresolvedHandlerClasses.length > 0
+            ? `No source changes were applied because handler class skeleton(s) ${unresolvedHandlerClasses.join(', ')} were not found in main, definitions, or implementations. Create the local handler class skeleton(s) first (for example with the ADT quick fix "Create local handler class"), then rerun with autoApply=true.`
+            : undefined;
         return textResult(
           JSON.stringify(
             {
               ...summary,
               applied: false,
+              hint: unresolvedHint,
               applyResult: {
                 main: scaffoldPlan.signatures.main,
                 definitions: scaffoldPlan.signatures.definitions,

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -125,8 +125,7 @@ import {
   switchBranch as gctsSwitchBranch,
 } from '../adt/gcts.js';
 import {
-  applyRapHandlerImplementationStubs,
-  applyRapHandlerSignatures,
+  applyRapHandlerScaffold,
   extractRapHandlerRequirements,
   findMissingRapHandlerImplementationStubs,
   findMissingRapHandlerRequirements,
@@ -2564,8 +2563,8 @@ async function handleSAPWrite(
       //   the class for every `lhc_<alias>` local handler class and make
       //   sure it declares a METHOD for every action / determination /
       //   validation / authorization master the BDEF requires. When autoApply
-      //   is true, the missing METHODS signatures are inserted directly and
-      //   the class is saved.
+      //   is true, missing METHODS signatures plus empty METHOD stubs are
+      //   inserted directly and the class is saved.
       //
       // Why this exists:
       //   Without it, the LLM agent trying to author a RAP behavior pool has
@@ -2650,105 +2649,30 @@ async function handleSAPWrite(
         return textResult(JSON.stringify({ ...summary, applied: false }, null, 2));
       }
 
-      // Apply fall-through: try main first, then feed anything `applyRap...`
-      // couldn't place (handler class not present in that include) into the
-      // next include. The `pending` list carries the un-placed requirements
-      // forward; anything still pending after implementations genuinely has
-      // no matching `lhc_<alias>` class anywhere in the pool and will be
-      // reported as `unresolved` in the response for the user to fix.
-      const applyMain = applyRapHandlerSignatures(classMainSource, missing);
-      let pending = applyMain.skipped.map((entry) => entry.requirement);
-
-      let applyDefinitions:
-        | ReturnType<typeof applyRapHandlerSignatures>
-        | {
-            updatedSource: string;
-            inserted: [];
-            skipped: typeof applyMain.skipped;
-            changed: false;
-          }
-        | undefined;
-      if (pending.length > 0 && classDefinitionsSource) {
-        applyDefinitions = applyRapHandlerSignatures(classDefinitionsSource, pending);
-        pending = applyDefinitions.skipped.map((entry) => entry.requirement);
-      }
-
-      let applyImplementations:
-        | ReturnType<typeof applyRapHandlerSignatures>
-        | {
-            updatedSource: string;
-            inserted: [];
-            skipped: typeof applyMain.skipped;
-            changed: false;
-          }
-        | undefined;
-      if (pending.length > 0 && classImplementationsSource) {
-        applyImplementations = applyRapHandlerSignatures(classImplementationsSource, pending);
-        pending = applyImplementations.skipped.map((entry) => entry.requirement);
-      }
-
-      const unresolvedDeclarationKeys = new Set(
-        pending.map(
-          (req) =>
-            `${req.targetHandlerClass.toLowerCase()}|${req.kind}|${req.methodName.toLowerCase()}|${req.entityAlias.toLowerCase()}`,
-        ),
+      // Pure RAP transformation planning lives in rap-handlers.ts. Keep this
+      // handler focused on MCP/ADT concerns: safety, linting, locking, writes.
+      const scaffoldPlan = applyRapHandlerScaffold(
+        {
+          main: classMainSource,
+          definitions: classDefinitionsSource || undefined,
+          implementations: classImplementationsSource || undefined,
+        },
+        missing,
+        missingImplementationStubs,
       );
-      const stubRequirements = missingImplementationStubs.filter(
-        (req) =>
-          !unresolvedDeclarationKeys.has(
-            `${req.targetHandlerClass.toLowerCase()}|${req.kind}|${req.methodName.toLowerCase()}|${req.entityAlias.toLowerCase()}`,
-          ),
-      );
-      const definitionLookupSource = [
-        applyMain.updatedSource,
-        applyDefinitions?.updatedSource ?? classDefinitionsSource,
-        applyImplementations?.updatedSource ?? classImplementationsSource,
-      ]
-        .filter(Boolean)
-        .join('\n\n');
 
-      const stubMain = applyRapHandlerImplementationStubs(applyMain.updatedSource, stubRequirements, {
-        createImplementationBlocks: true,
-        definitionSource: definitionLookupSource,
-      });
-      const stubDefinitions = classDefinitionsSource
-        ? applyRapHandlerImplementationStubs(
-            applyDefinitions?.updatedSource ?? classDefinitionsSource,
-            stubRequirements,
-            { definitionSource: definitionLookupSource },
-          )
-        : undefined;
-      const stubImplementations = classImplementationsSource
-        ? applyRapHandlerImplementationStubs(
-            applyImplementations?.updatedSource ?? classImplementationsSource,
-            stubRequirements,
-            { createImplementationBlocks: true, definitionSource: definitionLookupSource },
-          )
-        : undefined;
-
-      const finalMainSource = stubMain.updatedSource;
-      const finalDefinitionsSource = stubDefinitions?.updatedSource ?? applyDefinitions?.updatedSource;
-      const finalImplementationsSource = stubImplementations?.updatedSource ?? applyImplementations?.updatedSource;
-      const changedMain = applyMain.changed || stubMain.changed;
-      const changedDefinitions = (applyDefinitions?.changed ?? false) || (stubDefinitions?.changed ?? false);
-      const changedImplementations =
-        (applyImplementations?.changed ?? false) || (stubImplementations?.changed ?? false);
-      if (!changedMain && !changedDefinitions && !changedImplementations) {
+      if (scaffoldPlan.changedSections.length === 0) {
         return textResult(
           JSON.stringify(
             {
               ...summary,
               applied: false,
               applyResult: {
-                main: applyMain,
-                definitions: applyDefinitions,
-                implementations: applyImplementations,
-                implementationStubs: {
-                  main: stubMain,
-                  definitions: stubDefinitions,
-                  implementations: stubImplementations,
-                },
-                unresolved: pending,
+                main: scaffoldPlan.signatures.main,
+                definitions: scaffoldPlan.signatures.definitions,
+                implementations: scaffoldPlan.signatures.implementations,
+                implementationStubs: scaffoldPlan.implementationStubs,
+                unresolved: scaffoldPlan.unresolved,
               },
             },
             null,
@@ -2757,23 +2681,27 @@ async function handleSAPWrite(
         );
       }
 
+      const finalMainSource = scaffoldPlan.sections.main;
+      const finalDefinitionsSource = scaffoldPlan.sections.definitions;
+      const finalImplementationsSource = scaffoldPlan.sections.implementations;
+      const { changed } = scaffoldPlan;
+
       // Run lint for every section we are about to update; block before any write to avoid partial state.
       let lintWarningsMain: PreWriteLintResult | undefined;
-      if (changedMain) {
+      if (changed.main) {
         lintWarningsMain = runPreWriteLint(finalMainSource, type, name, config, lintOverride);
         if (lintWarningsMain.blocked) return lintWarningsMain.result!;
       }
       let lintWarningsDefinitions: PreWriteLintResult | undefined;
-      if (changedDefinitions && finalDefinitionsSource) {
+      if (changed.definitions && finalDefinitionsSource) {
         lintWarningsDefinitions = runPreWriteLint(finalDefinitionsSource, type, name, config, lintOverride);
         if (lintWarningsDefinitions.blocked) return lintWarningsDefinitions.result!;
       }
       let lintWarningsImplementations: PreWriteLintResult | undefined;
-      if (changedImplementations && finalImplementationsSource) {
+      if (changed.implementations && finalImplementationsSource) {
         lintWarningsImplementations = runPreWriteLint(finalImplementationsSource, type, name, config, lintOverride);
         if (lintWarningsImplementations.blocked) return lintWarningsImplementations.result!;
       }
-
       // All modified includes share one lock so we never end up in a partial-state
       // (e.g. main written, implementations errored → handler class declares but
       // doesn't implement methods → class cannot activate). The lock is taken once
@@ -2783,10 +2711,10 @@ async function handleSAPWrite(
         const lock = await lockObject(session, client.safety, objectUrl);
         const effectiveTransport = transport ?? (lock.corrNr || undefined);
         try {
-          if (changedMain) {
+          if (changed.main) {
             await updateSource(session, client.safety, srcUrl, finalMainSource, lock.lockHandle, effectiveTransport);
           }
-          if (changedDefinitions && finalDefinitionsSource) {
+          if (changed.definitions && finalDefinitionsSource) {
             await updateSource(
               session,
               client.safety,
@@ -2796,7 +2724,7 @@ async function handleSAPWrite(
               effectiveTransport,
             );
           }
-          if (changedImplementations && finalImplementationsSource) {
+          if (changed.implementations && finalImplementationsSource) {
             await updateSource(
               session,
               client.safety,
@@ -2819,22 +2747,9 @@ async function handleSAPWrite(
       });
       cachingLayer?.invalidate(type, name);
 
-      const insertedCount =
-        applyMain.inserted.length +
-        (applyDefinitions?.inserted.length ?? 0) +
-        (applyImplementations?.inserted.length ?? 0);
-      const implementationStubCount =
-        stubMain.inserted.length +
-        (stubDefinitions?.inserted.length ?? 0) +
-        (stubImplementations?.inserted.length ?? 0);
-      const updatedSections = [
-        changedMain ? 'main' : undefined,
-        changedDefinitions ? 'definitions' : undefined,
-        changedImplementations ? 'implementations' : undefined,
-      ].filter(Boolean);
       const msg =
-        `Scaffolded ${insertedCount} RAP handler signature(s) and ${implementationStubCount} implementation stub(s) in ${type} ${name} from BDEF ${bdefName}. ` +
-        `Updated section(s): ${updatedSections.join(', ')}.`;
+        `Scaffolded ${scaffoldPlan.insertedSignatureCount} RAP handler signature(s) and ${scaffoldPlan.insertedImplementationStubCount} implementation stub(s) in ${type} ${name} from BDEF ${bdefName}. ` +
+        `Updated section(s): ${scaffoldPlan.changedSections.join(', ')}.`;
       const warnings = mergePreWriteWarnings(
         lintWarningsMain?.warnings,
         lintWarningsDefinitions?.warnings,
@@ -2845,15 +2760,11 @@ async function handleSAPWrite(
           ...summary,
           applied: true,
           applyResult: {
-            main: applyMain,
-            definitions: applyDefinitions,
-            implementations: applyImplementations,
-            implementationStubs: {
-              main: stubMain,
-              definitions: stubDefinitions,
-              implementations: stubImplementations,
-            },
-            unresolved: pending,
+            main: scaffoldPlan.signatures.main,
+            definitions: scaffoldPlan.signatures.definitions,
+            implementations: scaffoldPlan.signatures.implementations,
+            implementationStubs: scaffoldPlan.implementationStubs,
+            unresolved: scaffoldPlan.unresolved,
           },
         },
         null,

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -48,6 +48,7 @@ import {
   safeUpdateSource,
   unlockObject,
   updateObject,
+  updateSource,
 } from '../adt/crud.js';
 import {
   buildDataElementXml,
@@ -2556,6 +2557,22 @@ async function handleSAPWrite(
       return lintWarnings.warnings ? textResult(`${msg}\n\n${lintWarnings.warnings}`) : textResult(msg);
     }
     case 'scaffold_rap_handlers': {
+      // What this action does:
+      //   Given a behavior-pool class (ZBP_*) and its interface BDEF, inspect
+      //   the class for every `lhc_<alias>` local handler class and make
+      //   sure it declares a METHOD for every action / determination /
+      //   validation / authorization master the BDEF requires. When autoApply
+      //   is true, the missing METHODS signatures are inserted directly and
+      //   the class is saved.
+      //
+      // Why this exists:
+      //   Without it, the LLM agent trying to author a RAP behavior pool has
+      //   to manually read the BDEF, compute the required handler signatures,
+      //   paste them into the correct local class, and then save — a
+      //   boilerplate-heavy step that is easy to get wrong (alias case,
+      //   RESULT vs no RESULT, factory/static modifiers). The activation
+      //   errors for an incomplete pool are particularly unhelpful. See
+      //   docs/plans/completed/rap-onprem-agent-gap-closure.md.
       if (type !== 'CLAS') {
         return errorResult('scaffold_rap_handlers is only supported for type=CLAS behavior pool classes.');
       }
@@ -2570,9 +2587,18 @@ async function handleSAPWrite(
 
       await enforcePackageForExistingObject();
 
-      // Behavior pools frequently keep handler class declarations in CLAS include
-      // "definitions" or even "implementations" on older templates.
-      // Read structured class parts so we can inspect/apply across all sections.
+      // Why scan all three CLAS includes (main, definitions, implementations):
+      //   Behavior-pool handler classes CAN live in any of the three, and
+      //   which include they occupy depends on how the pool was generated:
+      //     - "main" (source/main) — unusual; some hand-written pools put
+      //       lhc_* alongside the global class definition
+      //     - "definitions" (CCDEF) — the ADT "Create Behavior Impl Class"
+      //       wizard default target
+      //     - "implementations" (CCIMP) — older SAP templates and every
+      //       example under /DMO/* ship the handler classes here
+      //   We read all three so the diff (findMissingRapHandlerRequirements)
+      //   reflects what's actually declared anywhere in the class, and the
+      //   apply flow can fall through main → definitions → implementations.
       const classStructured = await client.getClassStructured(name);
       const classMainSource = classStructured.main ?? '';
       const classDefinitionsSource = classStructured.definitions ?? '';
@@ -2617,6 +2643,12 @@ async function handleSAPWrite(
         return textResult(JSON.stringify({ ...summary, applied: false }, null, 2));
       }
 
+      // Apply fall-through: try main first, then feed anything `applyRap...`
+      // couldn't place (handler class not present in that include) into the
+      // next include. The `pending` list carries the un-placed requirements
+      // forward; anything still pending after implementations genuinely has
+      // no matching `lhc_<alias>` class anywhere in the pool and will be
+      // reported as `unresolved` in the response for the user to fix.
       const applyMain = applyRapHandlerSignatures(classMainSource, missing);
       let pending = applyMain.skipped.map((entry) => entry.requirement);
 
@@ -2693,29 +2725,56 @@ async function handleSAPWrite(
         if (lintWarningsImplementations.blocked) return lintWarningsImplementations.result!;
       }
 
-      if (changedMain) {
-        await safeUpdateSource(client.http, client.safety, objectUrl, srcUrl, applyMain.updatedSource, transport);
-      }
-      if (changedDefinitions && applyDefinitions) {
-        await safeUpdateSource(
-          client.http,
-          client.safety,
-          objectUrl,
-          classIncludeUrl(name, 'definitions'),
-          applyDefinitions.updatedSource,
-          transport,
-        );
-      }
-      if (changedImplementations && applyImplementations) {
-        await safeUpdateSource(
-          client.http,
-          client.safety,
-          objectUrl,
-          classIncludeUrl(name, 'implementations'),
-          applyImplementations.updatedSource,
-          transport,
-        );
-      }
+      // All modified includes share one lock so we never end up in a partial-state
+      // (e.g. main written, implementations errored → handler class declares but
+      // doesn't implement methods → class cannot activate). The lock is taken once
+      // at the class object URL, and every include PUT carries the same lockHandle.
+      // This mirrors how ADT-in-Eclipse saves a multi-include class in one commit.
+      await client.http.withStatefulSession(async (session) => {
+        const lock = await lockObject(session, client.safety, objectUrl);
+        const effectiveTransport = transport ?? (lock.corrNr || undefined);
+        try {
+          if (changedMain) {
+            await updateSource(
+              session,
+              client.safety,
+              srcUrl,
+              applyMain.updatedSource,
+              lock.lockHandle,
+              effectiveTransport,
+            );
+          }
+          if (changedDefinitions && applyDefinitions) {
+            await updateSource(
+              session,
+              client.safety,
+              classIncludeUrl(name, 'definitions'),
+              applyDefinitions.updatedSource,
+              lock.lockHandle,
+              effectiveTransport,
+            );
+          }
+          if (changedImplementations && applyImplementations) {
+            await updateSource(
+              session,
+              client.safety,
+              classIncludeUrl(name, 'implementations'),
+              applyImplementations.updatedSource,
+              lock.lockHandle,
+              effectiveTransport,
+            );
+          }
+        } finally {
+          // Best-effort unlock — if the object was already removed or the session
+          // expired, we still want to surface the original error instead of masking
+          // it with an unlock failure.
+          try {
+            await unlockObject(session, objectUrl, lock.lockHandle);
+          } catch {
+            // Swallowed intentionally; see comment above.
+          }
+        }
+      });
       cachingLayer?.invalidate(type, name);
 
       const insertedCount =

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -2699,21 +2699,30 @@ async function handleSAPWrite(
             `${req.targetHandlerClass.toLowerCase()}|${req.kind}|${req.methodName.toLowerCase()}|${req.entityAlias.toLowerCase()}`,
           ),
       );
+      const definitionLookupSource = [
+        applyMain.updatedSource,
+        applyDefinitions?.updatedSource ?? classDefinitionsSource,
+        applyImplementations?.updatedSource ?? classImplementationsSource,
+      ]
+        .filter(Boolean)
+        .join('\n\n');
 
       const stubMain = applyRapHandlerImplementationStubs(applyMain.updatedSource, stubRequirements, {
         createImplementationBlocks: true,
+        definitionSource: definitionLookupSource,
       });
       const stubDefinitions = classDefinitionsSource
         ? applyRapHandlerImplementationStubs(
             applyDefinitions?.updatedSource ?? classDefinitionsSource,
             stubRequirements,
+            { definitionSource: definitionLookupSource },
           )
         : undefined;
       const stubImplementations = classImplementationsSource
         ? applyRapHandlerImplementationStubs(
             applyImplementations?.updatedSource ?? classImplementationsSource,
             stubRequirements,
-            { createImplementationBlocks: true },
+            { createImplementationBlocks: true, definitionSource: definitionLookupSource },
           )
         : undefined;
 

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -123,6 +123,12 @@ import {
   pullRepo as gctsPullRepo,
   switchBranch as gctsSwitchBranch,
 } from '../adt/gcts.js';
+import {
+  applyRapHandlerSignatures,
+  extractRapHandlerRequirements,
+  findMissingRapHandlerRequirements,
+} from '../adt/rap-handlers.js';
+import { formatRapPreflightFindings, validateRapSource } from '../adt/rap-preflight.js';
 import { changePackage } from '../adt/refactoring.js';
 import { checkOperation, checkPackage, isOperationAllowed, OperationType } from '../adt/safety.js';
 import {
@@ -313,6 +319,10 @@ function formatErrorForLLM(err: unknown, message: string, tool: string, args: Re
           `sqlFilter="MANDT = '100'" or sqlFilter="MATNR LIKE 'Z%'".`
         );
       }
+    }
+    const behaviorPoolHint = getBehaviorPoolSaveFailureHint(err, args);
+    if (behaviorPoolHint) {
+      return `${enriched}\n\nHint: ${behaviorPoolHint}`;
     }
     if ((err.statusCode === 400 || err.statusCode === 409) && DDIC_SAVE_HINT_TYPES.has(argType)) {
       return (
@@ -545,6 +555,40 @@ function getTransportHint(err: AdtApiError): string | undefined {
   }
 
   return undefined;
+}
+
+function inferBdefNameFromBehaviorPoolSource(source: string): string | undefined {
+  const match = source.match(/\bfor\s+behavior\s+of\s+([A-Za-z_][\w/]+)/i);
+  return match?.[1];
+}
+
+function getBehaviorPoolSaveFailureHint(err: AdtApiError, args: Record<string, unknown>): string | undefined {
+  const type = normalizeObjectType(String(args.type ?? ''));
+  if (type !== 'CLAS') return undefined;
+
+  const name = String(args.name ?? '');
+  const source = String(args.source ?? '');
+  const clean = AdtApiError.extractCleanMessage(err.responseBody ?? '').toLowerCase();
+  const body = (err.responseBody ?? '').toLowerCase();
+  const isGenericSaveFailure =
+    clean.includes('an error occured during the save operation') ||
+    clean.includes('an error occurred during the save operation') ||
+    body.includes('an error occured during the save operation') ||
+    body.includes('an error occurred during the save operation');
+  if (!isGenericSaveFailure) return undefined;
+
+  const looksLikeBehaviorPool = /\bfor\s+behavior\s+of\b/i.test(source) || /^zbp_/i.test(name) || /^ybp_/i.test(name);
+  if (!looksLikeBehaviorPool) return undefined;
+
+  const inferredBdef = inferBdefNameFromBehaviorPoolSource(source);
+  const bdefHint = inferredBdef ? `, bdefName="${inferredBdef}"` : ', bdefName="<interface_bdef_name>"';
+
+  return (
+    `Behavior-pool class save failed on handler declarations. Use ` +
+    `SAPWrite(action="scaffold_rap_handlers", type="CLAS", name="${name}"${bdefHint}) ` +
+    `to list missing RAP handler signatures, then rerun with autoApply=true to inject declarations. ` +
+    `If SAP still rejects the full-class write, use ADT quick-fix to stamp signatures and continue with SAPWrite(action="edit_method").`
+  );
 }
 
 function classifyError(err: unknown): string {
@@ -2171,6 +2215,11 @@ function sourceUrlForType(type: string, name: string): string {
   return `${objectUrlForType(type, name)}/source/main`;
 }
 
+/** Get a CLAS include URL (definitions/implementations/macros/testclasses) */
+function classIncludeUrl(name: string, include: 'definitions' | 'implementations' | 'macros' | 'testclasses'): string {
+  return `/sap/bc/adt/oo/classes/${encodeURIComponent(name)}/includes/${include}`;
+}
+
 // ─── SAPWrite Handler ────────────────────────────────────────────────
 
 async function handleSAPWrite(
@@ -2185,6 +2234,7 @@ async function handleSAPWrite(
   const source = String(args.source ?? '');
   const transport = args.transport as string | undefined;
   const lintOverride = args.lintBeforeWrite as boolean | undefined;
+  const preflightOverride = args.preflightBeforeWrite as boolean | undefined;
 
   // type and name are required for all actions except batch_create
   if (action !== 'batch_create' && (!type || !name)) {
@@ -2194,7 +2244,7 @@ async function handleSAPWrite(
   const objectUrl = objectUrlForType(type, name);
   const srcUrl = sourceUrlForType(type, name);
 
-  // Helper: enforce allowedPackages for existing objects (update/delete/edit_method).
+  // Helper: enforce allowedPackages for existing objects (update/delete/edit_method/scaffold_rap_handlers).
   // Only fetches metadata when package restrictions are configured — no extra HTTP call otherwise.
   async function enforcePackageForExistingObject(): Promise<string | undefined> {
     if (client.safety.allowedPackages.length === 0) return undefined;
@@ -2235,6 +2285,17 @@ async function handleSAPWrite(
         return textResult(`Successfully updated ${type} ${name}.`);
       }
 
+      // RAP deterministic preflight validation
+      const preflightWarnings = runRapPreflightValidation(
+        source,
+        type,
+        name,
+        cachedFeatures,
+        config.systemType,
+        preflightOverride,
+      );
+      if (preflightWarnings.blocked) return preflightWarnings.result!;
+
       // CDS pre-write validation: reject unsupported syntax early
       const cdsGuardUpdate = guardCdsSyntax(type, source, cachedFeatures);
       if (cdsGuardUpdate) return cdsGuardUpdate;
@@ -2246,7 +2307,8 @@ async function handleSAPWrite(
       await safeUpdateSource(client.http, client.safety, objectUrl, srcUrl, source, transport);
       cachingLayer?.invalidate(type, name);
       const msg = `Successfully updated ${type} ${name}.`;
-      return lintWarnings.warnings ? textResult(`${msg}\n\n${lintWarnings.warnings}`) : textResult(msg);
+      const warnings = mergePreWriteWarnings(preflightWarnings.warnings, lintWarnings.warnings);
+      return warnings ? textResult(`${msg}\n\n${warnings}`) : textResult(msg);
     }
     case 'create': {
       const pkg = String(args.package ?? '$TMP');
@@ -2292,6 +2354,17 @@ async function handleSAPWrite(
       // CDS pre-write validation: reject unsupported syntax early
       const cdsGuard = guardCdsSyntax(type, source, cachedFeatures);
       if (cdsGuard) return cdsGuard;
+
+      // RAP deterministic preflight validation (before object creation to avoid stubs)
+      const preflightWarnings = runRapPreflightValidation(
+        source,
+        type,
+        name,
+        cachedFeatures,
+        config.systemType,
+        preflightOverride,
+      );
+      if (preflightWarnings.blocked) return preflightWarnings.result!;
 
       // AFF header validation (if schema available for this type)
       const affResult = validateAffHeader(type, { description, originalLanguage: 'en' });
@@ -2443,7 +2516,8 @@ async function handleSAPWrite(
         await safeUpdateSource(client.http, client.safety, objectUrl, srcUrl, source, effectiveTransport);
         cachingLayer?.invalidate(type, name);
         const msg = `Created ${type} ${name} in package ${pkg} and wrote source code.`;
-        return lintWarnings.warnings ? textResult(`${msg}\n\n${lintWarnings.warnings}`) : textResult(msg);
+        const warnings = mergePreWriteWarnings(preflightWarnings.warnings, lintWarnings.warnings);
+        return warnings ? textResult(`${msg}\n\n${warnings}`) : textResult(msg);
       }
 
       return textResult(`Created ${type} ${name} in package ${pkg}.\n${result}`);
@@ -2480,6 +2554,202 @@ async function handleSAPWrite(
       cachingLayer?.invalidate(type, name);
       const msg = `Successfully updated method "${method}" in ${type} ${name}.`;
       return lintWarnings.warnings ? textResult(`${msg}\n\n${lintWarnings.warnings}`) : textResult(msg);
+    }
+    case 'scaffold_rap_handlers': {
+      if (type !== 'CLAS') {
+        return errorResult('scaffold_rap_handlers is only supported for type=CLAS behavior pool classes.');
+      }
+      const bdefName = String(args.bdefName ?? '').trim();
+      if (!bdefName) {
+        return errorResult('"bdefName" is required for scaffold_rap_handlers (interface behavior definition name).');
+      }
+      const autoApply = Boolean(args.autoApply ?? false);
+      const targetAlias = String(args.targetAlias ?? '')
+        .trim()
+        .toLowerCase();
+
+      await enforcePackageForExistingObject();
+
+      // Behavior pools frequently keep handler class declarations in CLAS include
+      // "definitions" or even "implementations" on older templates.
+      // Read structured class parts so we can inspect/apply across all sections.
+      const classStructured = await client.getClassStructured(name);
+      const classMainSource = classStructured.main ?? '';
+      const classDefinitionsSource = classStructured.definitions ?? '';
+      const classImplementationsSource = classStructured.implementations ?? '';
+      const classCombinedSource = [classMainSource, classDefinitionsSource, classImplementationsSource]
+        .filter(Boolean)
+        .join('\n\n');
+      const bdefSource = cachingLayer
+        ? (await cachingLayer.getSource('BDEF', bdefName, () => client.getBdef(bdefName))).source
+        : await client.getBdef(bdefName);
+
+      let requirements = extractRapHandlerRequirements(bdefSource);
+      if (targetAlias) {
+        requirements = requirements.filter((req) => req.entityAlias.toLowerCase() === targetAlias);
+      }
+
+      if (requirements.length === 0) {
+        const allAliases = Array.from(new Set(extractRapHandlerRequirements(bdefSource).map((req) => req.entityAlias)));
+        const aliasHint =
+          targetAlias && allAliases.length > 0
+            ? ` Available aliases in ${bdefName}: ${allAliases.join(', ')}.`
+            : ' No RAP action/determination/validation/auth handler declarations were found in the BDEF source.';
+        return errorResult(`No RAP handler requirements were found for the requested scope.${aliasHint}`);
+      }
+
+      const missing = findMissingRapHandlerRequirements(requirements, classCombinedSource);
+      const summary = {
+        className: name,
+        bdefName,
+        targetAlias: targetAlias || undefined,
+        scannedSections: [
+          'main',
+          classDefinitionsSource ? 'definitions' : undefined,
+          classImplementationsSource ? 'implementations' : undefined,
+        ].filter(Boolean),
+        requiredCount: requirements.length,
+        missingCount: missing.length,
+        missing,
+      };
+
+      if (!autoApply || missing.length === 0) {
+        return textResult(JSON.stringify({ ...summary, applied: false }, null, 2));
+      }
+
+      const applyMain = applyRapHandlerSignatures(classMainSource, missing);
+      let pending = applyMain.skipped.map((entry) => entry.requirement);
+
+      let applyDefinitions:
+        | ReturnType<typeof applyRapHandlerSignatures>
+        | {
+            updatedSource: string;
+            inserted: [];
+            skipped: typeof applyMain.skipped;
+            changed: false;
+          }
+        | undefined;
+      if (pending.length > 0 && classDefinitionsSource) {
+        applyDefinitions = applyRapHandlerSignatures(classDefinitionsSource, pending);
+        pending = applyDefinitions.skipped.map((entry) => entry.requirement);
+      }
+
+      let applyImplementations:
+        | ReturnType<typeof applyRapHandlerSignatures>
+        | {
+            updatedSource: string;
+            inserted: [];
+            skipped: typeof applyMain.skipped;
+            changed: false;
+          }
+        | undefined;
+      if (pending.length > 0 && classImplementationsSource) {
+        applyImplementations = applyRapHandlerSignatures(classImplementationsSource, pending);
+        pending = applyImplementations.skipped.map((entry) => entry.requirement);
+      }
+
+      const changedMain = applyMain.changed;
+      const changedDefinitions = applyDefinitions?.changed ?? false;
+      const changedImplementations = applyImplementations?.changed ?? false;
+      if (!changedMain && !changedDefinitions && !changedImplementations) {
+        return textResult(
+          JSON.stringify(
+            {
+              ...summary,
+              applied: false,
+              applyResult: {
+                main: applyMain,
+                definitions: applyDefinitions,
+                implementations: applyImplementations,
+                unresolved: pending,
+              },
+            },
+            null,
+            2,
+          ),
+        );
+      }
+
+      // Run lint for every section we are about to update; block before any write to avoid partial state.
+      let lintWarningsMain: PreWriteLintResult | undefined;
+      if (changedMain) {
+        lintWarningsMain = runPreWriteLint(applyMain.updatedSource, type, name, config, lintOverride);
+        if (lintWarningsMain.blocked) return lintWarningsMain.result!;
+      }
+      let lintWarningsDefinitions: PreWriteLintResult | undefined;
+      if (changedDefinitions && applyDefinitions) {
+        lintWarningsDefinitions = runPreWriteLint(applyDefinitions.updatedSource, type, name, config, lintOverride);
+        if (lintWarningsDefinitions.blocked) return lintWarningsDefinitions.result!;
+      }
+      let lintWarningsImplementations: PreWriteLintResult | undefined;
+      if (changedImplementations && applyImplementations) {
+        lintWarningsImplementations = runPreWriteLint(
+          applyImplementations.updatedSource,
+          type,
+          name,
+          config,
+          lintOverride,
+        );
+        if (lintWarningsImplementations.blocked) return lintWarningsImplementations.result!;
+      }
+
+      if (changedMain) {
+        await safeUpdateSource(client.http, client.safety, objectUrl, srcUrl, applyMain.updatedSource, transport);
+      }
+      if (changedDefinitions && applyDefinitions) {
+        await safeUpdateSource(
+          client.http,
+          client.safety,
+          objectUrl,
+          classIncludeUrl(name, 'definitions'),
+          applyDefinitions.updatedSource,
+          transport,
+        );
+      }
+      if (changedImplementations && applyImplementations) {
+        await safeUpdateSource(
+          client.http,
+          client.safety,
+          objectUrl,
+          classIncludeUrl(name, 'implementations'),
+          applyImplementations.updatedSource,
+          transport,
+        );
+      }
+      cachingLayer?.invalidate(type, name);
+
+      const insertedCount =
+        applyMain.inserted.length +
+        (applyDefinitions?.inserted.length ?? 0) +
+        (applyImplementations?.inserted.length ?? 0);
+      const updatedSections = [
+        changedMain ? 'main' : undefined,
+        changedDefinitions ? 'definitions' : undefined,
+        changedImplementations ? 'implementations' : undefined,
+      ].filter(Boolean);
+      const msg =
+        `Scaffolded ${insertedCount} RAP handler signature(s) in ${type} ${name} from BDEF ${bdefName}. ` +
+        `Updated section(s): ${updatedSections.join(', ')}.`;
+      const warnings = mergePreWriteWarnings(
+        lintWarningsMain?.warnings,
+        lintWarningsDefinitions?.warnings,
+        lintWarningsImplementations?.warnings,
+      );
+      const details = JSON.stringify(
+        {
+          ...summary,
+          applied: true,
+          applyResult: {
+            main: applyMain,
+            definitions: applyDefinitions,
+            implementations: applyImplementations,
+            unresolved: pending,
+          },
+        },
+        null,
+        2,
+      );
+      return warnings ? textResult(`${msg}\n\n${warnings}\n\n${details}`) : textResult(`${msg}\n\n${details}`);
     }
     case 'delete': {
       await enforcePackageForExistingObject();
@@ -2546,6 +2816,7 @@ async function handleSAPWrite(
       }
 
       const results: Array<{ type: string; name: string; status: 'success' | 'failed'; error?: string }> = [];
+      const batchWarnings: string[] = [];
 
       for (const obj of objects) {
         const objType = normalizeObjectType(String(obj.type ?? ''));
@@ -2570,6 +2841,27 @@ async function handleSAPWrite(
           // Pre-validate source with lint BEFORE creating the object to avoid orphaned objects.
           // Metadata objects (DOMA/DTEL) are XML-only and intentionally skip source lint.
           if (!metadataObject && objSource) {
+            const preflightWarnings = runRapPreflightValidation(
+              objSource,
+              objType,
+              objName,
+              cachedFeatures,
+              config.systemType,
+              preflightOverride,
+            );
+            if (preflightWarnings.blocked) {
+              results.push({
+                type: objType,
+                name: objName,
+                status: 'failed',
+                error: preflightWarnings.result!.content[0].text,
+              });
+              break;
+            }
+            if (preflightWarnings.warnings) {
+              batchWarnings.push(`${objType} ${objName}: ${preflightWarnings.warnings}`);
+            }
+
             const lintWarnings = runPreWriteLint(objSource, objType, objName, config, lintOverride);
             if (lintWarnings.blocked) {
               results.push({
@@ -2669,6 +2961,8 @@ async function handleSAPWrite(
         .join(', ');
       const successCount = results.filter((r) => r.status === 'success').length;
       const hasFailure = results.some((r) => r.status === 'failed');
+      const warningSuffix =
+        batchWarnings.length > 0 ? `\n\nRAP preflight warnings:\n- ${batchWarnings.join('\n- ')}` : '';
 
       if (hasFailure) {
         const cleanupHint =
@@ -2676,14 +2970,14 @@ async function handleSAPWrite(
             ? ` Note: ${successCount} already-created object(s) remain on the SAP system and may need manual cleanup.`
             : '';
         return errorResult(
-          `Batch created ${successCount}/${objects.length} objects in package ${pkg}: ${summary}${cleanupHint}`,
+          `Batch created ${successCount}/${objects.length} objects in package ${pkg}: ${summary}${cleanupHint}${warningSuffix}`,
         );
       }
-      return textResult(`Batch created ${successCount} objects in package ${pkg}: ${summary}`);
+      return textResult(`Batch created ${successCount} objects in package ${pkg}: ${summary}${warningSuffix}`);
     }
     default:
       return errorResult(
-        `Unknown SAPWrite action: ${action}. Supported: create, update, delete, edit_method, batch_create`,
+        `Unknown SAPWrite action: ${action}. Supported: create, update, delete, edit_method, batch_create, scaffold_rap_handlers`,
       );
   }
 }
@@ -2696,6 +2990,70 @@ interface PreWriteLintResult {
   result?: ToolResult;
   /** Warning text to append to success message */
   warnings?: string;
+}
+
+/** Pre-write RAP preflight check result */
+interface PreWriteRapPreflightResult {
+  /** Whether the write was blocked by RAP preflight errors */
+  blocked: boolean;
+  /** Error result to return if blocked */
+  result?: ToolResult;
+  /** Warning text to append to success message */
+  warnings?: string;
+}
+
+/**
+ * Run deterministic RAP preflight checks for non-ABAP RAP artifact types.
+ *
+ * Unlike lint, this check is intentionally narrow and rule-based. It focuses on
+ * known activation churn patterns (TABL curr/quan semantics, BDEF enum/header
+ * misuse, DDLX scope/duplicate annotations) and can cover types that offline
+ * abaplint does not parse well.
+ */
+function runRapPreflightValidation(
+  source: string,
+  type: string,
+  name: string,
+  features: ResolvedFeatures | undefined,
+  configSystemType: ServerConfig['systemType'],
+  perCallOverride?: boolean,
+): PreWriteRapPreflightResult {
+  const enabled = perCallOverride ?? true;
+  if (!enabled || !source) {
+    return { blocked: false };
+  }
+
+  const systemType = features?.systemType ?? (configSystemType !== 'auto' ? configSystemType : undefined);
+  const result = validateRapSource(type, source, {
+    systemType,
+    abapRelease: features?.abapRelease,
+  });
+
+  if (result.errors.length > 0) {
+    const details = formatRapPreflightFindings(result.errors);
+    return {
+      blocked: true,
+      result: errorResult(
+        `RAP preflight validation failed for ${type} ${name}. Fix these issues before writing:\n${details}\n\n` +
+          'Set preflightBeforeWrite=false only when you intentionally need to bypass these checks.',
+      ),
+    };
+  }
+
+  if (result.warnings.length > 0) {
+    return {
+      blocked: false,
+      warnings: `RAP preflight warnings:\n${formatRapPreflightFindings(result.warnings)}`,
+    };
+  }
+
+  return { blocked: false };
+}
+
+function mergePreWriteWarnings(...warnings: Array<string | undefined>): string | undefined {
+  const parts = warnings.filter((w): w is string => Boolean(w));
+  if (parts.length === 0) return undefined;
+  return parts.join('\n\n');
 }
 
 /**
@@ -2886,18 +3244,18 @@ async function handleSAPActivate(client: AdtClient, args: Record<string, unknown
     const objects = (args.objects as Array<Record<string, unknown>>).map((o) => {
       const objType = normalizeObjectType(String(o.type ?? type));
       const objName = String(o.name ?? '');
-      return { url: objectUrlForType(objType, objName), name: objName };
+      return { type: objType, name: objName, url: objectUrlForType(objType, objName) };
     });
 
     const result = await activateBatch(client.http, client.safety, objects, activateOpts);
     const names = objects.map((o) => o.name).join(', ');
+    const batchStatuses = buildBatchActivationStatuses(objects, result);
+    const statusDetails = formatBatchActivationStatuses(batchStatuses);
 
     if (result.success) {
-      return textResult(
-        `Successfully activated ${objects.length} objects: ${names}.${formatActivationMessages(result)}`,
-      );
+      return textResult(`Successfully activated ${objects.length} objects: ${names}.${statusDetails}`);
     }
-    return errorResult(`Batch activation failed for: ${names}.\n${formatActivationMessages(result)}`);
+    return errorResult(`Batch activation failed for: ${names}.${statusDetails}`);
   }
 
   // Single activation (existing behavior)
@@ -2943,6 +3301,72 @@ function formatActivationMessages(result: ActivationResult): string {
   }
 
   return parts.length > 0 ? `\n${parts.join('\n')}` : '';
+}
+
+interface BatchActivationObject {
+  type: string;
+  name: string;
+  url: string;
+}
+
+interface BatchActivationObjectStatus {
+  type: string;
+  name: string;
+  status: 'active' | 'warning' | 'error';
+  messages: string[];
+}
+
+function normalizeActivationUri(uri: string | undefined): string | undefined {
+  if (!uri) return undefined;
+  return uri.replace(/#.*$/, '').replace(/\/+$/, '');
+}
+
+function buildBatchActivationStatuses(
+  objects: BatchActivationObject[],
+  result: ActivationResult,
+): BatchActivationObjectStatus[] {
+  const byUri = new Map<string, Array<{ severity: 'error' | 'warning' | 'info'; text: string }>>();
+  const unassigned: string[] = [];
+
+  for (const detail of result.details) {
+    const key = normalizeActivationUri(detail.uri);
+    if (!key) {
+      const prefix = detail.line ? `[line ${detail.line}] ` : '';
+      unassigned.push(`${prefix}${detail.text}`);
+      continue;
+    }
+    const list = byUri.get(key) ?? [];
+    const prefix = detail.line ? `[line ${detail.line}] ` : '';
+    list.push({ severity: detail.severity, text: `${prefix}${detail.text}` });
+    byUri.set(key, list);
+  }
+
+  return objects.map((obj, index) => {
+    const key = normalizeActivationUri(obj.url) ?? '';
+    const details = byUri.get(key) ?? [];
+    const hasError = details.some((detail) => detail.severity === 'error');
+    const hasWarning = details.some((detail) => detail.severity === 'warning');
+    const status: BatchActivationObjectStatus['status'] = hasError ? 'error' : hasWarning ? 'warning' : 'active';
+    const messages = details.map((detail) => detail.text);
+    if (index === 0 && unassigned.length > 0) {
+      messages.push(...unassigned);
+    }
+    return {
+      type: obj.type,
+      name: obj.name,
+      status,
+      messages,
+    };
+  });
+}
+
+function formatBatchActivationStatuses(statuses: BatchActivationObjectStatus[]): string {
+  if (statuses.length === 0) return '';
+  const lines = statuses.map((status) => {
+    const messages = status.messages.length > 0 ? ` — ${status.messages.join('; ')}` : '';
+    return `- ${status.name} (${status.type}): ${status.status}${messages}`;
+  });
+  return `\nPer-object status:\n${lines.join('\n')}`;
 }
 
 // ─── SAPNavigate Handler ─────────────────────────────────────────────

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -2585,7 +2585,9 @@ async function handleSAPWrite(
         .trim()
         .toLowerCase();
 
-      await enforcePackageForExistingObject();
+      if (autoApply) {
+        await enforcePackageForExistingObject();
+      }
 
       // Why scan all three CLAS includes (main, definitions, implementations):
       //   Behavior-pool handler classes CAN live in any of the three, and

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -326,7 +326,7 @@ const batchObjectSchemaBtp = z.object({
 });
 
 export const SAPWriteSchema = z.object({
-  action: z.enum(['create', 'update', 'delete', 'edit_method', 'batch_create']),
+  action: z.enum(['create', 'update', 'delete', 'edit_method', 'batch_create', 'scaffold_rap_handlers']),
   type: z.enum(SAPWRITE_TYPES_ONPREM).optional(),
   name: z.string().optional(),
   source: z.string().optional(),
@@ -362,14 +362,18 @@ export const SAPWriteSchema = z.object({
   category: z.enum(['0', '1']).optional(),
   version: z.string().optional(),
   lintBeforeWrite: z.coerce.boolean().optional(),
+  preflightBeforeWrite: z.coerce.boolean().optional(),
   refObjectType: z.string().optional(),
   refObjectName: z.string().optional(),
   refObjectDescription: z.string().optional(),
+  bdefName: z.string().optional(),
+  autoApply: z.coerce.boolean().optional(),
+  targetAlias: z.string().optional(),
   objects: z.array(batchObjectSchemaOnprem).optional(),
 });
 
 export const SAPWriteSchemaBtp = z.object({
-  action: z.enum(['create', 'update', 'delete', 'edit_method', 'batch_create']),
+  action: z.enum(['create', 'update', 'delete', 'edit_method', 'batch_create', 'scaffold_rap_handlers']),
   type: z.enum(SAPWRITE_TYPES_BTP).optional(),
   name: z.string().optional(),
   source: z.string().optional(),
@@ -405,9 +409,13 @@ export const SAPWriteSchemaBtp = z.object({
   category: z.enum(['0', '1']).optional(),
   version: z.string().optional(),
   lintBeforeWrite: z.coerce.boolean().optional(),
+  preflightBeforeWrite: z.coerce.boolean().optional(),
   refObjectType: z.string().optional(),
   refObjectName: z.string().optional(),
   refObjectDescription: z.string().optional(),
+  bdefName: z.string().optional(),
+  autoApply: z.coerce.boolean().optional(),
+  targetAlias: z.string().optional(),
   objects: z.array(batchObjectSchemaBtp).optional(),
 });
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -154,7 +154,8 @@ const SAPWRITE_DESC_ONPREM =
   'SKTD (Knowledge Transfer Documents, Markdown docs attached to an ABAP object): create requires refObjectType (parent ADT type+subtype, e.g., "DDLS/DF"). A KTD inherits the name of the object it documents — so "name" MUST equal the parent object name (one KTD per object; refObjectName defaults to name and cannot differ). Update takes Markdown in "source"; delete uses the ADT deletion framework (two-step check/delete). Follow creates/updates with SAPActivate(type="SKTD", name="..."). ' +
   'For edit_method: surgically replace a single method body in a CLAS without sending the full class source. ' +
   'Provide just the new method implementation code in "source" — 95% fewer tokens than full-class updates. ' +
-  'For batch_create: create and activate multiple objects in a single call — ideal for RAP stacks (TABL → DDLS → DCLS → BDEF → SRVD). Pass "objects" array with dependency order.';
+  'For batch_create: create and activate multiple objects in a single call — ideal for RAP stacks (TABL → DDLS → DCLS → BDEF → SRVD). Pass "objects" array with dependency order. ' +
+  'For scaffold_rap_handlers: derive missing RAP behavior handler signatures from an interface BDEF and optionally inject declarations into an existing behavior pool class.';
 
 const SAPWRITE_DESC_BTP =
   'Create or update ABAP source code and DDIC metadata (BTP ABAP Environment). Handles lock/modify/unlock automatically. Supports CLAS, INTF, DDLS, DDLX, BDEF, SRVD, SRVB, SKTD, TABL, DOMA, DTEL, MSAG. ' +
@@ -167,7 +168,8 @@ const SAPWRITE_DESC_BTP =
   'SKTD (Knowledge Transfer Documents, Markdown docs attached to an ABAP object): create requires refObjectType (parent ADT type+subtype, e.g., "DDLS/DF"). A KTD inherits the name of the object it documents — so "name" MUST equal the parent object name (one KTD per object; refObjectName defaults to name and cannot differ). Update takes Markdown in "source"; delete uses the ADT deletion framework (two-step check/delete). Follow creates/updates with SAPActivate(type="SKTD", name="..."). ' +
   'Must use ABAP Cloud language version (no classic statements). Only Z*/Y* namespace allowed on BTP. ' +
   'For edit_method: surgically replace a single method body in a CLAS without sending the full class source. ' +
-  'For batch_create: create and activate multiple objects in a single call — ideal for RAP stacks (TABL → DDLS → DCLS → BDEF → SRVD).';
+  'For batch_create: create and activate multiple objects in a single call — ideal for RAP stacks (TABL → DDLS → DCLS → BDEF → SRVD). ' +
+  'For scaffold_rap_handlers: derive missing RAP behavior handler signatures from an interface BDEF and optionally inject declarations into an existing behavior pool class.';
 
 // ─── SAPContext Types ───────────────────────────────────────────────
 
@@ -514,9 +516,9 @@ export function getToolDefinitions(
         properties: {
           action: {
             type: 'string',
-            enum: ['create', 'update', 'delete', 'edit_method', 'batch_create'],
+            enum: ['create', 'update', 'delete', 'edit_method', 'batch_create', 'scaffold_rap_handlers'],
             description:
-              'Write action. edit_method: surgically replace a single method body (requires type=CLAS, method, and source params). batch_create: create and activate multiple objects in sequence (requires objects array)',
+              'Write action. edit_method: surgically replace a single method body (requires type=CLAS, method, and source params). batch_create: create and activate multiple objects in sequence (requires objects array). scaffold_rap_handlers: derive missing behavior-pool handler signatures from interface BDEF declarations and optionally inject them into the class declaration.',
           },
           type: {
             type: 'string',
@@ -530,6 +532,21 @@ export function getToolDefinitions(
           method: {
             type: 'string',
             description: 'For edit_method action: method name to replace (e.g., "get_name", "zif_order~process")',
+          },
+          bdefName: {
+            type: 'string',
+            description:
+              'For scaffold_rap_handlers action: interface BDEF name used to derive required handler signatures (e.g., ZI_TRAVELREQ).',
+          },
+          autoApply: {
+            type: 'boolean',
+            description:
+              'For scaffold_rap_handlers: if true, inject missing signatures into matching lhc_* class definitions and write the class source back.',
+          },
+          targetAlias: {
+            type: 'string',
+            description:
+              'For scaffold_rap_handlers: optional RAP entity alias filter (e.g., Travel, Segment) to scaffold only one handler class.',
           },
           description: {
             type: 'string',
@@ -603,7 +620,12 @@ export function getToolDefinitions(
           lintBeforeWrite: {
             type: 'boolean',
             description:
-              'Override server lint-before-write setting for this call. Set false to skip pre-write lint validation. Lint applies to ABAP types (PROG, CLAS, INTF, FUNC) and CDS views (DDLS). BDEF/SRVD/SRVB/DDLX/TABL are skipped (not supported by offline linter).',
+              'Override server lint-before-write setting for this call. Set false to skip pre-write lint validation. Lint applies to ABAP types (PROG, CLAS, INTF, FUNC) and CDS views (DDLS). BDEF/SRVD/SRVB/DDLX/TABL are skipped by offline linter; RAP preflight may still catch deterministic issues for those types.',
+          },
+          preflightBeforeWrite: {
+            type: 'boolean',
+            description:
+              'Enable/disable deterministic RAP preflight checks for this call (default: true). Useful for TABL/BDEF/DDLX static rules (e.g., curr/quan semantics, invalid BDEF enums, unsupported DDLX annotation scope on on-prem 7.5x).',
           },
           refObjectType: {
             type: 'string',

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -536,17 +536,17 @@ export function getToolDefinitions(
           bdefName: {
             type: 'string',
             description:
-              'For scaffold_rap_handlers action: interface BDEF name used to derive required handler signatures (e.g., ZI_TRAVELREQ).',
+              'For scaffold_rap_handlers action: interface BDEF name used to derive required handler signatures (e.g., ZI_TRAVELREQ). The BDEF is parsed to find every action/determination/validation/authorization that must exist in the behavior pool.',
           },
           autoApply: {
             type: 'boolean',
             description:
-              'For scaffold_rap_handlers: if true, inject missing signatures into matching lhc_* class definitions and write the class source back.',
+              'For scaffold_rap_handlers: when true, missing METHODS signatures are inserted into matching lhc_* class definitions and the class source is written back under a single lock. When false (default), returns a JSON report of required vs. missing signatures without modifying the class — use this first to preview, then re-run with autoApply=true to commit.',
           },
           targetAlias: {
             type: 'string',
             description:
-              'For scaffold_rap_handlers: optional RAP entity alias filter (e.g., Travel, Segment) to scaffold only one handler class.',
+              'For scaffold_rap_handlers: optional RAP entity alias filter (e.g., Travel, Segment) to scaffold only one handler class. When omitted, all entities declared in the BDEF are scaffolded. Case-insensitive.',
           },
           description: {
             type: 'string',

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -155,7 +155,7 @@ const SAPWRITE_DESC_ONPREM =
   'For edit_method: surgically replace a single method body in a CLAS without sending the full class source. ' +
   'Provide just the new method implementation code in "source" — 95% fewer tokens than full-class updates. ' +
   'For batch_create: create and activate multiple objects in a single call — ideal for RAP stacks (TABL → DDLS → DCLS → BDEF → SRVD). Pass "objects" array with dependency order. ' +
-  'For scaffold_rap_handlers: derive missing RAP behavior handler signatures from an interface BDEF and optionally inject declarations into an existing behavior pool class.';
+  'For scaffold_rap_handlers: derive missing RAP behavior handler signatures from an interface BDEF and optionally inject declarations plus empty implementation stubs into an existing behavior pool class.';
 
 const SAPWRITE_DESC_BTP =
   'Create or update ABAP source code and DDIC metadata (BTP ABAP Environment). Handles lock/modify/unlock automatically. Supports CLAS, INTF, DDLS, DDLX, BDEF, SRVD, SRVB, SKTD, TABL, DOMA, DTEL, MSAG. ' +
@@ -169,7 +169,7 @@ const SAPWRITE_DESC_BTP =
   'Must use ABAP Cloud language version (no classic statements). Only Z*/Y* namespace allowed on BTP. ' +
   'For edit_method: surgically replace a single method body in a CLAS without sending the full class source. ' +
   'For batch_create: create and activate multiple objects in a single call — ideal for RAP stacks (TABL → DDLS → DCLS → BDEF → SRVD). ' +
-  'For scaffold_rap_handlers: derive missing RAP behavior handler signatures from an interface BDEF and optionally inject declarations into an existing behavior pool class.';
+  'For scaffold_rap_handlers: derive missing RAP behavior handler signatures from an interface BDEF and optionally inject declarations plus empty implementation stubs into an existing behavior pool class.';
 
 // ─── SAPContext Types ───────────────────────────────────────────────
 
@@ -518,7 +518,7 @@ export function getToolDefinitions(
             type: 'string',
             enum: ['create', 'update', 'delete', 'edit_method', 'batch_create', 'scaffold_rap_handlers'],
             description:
-              'Write action. edit_method: surgically replace a single method body (requires type=CLAS, method, and source params). batch_create: create and activate multiple objects in sequence (requires objects array). scaffold_rap_handlers: derive missing behavior-pool handler signatures from interface BDEF declarations and optionally inject them into the class declaration.',
+              'Write action. edit_method: surgically replace a single method body (requires type=CLAS, method, and source params). batch_create: create and activate multiple objects in sequence (requires objects array). scaffold_rap_handlers: derive missing behavior-pool handler signatures from interface BDEF declarations and optionally inject declarations plus empty implementation stubs.',
           },
           type: {
             type: 'string',
@@ -541,7 +541,7 @@ export function getToolDefinitions(
           autoApply: {
             type: 'boolean',
             description:
-              'For scaffold_rap_handlers: when true, missing METHODS signatures are inserted into matching lhc_* class definitions and the class source is written back under a single lock. When false (default), returns a JSON report of required vs. missing signatures without modifying the class — use this first to preview, then re-run with autoApply=true to commit.',
+              'For scaffold_rap_handlers: when true, missing METHODS signatures are inserted into matching lhc_* class definitions, empty METHOD stubs are inserted into matching implementation blocks where possible, and the class source is written back under a single lock. When false (default), returns a JSON report of required vs. missing signatures without modifying the class — use this first to preview, then re-run with autoApply=true to commit.',
           },
           targetAlias: {
             type: 'string',

--- a/tests/integration/adt.integration.test.ts
+++ b/tests/integration/adt.integration.test.ts
@@ -29,6 +29,11 @@ import {
   listGroups,
   listTiles,
 } from '../../src/adt/flp.js';
+import {
+  applyRapHandlerSignatures,
+  extractRapHandlerRequirements,
+  findMissingRapHandlerRequirements,
+} from '../../src/adt/rap-handlers.js';
 import { unrestrictedSafetyConfig } from '../../src/adt/safety.js';
 import { expectSapFailureClass } from '../helpers/expected-error.js';
 import { requireOrSkip, SkipReason } from '../helpers/skip-policy.js';
@@ -1107,6 +1112,114 @@ describe('ADT Integration Tests', () => {
         expectSapFailureClass(err, [403, 404, 500], [/not found/i, /forbidden/i, /usageReferences/i]);
         requireOrSkip(ctx, undefined, SkipReason.BACKEND_UNSUPPORTED);
       }
+    });
+  });
+
+  // ─── RAP Handler Scaffolding Helpers ───────────────────────────────
+
+  describe('RAP handler scaffolding helpers', () => {
+    const bdefFixture = '/DMO/I_CARRIERSLOCKSINGLETON_S';
+
+    async function readRapFixture(ctx: import('vitest').TaskContext): Promise<{
+      bdefSource: string;
+      behaviorPoolClass: string;
+      classStructured: Awaited<ReturnType<AdtClient['getClassStructured']>>;
+    }> {
+      try {
+        const bdefSource = await client.getBdef(bdefFixture);
+        const behaviorPoolClass = bdefSource.match(/implementation\s+in\s+class\s+([^\s;]+)/i)?.[1];
+        requireOrSkip(ctx, behaviorPoolClass, `${SkipReason.NO_FIXTURE} (${bdefFixture}) — no implementation class`);
+        const classStructured = await client.getClassStructured(behaviorPoolClass);
+        return { bdefSource, behaviorPoolClass, classStructured };
+      } catch (err) {
+        expectSapFailureClass(err, [403, 404], [/not found/i, /forbidden/i]);
+        requireOrSkip(ctx, undefined, `${SkipReason.NO_FIXTURE} (${bdefFixture}) — RAP demo fixture not available`);
+      }
+    }
+
+    it('extracts handler requirements from live BDEF source', async (ctx) => {
+      const { bdefSource } = await readRapFixture(ctx);
+      const requirements = extractRapHandlerRequirements(bdefSource);
+      const firstRequirement = requirements[0];
+      requireOrSkip(
+        ctx,
+        firstRequirement,
+        `${SkipReason.NO_FIXTURE} (${bdefFixture}) — no action/validation/auth requirements in BDEF`,
+      );
+
+      expect(requirements.length).toBeGreaterThan(0);
+      expect(requirements.some((req) => req.kind === 'validation' || req.kind === 'action')).toBe(true);
+    });
+
+    it('matches requirements against live class source across includes', async (ctx) => {
+      const { bdefSource, classStructured } = await readRapFixture(ctx);
+      const requirements = extractRapHandlerRequirements(bdefSource);
+      const firstRequirement = requirements[0];
+      requireOrSkip(
+        ctx,
+        firstRequirement,
+        `${SkipReason.NO_FIXTURE} (${bdefFixture}) — no requirements to match against class source`,
+      );
+
+      const combinedClassSource = [
+        classStructured.main,
+        classStructured.definitions ?? '',
+        classStructured.implementations ?? '',
+      ]
+        .filter(Boolean)
+        .join('\n\n');
+      const missing = findMissingRapHandlerRequirements(requirements, combinedClassSource);
+
+      expect(missing.length).toBeLessThanOrEqual(requirements.length);
+      expect(
+        missing.every((missingReq) =>
+          requirements.some(
+            (requirement) =>
+              requirement.targetHandlerClass === missingReq.targetHandlerClass &&
+              requirement.methodName === missingReq.methodName,
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it('can re-insert a deliberately removed signature in the live implementation include', async (ctx) => {
+      const { bdefSource, classStructured } = await readRapFixture(ctx);
+      const requirements = extractRapHandlerRequirements(bdefSource);
+      const implementationSource = classStructured.implementations;
+      requireOrSkip(
+        ctx,
+        implementationSource,
+        `${SkipReason.NO_FIXTURE} (${bdefFixture}) — no implementations include available`,
+      );
+
+      const requirement = requirements.find(
+        (req) =>
+          req.targetHandlerClass.toLowerCase() === 'lhc_carrier' &&
+          (req.kind === 'validation' || req.kind === 'action'),
+      );
+      requireOrSkip(
+        ctx,
+        requirement,
+        `${SkipReason.NO_FIXTURE} (${bdefFixture}) — expected handler requirement not found`,
+      );
+
+      const declarationRegex = new RegExp(
+        `(^|\\n)\\s*METHODS\\s+${requirement.methodName}\\b[\\s\\S]*?\\.\\s*(?=\\n\\s*(?:METHODS\\b|ENDCLASS\\.))`,
+        'i',
+      );
+      if (!declarationRegex.test(implementationSource)) {
+        requireOrSkip(
+          ctx,
+          undefined,
+          `${SkipReason.NO_FIXTURE} (${bdefFixture}) — method declaration ${requirement.methodName} not present in fixture`,
+        );
+      }
+      const stripped = implementationSource.replace(declarationRegex, '\n');
+
+      const apply = applyRapHandlerSignatures(stripped, [requirement]);
+      expect(apply.changed).toBe(true);
+      expect(apply.inserted).toHaveLength(1);
+      expect(apply.updatedSource.toLowerCase()).toContain(`methods ${requirement.methodName}`);
     });
   });
 

--- a/tests/unit/adt/rap-handlers.test.ts
+++ b/tests/unit/adt/rap-handlers.test.ts
@@ -46,6 +46,56 @@ describe('extractRapHandlerRequirements', () => {
     expect(segmentAction?.entityAlias).toBe('Segment');
     expect(segmentAction?.targetHandlerClass).toBe('lhc_segment');
   });
+
+  it('extracts factory, internal, and static action variants and omits RESULT when BDEF has none', () => {
+    const source = `managed implementation in class zbp_i_travel unique;
+define behavior for zi_travel alias travel
+authorization master ( global )
+{
+  action  ( features: instance ) acceptTravel result [1] $self;
+  internal action reCalcTotalPrice;
+  factory action copyTravel [1];
+  static action doStaticThing;
+  static factory action staticCreate;
+}`;
+    const requirements = extractRapHandlerRequirements(source);
+    const accept = requirements.find((req) => req.methodName === 'accepttravel');
+    expect(accept?.signature).toContain('FOR ACTION travel~acceptTravel RESULT result');
+
+    const recalc = requirements.find((req) => req.methodName === 'recalctotalprice');
+    expect(recalc).toBeDefined();
+    expect(recalc?.signature).toContain('FOR ACTION travel~reCalcTotalPrice.');
+    expect(recalc?.signature).not.toContain('RESULT');
+
+    const copy = requirements.find((req) => req.methodName === 'copytravel');
+    expect(copy, 'factory action should be detected').toBeDefined();
+    expect(copy?.signature).toContain('FOR ACTION travel~copyTravel.');
+    expect(copy?.signature).not.toContain('RESULT');
+
+    const staticThing = requirements.find((req) => req.methodName === 'dostaticthing');
+    expect(staticThing, 'static action should be detected').toBeDefined();
+    expect(staticThing?.signature).not.toContain('RESULT');
+
+    const staticCreate = requirements.find((req) => req.methodName === 'staticcreate');
+    expect(staticCreate, 'static factory action should be detected').toBeDefined();
+  });
+
+  it('detects RESULT clause even when action declaration spans multiple lines', () => {
+    const source = `define behavior for zi_travel alias travel
+authorization master ( global )
+{
+  action acceptTravel
+    result [1] $self;
+  action cancelTravel
+    ;
+}`;
+    const requirements = extractRapHandlerRequirements(source);
+    const accept = requirements.find((req) => req.methodName === 'accepttravel');
+    expect(accept?.signature).toContain('RESULT result');
+
+    const cancel = requirements.find((req) => req.methodName === 'canceltravel');
+    expect(cancel?.signature).not.toContain('RESULT');
+  });
 });
 
 describe('findMissingRapHandlerRequirements', () => {

--- a/tests/unit/adt/rap-handlers.test.ts
+++ b/tests/unit/adt/rap-handlers.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyRapHandlerSignatures,
+  extractRapHandlerRequirements,
+  findMissingRapHandlerRequirements,
+  parseClassDefinitionMethods,
+} from '../../../src/adt/rap-handlers.js';
+
+const BDEF_SOURCE = `managed implementation in class ZBP_I_TRAVELREQ unique;
+define behavior for ZI_TRAVELREQ alias Travel
+authorization master ( instance )
+{
+  create;
+  action SubmitForApproval result [1] $self;
+  action RecalculateTotalCost result [1] $self;
+  determination SetDefaults on modify { create; }
+  validation ValidateDates on save { create; }
+}
+
+define behavior for ZI_TRAVELSEG alias Segment
+{
+  action Reprice result [1] $self;
+}`;
+
+describe('extractRapHandlerRequirements', () => {
+  it('extracts action, determination, validation, and authorization requirements from BDEF', () => {
+    const requirements = extractRapHandlerRequirements(BDEF_SOURCE);
+    const kinds = requirements.map((req) => req.kind);
+    expect(kinds).toContain('action');
+    expect(kinds).toContain('determination');
+    expect(kinds).toContain('validation');
+    expect(kinds).toContain('instance_authorization');
+
+    const submit = requirements.find((req) => req.methodName === 'submitforapproval');
+    expect(submit?.targetHandlerClass).toBe('lhc_travel');
+    expect(submit?.signature).toContain('FOR ACTION Travel~SubmitForApproval');
+
+    const auth = requirements.find((req) => req.kind === 'instance_authorization');
+    expect(auth?.signature).toContain('FOR INSTANCE AUTHORIZATION');
+    expect(auth?.signature).toContain('FOR Travel RESULT result');
+  });
+
+  it('derives handler class names from aliases across multiple entities', () => {
+    const requirements = extractRapHandlerRequirements(BDEF_SOURCE);
+    const segmentAction = requirements.find((req) => req.methodName === 'reprice');
+    expect(segmentAction?.entityAlias).toBe('Segment');
+    expect(segmentAction?.targetHandlerClass).toBe('lhc_segment');
+  });
+});
+
+describe('findMissingRapHandlerRequirements', () => {
+  it('returns only requirements not declared in class definitions', () => {
+    const classSource = `CLASS zbp_i_travelreq DEFINITION PUBLIC ABSTRACT FINAL FOR BEHAVIOR OF zi_travelreq.
+ENDCLASS.
+
+CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS submitforapproval FOR MODIFY
+      IMPORTING keys FOR ACTION Travel~SubmitForApproval RESULT result.
+ENDCLASS.
+
+CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.
+
+CLASS lhc_segment DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+ENDCLASS.`;
+
+    const requirements = extractRapHandlerRequirements(BDEF_SOURCE);
+    const missing = findMissingRapHandlerRequirements(requirements, classSource);
+    expect(missing.some((req) => req.methodName === 'submitforapproval')).toBe(false);
+    expect(missing.some((req) => req.methodName === 'recalculatetotalcost')).toBe(true);
+    expect(missing.some((req) => req.methodName === 'reprice')).toBe(true);
+  });
+});
+
+describe('parseClassDefinitionMethods', () => {
+  it('extracts METHODS declarations per class', () => {
+    const source = `CLASS lhc_travel DEFINITION.
+  PRIVATE SECTION.
+    METHODS submitforapproval FOR MODIFY IMPORTING keys FOR ACTION Travel~SubmitForApproval RESULT result.
+ENDCLASS.
+CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.`;
+
+    const methods = parseClassDefinitionMethods(source);
+    expect(methods.get('lhc_travel')?.has('submitforapproval')).toBe(true);
+  });
+
+  it('does not skip concrete class definitions after deferred declarations', () => {
+    const source = `CLASS lthc_carrier DEFINITION DEFERRED FOR TESTING.
+
+CLASS lhc_carrier DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS validatename FOR VALIDATE ON SAVE
+      IMPORTING keys FOR carrier~validatename.
+ENDCLASS.`;
+
+    const methods = parseClassDefinitionMethods(source);
+    expect(methods.get('lhc_carrier')?.has('validatename')).toBe(true);
+  });
+});
+
+describe('applyRapHandlerSignatures', () => {
+  it('injects missing signatures into existing handler class private sections', () => {
+    const classSource = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+ENDCLASS.
+
+CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.`;
+    const requirements = extractRapHandlerRequirements(BDEF_SOURCE).filter(
+      (req) => req.targetHandlerClass === 'lhc_travel',
+    );
+    const result = applyRapHandlerSignatures(classSource, requirements);
+
+    expect(result.changed).toBe(true);
+    expect(result.inserted.length).toBeGreaterThan(0);
+    expect(result.updatedSource).toContain('METHODS submitforapproval FOR MODIFY');
+    expect(result.updatedSource).toContain('METHODS recalculatetotalcost FOR MODIFY');
+    expect(result.updatedSource).toContain('METHODS get_instance_authorizations FOR INSTANCE AUTHORIZATION');
+  });
+
+  it('adds PRIVATE SECTION when missing in a handler class definition', () => {
+    const classSource = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+ENDCLASS.
+
+CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.`;
+    const requirement = extractRapHandlerRequirements(BDEF_SOURCE).find(
+      (req) => req.methodName === 'submitforapproval',
+    );
+    expect(requirement).toBeDefined();
+    const result = applyRapHandlerSignatures(classSource, requirement ? [requirement] : []);
+
+    expect(result.changed).toBe(true);
+    expect(result.updatedSource).toContain('PRIVATE SECTION.');
+    expect(result.updatedSource).toContain('METHODS submitforapproval FOR MODIFY');
+  });
+
+  it('reports skipped requirements when target handler class is not present', () => {
+    const classSource = `CLASS zbp_i_travelreq DEFINITION PUBLIC.
+ENDCLASS.`;
+    const requirements = extractRapHandlerRequirements(BDEF_SOURCE).filter(
+      (req) => req.targetHandlerClass === 'lhc_segment',
+    );
+    const result = applyRapHandlerSignatures(classSource, requirements);
+
+    expect(result.changed).toBe(false);
+    expect(result.inserted).toHaveLength(0);
+    expect(result.skipped).toHaveLength(requirements.length);
+    expect(result.skipped[0]?.reason).toContain('not found');
+  });
+});

--- a/tests/unit/adt/rap-handlers.test.ts
+++ b/tests/unit/adt/rap-handlers.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applyRapHandlerImplementationStubs,
   applyRapHandlerSignatures,
   extractRapHandlerRequirements,
+  findMissingRapHandlerImplementationStubs,
   findMissingRapHandlerRequirements,
   parseClassDefinitionMethods,
 } from '../../../src/adt/rap-handlers.js';
+import { spliceMethod } from '../../../src/context/method-surgery.js';
 
 const BDEF_SOURCE = `managed implementation in class ZBP_I_TRAVELREQ unique;
 define behavior for ZI_TRAVELREQ alias Travel
@@ -199,6 +202,28 @@ ENDCLASS.`;
   });
 });
 
+describe('findMissingRapHandlerImplementationStubs', () => {
+  it('reports declarations that still lack implementation blocks', () => {
+    const bdef = `define behavior for zi_travel alias travel
+{
+  action SubmitForApproval result [1] $self;
+}`;
+    const classSource = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS submitforapproval FOR MODIFY
+      IMPORTING keys FOR ACTION travel~SubmitForApproval RESULT result.
+ENDCLASS.
+
+CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.`;
+
+    const requirements = extractRapHandlerRequirements(bdef);
+    const missing = findMissingRapHandlerImplementationStubs(requirements, classSource);
+
+    expect(missing.map((req) => req.methodName)).toEqual(['submitforapproval']);
+  });
+});
+
 describe('applyRapHandlerSignatures', () => {
   it('injects missing signatures into existing handler class private sections', () => {
     const classSource = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
@@ -217,6 +242,30 @@ ENDCLASS.`;
     expect(result.updatedSource).toContain('METHODS submitforapproval FOR MODIFY');
     expect(result.updatedSource).toContain('METHODS recalculatetotalcost FOR MODIFY');
     expect(result.updatedSource).toContain('METHODS get_instance_authorizations FOR INSTANCE AUTHORIZATION');
+  });
+
+  it('ignores deferred handler declarations when choosing insertion target', () => {
+    const classSource = `CLASS lhc_travel DEFINITION DEFERRED.
+
+CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+ENDCLASS.
+
+CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.`;
+    const requirement = extractRapHandlerRequirements(BDEF_SOURCE).find(
+      (req) => req.methodName === 'submitforapproval',
+    );
+    expect(requirement).toBeDefined();
+
+    const result = applyRapHandlerSignatures(classSource, requirement ? [requirement] : []);
+
+    expect(result.changed).toBe(true);
+    expect(result.updatedSource).toMatch(/^CLASS lhc_travel DEFINITION DEFERRED\./);
+    expect(result.updatedSource).toContain(`CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS submitforapproval FOR MODIFY`);
+    expect(result.updatedSource).not.toMatch(/^ {2}PRIVATE SECTION\./);
   });
 
   it('adds PRIVATE SECTION when missing in a handler class definition', () => {
@@ -248,5 +297,77 @@ ENDCLASS.`;
     expect(result.inserted).toHaveLength(0);
     expect(result.skipped).toHaveLength(requirements.length);
     expect(result.skipped[0]?.reason).toContain('not found');
+  });
+});
+
+describe('applyRapHandlerImplementationStubs', () => {
+  it('inserts empty method stubs into matching implementation classes', () => {
+    const classSource = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS submitforapproval FOR MODIFY
+      IMPORTING keys FOR ACTION Travel~SubmitForApproval RESULT result.
+ENDCLASS.
+
+CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.`;
+    const requirement = extractRapHandlerRequirements(BDEF_SOURCE).find(
+      (req) => req.methodName === 'submitforapproval',
+    );
+    expect(requirement).toBeDefined();
+
+    const result = applyRapHandlerImplementationStubs(classSource, requirement ? [requirement] : []);
+
+    expect(result.changed).toBe(true);
+    expect(result.updatedSource).toContain('CLASS lhc_travel IMPLEMENTATION.');
+    expect(result.updatedSource).toContain('  METHOD submitforapproval.');
+    expect(result.updatedSource).toContain('  ENDMETHOD.');
+
+    const spliced = spliceMethod(
+      result.updatedSource,
+      'zbp_i_travelreq',
+      'submitforapproval',
+      '    reported = reported.',
+    );
+    expect(spliced.success).toBe(true);
+    expect(spliced.newSource).toContain('reported = reported.');
+  });
+
+  it('creates implementation blocks in implementation includes when requested', () => {
+    const classSource = `*"* implementations placeholder
+CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS submitforapproval FOR MODIFY
+      IMPORTING keys FOR ACTION Travel~SubmitForApproval RESULT result.
+ENDCLASS.`;
+    const requirement = extractRapHandlerRequirements(BDEF_SOURCE).find(
+      (req) => req.methodName === 'submitforapproval',
+    );
+    expect(requirement).toBeDefined();
+
+    const result = applyRapHandlerImplementationStubs(classSource, requirement ? [requirement] : [], {
+      createImplementationBlocks: true,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.updatedSource).toContain(`CLASS lhc_travel IMPLEMENTATION.
+  METHOD submitforapproval.
+  ENDMETHOD.
+ENDCLASS.`);
+  });
+
+  it('does not duplicate existing implementation stubs', () => {
+    const classSource = `CLASS lhc_travel IMPLEMENTATION.
+  METHOD submitforapproval.
+  ENDMETHOD.
+ENDCLASS.`;
+    const requirement = extractRapHandlerRequirements(BDEF_SOURCE).find(
+      (req) => req.methodName === 'submitforapproval',
+    );
+    expect(requirement).toBeDefined();
+
+    const result = applyRapHandlerImplementationStubs(classSource, requirement ? [requirement] : []);
+
+    expect(result.changed).toBe(false);
+    expect(result.updatedSource.match(/METHOD submitforapproval/g)).toHaveLength(1);
   });
 });

--- a/tests/unit/adt/rap-handlers.test.ts
+++ b/tests/unit/adt/rap-handlers.test.ts
@@ -222,6 +222,28 @@ ENDCLASS.`;
 
     expect(missing.map((req) => req.methodName)).toEqual(['submitforapproval']);
   });
+
+  it('treats semantic method implementations as satisfying their BDEF action binding', () => {
+    const bdef = `define behavior for zi_travel alias travel
+{
+  action acceptTravel result [1] $self;
+}`;
+    const classSource = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS set_status_accepted FOR MODIFY
+      IMPORTING keys FOR ACTION travel~acceptTravel RESULT result.
+ENDCLASS.
+
+CLASS lhc_travel IMPLEMENTATION.
+  METHOD set_status_accepted.
+  ENDMETHOD.
+ENDCLASS.`;
+
+    const requirements = extractRapHandlerRequirements(bdef);
+    const missing = findMissingRapHandlerImplementationStubs(requirements, classSource);
+
+    expect(missing).toEqual([]);
+  });
 });
 
 describe('applyRapHandlerSignatures', () => {
@@ -353,6 +375,27 @@ ENDCLASS.`;
   METHOD submitforapproval.
   ENDMETHOD.
 ENDCLASS.`);
+  });
+
+  it('uses the declared semantic method name when creating stubs for bound BDEF actions', () => {
+    const bdef = `define behavior for zi_travel alias travel
+{
+  action acceptTravel result [1] $self;
+}`;
+    const definitionSource = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS set_status_accepted FOR MODIFY
+      IMPORTING keys FOR ACTION travel~acceptTravel RESULT result.
+ENDCLASS.`;
+    const implementationSource = `CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.`;
+    const requirements = extractRapHandlerRequirements(bdef);
+
+    const result = applyRapHandlerImplementationStubs(implementationSource, requirements, { definitionSource });
+
+    expect(result.changed).toBe(true);
+    expect(result.updatedSource).toContain('METHOD set_status_accepted.');
+    expect(result.updatedSource).not.toContain('METHOD accepttravel.');
   });
 
   it('does not duplicate existing implementation stubs', () => {

--- a/tests/unit/adt/rap-handlers.test.ts
+++ b/tests/unit/adt/rap-handlers.test.ts
@@ -149,6 +149,54 @@ ENDCLASS.`;
     const methods = parseClassDefinitionMethods(source);
     expect(methods.get('lhc_carrier')?.has('validatename')).toBe(true);
   });
+
+  it('indexes FOR ACTION binding keys so semantic method names satisfy BDEF actions', () => {
+    // This is the shape used by SAP's shipped /DMO/BP_TRAVEL_M: the method
+    // name (`set_status_accepted`) is semantic, bound to BDEF action
+    // `acceptTravel` via `FOR ACTION travel~accepttravel`. The scaffolder
+    // compares against BDEF identifiers, so the binding key MUST also be
+    // indexed — otherwise we'd falsely report `accepttravel` as missing and
+    // try to re-inject it as a duplicate METHOD declaration.
+    const source = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS set_status_accepted FOR MODIFY
+      IMPORTING keys FOR ACTION travel~accepttravel RESULT result.
+    METHODS recalc_total FOR DETERMINE ON MODIFY
+      IMPORTING keys FOR travel~recalctotalprice.
+ENDCLASS.`;
+    const methods = parseClassDefinitionMethods(source);
+    const travel = methods.get('lhc_travel');
+    expect(travel).toBeDefined();
+    // Method names are present…
+    expect(travel?.has('set_status_accepted')).toBe(true);
+    expect(travel?.has('recalc_total')).toBe(true);
+    // …AND their binding keys are also indexed so the BDEF identifier
+    // matches.
+    expect(travel?.has('accepttravel')).toBe(true);
+    expect(travel?.has('recalctotalprice')).toBe(true);
+  });
+});
+
+describe('findMissingRapHandlerRequirements with semantic method names', () => {
+  it('treats a BDEF action as fulfilled when bound via FOR ACTION alias~name', () => {
+    // Regression for the /DMO/BP_TRAVEL_M pattern — without binding-key
+    // extraction the scaffolder would incorrectly consider `accepttravel`
+    // missing even though the hand-crafted pool fully implements it.
+    const bdef = `managed implementation in class zbp_i_travel unique;
+define behavior for zi_travel alias travel
+authorization master ( global )
+{
+  action acceptTravel result [1] $self;
+}`;
+    const classSource = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS set_status_accepted FOR MODIFY
+      IMPORTING keys FOR ACTION travel~accepttravel RESULT result.
+ENDCLASS.`;
+    const requirements = extractRapHandlerRequirements(bdef);
+    const missing = findMissingRapHandlerRequirements(requirements, classSource);
+    expect(missing.some((req) => req.methodName === 'accepttravel')).toBe(false);
+  });
 });
 
 describe('applyRapHandlerSignatures', () => {

--- a/tests/unit/adt/rap-handlers.test.ts
+++ b/tests/unit/adt/rap-handlers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyRapHandlerImplementationStubs,
+  applyRapHandlerScaffold,
   applyRapHandlerSignatures,
   extractRapHandlerRequirements,
   findMissingRapHandlerImplementationStubs,
@@ -412,5 +413,38 @@ ENDCLASS.`;
 
     expect(result.changed).toBe(false);
     expect(result.updatedSource.match(/METHOD submitforapproval/g)).toHaveLength(1);
+  });
+});
+
+describe('applyRapHandlerScaffold', () => {
+  it('plans signatures and stubs across behavior-pool includes without ADT I/O', () => {
+    const bdef = `define behavior for zi_travel alias travel
+{
+  action acceptTravel result [1] $self;
+  action RecalculateTotalCost result [1] $self;
+}`;
+    const definitions = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS set_status_accepted FOR MODIFY
+      IMPORTING keys FOR ACTION travel~acceptTravel RESULT result.
+ENDCLASS.`;
+    const implementations = `CLASS lhc_travel IMPLEMENTATION.
+  METHOD set_status_accepted.
+  ENDMETHOD.
+ENDCLASS.`;
+    const requirements = extractRapHandlerRequirements(bdef);
+    const missing = findMissingRapHandlerRequirements(requirements, `${definitions}\n${implementations}`);
+    const missingStubs = findMissingRapHandlerImplementationStubs(requirements, `${definitions}\n${implementations}`);
+
+    const plan = applyRapHandlerScaffold({ main: '', definitions, implementations }, missing, missingStubs);
+
+    expect(plan.changed.definitions).toBe(true);
+    expect(plan.changed.implementations).toBe(true);
+    expect(plan.insertedSignatureCount).toBe(1);
+    expect(plan.insertedImplementationStubCount).toBe(1);
+    expect(plan.sections.definitions).toContain('METHODS recalculatetotalcost FOR MODIFY');
+    expect(plan.sections.implementations).toContain('METHOD recalculatetotalcost.');
+    expect(plan.sections.implementations).not.toContain('METHOD accepttravel.');
+    expect(plan.unresolved).toEqual([]);
   });
 });

--- a/tests/unit/adt/rap-preflight.test.ts
+++ b/tests/unit/adt/rap-preflight.test.ts
@@ -68,6 +68,7 @@ define behavior for ZC_Travel alias Travel
 }`;
     const result = validateRapSource('BDEF', source, { systemType: 'onprem', abapRelease: '758' });
     expect(result.errors.some((f) => f.ruleId === 'BDEF_PROJECTION_USE_ETAG_UNSUPPORTED')).toBe(true);
+    expect(result.errors.find((f) => f.ruleId === 'BDEF_PROJECTION_USE_ETAG_UNSUPPORTED')?.line).toBe(2);
   });
 
   it('does NOT flag per-entity "use etag" in projection BDEF (SAP /DMO/ pattern)', () => {

--- a/tests/unit/adt/rap-preflight.test.ts
+++ b/tests/unit/adt/rap-preflight.test.ts
@@ -70,6 +70,34 @@ define behavior for ZC_Travel alias Travel
     expect(result.errors.some((f) => f.ruleId === 'BDEF_PROJECTION_USE_ETAG_UNSUPPORTED')).toBe(true);
   });
 
+  it('does NOT flag per-entity "use etag" in projection BDEF (SAP /DMO/ pattern)', () => {
+    // This is the exact pattern used by SAP's shipped /DMO/C_TRAVEL_PROCESSOR_M
+    // — `use etag` attached to a `define behavior for X alias Y` block is the
+    // supported modern form and MUST NOT be flagged. Earlier versions of the
+    // rule matched `use etag` anywhere in the source, producing a false
+    // positive on working SAP-delivered code.
+    const source = `projection;
+strict(2);
+
+define behavior for /DMO/C_Travel_Processor_M alias TravelProcessor
+use etag
+
+{
+  field ( readonly ) TotalPrice;
+  use create;
+  use update;
+  use delete;
+}
+
+define behavior for /DMO/C_Booking_Processor_M alias BookingProcessor
+use etag
+{
+  use update;
+}`;
+    const result = validateRapSource('BDEF', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.errors.some((f) => f.ruleId === 'BDEF_PROJECTION_USE_ETAG_UNSUPPORTED')).toBe(false);
+  });
+
   it('adds warning for duplicate etag master names in BDEF', () => {
     const source = `define behavior for ZI_Travel alias Travel
 {

--- a/tests/unit/adt/rap-preflight.test.ts
+++ b/tests/unit/adt/rap-preflight.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { formatRapPreflightFindings, validateRapSource } from '../../../src/adt/rap-preflight.js';
+
+describe('validateRapSource', () => {
+  it('flags TABL curr fields without currency semantics annotation', () => {
+    const source = `define table ztravel_req {
+  key client : abap.clnt not null;
+  key id     : sysuuid_x16 not null;
+  total_cost : abap.curr(15,2);
+}`;
+    const result = validateRapSource('TABL', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.blocked).toBe(true);
+    expect(result.errors.some((f) => f.ruleId === 'TABL_CURR_REQUIRES_CURRENCY_CODE')).toBe(true);
+  });
+
+  it('accepts TABL curr fields when currency semantics annotation exists', () => {
+    const source = `define table ztravel_req {
+  key client : abap.clnt not null;
+  key id     : sysuuid_x16 not null;
+  currency_code : abap.cuky;
+  @Semantics.amount.currencyCode : 'ztravel_req.currency_code'
+  total_cost : abap.curr(15,2);
+}`;
+    const result = validateRapSource('TABL', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.errors.some((f) => f.ruleId === 'TABL_CURR_REQUIRES_CURRENCY_CODE')).toBe(false);
+  });
+
+  it('flags TABL quan fields without unit semantics annotation', () => {
+    const source = `define table ztravel_exp {
+  key client : abap.clnt not null;
+  key id     : sysuuid_x16 not null;
+  qty        : abap.quan(13,3);
+}`;
+    const result = validateRapSource('TABL', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.errors.some((f) => f.ruleId === 'TABL_QUAN_REQUIRES_UNIT')).toBe(true);
+  });
+
+  it('flags on-prem 7.5x TABL forbidden types', () => {
+    const source = `define table ztravel_req {
+  key client : abap.clnt not null;
+  created_by : abap.uname;
+  created_at : abap.utclong;
+  receipt_required : abap.boolean;
+}`;
+    const result = validateRapSource('TABL', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.errors.some((f) => f.ruleId === 'TABL_FORBIDDEN_ABAP_UNAME')).toBe(true);
+    expect(result.errors.some((f) => f.ruleId === 'TABL_FORBIDDEN_ABAP_UTCLONG')).toBe(true);
+    expect(result.errors.some((f) => f.ruleId === 'TABL_FORBIDDEN_ABAP_BOOLEAN')).toBe(true);
+  });
+
+  it('flags BDEF authorization master (none)', () => {
+    const source = `managed implementation in class zbp_i_travel unique;
+define behavior for ZI_Travel alias Travel
+authorization master ( none )
+{
+}`;
+    const result = validateRapSource('BDEF', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.blocked).toBe(true);
+    expect(result.errors.some((f) => f.ruleId === 'BDEF_INVALID_AUTH_MASTER_NONE')).toBe(true);
+  });
+
+  it('flags projection BDEF use etag on on-prem 7.5x', () => {
+    const source = `projection;
+use etag;
+define behavior for ZC_Travel alias Travel
+{
+  use update;
+}`;
+    const result = validateRapSource('BDEF', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.errors.some((f) => f.ruleId === 'BDEF_PROJECTION_USE_ETAG_UNSUPPORTED')).toBe(true);
+  });
+
+  it('adds warning for duplicate etag master names in BDEF', () => {
+    const source = `define behavior for ZI_Travel alias Travel
+{
+  etag master LocalLastChangedAt;
+}
+define behavior for ZI_TravelItem alias Item
+{
+  etag master LocalLastChangedAt;
+}`;
+    const result = validateRapSource('BDEF', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.warnings.some((f) => f.ruleId === 'BDEF_DUPLICATE_ETAG_MASTER_NAME')).toBe(true);
+  });
+
+  it('flags unsupported DDLX annotation scope on on-prem 7.5x', () => {
+    const source = `@UI.headerInfo: { typeName: 'Travel' }
+annotate view ZC_Travel with {
+  travel_id;
+}`;
+    const result = validateRapSource('DDLX', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.blocked).toBe(true);
+    expect(result.errors.some((f) => f.ruleId === 'DDLX_ANNOTATION_SCOPE_ONPREM_75X')).toBe(true);
+  });
+
+  it('detects duplicate DDLX UI annotations for the same field', () => {
+    const source = `annotate view ZC_Travel with {
+  @UI.lineItem: [{ position: 10 }]
+  travel_id;
+
+  @UI.lineItem: [{ position: 20 }]
+  travel_id;
+}`;
+    const result = validateRapSource('DDLX', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.errors.some((f) => f.ruleId === 'DDLX_DUPLICATE_UI_ANNOTATION')).toBe(true);
+  });
+
+  it('adds DDLS client-field warning', () => {
+    const source = `define view entity ZI_Test as select from ztab {
+  key client,
+  key id
+}`;
+    const result = validateRapSource('DDLS', source, { systemType: 'onprem', abapRelease: '758' });
+    expect(result.warnings.some((f) => f.ruleId === 'DDLS_CLIENT_FIELD_IN_SELECT_LIST')).toBe(true);
+  });
+
+  it('does not enforce on-prem-only DDLX scope checks on BTP', () => {
+    const source = `@UI.headerInfo: { typeName: 'Travel' }
+annotate view ZC_Travel with {
+  travel_id;
+}`;
+    const result = validateRapSource('DDLX', source, { systemType: 'btp', abapRelease: 'cloud' });
+    expect(result.errors.some((f) => f.ruleId === 'DDLX_ANNOTATION_SCOPE_ONPREM_75X')).toBe(false);
+  });
+});
+
+describe('formatRapPreflightFindings', () => {
+  it('formats finding entries with rule id, line and suggestion', () => {
+    const formatted = formatRapPreflightFindings([
+      {
+        severity: 'error',
+        ruleId: 'TABL_CURR_REQUIRES_CURRENCY_CODE',
+        message: 'Missing currency annotation',
+        line: 12,
+        suggestion: 'Add @Semantics.amount.currencyCode',
+      },
+    ]);
+    expect(formatted).toContain('[TABL_CURR_REQUIRES_CURRENCY_CODE]');
+    expect(formatted).toContain('line 12');
+    expect(formatted).toContain('Suggestion: Add @Semantics.amount.currencyCode');
+  });
+});

--- a/tests/unit/authz/policy.test.ts
+++ b/tests/unit/authz/policy.test.ts
@@ -118,6 +118,17 @@ describe('ACTION_POLICY matrix', () => {
       expect(getActionPolicy('SAPManage', action)?.scope, `SAPManage.${action}`).toBe('write');
     }
   });
+
+  it('SAPWrite.scaffold_rap_handlers has explicit entry with rap feature gate', () => {
+    // Regression: after the authz refactor (commit 7be4ff0), every SAPWrite
+    // action has its own entry so admins can target them individually in
+    // SAP_DENY_ACTIONS. Without this entry, deny-actions startup validation
+    // rejects `SAPWrite.scaffold_rap_handlers` as "matches no actions".
+    const policy = getActionPolicy('SAPWrite', 'scaffold_rap_handlers');
+    expect(policy?.scope).toBe('write');
+    expect(policy?.opType).toBe(OperationType.Update);
+    expect(policy?.featureGate).toBe('rap');
+  });
 });
 
 describe('getActionPolicy', () => {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -3332,6 +3332,29 @@ ENDCLASS.`;
       expect(result.content[0]?.text).toContain('Successfully activated 2 objects');
     });
 
+    it('batch activation returns per-object status details on mixed outcomes', async () => {
+      const xml = `<messages>
+        <msg type="W" severity="warning" shortText="Root warning" uri="/sap/bc/adt/ddic/ddl/sources/ZI_TRAVEL" line="8"/>
+        <msg type="E" severity="error" shortText="BDEF activation failed" uri="/sap/bc/adt/bo/behaviordefinitions/ZI_TRAVEL" line="21"/>
+      </messages>`;
+      mockFetch
+        .mockResolvedValueOnce(mockResponse(200, '', { 'x-csrf-token': 'T' }))
+        .mockResolvedValueOnce(mockResponse(200, xml, { 'x-csrf-token': 'T' }));
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPActivate', {
+        objects: [
+          { type: 'DDLS', name: 'ZI_TRAVEL' },
+          { type: 'BDEF', name: 'ZI_TRAVEL' },
+        ],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('Per-object status:');
+      expect(result.content[0]?.text).toContain('ZI_TRAVEL (DDLS): warning');
+      expect(result.content[0]?.text).toContain('ZI_TRAVEL (BDEF): error');
+      expect(result.content[0]?.text).toContain('[line 21] BDEF activation failed');
+    });
+
     it('publishes a service binding', async () => {
       // Mock: 1) getSrvb for service type detection (GET, also delivers CSRF), 2) publish POST, 3) getSrvb readback
       mockFetch
@@ -4446,7 +4469,7 @@ ENDCLASS.`;
       const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', { type: 'PROG', name: 'ZA_TEST' });
       expect(result.isError).toBe(true);
       expect(result.content[0]?.text).toContain('already exists');
-      expect(result.content[0]?.text).toContain('Use SAPRead');
+      expect(result.content[0]?.text).toContain('action="update"');
     });
 
     it('400 activation dependency message returns activation hint', async () => {
@@ -6475,6 +6498,243 @@ define role ZTEST_DCL {
     });
   });
 
+  describe('SAPWrite scaffold_rap_handlers', () => {
+    const bdefSource = `managed implementation in class ZBP_I_TRAVELREQ unique;
+define behavior for ZI_TRAVELREQ alias Travel
+authorization master ( instance )
+{
+  action SubmitForApproval result [1] $self;
+  action RecalculateTotalCost result [1] $self;
+}`;
+
+    const classMetadataXml = `<?xml version="1.0" encoding="UTF-8"?>
+<class:abapClass
+  xmlns:class="http://www.sap.com/adt/classlib"
+  xmlns:adtcore="http://www.sap.com/adt/core"
+  adtcore:name="ZBP_I_TRAVELREQ"
+  adtcore:type="CLAS/OC"
+  adtcore:description="Behavior pool"
+  class:abapLanguageVersion="standard"/>`;
+
+    const classMainSource = `CLASS zbp_i_travelreq DEFINITION PUBLIC ABSTRACT FINAL FOR BEHAVIOR OF zi_travelreq.
+ENDCLASS.
+
+CLASS zbp_i_travelreq IMPLEMENTATION.
+ENDCLASS.`;
+
+    const classDefinitionsSource = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS submitforapproval FOR MODIFY
+      IMPORTING keys FOR ACTION Travel~SubmitForApproval RESULT result.
+ENDCLASS.
+`;
+
+    it('returns missing handler signatures without applying changes', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = opts?.method ?? 'GET';
+        const urlStr = String(url);
+        if (method === 'GET' && urlStr.endsWith('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ')) {
+          return Promise.resolve(mockResponse(200, classMetadataXml, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/source/main')) {
+          return Promise.resolve(mockResponse(200, classMainSource, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/definitions')) {
+          return Promise.resolve(mockResponse(200, classDefinitionsSource, { 'x-csrf-token': 'T' }));
+        }
+        if (
+          method === 'GET' &&
+          (urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/testclasses') ||
+            urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations') ||
+            urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/macros'))
+        ) {
+          return Promise.reject(new AdtApiError('Not found', 404, urlStr));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/bo/behaviordefinitions/ZI_TRAVELREQ/source/main')) {
+          return Promise.resolve(mockResponse(200, bdefSource, { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '<ok/>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'scaffold_rap_handlers',
+        type: 'CLAS',
+        name: 'ZBP_I_TRAVELREQ',
+        bdefName: 'ZI_TRAVELREQ',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(parsed.applied).toBe(false);
+      expect(parsed.missingCount).toBeGreaterThan(0);
+      expect(
+        parsed.missing.some(
+          (req: { methodName: string }) =>
+            req.methodName === 'recalculatetotalcost' || req.methodName === 'get_instance_authorizations',
+        ),
+      ).toBe(true);
+    });
+
+    it('autoApply injects signatures and writes class source', async () => {
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockImplementation(
+        (
+          url: string | URL,
+          opts?: { method?: string; body?: string | Buffer | null; headers?: Record<string, string> },
+        ) => {
+          const method = opts?.method ?? 'GET';
+          const urlStr = String(url);
+          calls.push({
+            method,
+            url: urlStr,
+            body: typeof opts?.body === 'string' ? opts.body : undefined,
+          });
+          if (method === 'GET' && urlStr.endsWith('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ')) {
+            return Promise.resolve(mockResponse(200, classMetadataXml, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/source/main')) {
+            return Promise.resolve(mockResponse(200, classMainSource, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/definitions')) {
+            return Promise.resolve(mockResponse(200, classDefinitionsSource, { 'x-csrf-token': 'T' }));
+          }
+          if (
+            method === 'GET' &&
+            (urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/testclasses') ||
+              urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations') ||
+              urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/macros'))
+          ) {
+            return Promise.reject(new AdtApiError('Not found', 404, urlStr));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/bo/behaviordefinitions/ZI_TRAVELREQ/source/main')) {
+            return Promise.resolve(mockResponse(200, bdefSource, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'POST' && urlStr.includes('_action=LOCK')) {
+            return Promise.resolve(
+              mockResponse(
+                200,
+                '<asx:abap><asx:values><DATA><LOCK_HANDLE>LH1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>',
+                { 'x-csrf-token': 'T' },
+              ),
+            );
+          }
+          return Promise.resolve(mockResponse(200, '<ok/>', { 'x-csrf-token': 'T' }));
+        },
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'scaffold_rap_handlers',
+        type: 'CLAS',
+        name: 'ZBP_I_TRAVELREQ',
+        bdefName: 'ZI_TRAVELREQ',
+        autoApply: true,
+        lintBeforeWrite: false,
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('Scaffolded');
+      const putCall = calls.find(
+        (call) =>
+          call.method === 'PUT' && call.url.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/definitions'),
+      );
+      expect(putCall).toBeDefined();
+      expect(putCall?.body).toContain('METHODS recalculatetotalcost FOR MODIFY');
+      expect(putCall?.body).toContain('METHODS get_instance_authorizations FOR INSTANCE AUTHORIZATION');
+    });
+
+    it('autoApply falls back to implementations include when handler class is declared there', async () => {
+      const classDefinitionsNoHandlers = `*"* definitions placeholder`;
+      const classImplementationsWithHandlers = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS submitforapproval FOR MODIFY
+      IMPORTING keys FOR ACTION Travel~SubmitForApproval RESULT result.
+ENDCLASS.
+
+CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.`;
+
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockImplementation(
+        (
+          url: string | URL,
+          opts?: { method?: string; body?: string | Buffer | null; headers?: Record<string, string> },
+        ) => {
+          const method = opts?.method ?? 'GET';
+          const urlStr = String(url);
+          calls.push({
+            method,
+            url: urlStr,
+            body: typeof opts?.body === 'string' ? opts.body : undefined,
+          });
+
+          if (method === 'GET' && urlStr.endsWith('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ')) {
+            return Promise.resolve(mockResponse(200, classMetadataXml, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/source/main')) {
+            return Promise.resolve(mockResponse(200, classMainSource, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/definitions')) {
+            return Promise.resolve(mockResponse(200, classDefinitionsNoHandlers, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations')) {
+            return Promise.resolve(mockResponse(200, classImplementationsWithHandlers, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/macros')) {
+            return Promise.reject(new AdtApiError('Not found', 404, urlStr));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/testclasses')) {
+            return Promise.reject(new AdtApiError('Not found', 404, urlStr));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/bo/behaviordefinitions/ZI_TRAVELREQ/source/main')) {
+            return Promise.resolve(mockResponse(200, bdefSource, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'POST' && urlStr.includes('_action=LOCK')) {
+            return Promise.resolve(
+              mockResponse(
+                200,
+                '<asx:abap><asx:values><DATA><LOCK_HANDLE>LH1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>',
+                { 'x-csrf-token': 'T' },
+              ),
+            );
+          }
+
+          return Promise.resolve(mockResponse(200, '<ok/>', { 'x-csrf-token': 'T' }));
+        },
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'scaffold_rap_handlers',
+        type: 'CLAS',
+        name: 'ZBP_I_TRAVELREQ',
+        bdefName: 'ZI_TRAVELREQ',
+        autoApply: true,
+        lintBeforeWrite: false,
+      });
+
+      expect(result.isError).toBeUndefined();
+      const putCall = calls.find(
+        (call) =>
+          call.method === 'PUT' && call.url.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations'),
+      );
+      expect(putCall).toBeDefined();
+      expect(putCall?.body).toContain('METHODS recalculatetotalcost FOR MODIFY');
+      expect(putCall?.body).toContain('METHODS get_instance_authorizations FOR INSTANCE AUTHORIZATION');
+    });
+
+    it('returns validation error when bdefName is missing', async () => {
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'scaffold_rap_handlers',
+        type: 'CLAS',
+        name: 'ZBP_I_TRAVELREQ',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('bdefName');
+    });
+  });
+
   describe('hyperfocused mode (SAP tool)', () => {
     it('routes SAP(read) to SAPRead', async () => {
       const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAP', {
@@ -7862,6 +8122,51 @@ define role ZTEST_DCL {
       expect(result.isError).toBe(true);
       expect(result.content[0]?.text).toContain('Hint: DDIC save failed.');
       expect(result.content[0]?.text).not.toContain('choose a different name');
+    });
+
+    it('adds behavior-pool save failure remediation hint for generic CLAS save errors', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = opts?.method ?? 'GET';
+        const urlStr = String(url);
+
+        if (method === 'POST' && urlStr.includes('_action=LOCK')) {
+          return Promise.resolve(
+            mockResponse(
+              200,
+              '<asx:abap><asx:values><DATA><LOCK_HANDLE>LH1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>',
+              { 'x-csrf-token': 'T' },
+            ),
+          );
+        }
+        if (method === 'PUT' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/source/main')) {
+          return Promise.reject(
+            new AdtApiError(
+              'Bad Request',
+              400,
+              '/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/source/main',
+              '<exc:exception><localizedMessage>An error occured during the save operation. The changes were not stored.</localizedMessage></exc:exception>',
+            ),
+          );
+        }
+        return Promise.resolve(mockResponse(200, '<ok/>', { 'x-csrf-token': 'T' }));
+      });
+
+      const source = `CLASS zbp_i_travelreq DEFINITION PUBLIC ABSTRACT FINAL FOR BEHAVIOR OF zi_travelreq.
+ENDCLASS.
+CLASS zbp_i_travelreq IMPLEMENTATION.
+ENDCLASS.`;
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'update',
+        type: 'CLAS',
+        name: 'ZBP_I_TRAVELREQ',
+        source,
+        lintBeforeWrite: false,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('scaffold_rap_handlers');
+      expect(result.content[0]?.text).toContain('edit_method');
     });
 
     it('does not add DDIC hint for 404 not-found path', async () => {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -6669,6 +6669,9 @@ ENDCLASS.
     });
 
     it('autoApply injects signatures and writes class source', async () => {
+      const classImplementationsSource = `CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.`;
+
       mockFetch.mockReset();
       const calls: Array<{ method: string; url: string; body?: string }> = [];
       mockFetch.mockImplementation(
@@ -6692,10 +6695,12 @@ ENDCLASS.
           if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/definitions')) {
             return Promise.resolve(mockResponse(200, classDefinitionsSource, { 'x-csrf-token': 'T' }));
           }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations')) {
+            return Promise.resolve(mockResponse(200, classImplementationsSource, { 'x-csrf-token': 'T' }));
+          }
           if (
             method === 'GET' &&
             (urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/testclasses') ||
-              urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations') ||
               urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/macros'))
           ) {
             return Promise.reject(new AdtApiError('Not found', 404, urlStr));
@@ -6734,6 +6739,13 @@ ENDCLASS.
       expect(putCall).toBeDefined();
       expect(putCall?.body).toContain('METHODS recalculatetotalcost FOR MODIFY');
       expect(putCall?.body).toContain('METHODS get_instance_authorizations FOR INSTANCE AUTHORIZATION');
+      const implPutCall = calls.find(
+        (call) =>
+          call.method === 'PUT' && call.url.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations'),
+      );
+      expect(implPutCall).toBeDefined();
+      expect(implPutCall?.body).toContain('METHOD recalculatetotalcost.');
+      expect(implPutCall?.body).toContain('METHOD get_instance_authorizations.');
     });
 
     it('autoApply falls back to implementations include when handler class is declared there', async () => {
@@ -6814,6 +6826,93 @@ ENDCLASS.`;
       expect(putCall).toBeDefined();
       expect(putCall?.body).toContain('METHODS recalculatetotalcost FOR MODIFY');
       expect(putCall?.body).toContain('METHODS get_instance_authorizations FOR INSTANCE AUTHORIZATION');
+      expect(putCall?.body).toContain('METHOD recalculatetotalcost.');
+      expect(putCall?.body).toContain('METHOD get_instance_authorizations.');
+    });
+
+    it('autoApply adds implementation stubs even when declarations already exist', async () => {
+      const classDefinitionsAllHandlers = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS submitforapproval FOR MODIFY
+      IMPORTING keys FOR ACTION Travel~SubmitForApproval RESULT result.
+    METHODS recalculatetotalcost FOR MODIFY
+      IMPORTING keys FOR ACTION Travel~RecalculateTotalCost RESULT result.
+    METHODS get_instance_authorizations FOR INSTANCE AUTHORIZATION
+      IMPORTING keys REQUEST requested_authorizations FOR Travel RESULT result.
+ENDCLASS.`;
+      const classImplementationsEmpty = `CLASS lhc_travel IMPLEMENTATION.
+ENDCLASS.`;
+
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockImplementation(
+        (
+          url: string | URL,
+          opts?: { method?: string; body?: string | Buffer | null; headers?: Record<string, string> },
+        ) => {
+          const method = opts?.method ?? 'GET';
+          const urlStr = String(url);
+          calls.push({ method, url: urlStr, body: typeof opts?.body === 'string' ? opts.body : undefined });
+
+          if (method === 'GET' && urlStr.endsWith('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ')) {
+            return Promise.resolve(mockResponse(200, classMetadataXml, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/source/main')) {
+            return Promise.resolve(mockResponse(200, classMainSource, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/definitions')) {
+            return Promise.resolve(mockResponse(200, classDefinitionsAllHandlers, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations')) {
+            return Promise.resolve(mockResponse(200, classImplementationsEmpty, { 'x-csrf-token': 'T' }));
+          }
+          if (
+            method === 'GET' &&
+            (urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/testclasses') ||
+              urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/macros'))
+          ) {
+            return Promise.reject(new AdtApiError('Not found', 404, urlStr));
+          }
+          if (method === 'GET' && urlStr.includes('/sap/bc/adt/bo/behaviordefinitions/ZI_TRAVELREQ/source/main')) {
+            return Promise.resolve(mockResponse(200, bdefSource, { 'x-csrf-token': 'T' }));
+          }
+          if (method === 'POST' && urlStr.includes('_action=LOCK')) {
+            return Promise.resolve(
+              mockResponse(
+                200,
+                '<asx:abap><asx:values><DATA><LOCK_HANDLE>LH1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>',
+                { 'x-csrf-token': 'T' },
+              ),
+            );
+          }
+          return Promise.resolve(mockResponse(200, '<ok/>', { 'x-csrf-token': 'T' }));
+        },
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'scaffold_rap_handlers',
+        type: 'CLAS',
+        name: 'ZBP_I_TRAVELREQ',
+        bdefName: 'ZI_TRAVELREQ',
+        autoApply: true,
+        lintBeforeWrite: false,
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('0 RAP handler signature(s) and 3 implementation stub(s)');
+      const definitionPutCall = calls.find(
+        (call) =>
+          call.method === 'PUT' && call.url.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/definitions'),
+      );
+      expect(definitionPutCall).toBeUndefined();
+      const implPutCall = calls.find(
+        (call) =>
+          call.method === 'PUT' && call.url.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations'),
+      );
+      expect(implPutCall).toBeDefined();
+      expect(implPutCall?.body).toContain('METHOD submitforapproval.');
+      expect(implPutCall?.body).toContain('METHOD recalculatetotalcost.');
+      expect(implPutCall?.body).toContain('METHOD get_instance_authorizations.');
     });
 
     it('returns validation error when bdefName is missing', async () => {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -6642,6 +6642,64 @@ ENDCLASS.
       expect(resolvePackageSpy).not.toHaveBeenCalled();
     });
 
+    it('dry-run does not report semantic FOR ACTION implementations as missing stubs', async () => {
+      const semanticBdefSource = `managed implementation in class ZBP_I_TRAVELREQ unique;
+define behavior for ZI_TRAVELREQ alias Travel
+{
+  action acceptTravel result [1] $self;
+}`;
+      const semanticDefinitionsSource = `CLASS lhc_travel DEFINITION INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS set_status_accepted FOR MODIFY
+      IMPORTING keys FOR ACTION Travel~acceptTravel RESULT result.
+ENDCLASS.`;
+      const semanticImplementationsSource = `CLASS lhc_travel IMPLEMENTATION.
+  METHOD set_status_accepted.
+  ENDMETHOD.
+ENDCLASS.`;
+
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = opts?.method ?? 'GET';
+        const urlStr = String(url);
+        if (method === 'GET' && urlStr.endsWith('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ')) {
+          return Promise.resolve(mockResponse(200, classMetadataXml, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/source/main')) {
+          return Promise.resolve(mockResponse(200, classMainSource, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/definitions')) {
+          return Promise.resolve(mockResponse(200, semanticDefinitionsSource, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations')) {
+          return Promise.resolve(mockResponse(200, semanticImplementationsSource, { 'x-csrf-token': 'T' }));
+        }
+        if (
+          method === 'GET' &&
+          (urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/testclasses') ||
+            urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/macros'))
+        ) {
+          return Promise.reject(new AdtApiError('Not found', 404, urlStr));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/bo/behaviordefinitions/ZI_TRAVELREQ/source/main')) {
+          return Promise.resolve(mockResponse(200, semanticBdefSource, { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '<ok/>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'scaffold_rap_handlers',
+        type: 'CLAS',
+        name: 'ZBP_I_TRAVELREQ',
+        bdefName: 'ZI_TRAVELREQ',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(parsed.missingCount).toBe(0);
+      expect(parsed.missingImplementationStubCount).toBe(0);
+    });
+
     it('autoApply still enforces write package allowlist for existing behavior pools', async () => {
       mockFetch.mockReset();
       const restrictedClient = new AdtClient({

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -6516,6 +6516,17 @@ authorization master ( instance )
   adtcore:description="Behavior pool"
   class:abapLanguageVersion="standard"/>`;
 
+    const classMetadataForbiddenPackageXml = `<?xml version="1.0" encoding="UTF-8"?>
+<class:abapClass
+  xmlns:class="http://www.sap.com/adt/classlib"
+  xmlns:adtcore="http://www.sap.com/adt/core"
+  adtcore:name="/DMO/BP_TRAVEL_M"
+  adtcore:type="CLAS/OC"
+  adtcore:description="Behavior pool"
+  class:abapLanguageVersion="standard">
+  <adtcore:packageRef adtcore:name="/DMO/FLIGHT_MANAGED"/>
+</class:abapClass>`;
+
     const classMainSource = `CLASS zbp_i_travelreq DEFINITION PUBLIC ABSTRACT FINAL FOR BEHAVIOR OF zi_travelreq.
 ENDCLASS.
 
@@ -6574,6 +6585,87 @@ ENDCLASS.
             req.methodName === 'recalculatetotalcost' || req.methodName === 'get_instance_authorizations',
         ),
       ).toBe(true);
+    });
+
+    it('dry-run does not enforce write package allowlist for existing behavior pools', async () => {
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string }> = [];
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = opts?.method ?? 'GET';
+        const urlStr = String(url);
+        calls.push({ method, url: urlStr });
+
+        if (method === 'GET' && urlStr.endsWith('/sap/bc/adt/oo/classes/%2FDMO%2FBP_TRAVEL_M')) {
+          return Promise.resolve(mockResponse(200, classMetadataForbiddenPackageXml, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/%2FDMO%2FBP_TRAVEL_M/source/main')) {
+          return Promise.resolve(mockResponse(200, classMainSource, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/%2FDMO%2FBP_TRAVEL_M/includes/definitions')) {
+          return Promise.resolve(mockResponse(200, classDefinitionsSource, { 'x-csrf-token': 'T' }));
+        }
+        if (
+          method === 'GET' &&
+          (urlStr.includes('/sap/bc/adt/oo/classes/%2FDMO%2FBP_TRAVEL_M/includes/testclasses') ||
+            urlStr.includes('/sap/bc/adt/oo/classes/%2FDMO%2FBP_TRAVEL_M/includes/implementations') ||
+            urlStr.includes('/sap/bc/adt/oo/classes/%2FDMO%2FBP_TRAVEL_M/includes/macros'))
+        ) {
+          return Promise.reject(new AdtApiError('Not found', 404, urlStr));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/bo/behaviordefinitions/%2FDMO%2FI_TRAVEL_M/source/main')) {
+          return Promise.resolve(mockResponse(200, bdefSource, { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '<ok/>', { 'x-csrf-token': 'T' }));
+      });
+
+      const restrictedClient = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'admin',
+        password: 'secret',
+        safety: { ...unrestrictedSafetyConfig(), allowedPackages: ['$TMP'] },
+      });
+      const resolvePackageSpy = vi.spyOn(restrictedClient, 'resolveObjectPackage');
+
+      const result = await handleToolCall(restrictedClient, DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'scaffold_rap_handlers',
+        type: 'CLAS',
+        name: '/DMO/BP_TRAVEL_M',
+        bdefName: '/DMO/I_TRAVEL_M',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(parsed.applied).toBe(false);
+      expect(parsed.requiredCount).toBeGreaterThan(0);
+      expect(result.content[0]?.text).not.toContain('blocked by safety');
+      expect(calls.some((call) => call.method === 'PUT' || call.url.includes('_action=LOCK'))).toBe(false);
+      expect(resolvePackageSpy).not.toHaveBeenCalled();
+    });
+
+    it('autoApply still enforces write package allowlist for existing behavior pools', async () => {
+      mockFetch.mockReset();
+      const restrictedClient = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'admin',
+        password: 'secret',
+        safety: { ...unrestrictedSafetyConfig(), allowedPackages: ['$TMP'] },
+      });
+      const resolvePackageSpy = vi
+        .spyOn(restrictedClient, 'resolveObjectPackage')
+        .mockResolvedValue('/DMO/FLIGHT_MANAGED');
+
+      const result = await handleToolCall(restrictedClient, DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'scaffold_rap_handlers',
+        type: 'CLAS',
+        name: '/DMO/BP_TRAVEL_M',
+        bdefName: '/DMO/I_TRAVEL_M',
+        autoApply: true,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('/DMO/FLIGHT_MANAGED');
+      expect(result.content[0]?.text).toContain('blocked');
+      expect(resolvePackageSpy).toHaveBeenCalledOnce();
     });
 
     it('autoApply injects signatures and writes class source', async () => {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -6726,6 +6726,94 @@ ENDCLASS.`;
       expect(resolvePackageSpy).toHaveBeenCalledOnce();
     });
 
+    it('returns available aliases when targetAlias does not match BDEF requirements', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = opts?.method ?? 'GET';
+        const urlStr = String(url);
+        if (method === 'GET' && urlStr.endsWith('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ')) {
+          return Promise.resolve(mockResponse(200, classMetadataXml, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/source/main')) {
+          return Promise.resolve(mockResponse(200, classMainSource, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/definitions')) {
+          return Promise.resolve(mockResponse(200, classDefinitionsSource, { 'x-csrf-token': 'T' }));
+        }
+        if (
+          method === 'GET' &&
+          (urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/testclasses') ||
+            urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations') ||
+            urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/macros'))
+        ) {
+          return Promise.reject(new AdtApiError('Not found', 404, urlStr));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/bo/behaviordefinitions/ZI_TRAVELREQ/source/main')) {
+          return Promise.resolve(mockResponse(200, bdefSource, { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '<ok/>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'scaffold_rap_handlers',
+        type: 'CLAS',
+        name: 'ZBP_I_TRAVELREQ',
+        bdefName: 'ZI_TRAVELREQ',
+        targetAlias: 'DoesNotExist',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('No RAP handler requirements were found');
+      expect(result.content[0]?.text).toContain('Available aliases in ZI_TRAVELREQ: Travel');
+    });
+
+    it('autoApply reports unresolved handler skeletons with a recovery hint', async () => {
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string }> = [];
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = opts?.method ?? 'GET';
+        const urlStr = String(url);
+        calls.push({ method, url: urlStr });
+
+        if (method === 'GET' && urlStr.endsWith('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ')) {
+          return Promise.resolve(mockResponse(200, classMetadataXml, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/source/main')) {
+          return Promise.resolve(mockResponse(200, classMainSource, { 'x-csrf-token': 'T' }));
+        }
+        if (
+          method === 'GET' &&
+          (urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/definitions') ||
+            urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/implementations') ||
+            urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/testclasses') ||
+            urlStr.includes('/sap/bc/adt/oo/classes/ZBP_I_TRAVELREQ/includes/macros'))
+        ) {
+          return Promise.reject(new AdtApiError('Not found', 404, urlStr));
+        }
+        if (method === 'GET' && urlStr.includes('/sap/bc/adt/bo/behaviordefinitions/ZI_TRAVELREQ/source/main')) {
+          return Promise.resolve(mockResponse(200, bdefSource, { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '<ok/>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'scaffold_rap_handlers',
+        type: 'CLAS',
+        name: 'ZBP_I_TRAVELREQ',
+        bdefName: 'ZI_TRAVELREQ',
+        autoApply: true,
+        lintBeforeWrite: false,
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(parsed.applied).toBe(false);
+      expect(parsed.applyResult.unresolved.length).toBeGreaterThan(0);
+      expect(parsed.hint).toContain('lhc_travel');
+      expect(parsed.hint).toContain('Create local handler class');
+      expect(calls.some((call) => call.method === 'PUT' || call.url.includes('_action=LOCK'))).toBe(false);
+    });
+
     it('autoApply injects signatures and writes class source', async () => {
       const classImplementationsSource = `CLASS lhc_travel IMPLEMENTATION.
 ENDCLASS.`;

--- a/tests/unit/handlers/schemas.test.ts
+++ b/tests/unit/handlers/schemas.test.ts
@@ -359,6 +359,20 @@ describe('SAPWriteSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts preflightBeforeWrite override', () => {
+    const result = SAPWriteSchema.safeParse({
+      action: 'update',
+      type: 'TABL',
+      name: 'ZTABL_TEST',
+      source: 'define table ztabl_test { key client : abap.clnt not null; }',
+      preflightBeforeWrite: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.preflightBeforeWrite).toBe(false);
+    }
+  });
+
   it('accepts TABL for source-based writes', () => {
     const result = SAPWriteSchema.safeParse({
       action: 'create',
@@ -388,6 +402,21 @@ describe('SAPWriteSchema', () => {
       ],
     });
     expect(result.success).toBe(true);
+  });
+
+  it('accepts scaffold_rap_handlers action fields', () => {
+    const result = SAPWriteSchema.safeParse({
+      action: 'scaffold_rap_handlers',
+      type: 'CLAS',
+      name: 'ZBP_I_TRAVELREQ',
+      bdefName: 'ZI_TRAVELREQ',
+      autoApply: 'true',
+      targetAlias: 'Travel',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.autoApply).toBe(true);
+    }
   });
 
   it('validates objects array structure', () => {

--- a/tests/unit/server/deny-actions.test.ts
+++ b/tests/unit/server/deny-actions.test.ts
@@ -79,6 +79,13 @@ describe('validateDenyActions', () => {
     expect(() => validateDenyActions(['SAPWrite.delete', 'SAPManage.flp_list_catalogs'])).not.toThrow();
   });
 
+  it('accepts SAPWrite.scaffold_rap_handlers (RAP handler scaffolder)', () => {
+    // Regression: this action was added after the main SAPWrite enum and
+    // must be listed in ACTION_POLICY so admins can specifically deny it
+    // via SAP_DENY_ACTIONS without having to block the whole SAPWrite tool.
+    expect(() => validateDenyActions(['SAPWrite.scaffold_rap_handlers'])).not.toThrow();
+  });
+
   it('accepts valid Tool.glob* patterns', () => {
     expect(() => validateDenyActions(['SAPManage.flp_*', 'SAPTransport.*'])).not.toThrow();
   });


### PR DESCRIPTION
## Goal
Implement the RAP on-prem gap-closure plan by reducing retry-heavy RAP authoring failures and improving end-to-end behavior-pool workflow support.

## What changed
- Added deterministic RAP preflight validation for TABL/BDEF/DDLX/DDLS in `SAPWrite` with a `preflightBeforeWrite` toggle.
- Added `SAPWrite` action `scaffold_rap_handlers` with dry-run and auto-apply support.
- Improved behavior-pool handling by scanning/patching class includes (`main`, `definitions`, `implementations`) and fixed deferred class parsing in handler extraction.
- Added stronger write/activation hints (object-exists update hint, behavior-pool `[?/011]` remediation, per-object batch activation status).
- Updated RAP-related skills and docs (`docs_page/tools.md`, roadmap, CLAUDE references).
- Moved the implementation plan to completed: `docs/plans/completed/rap-onprem-agent-gap-closure.md`.

## Verification
- `npm test` ✅
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:integration -- --run tests/integration/adt.integration.test.ts -t "RAP"` requires configured `TEST_SAP_*` / `SAP_*` credentials in this shell; status is documented in the completed plan notes.
