### PR TITLE
fix: restore npx package execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      - name: npx package smoke test
+        run: npm run test:npx-smoke
+
       - name: Run unit tests
         run: npm test
 

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -32,7 +32,6 @@
       "args": [
         "--url", "https://prod:44300",
         "--user", "PROD_USER",
-        "--read-only",
         "--allowed-packages", "Z*,Y*"
       ],
       "env": {"SAP_PASSWORD": "prod_password"}

--- a/docs_page/index.md
+++ b/docs_page/index.md
@@ -124,9 +124,29 @@ Add `.mcp.json` to your project root:
 }
 ```
 
-### GitHub Copilot / VS Code (HTTP Streamable)
+### GitHub Copilot / VS Code
 
-Start arc1 as an HTTP server, then point your MCP client to it:
+For local stdio mode, use the same `npx` command shape shown above. VS Code's `servers` form looks like this:
+
+```json
+{
+  "servers": {
+    "sap": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "arc-1@latest"],
+      "env": {
+        "SAP_URL": "https://your-sap-host:44300",
+        "SAP_USER": "your-username",
+        "SAP_PASSWORD": "your-password",
+        "SAP_CLIENT": "100"
+      }
+    }
+  }
+}
+```
+
+For HTTP Streamable mode, start arc1 as an HTTP server, then point your MCP client to it:
 
 ```bash
 SAP_URL=https://host:44300 SAP_USER=dev SAP_PASSWORD=secret \

--- a/docs_page/local-development.md
+++ b/docs_page/local-development.md
@@ -115,9 +115,29 @@ Project-scoped: create `.mcp.json` in the repo root with the same shape as above
 
 Cursor Settings → MCP — same JSON shape as Claude Desktop.
 
-### VS Code / GitHub Copilot (HTTP mode)
+### VS Code / GitHub Copilot
 
