### PR TITLE
fix: detect HANA via S4CORE/HDB components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ tests/
 | Add / modify auth combination rule | `src/server/config.ts` (validateConfig at ~line 305), `src/server/types.ts` (ServerConfig), `tests/unit/server/config.test.ts`, `docs/enterprise-auth.md` (Coexistence Matrix) |
 | Add Layer B auth mechanism | `src/adt/http.ts` (applyAuthHeader at ~line 830, fetchCsrfToken at ~line 669), `src/server/server.ts` (buildAdtConfig — perUser flag), `tests/unit/adt/http.test.ts` |
 | Add safety config option | `src/adt/safety.ts`, `src/server/config.ts`, `src/server/types.ts` |
-| Add feature probe | `src/adt/features.ts` |
+| Add feature probe | `src/adt/features.ts` (`PROBES` array — single endpoint per feature; HTTP-status classification handled centrally by `classifyFeatureProbeStatus`: 2xx/400/405/5xx → available, 401/403/404 → unavailable with diagnostic reason. Surface the reason via `FeatureStatus.message`.) |
 | Add feature-gated write guard | `src/handlers/intent.ts` (checkRapAvailable pattern), `src/adt/features.ts` |
 | Add E2E test | `tests/e2e/`, helpers in `tests/e2e/helpers.ts`, fixtures in `tests/e2e/fixtures.ts` |
 | Add/modify E2E fixture | `tests/e2e/fixtures.ts` (define object), `tests/fixtures/abap/` (source file), `tests/e2e/setup.ts` (sync logic) |

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -18,7 +18,7 @@
 
 import type { AdtClientConfig } from './config.js';
 import { defaultAdtClientConfig } from './config.js';
-import { isNotFoundError } from './errors.js';
+import { AdtApiError, isNotFoundError } from './errors.js';
 import { AdtHttpClient, type AdtHttpConfig } from './http.js';
 import { checkOperation, OperationType, type SafetyConfig } from './safety.js';
 import { Semaphore } from './semaphore.js';
@@ -544,8 +544,13 @@ export class AdtClient {
   /** Get installed SAP components */
   async getInstalledComponents(): Promise<Array<{ name: string; release: string; description: string }>> {
     checkOperation(this.safety, OperationType.Read, 'GetInstalledComponents');
-    const resp = await this.http.get('/sap/bc/adt/system/components');
-    return parseInstalledComponents(resp.body);
+    try {
+      const resp = await this.http.get('/sap/bc/adt/system/components', { Accept: 'application/atom+xml;type=feed' });
+      return parseInstalledComponents(resp.body);
+    } catch (err) {
+      if (err instanceof AdtApiError && err.statusCode === 406) return [];
+      throw err;
+    }
   }
 
   /** Get message class messages (legacy endpoint — may fail for some classes) */

--- a/src/adt/discovery.ts
+++ b/src/adt/discovery.ts
@@ -4,15 +4,30 @@ import type { AdtHttpClient } from './http.js';
 import type { DiscoveryMap } from './types.js';
 import { parseDiscoveryDocument } from './xml-parser.js';
 
+export interface DiscoveryFetchResult {
+  map: DiscoveryMap;
+  /** True when the discovery document contains any NHI (Native HANA Integration) endpoint. */
+  nhiPresent: boolean;
+}
+
+/**
+ * Return true when the raw ADT discovery XML contains at least one NHI collection href.
+ * NHI (/sap/bc/adt/nhi/*) workspaces are only registered on HANA-based systems.
+ * Exported for unit testing.
+ */
+export function hasNhiWorkspace(xml: string): boolean {
+  return /\/sap\/bc\/adt\/nhi\//.test(xml);
+}
+
 /**
  * Fetch ADT discovery service document.
  *
- * Graceful degradation: never throws, always returns a map.
+ * Graceful degradation: never throws, always returns a result.
  */
-export async function fetchDiscoveryDocument(client: AdtHttpClient): Promise<DiscoveryMap> {
+export async function fetchDiscoveryDocument(client: AdtHttpClient): Promise<DiscoveryFetchResult> {
   try {
     const resp = await client.get('/sap/bc/adt/discovery', { Accept: 'application/atomsvc+xml' });
-    return parseDiscoveryDocument(resp.body);
+    return { map: parseDiscoveryDocument(resp.body), nhiPresent: hasNhiWorkspace(resp.body) };
   } catch (err) {
     const reason =
       err instanceof AdtApiError
@@ -21,7 +36,7 @@ export async function fetchDiscoveryDocument(client: AdtHttpClient): Promise<Dis
           ? err.message
           : String(err ?? 'unknown');
     logger.warn(`ADT discovery unavailable (${reason}) — continuing without proactive MIME negotiation`);
-    return new Map();
+    return { map: new Map(), nhiPresent: false };
   }
 }
 

--- a/src/adt/discovery.ts
+++ b/src/adt/discovery.ts
@@ -13,10 +13,16 @@ export interface DiscoveryFetchResult {
 /**
  * Return true when the raw ADT discovery XML contains at least one NHI collection href.
  * NHI (/sap/bc/adt/nhi/*) workspaces are only registered on HANA-based systems.
+ *
+ * The match is anchored to an `href="..."` attribute so that mentions of the path in
+ * `<atom:title>` text, descriptions, or non-href attributes do not false-positive.
+ * The optional `https://host` prefix lets us still match the rare absolute-URL form some
+ * SAP servers emit. Namespace prefix on the surrounding element is irrelevant.
+ *
  * Exported for unit testing.
  */
 export function hasNhiWorkspace(xml: string): boolean {
-  return /\/sap\/bc\/adt\/nhi\//.test(xml);
+  return /href\s*=\s*["'](?:https?:\/\/[^"'/]+)?\/sap\/bc\/adt\/nhi\//i.test(xml);
 }
 
 /**

--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -48,8 +48,15 @@ const PROBES: FeatureProbe[] = [
   },
 ];
 
+/** Per-feature probe outcome — `available` plus an optional human-readable reason. */
+interface ProbeOutcome {
+  available: boolean;
+  /** Free-text diagnostic, surfaced via FeatureStatus.message when present. */
+  reason?: string;
+}
+
 /** Resolve a single feature based on its mode */
-function resolveFeature(mode: FeatureMode, probeResult: boolean, id: string, description: string): FeatureStatus {
+function resolveFeature(mode: FeatureMode, probeOutcome: ProbeOutcome, id: string, description: string): FeatureStatus {
   if (mode === 'on') {
     return { id, available: true, mode: 'on', message: 'Forced on by configuration' };
   }
@@ -57,11 +64,13 @@ function resolveFeature(mode: FeatureMode, probeResult: boolean, id: string, des
     return { id, available: false, mode: 'off', message: 'Disabled by configuration' };
   }
   // auto
+  const baseMessage = probeOutcome.available ? `${description} is available` : `${description} is not available`;
+  const message = probeOutcome.reason ? `${baseMessage} — ${probeOutcome.reason}` : baseMessage;
   return {
     id,
-    available: probeResult,
+    available: probeOutcome.available,
     mode: 'auto',
-    message: probeResult ? `${description} is available` : `${description} is not available`,
+    message,
     probedAt: new Date().toISOString(),
   };
 }
@@ -98,19 +107,14 @@ export async function probeFeatures(
     Promise.all(
       probesToRun.map(async (probe) => {
         try {
-          // GET on collection endpoints may return 4xx/5xx when the feature is available
-          // (e.g. /ddic/ddl/sources returns 400 without an object name, transport returns 200).
-          // handleResponse() throws AdtApiError for all status >= 400, so we catch here:
-          // - 404 = ICF service not activated / endpoint doesn't exist → unavailable
-          // - any other HTTP error (400, 403, 405, 500) = endpoint exists → available
-          // - network-level error (no AdtApiError) → unavailable
           await client.get(probe.endpoint);
-          return { id: probe.id, available: true };
+          return classifyFeatureProbeStatus(probe.id, 200);
         } catch (err) {
-          if (err instanceof AdtApiError && err.statusCode !== 404) {
-            return { id: probe.id, available: true };
+          if (err instanceof AdtApiError) {
+            return classifyFeatureProbeStatus(probe.id, err.statusCode);
           }
-          return { id: probe.id, available: false };
+          // Network-level error (no AdtApiError) → cannot reach SAP at all → unavailable.
+          return { id: probe.id, available: false, reason: 'network error' };
         }
       }),
     ),
@@ -120,24 +124,27 @@ export async function probeFeatures(
     fetchDiscoveryDocument(client),
   ]);
 
-  // Build result map
-  const resultMap = new Map<string, boolean>();
+  // Build result map keyed by feature id, carrying both availability and any diagnostic reason.
+  const resultMap = new Map<string, ProbeOutcome>();
   for (const result of probeResults) {
-    resultMap.set(result.id, result.available);
+    resultMap.set(result.id, { available: result.available, reason: result.reason });
   }
 
   // Component-based HANA detection overrides the endpoint probe when the hanainfo
   // endpoint is absent (e.g. some S/4HANA releases). Only applies in auto mode.
-  if (!resultMap.get('hana') && systemDetection.hasHana && modeMap.hana === 'auto') {
-    resultMap.set('hana', true);
+  if (!resultMap.get('hana')?.available && systemDetection.hasHana && modeMap.hana === 'auto') {
+    resultMap.set('hana', {
+      available: true,
+      reason: 'inferred from installed components (hanainfo endpoint absent)',
+    });
   }
 
   // Resolve all features
   const result: Record<string, FeatureStatus> = {};
   for (const probe of PROBES) {
     const mode = modeMap[probe.id] ?? 'auto';
-    const probeResult = resultMap.get(probe.id) ?? false;
-    result[probe.id] = resolveFeature(mode, probeResult, probe.id, probe.description);
+    const outcome = resultMap.get(probe.id) ?? { available: false };
+    result[probe.id] = resolveFeature(mode, outcome, probe.id, probe.description);
   }
 
   const resolved = result as unknown as ResolvedFeatures;
@@ -351,6 +358,45 @@ async function probeTransportAccess(client: AdtHttpClient): Promise<{ available:
   }
 }
 
+/**
+ * Classify the HTTP status of a single feature-probe request into `{ available, reason? }`.
+ *
+ * Decision table:
+ * - **2xx** → endpoint exists and we got a clean response → available.
+ * - **400, 405, 500, other 4xx/5xx** → endpoint exists; SAP returned a request-shape /
+ *   server error after dispatching to the handler → available. (Some collection endpoints
+ *   intentionally return 400 without query params, e.g. `/ddic/ddl/sources`.)
+ * - **401** → request was rejected by ICM/SICF before authorization could even run.
+ *   This carries NO signal about endpoint existence — could be missing creds, expired
+ *   session, wrong client, etc. Reporting `available: true` here would be a lie on
+ *   any system where auth is misconfigured. Classify as unavailable.
+ * - **403** → endpoint exists, but the user lacks the specific authorization to use it.
+ *   From the caller's perspective the feature is unusable, so report unavailable —
+ *   matches `classifyAuthProbeError` semantics for textSearch / authProbe.
+ * - **404** → ICF service not activated, endpoint not registered → unavailable.
+ *
+ * Exported for testing.
+ */
+export function classifyFeatureProbeStatus(
+  id: string,
+  statusCode: number,
+): { id: string; available: boolean; reason?: string } {
+  if (statusCode >= 200 && statusCode < 300) {
+    return { id, available: true };
+  }
+  if (statusCode === 401) {
+    return { id, available: false, reason: 'auth failure (401) — cannot determine availability' };
+  }
+  if (statusCode === 403) {
+    return { id, available: false, reason: 'forbidden (403) — endpoint exists but user lacks authorization' };
+  }
+  if (statusCode === 404) {
+    return { id, available: false, reason: 'endpoint not found (404) — ICF service not activated' };
+  }
+  // 400 / 405 / 4xx / 5xx other than auth/missing → endpoint exists, request was dispatched.
+  return { id, available: true };
+}
+
 export function classifyAuthProbeError(
   statusCode: number,
   probeType: 'search' | 'transport',
@@ -394,7 +440,8 @@ export function resolveWithoutProbing(config: FeatureConfig): ResolvedFeatures {
   for (const [id, mode] of Object.entries(config)) {
     result[id] = resolveFeature(
       mode as FeatureMode,
-      mode === 'on', // Without probing, "auto" defaults to unavailable
+      // Without probing, "auto" defaults to unavailable. No probe ran, so no reason to surface.
+      { available: mode === 'on' },
       id,
       descriptions[id] ?? id,
     );

--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -103,7 +103,7 @@ export async function probeFeatures(
   const probesToRun = PROBES.filter((p) => modeMap[p.id] === 'auto');
 
   // Run feature probes + system detection + text search probe + auth probe + discovery in parallel
-  const [probeResults, systemDetection, textSearchResult, authProbeResult, discoveryMap] = await Promise.all([
+  const [probeResults, systemDetection, textSearchResult, authProbeResult, discoveryResult] = await Promise.all([
     Promise.all(
       probesToRun.map(async (probe) => {
         try {
@@ -124,6 +124,8 @@ export async function probeFeatures(
     fetchDiscoveryDocument(client),
   ]);
 
+  const { map: discoveryMap, nhiPresent: discoveryNhiPresent } = discoveryResult;
+
   // Build result map keyed by feature id, carrying both availability and any diagnostic reason.
   const resultMap = new Map<string, ProbeOutcome>();
   for (const result of probeResults) {
@@ -136,6 +138,16 @@ export async function probeFeatures(
     resultMap.set('hana', {
       available: true,
       reason: 'inferred from installed components (hanainfo endpoint absent)',
+    });
+  }
+
+  // Discovery-based HANA detection: NHI (Native HANA Integration) workspaces are only
+  // registered on HANA-based systems. Fires when both the hanainfo probe and the components
+  // feed failed to confirm HANA (e.g. empty components feed + hanainfo 404).
+  if (!resultMap.get('hana')?.available && discoveryNhiPresent && modeMap.hana === 'auto') {
+    resultMap.set('hana', {
+      available: true,
+      reason: 'inferred from ADT discovery document (NHI workspace present — Native HANA Integration)',
     });
   }
 
@@ -228,6 +240,17 @@ async function detectSystemFromComponents(client: AdtHttpClient): Promise<System
   } catch {
     return {};
   }
+}
+
+/**
+ * Detect HANA presence from ADT discovery document NHI signal (exported for testing).
+ *
+ * NHI (Native HANA Integration) workspaces at /sap/bc/adt/nhi/* are only registered
+ * on HANA-based SAP systems. This is the last fallback when both the hanainfo endpoint
+ * probe and the software components feed fail to produce a signal.
+ */
+export function detectHanaFromDiscovery(nhiPresent: boolean): boolean {
+  return nhiPresent;
 }
 
 /**

--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -194,7 +194,6 @@ interface SystemDetection {
   abapRelease?: string;
   systemType?: SystemType;
   hasHana?: boolean;
-  hanaRelease?: string;
 }
 
 /**
@@ -214,12 +213,10 @@ async function detectSystemFromComponents(client: AdtHttpClient): Promise<System
     const basis = components.find((c) => c.name.toUpperCase() === 'SAP_BASIS');
     const hasSapCloud = components.some((c) => c.name.toUpperCase() === 'SAP_CLOUD');
     const systemType: SystemType | undefined = hasSapCloud ? 'btp' : 'onprem';
-    const { hasHana, hanaRelease } = detectHanaFromComponents(components);
     return {
       abapRelease: basis?.release || undefined,
       systemType,
-      hasHana,
-      hanaRelease,
+      hasHana: detectHanaFromComponents(components),
     };
   } catch {
     return {};
@@ -227,23 +224,33 @@ async function detectSystemFromComponents(client: AdtHttpClient): Promise<System
 }
 
 /**
+ * Detect HANA DB presence from installed software components (exported for testing).
+ *
+ * Rules (any match → HANA):
+ * 1. Component name contains `HDB` or `HANA` (e.g. `HDB`, `HANA_XS`) — direct DB indicator,
+ *    typically present on Suite-on-HANA systems.
+ * 2. Component name starts with `S4` (e.g. `S4CORE`, `S4FND`, `S4CEXT`) — S/4HANA is
+ *    HANA-only, and `S4` is SAP's reserved prefix for S/4HANA software components.
+ *    On S/4HANA 2021+ the core component is `S4FND`, not `S4CORE`.
+ * 3. Component name `BW4CORE` — BW/4HANA is also HANA-only.
+ *
+ * DB release info is intentionally not surfaced: only HDB-named components carry a
+ * meaningful release; S4/BW4CORE releases describe the ABAP stack, not the DB.
+ */
+export function detectHanaFromComponents(components: Array<{ name: string }>): boolean {
+  for (const c of components) {
+    const name = c.name.toUpperCase();
+    if (/HDB|HANA/.test(name)) return true;
+    if (/^S4[A-Z]/.test(name)) return true;
+    if (name === 'BW4CORE') return true;
+  }
+  return false;
+}
+
+/**
  * Detect system type from installed components (exported for testing).
  * Returns 'btp' if SAP_CLOUD component is present, 'onprem' otherwise.
  */
-export function detectHanaFromComponents(components: Array<{ name: string; release: string }>): {
-  hasHana: boolean;
-  hanaRelease?: string;
-} {
-  // Step 1: component whose name contains HDB or HANA — direct DB indicator, release available
-  const hanaComponent = components.find((c) => /HDB|HANA/i.test(c.name));
-  if (hanaComponent) {
-    return { hasHana: true, hanaRelease: hanaComponent.release };
-  }
-  // Step 2: S4CORE implies S/4HANA → always runs on HANA; DB release cannot be inferred
-  const hasS4Core = components.some((c) => c.name.toUpperCase() === 'S4CORE');
-  return { hasHana: hasS4Core };
-}
-
 export function detectSystemType(
   components: Array<{ name: string; release: string; description: string }>,
 ): SystemType {

--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -126,6 +126,12 @@ export async function probeFeatures(
     resultMap.set(result.id, result.available);
   }
 
+  // Component-based HANA detection overrides the endpoint probe when the hanainfo
+  // endpoint is absent (e.g. some S/4HANA releases). Only applies in auto mode.
+  if (!resultMap.get('hana') && systemDetection.hasHana && modeMap.hana === 'auto') {
+    resultMap.set('hana', true);
+  }
+
   // Resolve all features
   const result: Record<string, FeatureStatus> = {};
   for (const probe of PROBES) {
@@ -187,6 +193,8 @@ export function mapSapReleaseToAbaplintVersion(release: string): Version {
 interface SystemDetection {
   abapRelease?: string;
   systemType?: SystemType;
+  hasHana?: boolean;
+  hanaRelease?: string;
 }
 
 /**
@@ -200,15 +208,18 @@ interface SystemDetection {
  */
 async function detectSystemFromComponents(client: AdtHttpClient): Promise<SystemDetection> {
   try {
-    const resp = await client.get('/sap/bc/adt/system/components');
+    const resp = await client.get('/sap/bc/adt/system/components', { Accept: 'application/atom+xml;type=feed' });
     if (resp.statusCode >= 400) return {};
     const components = parseInstalledComponents(resp.body);
     const basis = components.find((c) => c.name.toUpperCase() === 'SAP_BASIS');
     const hasSapCloud = components.some((c) => c.name.toUpperCase() === 'SAP_CLOUD');
     const systemType: SystemType | undefined = hasSapCloud ? 'btp' : 'onprem';
+    const { hasHana, hanaRelease } = detectHanaFromComponents(components);
     return {
       abapRelease: basis?.release || undefined,
       systemType,
+      hasHana,
+      hanaRelease,
     };
   } catch {
     return {};
@@ -219,6 +230,20 @@ async function detectSystemFromComponents(client: AdtHttpClient): Promise<System
  * Detect system type from installed components (exported for testing).
  * Returns 'btp' if SAP_CLOUD component is present, 'onprem' otherwise.
  */
+export function detectHanaFromComponents(components: Array<{ name: string; release: string }>): {
+  hasHana: boolean;
+  hanaRelease?: string;
+} {
+  // Step 1: component whose name contains HDB or HANA — direct DB indicator, release available
+  const hanaComponent = components.find((c) => /HDB|HANA/i.test(c.name));
+  if (hanaComponent) {
+    return { hasHana: true, hanaRelease: hanaComponent.release };
+  }
+  // Step 2: S4CORE implies S/4HANA → always runs on HANA; DB release cannot be inferred
+  const hasS4Core = components.some((c) => c.name.toUpperCase() === 'S4CORE');
+  return { hasHana: hasS4Core };
+}
+
 export function detectSystemType(
   components: Array<{ name: string; release: string; description: string }>,
 ): SystemType {

--- a/tests/integration/adt.integration.test.ts
+++ b/tests/integration/adt.integration.test.ts
@@ -122,7 +122,7 @@ describe('ADT Integration Tests', () => {
 
   describe('discovery MIME negotiation', () => {
     it('fetches discovery map with key ADT endpoints and MIME types', async (ctx) => {
-      const discoveryMap = await fetchDiscoveryDocument(client.http);
+      const { map: discoveryMap } = await fetchDiscoveryDocument(client.http);
       const nonEmptyMap = discoveryMap.size > 0 ? discoveryMap : undefined;
       requireOrSkip(ctx, nonEmptyMap, SkipReason.BACKEND_UNSUPPORTED);
 
@@ -135,7 +135,7 @@ describe('ADT Integration Tests', () => {
     });
 
     it('resolveAcceptType returns sensible MIME type for known endpoints', async (ctx) => {
-      const discoveryMap = await fetchDiscoveryDocument(client.http);
+      const { map: discoveryMap } = await fetchDiscoveryDocument(client.http);
       const nonEmptyMap = discoveryMap.size > 0 ? discoveryMap : undefined;
       requireOrSkip(ctx, nonEmptyMap, SkipReason.BACKEND_UNSUPPORTED);
 

--- a/tests/unit/adt/discovery.test.ts
+++ b/tests/unit/adt/discovery.test.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { fetchDiscoveryDocument, resolveAcceptType, resolveContentType } from '../../../src/adt/discovery.js';
+import {
+  fetchDiscoveryDocument,
+  hasNhiWorkspace,
+  resolveAcceptType,
+  resolveContentType,
+} from '../../../src/adt/discovery.js';
 import type { AdtHttpClient } from '../../../src/adt/http.js';
 import { parseDiscoveryDocument } from '../../../src/adt/xml-parser.js';
 
@@ -87,7 +92,7 @@ describe('ADT Discovery', () => {
     it('fetches and parses discovery document successfully', async () => {
       const xml = loadFixture('discovery.xml');
       const client = mockClient(async () => ({ body: xml }));
-      const map = await fetchDiscoveryDocument(client);
+      const { map } = await fetchDiscoveryDocument(client);
       expect(map.size).toBe(9);
       expect((client as any).get).toHaveBeenCalledWith('/sap/bc/adt/discovery', {
         Accept: 'application/atomsvc+xml',
@@ -98,7 +103,7 @@ describe('ADT Discovery', () => {
       const client = mockClient(async () => {
         throw { statusCode: 404 };
       });
-      const map = await fetchDiscoveryDocument(client);
+      const { map } = await fetchDiscoveryDocument(client);
       expect(map).toEqual(new Map());
     });
 
@@ -106,7 +111,7 @@ describe('ADT Discovery', () => {
       const client = mockClient(async () => {
         throw { statusCode: 406 };
       });
-      const map = await fetchDiscoveryDocument(client);
+      const { map } = await fetchDiscoveryDocument(client);
       expect(map).toEqual(new Map());
     });
 
@@ -114,8 +119,57 @@ describe('ADT Discovery', () => {
       const client = mockClient(async () => {
         throw new Error('ECONNRESET');
       });
-      const map = await fetchDiscoveryDocument(client);
+      const { map } = await fetchDiscoveryDocument(client);
       expect(map).toEqual(new Map());
+    });
+
+    it('sets nhiPresent=true when NHI hrefs appear in discovery XML', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+<app:service xmlns:app="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom">
+  <app:workspace>
+    <atom:title>HANA-Integration</atom:title>
+    <app:collection href="/sap/bc/adt/nhi/repositories">
+      <atom:title>NHI Repositories</atom:title>
+    </app:collection>
+  </app:workspace>
+</app:service>`;
+      const client = mockClient(async () => ({ body: xml }));
+      const { map, nhiPresent } = await fetchDiscoveryDocument(client);
+      expect(nhiPresent).toBe(true);
+      expect(map.size).toBe(0); // NHI collections have no <app:accept>
+    });
+
+    it('sets nhiPresent=false when NHI hrefs are absent', async () => {
+      const xml = loadFixture('discovery.xml');
+      const client = mockClient(async () => ({ body: xml }));
+      const { nhiPresent } = await fetchDiscoveryDocument(client);
+      expect(nhiPresent).toBe(false);
+    });
+
+    it('sets nhiPresent=false when discovery fails', async () => {
+      const client = mockClient(async () => {
+        throw new Error('ECONNRESET');
+      });
+      const { nhiPresent } = await fetchDiscoveryDocument(client);
+      expect(nhiPresent).toBe(false);
+    });
+  });
+
+  describe('hasNhiWorkspace', () => {
+    it('returns true when NHI href is present', () => {
+      expect(hasNhiWorkspace('<app:collection href="/sap/bc/adt/nhi/repositories">')).toBe(true);
+    });
+
+    it('returns true for any NHI sub-path', () => {
+      expect(hasNhiWorkspace('/sap/bc/adt/nhi/configurations')).toBe(true);
+    });
+
+    it('returns false for standard ADT hrefs', () => {
+      expect(hasNhiWorkspace('<app:collection href="/sap/bc/adt/oo/classes">')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(hasNhiWorkspace('')).toBe(false);
     });
   });
 

--- a/tests/unit/adt/discovery.test.ts
+++ b/tests/unit/adt/discovery.test.ts
@@ -156,12 +156,18 @@ describe('ADT Discovery', () => {
   });
 
   describe('hasNhiWorkspace', () => {
-    it('returns true when NHI href is present', () => {
+    it('returns true when NHI href is present (relative)', () => {
       expect(hasNhiWorkspace('<app:collection href="/sap/bc/adt/nhi/repositories">')).toBe(true);
     });
 
-    it('returns true for any NHI sub-path', () => {
-      expect(hasNhiWorkspace('/sap/bc/adt/nhi/configurations')).toBe(true);
+    it('returns true for an NHI href with absolute URL prefix', () => {
+      // Some SAP servers emit absolute hrefs in the discovery document.
+      expect(hasNhiWorkspace('<app:collection href="https://server.example.com/sap/bc/adt/nhi/repos">')).toBe(true);
+    });
+
+    it('is namespace-prefix agnostic and tolerates whitespace around the equals sign', () => {
+      expect(hasNhiWorkspace('<collection href = "/sap/bc/adt/nhi/repos">')).toBe(true);
+      expect(hasNhiWorkspace("<atom:link href='/sap/bc/adt/nhi/repos'/>")).toBe(true);
     });
 
     it('returns false for standard ADT hrefs', () => {
@@ -170,6 +176,28 @@ describe('ADT Discovery', () => {
 
     it('returns false for empty string', () => {
       expect(hasNhiWorkspace('')).toBe(false);
+    });
+
+    // ─── False-positive guards (regex anchored to href= attribute context) ─
+
+    it('returns false when the path appears as bare text (not inside an href)', () => {
+      // The previous lax substring match would have returned true here.
+      expect(hasNhiWorkspace('/sap/bc/adt/nhi/configurations')).toBe(false);
+    });
+
+    it('returns false when the path appears in <atom:title> text', () => {
+      // Defensive: a workspace title that mentions the NHI path verbatim must not signal HANA.
+      expect(hasNhiWorkspace('<atom:title>NHI lives at /sap/bc/adt/nhi/configurations</atom:title>')).toBe(false);
+    });
+
+    it('returns false when the path appears in a non-href attribute', () => {
+      // `data-path`, `id`, etc. mentioning the path must not count.
+      expect(hasNhiWorkspace('<a data-path="/sap/bc/adt/nhi/foo">link</a>')).toBe(false);
+    });
+
+    it('returns false when the path is missing the leading slash inside href', () => {
+      // Defensive: `href="sap/bc/adt/nhi/..."` is invalid for an absolute server path.
+      expect(hasNhiWorkspace('<app:collection href="sap/bc/adt/nhi/repos">')).toBe(false);
     });
   });
 

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -6,6 +6,7 @@ import {
   classifyAuthProbeError,
   classifyFeatureProbeStatus,
   detectHanaFromComponents,
+  detectHanaFromDiscovery,
   detectSystemType,
   mapSapReleaseToAbaplintVersion,
   probeAuthorization,
@@ -361,6 +362,18 @@ describe('Feature Detection', () => {
     });
   });
 
+  // ─── detectHanaFromDiscovery ───────────────────────────────────────
+
+  describe('detectHanaFromDiscovery', () => {
+    it('returns true when NHI is present', () => {
+      expect(detectHanaFromDiscovery(true)).toBe(true);
+    });
+
+    it('returns false when NHI is absent', () => {
+      expect(detectHanaFromDiscovery(false)).toBe(false);
+    });
+  });
+
   // ─── probeFeatures (with discovery) ───────────────────────────────
 
   describe('probeFeatures', () => {
@@ -596,6 +609,92 @@ describe('Feature Detection', () => {
       const result = await probeFeatures(client, defaultConfig);
       expect(result.hana.available).toBe(true);
       expect(result.hana.message).toMatch(/inferred from installed components/);
+    });
+
+    // ─── Discovery-based HANA fallback ────────────────────────────────
+
+    const nhiDiscoveryXml = `<?xml version="1.0" encoding="utf-8"?>
+<app:service xmlns:app="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom">
+  <app:workspace>
+    <atom:title>HANA-Integration</atom:title>
+    <app:collection href="/sap/bc/adt/nhi/repositories">
+      <atom:title>NHI Repositories</atom:title>
+    </app:collection>
+    <app:collection href="/sap/bc/adt/nhi/configurations">
+      <atom:title>NHI Configurations</atom:title>
+    </app:collection>
+  </app:workspace>
+</app:service>`;
+
+    const emptyComponentsXml = `<?xml version="1.0" encoding="utf-8"?>
+<atom:feed xmlns:atom="http://www.w3.org/2005/Atom"/>`;
+
+    function mockProbeClientDiscoveryScenario(options: {
+      componentsXml: string;
+      discoveryXml: string;
+      hanaEndpoint404: boolean;
+    }): AdtHttpClient {
+      return {
+        get: vi.fn().mockImplementation((url: string) => {
+          if (url === '/sap/bc/adt/discovery') {
+            return Promise.resolve({ statusCode: 200, body: options.discoveryXml });
+          }
+          if (url === '/sap/bc/adt/system/components') {
+            return Promise.resolve({ statusCode: 200, body: options.componentsXml });
+          }
+          if (url === '/sap/bc/adt/ddic/sysinfo/hanainfo') {
+            if (options.hanaEndpoint404) {
+              return Promise.reject(new AdtApiError('Not Found', 404, url));
+            }
+            return Promise.resolve({ statusCode: 200, body: '' });
+          }
+          return Promise.resolve({ statusCode: 200, body: '' });
+        }),
+      } as unknown as AdtHttpClient;
+    }
+
+    it('detects HANA via NHI workspace when components feed is empty and hanainfo 404', async () => {
+      // Regression case: systems where /sap/bc/adt/system/components returns an empty feed
+      // AND hanainfo is not activated. Discovery NHI workspace is the last resort.
+      const client = mockProbeClientDiscoveryScenario({
+        componentsXml: emptyComponentsXml,
+        discoveryXml: nhiDiscoveryXml,
+        hanaEndpoint404: true,
+      });
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(true);
+      expect(result.hana.message).toMatch(/NHI|Native HANA Integration/);
+    });
+
+    it('reports HANA unavailable when all three signals are absent', async () => {
+      const client = mockProbeClientDiscoveryScenario({
+        componentsXml: emptyComponentsXml,
+        discoveryXml: discoveryXml, // standard fixture — no NHI
+        hanaEndpoint404: true,
+      });
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(false);
+    });
+
+    it('promotes hana to available via NHI even when hanainfo returns 401', async () => {
+      // 401 on hanainfo means auth failure on THAT endpoint, not that HANA is absent.
+      // The discovery NHI signal is from a separate, independently-trusted 200 OK response
+      // and should still override the hanainfo auth failure.
+      const client = {
+        get: vi.fn().mockImplementation((url: string) => {
+          if (url === '/sap/bc/adt/discovery') return Promise.resolve({ statusCode: 200, body: nhiDiscoveryXml });
+          if (url === '/sap/bc/adt/system/components') {
+            return Promise.resolve({ statusCode: 200, body: emptyComponentsXml });
+          }
+          if (url === '/sap/bc/adt/ddic/sysinfo/hanainfo') {
+            return Promise.reject(new AdtApiError('Unauthorized', 401, url));
+          }
+          return Promise.resolve({ statusCode: 200, body: '' });
+        }),
+      } as unknown as AdtHttpClient;
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(true);
+      expect(result.hana.message).toMatch(/NHI|Native HANA Integration/);
     });
   });
 

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -337,7 +337,26 @@ describe('Feature Detection', () => {
           { name: 'ZCUSTOM_DEVELOPMENT' },
           { name: 'ZLOCAL' },
         ]),
-      ).toBe(true);
+      ).toBe(true); // S4FND triggers the rule
+    });
+
+    it('returns false on real-world NetWeaver 7.50 SP02 trial (AnyDB / SAP MaxDB, no HANA)', () => {
+      // Captured from the NPL 7.50 SP02 dev-edition trial system
+      // (tests/fixtures/probe/npl-750-sp02-dev-edition/meta.json).
+      // Regression guard: the heuristic must not false-positive on plain NetWeaver +
+      // SAP_BW (BW on AnyDB ≠ BW/4HANA), and BI_CONT must not match HDB|HANA.
+      expect(
+        detectHanaFromComponents([
+          { name: 'BI_CONT' },
+          { name: 'DMIS' },
+          { name: 'SAP_ABA' },
+          { name: 'SAP_BASIS' },
+          { name: 'SAP_BW' },
+          { name: 'SAP_GWFND' },
+          { name: 'SAP_UI' },
+          { name: 'ST-PI' },
+        ]),
+      ).toBe(false);
     });
   });
 

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -4,6 +4,7 @@ import type { FeatureConfig } from '../../../src/adt/config.js';
 import { AdtApiError } from '../../../src/adt/errors.js';
 import {
   classifyAuthProbeError,
+  classifyFeatureProbeStatus,
   detectHanaFromComponents,
   detectSystemType,
   mapSapReleaseToAbaplintVersion,
@@ -508,6 +509,128 @@ describe('Feature Detection', () => {
       const client = mockProbeClientHanaScenario({ componentsXml: nonHanaComponents, hanaEndpoint404: true });
       const result = await probeFeatures(client, defaultConfig);
       expect(result.hana.available).toBe(false);
+    });
+
+    // ─── HTTP status classification (regression for the 401-as-available bug) ──
+
+    function mockProbeClientStatus(hanainfoStatus: number): AdtHttpClient {
+      return {
+        get: vi.fn().mockImplementation((url: string) => {
+          if (url === '/sap/bc/adt/discovery') return Promise.resolve({ statusCode: 200, body: discoveryXml });
+          if (url === '/sap/bc/adt/system/components') {
+            return Promise.resolve({
+              statusCode: 200,
+              body: makeComponentsXml([{ id: 'SAP_BASIS', title: '750;SAPKB75002;0002;SAP Basis Component' }]),
+            });
+          }
+          if (url === '/sap/bc/adt/ddic/sysinfo/hanainfo') {
+            if (hanainfoStatus >= 400) {
+              return Promise.reject(new AdtApiError(`HTTP ${hanainfoStatus}`, hanainfoStatus, url));
+            }
+            return Promise.resolve({ statusCode: hanainfoStatus, body: '' });
+          }
+          // Other probes: return success so we can isolate the hana-status assertion.
+          return Promise.resolve({ statusCode: 200, body: '' });
+        }),
+      } as unknown as AdtHttpClient;
+    }
+
+    it('classifies hanainfo 401 as unavailable (regression: was incorrectly true)', async () => {
+      const client = mockProbeClientStatus(401);
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(false);
+      expect(result.hana.message).toMatch(/auth failure \(401\)/);
+    });
+
+    it('classifies hanainfo 403 as unavailable (user lacks authorization)', async () => {
+      const client = mockProbeClientStatus(403);
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(false);
+      expect(result.hana.message).toMatch(/forbidden \(403\)/);
+    });
+
+    it('classifies hanainfo 404 as unavailable (endpoint not registered)', async () => {
+      const client = mockProbeClientStatus(404);
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(false);
+      expect(result.hana.message).toMatch(/endpoint not found \(404\)|not available/);
+    });
+
+    it('classifies hanainfo 400 as available (endpoint exists, request shape rejected)', async () => {
+      const client = mockProbeClientStatus(400);
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(true);
+    });
+
+    it('classifies hanainfo 500 as available (endpoint exists, server error)', async () => {
+      const client = mockProbeClientStatus(500);
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(true);
+    });
+
+    it('treats network error (no AdtApiError) as unavailable', async () => {
+      const client = {
+        get: vi.fn().mockImplementation((url: string) => {
+          if (url === '/sap/bc/adt/discovery') return Promise.resolve({ statusCode: 200, body: discoveryXml });
+          if (url === '/sap/bc/adt/system/components') {
+            return Promise.resolve({
+              statusCode: 200,
+              body: makeComponentsXml([{ id: 'SAP_BASIS', title: '750;SAPKB75002;0002;SAP Basis Component' }]),
+            });
+          }
+          if (url === '/sap/bc/adt/ddic/sysinfo/hanainfo') return Promise.reject(new Error('ECONNRESET'));
+          return Promise.resolve({ statusCode: 200, body: '' });
+        }),
+      } as unknown as AdtHttpClient;
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(false);
+      expect(result.hana.message).toMatch(/network error|not available/);
+    });
+
+    it('surfaces inferred-from-components reason when fallback overrides 404', async () => {
+      const s4Components = makeComponentsXml([
+        { id: 'SAP_BASIS', title: '758;SAPKB75801;0001;SAP Basis Component' },
+        { id: 'S4FND', title: '108;S4FND108;0001;S/4HANA Foundation' },
+      ]);
+      const client = mockProbeClientHanaScenario({ componentsXml: s4Components, hanaEndpoint404: true });
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(true);
+      expect(result.hana.message).toMatch(/inferred from installed components/);
+    });
+  });
+
+  // ─── classifyFeatureProbeStatus ────────────────────────────────────
+
+  describe('classifyFeatureProbeStatus', () => {
+    it('returns available=true on 2xx', () => {
+      expect(classifyFeatureProbeStatus('hana', 200)).toEqual({ id: 'hana', available: true });
+      expect(classifyFeatureProbeStatus('rap', 204)).toEqual({ id: 'rap', available: true });
+    });
+
+    it('returns available=false with auth-failure reason on 401', () => {
+      const r = classifyFeatureProbeStatus('hana', 401);
+      expect(r.available).toBe(false);
+      expect(r.reason).toMatch(/auth failure \(401\)/);
+    });
+
+    it('returns available=false with forbidden reason on 403', () => {
+      const r = classifyFeatureProbeStatus('amdp', 403);
+      expect(r.available).toBe(false);
+      expect(r.reason).toMatch(/forbidden \(403\)/);
+    });
+
+    it('returns available=false with not-found reason on 404', () => {
+      const r = classifyFeatureProbeStatus('amdp', 404);
+      expect(r.available).toBe(false);
+      expect(r.reason).toMatch(/endpoint not found \(404\)/);
+    });
+
+    it('returns available=true on 400 / 405 / 500 (endpoint exists, request rejected)', () => {
+      // 400 = e.g. /ddic/ddl/sources without query params; 405 = wrong method;
+      // 500 = backend error from a registered endpoint. All three confirm endpoint presence.
+      expect(classifyFeatureProbeStatus('rap', 400).available).toBe(true);
+      expect(classifyFeatureProbeStatus('hana', 405).available).toBe(true);
+      expect(classifyFeatureProbeStatus('hana', 500).available).toBe(true);
     });
   });
 

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -1,8 +1,10 @@
 import { Version } from '@abaplint/core';
 import { describe, expect, it, vi } from 'vitest';
 import type { FeatureConfig } from '../../../src/adt/config.js';
+import { AdtApiError } from '../../../src/adt/errors.js';
 import {
   classifyAuthProbeError,
+  detectHanaFromComponents,
   detectSystemType,
   mapSapReleaseToAbaplintVersion,
   probeAuthorization,
@@ -265,6 +267,59 @@ describe('Feature Detection', () => {
     });
   });
 
+  // ─── detectHanaFromComponents ──────────────────────────────────────
+
+  describe('detectHanaFromComponents', () => {
+    it('detects HANA when HDB component is present', () => {
+      const result = detectHanaFromComponents([{ name: 'HDB', release: '2.0' }]);
+      expect(result.hasHana).toBe(true);
+      expect(result.hanaRelease).toBe('2.0');
+    });
+
+    it('detects HANA when component name contains HANA', () => {
+      const result = detectHanaFromComponents([{ name: 'HANA_XS', release: '1.0' }]);
+      expect(result.hasHana).toBe(true);
+      expect(result.hanaRelease).toBe('1.0');
+    });
+
+    it('detects HANA via S4CORE with no hanaRelease', () => {
+      const result = detectHanaFromComponents([{ name: 'S4CORE', release: '108' }]);
+      expect(result.hasHana).toBe(true);
+      expect(result.hanaRelease).toBeUndefined();
+    });
+
+    it('returns false when no HANA indicators are present', () => {
+      const result = detectHanaFromComponents([
+        { name: 'SAP_BASIS', release: '758' },
+        { name: 'SAP_ABA', release: '758' },
+      ]);
+      expect(result.hasHana).toBe(false);
+      expect(result.hanaRelease).toBeUndefined();
+    });
+
+    it('returns false for empty component list', () => {
+      const result = detectHanaFromComponents([]);
+      expect(result.hasHana).toBe(false);
+    });
+
+    it('is case-insensitive for HDB/HANA component names', () => {
+      expect(detectHanaFromComponents([{ name: 'hdb', release: '2.0' }]).hasHana).toBe(true);
+      expect(detectHanaFromComponents([{ name: 'Hana_XS', release: '1.0' }]).hasHana).toBe(true);
+    });
+
+    // Note: not sure if this combination (HDB + S4CORE) is actually present in any real system.
+    // On native S/4HANA there is likely no HDB-named ABAP component in CVERS; HDB may only appear
+    // on ERP on HANA (Suite on HANA) systems, which would not have S4CORE.
+    it('HDB component takes priority over S4CORE for hanaRelease', () => {
+      const result = detectHanaFromComponents([
+        { name: 'HDB', release: '2.0' },
+        { name: 'S4CORE', release: '108' },
+      ]);
+      expect(result.hasHana).toBe(true);
+      expect(result.hanaRelease).toBe('2.0');
+    });
+  });
+
   // ─── probeFeatures (with discovery) ───────────────────────────────
 
   describe('probeFeatures', () => {
@@ -350,6 +405,56 @@ describe('Feature Detection', () => {
 
       expect(result.discoveryMap).toBeDefined();
       expect(result.discoveryMap?.size).toBe(0);
+    });
+
+    function makeComponentsXml(entries: Array<{ id: string; title: string }>): string {
+      const items = entries
+        .map(
+          (e) =>
+            `  <atom:entry>\n    <atom:id>${e.id}</atom:id>\n    <atom:title>${e.title}</atom:title>\n  </atom:entry>`,
+        )
+        .join('\n');
+      return `<?xml version="1.0" encoding="utf-8"?>\n<atom:feed xmlns:atom="http://www.w3.org/2005/Atom">\n${items}\n</atom:feed>`;
+    }
+
+    function mockProbeClientHanaScenario(options: { componentsXml: string; hanaEndpoint404: boolean }): AdtHttpClient {
+      return {
+        get: vi.fn().mockImplementation((url: string) => {
+          if (url === '/sap/bc/adt/discovery') {
+            return Promise.resolve({ statusCode: 200, body: discoveryXml });
+          }
+          if (url === '/sap/bc/adt/system/components') {
+            return Promise.resolve({ statusCode: 200, body: options.componentsXml });
+          }
+          if (url === '/sap/bc/adt/ddic/sysinfo/hanainfo') {
+            if (options.hanaEndpoint404) {
+              return Promise.reject(new AdtApiError('Not Found', 404, url));
+            }
+            return Promise.resolve({ statusCode: 200, body: '' });
+          }
+          return Promise.resolve({ statusCode: 200, body: '' });
+        }),
+      } as unknown as AdtHttpClient;
+    }
+
+    it('detects HANA via S4CORE component when hanainfo endpoint returns 404', async () => {
+      const s4Components = makeComponentsXml([
+        { id: 'SAP_BASIS', title: '758;SAPKB75801;0001;SAP Basis Component' },
+        { id: 'S4CORE', title: '108;S4CORE108;0001;S/4HANA Core' },
+      ]);
+      const client = mockProbeClientHanaScenario({ componentsXml: s4Components, hanaEndpoint404: true });
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(true);
+    });
+
+    it('reports HANA unavailable when hanainfo 404 and no HANA components', async () => {
+      const nonHanaComponents = makeComponentsXml([
+        { id: 'SAP_BASIS', title: '758;SAPKB75801;0001;SAP Basis Component' },
+        { id: 'SAP_ABA', title: '758;SAPK-75801INSAPABA;0001;SAP Application Basis' },
+      ]);
+      const client = mockProbeClientHanaScenario({ componentsXml: nonHanaComponents, hanaEndpoint404: true });
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(false);
     });
   });
 

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -271,52 +271,73 @@ describe('Feature Detection', () => {
 
   describe('detectHanaFromComponents', () => {
     it('detects HANA when HDB component is present', () => {
-      const result = detectHanaFromComponents([{ name: 'HDB', release: '2.0' }]);
-      expect(result.hasHana).toBe(true);
-      expect(result.hanaRelease).toBe('2.0');
+      expect(detectHanaFromComponents([{ name: 'HDB' }])).toBe(true);
     });
 
     it('detects HANA when component name contains HANA', () => {
-      const result = detectHanaFromComponents([{ name: 'HANA_XS', release: '1.0' }]);
-      expect(result.hasHana).toBe(true);
-      expect(result.hanaRelease).toBe('1.0');
+      expect(detectHanaFromComponents([{ name: 'HANA_XS' }])).toBe(true);
     });
 
-    it('detects HANA via S4CORE with no hanaRelease', () => {
-      const result = detectHanaFromComponents([{ name: 'S4CORE', release: '108' }]);
-      expect(result.hasHana).toBe(true);
-      expect(result.hanaRelease).toBeUndefined();
+    it('detects HANA via S4CORE (S/4HANA ≤ 2020)', () => {
+      expect(detectHanaFromComponents([{ name: 'S4CORE' }])).toBe(true);
+    });
+
+    it('detects HANA via S4FND (S/4HANA 2021+)', () => {
+      expect(detectHanaFromComponents([{ name: 'S4FND' }])).toBe(true);
+    });
+
+    it('detects HANA via S4CEXT', () => {
+      expect(detectHanaFromComponents([{ name: 'S4CEXT' }])).toBe(true);
+    });
+
+    it('detects HANA via BW4CORE (BW/4HANA)', () => {
+      expect(detectHanaFromComponents([{ name: 'BW4CORE' }])).toBe(true);
     });
 
     it('returns false when no HANA indicators are present', () => {
-      const result = detectHanaFromComponents([
-        { name: 'SAP_BASIS', release: '758' },
-        { name: 'SAP_ABA', release: '758' },
-      ]);
-      expect(result.hasHana).toBe(false);
-      expect(result.hanaRelease).toBeUndefined();
+      expect(detectHanaFromComponents([{ name: 'SAP_BASIS' }, { name: 'SAP_ABA' }, { name: 'SAP_APPL' }])).toBe(false);
     });
 
     it('returns false for empty component list', () => {
-      const result = detectHanaFromComponents([]);
-      expect(result.hasHana).toBe(false);
+      expect(detectHanaFromComponents([])).toBe(false);
     });
 
-    it('is case-insensitive for HDB/HANA component names', () => {
-      expect(detectHanaFromComponents([{ name: 'hdb', release: '2.0' }]).hasHana).toBe(true);
-      expect(detectHanaFromComponents([{ name: 'Hana_XS', release: '1.0' }]).hasHana).toBe(true);
+    it('is case-insensitive for component names', () => {
+      expect(detectHanaFromComponents([{ name: 'hdb' }])).toBe(true);
+      expect(detectHanaFromComponents([{ name: 'Hana_XS' }])).toBe(true);
+      expect(detectHanaFromComponents([{ name: 's4fnd' }])).toBe(true);
+      expect(detectHanaFromComponents([{ name: 'bw4core' }])).toBe(true);
     });
 
-    // Note: not sure if this combination (HDB + S4CORE) is actually present in any real system.
-    // On native S/4HANA there is likely no HDB-named ABAP component in CVERS; HDB may only appear
-    // on ERP on HANA (Suite on HANA) systems, which would not have S4CORE.
-    it('HDB component takes priority over S4CORE for hanaRelease', () => {
-      const result = detectHanaFromComponents([
-        { name: 'HDB', release: '2.0' },
-        { name: 'S4CORE', release: '108' },
-      ]);
-      expect(result.hasHana).toBe(true);
-      expect(result.hanaRelease).toBe('2.0');
+    it('does not false-positive on non-S/4 components starting with "S4"-adjacent text', () => {
+      // S4 must be followed by an uppercase letter (checked after uppercasing input), so "S4" alone,
+      // "S4" followed by a digit, or "SAP_S4" would not match. Only S/4HANA component naming fits.
+      expect(detectHanaFromComponents([{ name: 'S4' }])).toBe(false);
+      expect(detectHanaFromComponents([{ name: 'S40' }])).toBe(false);
+      expect(detectHanaFromComponents([{ name: 'SAP_S4' }])).toBe(false);
+    });
+
+    it('detects HANA on a real-world S/4HANA 2023 on-prem component list (S4FND + MDG_FND)', () => {
+      // Captured from /sap/bc/adt/system/components on an S/4HANA 2023 on-prem trial.
+      // Notably absent: S4CORE, HDB, anything named HANA — the original heuristic missed this.
+      expect(
+        detectHanaFromComponents([
+          { name: 'DMIS' },
+          { name: 'HOME' },
+          { name: 'LOCAL' },
+          { name: 'MDG_FND' },
+          { name: 'S4FND' },
+          { name: 'SAP_ABA' },
+          { name: 'SAP_BASIS' },
+          { name: 'SAP_BW' },
+          { name: 'SAP_GWFND' },
+          { name: 'SAP_UI' },
+          { name: 'ST-PI' },
+          { name: 'UIBAS001' },
+          { name: 'ZCUSTOM_DEVELOPMENT' },
+          { name: 'ZLOCAL' },
+        ]),
+      ).toBe(true);
     });
   });
 
@@ -441,6 +462,19 @@ describe('Feature Detection', () => {
       const s4Components = makeComponentsXml([
         { id: 'SAP_BASIS', title: '758;SAPKB75801;0001;SAP Basis Component' },
         { id: 'S4CORE', title: '108;S4CORE108;0001;S/4HANA Core' },
+      ]);
+      const client = mockProbeClientHanaScenario({ componentsXml: s4Components, hanaEndpoint404: true });
+      const result = await probeFeatures(client, defaultConfig);
+      expect(result.hana.available).toBe(true);
+    });
+
+    it('detects HANA via S4FND on S/4HANA 2021+ when hanainfo endpoint returns 404', async () => {
+      // S/4HANA 2021+ ships S4FND instead of S4CORE — this was the scenario that originally
+      // produced a false negative on the reporter's test system.
+      const s4Components = makeComponentsXml([
+        { id: 'SAP_BASIS', title: '758;SAPKB75801;0001;SAP Basis Component' },
+        { id: 'S4FND', title: '108;S4FND108;0001;S/4HANA Foundation' },
+        { id: 'MDG_FND', title: '808;MDGFND808;0001;S/4HANA MDG Foundation' },
       ]);
       const client = mockProbeClientHanaScenario({ componentsXml: s4Components, hanaEndpoint404: true });
       const result = await probeFeatures(client, defaultConfig);


### PR DESCRIPTION
## Problem

SAPManage probe reported hana.available: false on a confirmed S/4HANA system. The hanainfo endpoint was absent (404), and the component-based fallback that was meant to catch this returned an empty list due to a missing Accept header — so both signals silently failed.

## Root cause 1 — hanainfo 404 on some S/4HANA releases

probeFeatures() probes HANA via GET /sap/bc/adt/ddic/sysinfo/hanainfo. On some S/4HANA releases this ICF node is not activated. A 404 is treated as "no HANA", producing a false negative even on systems where HANA is the only supported database.

## Root cause 2 — missing Accept header on /sap/bc/adt/system/components

Both detectSystemFromComponents() (features.ts) and getInstalledComponents() (client.ts) fetched /sap/bc/adt/system/components without an Accept header. On the test system, omitting the header caused SAP to return a response the XML parser could not find a <feed> root in, silently yielding []. The required header is Accept: application/atom+xml;type=feed.

## Fix

### 1 — S4CORE/HDB component fallback (src/adt/features.ts)

New exported helper detectHanaFromComponents() inspects the already-fetched installed-components list (zero extra HTTP requests — the call is in-flight for system-type detection anyway):

- Component name matching /HDB|HANA/i -> hasHana: true, hanaRelease from that component's release field.
- Component name S4CORE -> hasHana: true, hanaRelease undefined (S/4HANA always runs on SAP HANA; DB release cannot be inferred from the software-component layer).

When the endpoint probe returns false but components confirm HANA, the result is overridden to true (auto mode only — forced on/off configs are unaffected).

### 2 — Content negotiation (src/adt/client.ts + src/adt/features.ts)

Both call sites now send Accept: application/atom+xml;type=feed. A 406 guard in getInstalledComponents() returns [] instead of throwing, so systems using a different MIME scheme degrade gracefully.

## Known limitation

On the specific test S/4HANA 2023 system that triggered this investigation, even with the correct Accept header the endpoint returns HTTP 200 with an empty Atom feed (no <entry> elements, no SU53 auth denials). The S4CORE fallback therefore does not trigger on that system and hana.available remains false.

The reference ADT client library (github.com/marcellourbani/abap-adt-api) does not implement /sap/bc/adt/system/components at all, suggesting there is no universally reliable ADT signal for HANA presence across all S/4HANA releases. The v2.5.0 "core discovery for hana 1909" fix in that library addressed empty workspace arrays in a different discovery flow, not HANA detection.

The detection logic (S4CORE => HANA, HDB component => HANA) is correct by design, but whether it fires in practice depends on the components feed being populated — something we cannot verify on this system. Input from maintainers or contributors with access to systems where the feed is non-empty would be valuable.

## Tests (tests/unit/adt/features.test.ts)

Nine new unit tests:
- detectHanaFromComponents: HDB direct, HANA in name, S4CORE alone, no indicators, empty list, case-insensitive match, HDB priority over S4CORE
- probeFeatures: S4CORE in components overrides a 404 hanainfo (available: true); no HANA indicators + 404 hanainfo stays available: false