-VS Code + Copilot speak HTTP Streamable, not stdio. Run ARC-1 as an HTTP server:
+For local stdio mode, use the same shape as Claude Desktop:
+
+```json
+{
+  "servers": {
+    "sap": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "arc-1@latest"],
+      "env": {
+        "SAP_URL": "https://your-sap-host:44300",
+        "SAP_USER": "YOUR_USER",
+        "SAP_PASSWORD": "YOUR_PASS",
+        "SAP_CLIENT": "100"
+      }
+    }
+  }
+}
+```
+
+For a long-running local server or shared endpoint, run ARC-1 as an HTTP Streamable server:
 
 ```bash
 npx arc-1@latest --url https://host:44300 --user dev --password secret \

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,9 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "arc1": "bin/arc1.js"
+        "arc-1": "bin/arc1.js",
+        "arc1": "bin/arc1.js",
+        "arc1-cli": "bin/arc1-cli.js"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node": ">=22.0.0"
   },
   "bin": {
+    "arc-1": "./bin/arc1.js",
     "arc1": "./bin/arc1.js",
     "arc1-cli": "./bin/arc1-cli.js"
   },
@@ -41,6 +42,7 @@
     "test:integration:btp:extended": "vitest run --config vitest.integration.config.ts tests/integration/btp-abap.integration.test.ts",
     "test:integration:crud": "vitest run --config vitest.integration.config.ts tests/integration/crud.lifecycle.integration.test.ts",
     "test:authz:http": "node scripts/check-authz-http-profiles.mjs",
+    "test:npx-smoke": "npm run build && node scripts/ci/assert-npx-bin-smoke.mjs",
     "test:integration:skip-summary": "vitest run --config vitest.integration.config.ts --reporter=verbose 2>&1 | node scripts/ci/summarize-skips.mjs",
     "test:coverage": "vitest run --coverage",
     "test:coverage-report": "node scripts/ci/coverage-summary.mjs",

--- a/scripts/ci/assert-npx-bin-smoke.mjs
+++ b/scripts/ci/assert-npx-bin-smoke.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+/**
+ * Smoke-test npm executable resolution for the package-name invocation:
+ *
+ *   npx -y arc-1@latest --help
+ *
+ * The registry version cannot be tested before publish, so this builds a local
+ * package tarball and asks npx to execute that tarball directly. This exercises
+ * npm's real bin-selection logic and catches the "could not determine
+ * executable to run" regression.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const tempDir = mkdtempSync(join(tmpdir(), 'arc1-npx-smoke-'));
+
+function fail(message, result) {
+  console.error(message);
+  if (result?.stdout) console.error(`\nstdout:\n${result.stdout}`);
+  if (result?.stderr) console.error(`\nstderr:\n${result.stderr}`);
+  process.exit(1);
+}
+
+function parsePackOutput(stdout) {
+  const jsonStart = stdout.indexOf('[');
+  if (jsonStart === -1) {
+    fail('npm pack did not emit JSON output.', { stdout });
+  }
+
+  try {
+    const metadata = JSON.parse(stdout.slice(jsonStart));
+    const filename = metadata?.[0]?.filename;
+    if (typeof filename !== 'string' || filename.length === 0) {
+      fail('npm pack JSON output did not include a tarball filename.', { stdout });
+    }
+    return filename;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    fail(`Failed to parse npm pack JSON output: ${message}`, { stdout });
+  }
+}
+
+try {
+  const pack = spawnSync('npm', ['pack', '--json', '--pack-destination', tempDir], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+
+  if (pack.status !== 0) {
+    fail('npm pack failed.', pack);
+  }
+
+  const filename = parsePackOutput(pack.stdout);
+  const tarballSpec = `./${filename}`;
+  const npx = spawnSync('npx', ['-y', tarballSpec, '--help'], {
+    cwd: tempDir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+      npm_config_loglevel: 'error',
+    },
+  });
+
+  if (npx.status !== 0) {
+    fail('npx could not execute the packed arc-1 tarball.', npx);
+  }
+
+  if (!npx.stdout.includes('ARC-1') || !npx.stdout.includes('Commands:')) {
+    fail('npx executed, but output did not look like the ARC-1 CLI help.', npx);
+  }
+
+  console.log('npx package-name executable smoke test passed.');
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}

--- a/tests/unit/package-metadata.test.ts
+++ b/tests/unit/package-metadata.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+type PackageJson = {
+  name: string;
+  bin?: Record<string, string>;
+};
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const packageJson = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8')) as PackageJson;
+
+describe('package metadata', () => {
+  it('exposes a bin matching the package name for npx package execution', () => {
+    expect(packageJson.name).toBe('arc-1');
+    expect(packageJson.bin?.[packageJson.name]).toBe('./bin/arc1.js');
+  });
+
+  it('keeps the explicit CLI binary aliases', () => {
+    expect(packageJson.bin?.arc1).toBe('./bin/arc1.js');
+    expect(packageJson.bin?.['arc1-cli']).toBe('./bin/arc1-cli.js');
+  });
+});


### PR DESCRIPTION
## Goal

Restore the documented `npx arc-1@latest` / `npx -y arc-1@latest` startup path for MCP clients.

## Root cause

The npm package exposes `arc1` and `arc1-cli` binaries, but no binary named `arc-1`. When a package has multiple bins and none match the package name, npm cannot infer which executable to run and exits with `could not determine executable to run`.

## Changes

- Add `arc-1` as a bin alias pointing at the MCP server entrypoint.
- Add a package metadata unit test so the package-name bin alias remains present.
- Add an npm pack/npx smoke test that executes the locally packed tarball through npm's real bin resolution.
- Wire the npx smoke test into CI.
- Update VS Code/Copilot docs to show stdio `npx -y arc-1@latest` config and remove legacy `--read-only` from the example MCP config.

## Validation

- `npm run test:npx-smoke`
- `npm test -- tests/unit/package-metadata.test.ts`
- `npm run lint`

Note: local install emitted an `undici@8.0.2` engine warning because this machine is Node `22.18.0` while that package requests `>=22.19.0`; installation and checks completed successfully.