### PR TITLE
feat: NW 7.50 compatibility fixes + cookie hot-reload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,11 +198,11 @@ tests/
 | Add RAP deterministic preflight checks | `src/adt/rap-preflight.ts`, `src/handlers/intent.ts` (`runRapPreflightValidation`), `src/handlers/tools.ts`, `src/handlers/schemas.ts`, `tests/unit/adt/rap-preflight.test.ts` |
 | Add RAP behavior handler scaffolding logic | `src/adt/rap-handlers.ts`, `src/handlers/intent.ts` (`SAPWrite action=scaffold_rap_handlers`), `src/handlers/tools.ts`, `src/handlers/schemas.ts`, `tests/unit/adt/rap-handlers.test.ts` |
 | Add new tool type | `src/handlers/tools.ts`, `src/handlers/schemas.ts`, `src/handlers/intent.ts` |
-| Add/modify tool input schema | `src/handlers/schemas.ts`, `src/handlers/tools.ts` |
+| Add/modify tool input schema | `src/handlers/schemas.ts`, `src/handlers/tools.ts` — **three-file sync required** (see invariant below) |
 | Add DDIC domain/data element write | `src/adt/ddic-xml.ts`, `src/adt/crud.ts`, `src/handlers/intent.ts` |
 | Modify ADT service discovery / MIME types | `src/adt/discovery.ts`, `src/adt/http.ts` |
 | Improve DDIC save diagnostics + SAP-domain error hints (T100/line + lock/auth/dependency hints) | `src/adt/errors.ts` (`extractDdicDiagnostics`, `formatDdicDiagnostics`, `classifySapDomainError`), `src/handlers/intent.ts` (`enrichWithSapDetails`, `formatErrorForLLM`) |
-| Add SAP error classification (new `category` + hint) | `src/adt/errors.ts` (`extractExceptionType`, `extractLockOwner`, `classifySapDomainError`, `SapErrorClassification`), `src/handlers/intent.ts` (`formatErrorForLLM`, `classifyError`), `tests/unit/adt/errors.test.ts`. Current categories: `lock-conflict`, `enqueue-error`, `authorization`, `activation-dependency`, `transport-issue`, `object-exists`, `method-not-supported`, `icf-handler-not-bound`. Ground hints in verified SAP Notes / KBAs when possible (use `mcp__sap-notes__search` or equivalent) — don't ship speculative tcode pointers. |
+| Add SAP error classification (new `category` + hint) | `src/adt/errors.ts` (`extractExceptionType`, `extractLockOwner`, `classifySapDomainError`, `SapErrorClassification`), `src/handlers/intent.ts` (`formatErrorForLLM`, `classifyError`), `tests/unit/adt/errors.test.ts`. Current categories: `lock-conflict`, `enqueue-error`, `authorization`, `activation-dependency`, `transport-issue`, `object-exists`, `method-not-supported`, `icf-handler-not-bound`, `deletion-blocked`. Ground hints in verified SAP Notes / KBAs when possible (use `mcp__sap-notes__search` or equivalent) — don't ship speculative tcode pointers. |
 | Add release-gated content-type fallback (e.g. DTEL v2→v1 on 415) | `src/adt/crud.ts` (`CONTENT_TYPE_FALLBACKS` map — narrow static allowlist, 415-only retry in both `createObject` and `updateObject`), `tests/unit/adt/crud.test.ts`. Don't turn it into a generic retry loop — each entry must be a specific, tested compatibility gap. |
 | Add / update test skip reason (integration or E2E) | `tests/helpers/skip-policy.ts` (`SkipReason` constants + `requireOrSkip`), `tests/e2e/helpers.ts` (`classifyToolErrorSkip` for MCP tool errors), `docs/integration-test-skips.md` (user-facing taxonomy — update the relevant category), `scripts/ci/summarize-skips.mjs` (regex patterns that group skips — extend when adding a new message shape). Every skip message is the public API of the taxonomy — changing wording means updating all four. |
 | Run ADT type-availability probe against a live system (diagnostic; no product behavior) | `scripts/probe-adt-types.ts` (CLI entry: `npm run probe`), `src/probe/catalog.ts` (per-type collection URL + known-object fixtures), `src/probe/runner.ts` (multi-signal classifier), `src/probe/fixtures.ts` (record/replay), `tests/unit/probe/replay.test.ts` (fixture-backed unit tests). Contribute new fixture sets via `npm run probe -- --save-fixtures tests/fixtures/probe/<name>`. See [docs/probe-adt-types.md](docs/probe-adt-types.md). |
@@ -291,7 +291,7 @@ HTTP Request (adt/http.ts)
   ├─ Proactive MIME negotiation via `/sap/bc/adt/discovery` map (startup-cached)
   ├─ CSRF token management (auto-fetch via HEAD, refresh on 403)
   ├─ Content negotiation fallback (one-retry on 406/415 with header mutation)
-  ├─ Cookie/session management
+  ├─ Cookie/session management (hot-reload from file on stale 401)
   ├─ Stateful sessions for lock→modify→unlock sequences
   │
   ▼
@@ -491,10 +491,12 @@ Automated via [release-please](https://github.com/googleapis/release-please). No
 - Sensitive fields (password, token, cookie) are redacted in logs
 - CSRF tokens are auto-managed by `src/adt/http.ts` (fetch via HEAD, refresh on 403)
 - **Safety config is the server ceiling** — per-user scopes (JWT) can only restrict further, never expand beyond server config
-- **Per-user auth never inherits shared credentials.** `buildAdtConfig(config, btpProxy?, bearerTokenProvider?, { perUser: true })` strips `username`/`password`/`cookies`. Any new Layer B field must respect this flag. Never add auth fields directly to `createPerUserClient`'s `adtConfig` without going through `buildAdtConfig`.
+- **Per-user auth never inherits shared credentials.** `buildAdtConfig(config, btpProxy?, bearerTokenProvider?, { perUser: true })` strips `username`/`password`/`cookies`/`cookieFile`/`cookieString`. Any new Layer B field must respect this flag. Never add auth fields directly to `createPerUserClient`'s `adtConfig` without going through `buildAdtConfig`.
+- **Cookie auth hot-reload**: When `SAP_COOKIE_FILE` is set, expired cookies don't require a restart. On persistent 401 the HTTP client clears stale cookies and re-reads the file on the next request (`cookiesCleared` flag in `src/adt/http.ts`). Startup preflight is non-blocking in cookie auth mode. `SAP_COOKIE_STRING` cannot hot-reload (logged warning).
 - **All ADT endpoints have safety guards** — every `http.get/post/put/delete` call is preceded by `checkOperation()`. No unguarded HTTP calls.
 - **Error types matter**: `AdtApiError` (SAP HTTP error), `AdtSafetyError` (blocked by config), `AdtNetworkError` (connectivity). `intent.ts` formats these with LLM-friendly hints.
 - **Stateful sessions**: Lock→modify→unlock sequences must use `http.withStatefulSession()` to share cookies/CSRF tokens across requests
+- **Tool schema three-file sync**: Every tool property must exist in all three files: `tools.ts` (JSON Schema for LLMs), `schemas.ts` (Zod validation), `intent.ts` (handler logic). A property missing from `tools.ts` is invisible to LLMs — they can't use it even though validation and the handler support it. When adding a new property, update all three files. When reviewing changes, verify the property appears in the tool's `inputSchema.properties` (tools.ts), the corresponding Zod schema (schemas.ts), and the handler's `args.*` access (intent.ts). Batch object schemas in `tools.ts` (e.g., `batch_create` items) are defined separately from the top-level schema — check both.
 
 ## History
 

--- a/docs/nw750-discovery-gap-analysis.md
+++ b/docs/nw750-discovery-gap-analysis.md
@@ -1,0 +1,185 @@
+# NW 7.50 ADT Discovery — Gap Analysis
+
+Cross-reference of every endpoint in the NW 7.50 ADT discovery document (`tests/fixtures/xml/discovery-nw750.xml`) against what ARC-1 implements. Only endpoints present in the discovery XML are listed — ARC-1 endpoints not in the discovery file (e.g., custom endpoints, OData services) are out of scope.
+
+## Potentially Valuable Gaps
+
+Endpoints present in NW 7.50 discovery but not implemented in ARC-1.
+
+| # | Discovery Endpoint | Title | Notes |
+|---|---|---|---|
+| 1 | `/sap/bc/adt/datapreview/cds` | Data Preview for CDS | Only `freestyle` and `ddic` are used. CDS preview supports association navigation. |
+| 2 | `/sap/bc/adt/abapsource/typehierarchy` | Type Hierarchy | Class/interface inheritance tree |
+| 3 | `/sap/bc/adt/abapsource/cleanup/source` | Source Cleanup | SAP's built-in source cleanup/refactoring |
+| 4 | `/sap/bc/adt/abapsource/codecompletion/elementinfo` | Element Info (code completion) | Hover-style type info for symbols |
+| 5 | `/sap/bc/adt/abapsource/codecompletion/insertion` | Code Insertion | Pattern-based code insertion |
+| 6 | `/sap/bc/adt/ddic/ddl/dependencies/graphdata` | DDL Dependency Graph | Server-computed CDS dependency graph |
+| 7 | `/sap/bc/adt/ddic/ddl/elementinfo` | DDL Element Info | CDS field/annotation metadata |
+| 8 | `/sap/bc/adt/ddic/ddl/elementinfos` | DDL Mass Element Info | Batch CDS field info |
+| 9 | `/sap/bc/adt/ddic/ddl/activeobject` | DDL Active Object | Resolve active CDS entity from data source |
+| 10 | `/sap/bc/adt/ddic/ddl/createstatements` | DDL sqlView Create Statement | Generated SQL view DDL |
+| 11 | `/sap/bc/adt/ddic/ddl/ddicrepositoryaccess` | DDL Dictionary Repository Access | CDS path-based field resolution |
+| 12 | `/sap/bc/adt/ddic/ddl/formatter/identifiers` | DDL Case Preserving Formatter | CDS identifier formatting |
+| 13 | `/sap/bc/adt/ddic/codecompletion` | DDIC Code Completion | Dictionary-level code completion |
+| 14 | `/sap/bc/adt/ddic/elementinfo` | DDIC Element Info | Dictionary element type info |
+| 15 | `/sap/bc/adt/ddic/typegroups` | Type Groups (TYPS) | Missing object type — can't read type group source |
+| 16 | `/sap/bc/adt/ddic/dbprocedureproxies` | Database Procedure Proxies | AMDP proxy objects |
+| 17 | `/sap/bc/adt/repository/informationsystem/usageSnippets` | Usage Snippets | Source snippets for where-used results |
+| 18 | `/sap/bc/adt/repository/informationsystem/messagesearch` | Message Search | Search T100 messages by text |
+| 19 | `/sap/bc/adt/repository/informationsystem/executableObjects` | Executable Objects | Find runnable programs |
+| 20 | `/sap/bc/adt/repository/informationsystem/fullnamemapping` | Full Name Mapping | Map full names to ADT URIs |
+| 21 | `/sap/bc/adt/repository/informationsystem/metadata` | Repository Metadata | Repository-level metadata |
+| 22 | `/sap/bc/adt/repository/informationsystem/objecttypes` | Object Types | Enumerate available object types |
+| 23 | `/sap/bc/adt/repository/informationsystem/releasestates` | Release States | C0/C1/C2 API release state list |
+| 24 | `/sap/bc/adt/repository/informationsystem/executableobjecttypes` | Executable Object Types | Enumerate executable object types |
+| 25 | `/sap/bc/adt/repository/nodepath` | Node Path | Object-to-package path |
+| 26 | `/sap/bc/adt/repository/objectstructure` | Object Structure | Object internal structure |
+| 27 | `/sap/bc/adt/repository/typestructure` | Type Structure | Type component breakdown |
+| 28 | `/sap/bc/adt/repository/proxyurimappings` | Proxy URI Mappings | Proxy URI resolution |
+| 29 | `/sap/bc/adt/oo/classrun` | Class Run | Execute `IF_OO_ADT_CLASSRUN` classes |
+| 30 | `/sap/bc/adt/oo/linenumber` | Line Number | Line mapping across includes |
+| 31 | `/sap/bc/adt/oo/validation/objectname` | OO Name Validation | Validate class/intf name before create |
+| 32 | `/sap/bc/adt/docu/abap/langu` | ABAP Language Help | ABAP keyword documentation |
+| 33 | `/sap/bc/adt/docu/ddl/langu` | DDL Language Help | CDS keyword documentation |
+| 34 | `/sap/bc/adt/docu/dcl/langu` | DCL Language Help | DCL keyword documentation |
+| 35 | `/sap/bc/adt/acm/dcl/parser` | DCL Parser Info | DCL parser metadata |
+| 36 | `/sap/bc/adt/acm/dcl/validation` | DCL Name Validation | Validate DCL name before create |
+| 37 | `/sap/bc/adt/ddic/ddl/parser` | DDL Parser Info | DDL parser metadata |
+| 38 | `/sap/bc/adt/ddic/ddl/validation` | DDL Name Validation | Validate DDL name before create |
+| 39 | `/sap/bc/adt/ddic/ddl/elementmappings` | DDL Element Mappings | CDS element mapping |
+| 40 | `/sap/bc/adt/ddic/ddl/elementmappings/strategies` | DDL Mapping Strategies | CDS mapping strategy options |
+| 41 | `/sap/bc/adt/classifications` | Object Classifications | C0/C1/C2 API release classification |
+| 42 | `/sap/bc/adt/runtime/traces/abaptraces/parameters` | Trace Parameters | Profiler trace configuration |
+| 43 | `/sap/bc/adt/runtime/traces/abaptraces/requests` | Trace Requests | Trigger profiler trace capture |
+| 44 | `/sap/bc/adt/enhancements/enhoxh` | Enhancement Implementation (alt URL) | ARC-1 uses `enhoxhb`, discovery lists `enhoxh` |
+| 45 | `/sap/bc/adt/enhancements/enhsxs` | Enhancement Spots | Enhancement spot definitions (not implementations) |
+| 46 | `/sap/bc/adt/xslt/transformations` | XSLT Transformations | Missing object type — XSLT/ST source |
+| 47 | `/sap/bc/adt/system/users` | Users | Query SAP users |
+| 48 | `/sap/bc/adt/system/clients` | Clients | List SAP clients |
+| 49 | `/sap/bc/adt/system/information` | System Information | System-level metadata |
+| 50 | `/sap/bc/adt/system/landscape/servers` | System Landscape | Application server list |
+| 51 | `/sap/bc/adt/packages/settings` | Package Settings | Package configuration metadata |
+| 52 | `/sap/bc/adt/cts/transportrequests/reference` | Transport Reference | Transport reference data |
+| 53 | `/sap/bc/adt/atc/customizing` | ATC Customizing | ATC check configuration |
+| 54 | `/sap/bc/adt/atc/ccstunnel` | ATC CCS Tunnel | CCS proxy tunnel |
+| 55 | `/sap/bc/adt/atc/results` | ATC Results | Persistent ATC result sets |
+| 56 | `/sap/bc/adt/atc/approvers` | ATC Approvers | Exemption approver list |
+| 57 | `/sap/bc/adt/atc/variants` | ATC Variants | Check variant list |
+| 58 | `/sap/bc/adt/atc/exemptions/apply` | ATC Exemptions | Apply ATC exemptions |
+| 59 | `/sap/bc/adt/checkruns/reporters` | Check Reporters | Available check reporters |
+| 60 | `/sap/bc/adt/basic/object/properties` | Basic Object Properties | Generic object property reader |
+| 61 | `/sap/bc/adt/urifragmentmappings` | URI Fragment Mapper | Map URI fragments to plain text |
+| 62 | `/sap/bc/adt/abapsource/occurencemarkers` | Occurrence Markers | Highlight all occurrences of a symbol |
+| 63 | `/sap/bc/adt/abapsource/parsers/rnd/grammar` | ABAP Parser Grammar | ABAP parser metadata |
+| 64 | `/sap/bc/adt/abapsource/abapdoc/exportjobs` | ABAP Doc Export | Export ABAP documentation |
+| 65 | `/sap/bc/adt/sqlm/data` | SQLM Marker Data | SQL Monitor marker data |
+| 66 | `/sap/bc/adt/security/reentranceticket` | Reentrance Ticket | Security reentrance ticket |
+| 67 | `/sap/bc/adt/ato/settings` | ATO Settings | Adaptation Transport Organizer |
+| 68 | `/sap/bc/adt/sscr/registration/objects` | SSCR Object Registration | Developer key management |
+| 69 | `/sap/bc/adt/sscr/registration/objects/validation` | SSCR Object Validation | SSCR validation |
+| 70 | `/sap/bc/adt/sscr/registration/developers/validation` | SSCR Developer Validation | Developer registration validation |
+| 71 | `/sap/bc/adt/businesslogicextensions/badis` | BAdI Definitions | BAdI read + compatibility check |
+| 72 | `/sap/bc/adt/businesslogicextensions/badinameproposals` | BAdI Name Proposals | BAdI naming suggestions |
+| 73 | `/sap/bc/adt/ddic/dataelements/validation` | Data Element Validation | Validate DTEL name before create |
+| 74 | `/sap/bc/adt/ddic/structures/validation` | Structure Validation | Validate structure name before create |
+| 75 | `/sap/bc/adt/ddic/views/$validation` | View Validation | Validate view name |
+| 76 | `/sap/bc/adt/ddic/validation` | DDIC SQSC Validation | DDIC-level validation |
+| 77 | `/sap/bc/adt/ddic/typegroups/validation` | Type Group Validation | Validate type group name |
+| 78 | `/sap/bc/adt/enhancements/enhoxh/validation` | Enhancement Impl Validation | Validate ENHO name |
+| 79 | `/sap/bc/adt/enhancements/enhsxs/validation` | Enhancement Spot Validation | Validate ENHS name |
+| 80 | `/sap/bc/adt/programs/validation` | Program Validation | Validate program name before create |
+| 81 | `/sap/bc/adt/includes/validation` | Include Validation | Validate include name |
+| 82 | `/sap/bc/adt/functions/validation` | Function Group Validation | Validate FUGR name |
+| 83 | `/sap/bc/adt/messageclass/validation` | Message Class Validation | Validate MSAG name |
+| 84 | `/sap/bc/adt/filestore/ui5-bsp/ui5-rt-version` | SAPUI5 Runtime Version | UI5 runtime version info |
+| 85 | `/sap/bc/adt/filestore/ui5-bsp/deploy-storage` | UI5 Deploy Storage Marker | Deploy storage support flag |
+
+## Eclipse-Only / Not Useful for MCP (excluded)
+
+| Category | Count | Endpoints | Why excluded |
+|---|---|---|---|
+| BOPF | 8 | `/sap/bc/adt/bopf/*` | Legacy BOL/BOPF, Eclipse wizard-specific |
+| Solution Manager CM | 3 | `/sap/bc/adt/solutionmanager/cm/*` | SolMan Change Management integration |
+| UI Flexibility | 1 | `/sap/bc/adt/ui_flex_dta_folder/` | DTA folder deployment |
+| AMDP Debugger | 1 | `/sap/bc/adt/amdp/debugger/main` | Interactive HANA debugging session |
+| Code Composer | 6 | `/sap/bc/adt/cmp_code_composer/*` | Eclipse template wizard |
+| Dummy types | 4 | `/sap/bc/adt/dummygroup/*` | SAP internal test types |
+| Object Type Admin | 4 | `/sap/bc/adt/objtype_admin/*` | Object type registration admin |
+| Enterprise Services | 13 | `/sap/bc/esproxy/*` | SOA proxy management |
+| Feed Repository | 3 | `/sap/bc/adt/dataproviders`, `/feeds` | ADT internal feed framework |
+| Dynamic Logpoints | 3 | `/sap/bc/adt/dlp/*` | Interactive runtime logging |
+| Debugger | 12 | `/sap/bc/adt/debugger/*` | Interactive ABAP debugging |
+| Web Dynpro | 27 | `/sap/bc/adt/wdy/*` | WDA component editor |
+| FPM | 1 | `/sap/bc/adt/fpm/creationtools` | FPM wizard |
+| NHI / HANA Integration | 6 | `/sap/bc/adt/nhi/*` | HANA repository transport |
+| Data Preview AMDP | 2 | `/sap/bc/adt/datapreview/amdp*` | AMDP-specific preview |
+| ADT HTTP Endpoint | 1 | System-specific full URL | ADT framework internal |
+
+## Already Implemented
+
+| Endpoint | ARC-1 Usage |
+|---|---|
+| `/sap/bc/adt/programs/programs` | SAPRead PROG |
+| `/sap/bc/adt/programs/includes` | SAPRead INCL |
+| `/sap/bc/adt/oo/classes` | SAPRead CLAS |
+| `/sap/bc/adt/oo/interfaces` | SAPRead INTF |
+| `/sap/bc/adt/functions/groups` | SAPRead FUGR/FUNC |
+| `/sap/bc/adt/ddic/ddl/sources` | SAPRead DDLS |
+| `/sap/bc/adt/acm/dcl/sources` | SAPRead DCLS |
+| `/sap/bc/adt/ddic/structures` | SAPRead STRU |
+| `/sap/bc/adt/ddic/dataelements` | SAPRead DTEL |
+| `/sap/bc/adt/ddic/views` | SAPRead VIEW |
+| `/sap/bc/adt/messageclass` | SAPRead MSAG |
+| `/sap/bc/adt/repository/informationsystem/search` | SAPSearch (quick search) |
+| `/sap/bc/adt/repository/informationsystem/usageReferences` | Where-used analysis |
+| `/sap/bc/adt/repository/nodestructure` | Package hierarchy browsing |
+| `/sap/bc/adt/datapreview/ddic` | SAPQuery table preview |
+| `/sap/bc/adt/datapreview/freestyle` | SAPQuery free SQL |
+| `/sap/bc/adt/activation` | SAPActivate |
+| `/sap/bc/adt/activation/inactiveobjects` | List inactive objects |
+| `/sap/bc/adt/checkruns` | Pre-write syntax check |
+| `/sap/bc/adt/abapunit/testruns` | Unit test execution |
+| `/sap/bc/adt/atc/runs` + `worklists` | ATC check runs |
+| `/sap/bc/adt/quickfixes/evaluation` | Quick fix proposals |
+| `/sap/bc/adt/abapsource/prettyprinter` + `/settings` | Pretty printer |
+| `/sap/bc/adt/abapsource/codecompletion/proposal` | Code completion |
+| `/sap/bc/adt/navigation/target` | Go-to-definition |
+| `/sap/bc/adt/cts/transports` | Transport info check |
+| `/sap/bc/adt/cts/transportrequests` | Transport management |
+| `/sap/bc/adt/cts/transportchecks` | Transport requirement checks |
+| `/sap/bc/adt/refactorings` | Refactoring framework |
+| `/sap/bc/adt/refactoring/changepackage` | Package move (incorrectly gated at 754) |
+| `/sap/bc/adt/runtime/dumps` + `dump/{id}` | Short dump listing + detail |
+| `/sap/bc/adt/runtime/systemmessages` | SM02 system messages |
+| `/sap/bc/adt/runtime/traces/abaptraces` | Profiler trace listing + detail |
+| `/sap/bc/adt/gw/errorlog` | Gateway error log |
+| `/sap/bc/adt/system/components` | System detection (SAP_BASIS release) |
+| `/sap/bc/adt/filestore/ui5-bsp/objects` | UI5 BSP app listing |
+
+## Top 10 Most Valuable Gaps (ranked by MCP usefulness)
+
+1. **`/sap/bc/adt/ddic/ddl/dependencies/graphdata`** — CDS dependency graph. Would supercharge `SAPContext action="impact"` with server-computed dependency trees instead of client-side where-used traversal.
+
+2. **`/sap/bc/adt/datapreview/cds`** — CDS-aware data preview with association navigation. Currently ARC-1 only has `ddic` (table) and `freestyle` (SQL). CDS preview would enable reading CDS view data directly.
+
+3. **`/sap/bc/adt/abapsource/typehierarchy`** — Inheritance tree. Useful when an LLM needs to understand class hierarchies for refactoring.
+
+4. **`/sap/bc/adt/ddic/typegroups`** — Type groups (TYPS). A missing object type — can't read type group source.
+
+5. **`/sap/bc/adt/classifications`** — API release classification (C0/C1/C2). Important for cloud-readiness checks.
+
+6. **`/sap/bc/adt/repository/informationsystem/messagesearch`** — Search T100 messages by text. Currently requires SQL (`SAPQuery`).
+
+7. **`/sap/bc/adt/xslt/transformations`** — XSLT/Simple Transformations source. A missing object type.
+
+8. **`/sap/bc/adt/oo/classrun`** — Execute `IF_OO_ADT_CLASSRUN` classes. Could enable running console apps.
+
+9. **`/sap/bc/adt/enhancements/enhsxs`** — Enhancement spots. Currently only ENHO (implementations) is supported, not ENHS (spots).
+
+10. **`/sap/bc/adt/businesslogicextensions/badis`** — BAdI definitions. Would let an LLM read BAdI structures and run compatibility checks.
+
+## Known Issues Found
+
+- **`change_package` incorrectly gated at `minRelease: 754`** — The NW 7.50 discovery XML (line 1287) explicitly lists `/sap/bc/adt/refactoring/changepackage` with title "Change Package Assignment". The `ACTION_RELEASE_GATES` entry in `tools.ts` and `intent.ts` should be removed.
+
+- **`enhoxh` vs `enhoxhb` URL mismatch** — Discovery lists `/sap/bc/adt/enhancements/enhoxh`, but ARC-1 uses `/sap/bc/adt/enhancements/enhoxhb`. Both may exist; worth verifying which URL the probe catalog should reference.

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -83,6 +83,8 @@ export class AdtClient {
       language: config.language,
       insecure: config.insecure,
       cookies: config.cookies,
+      cookieFile: config.cookieFile,
+      cookieString: config.cookieString,
       btpProxy: config.btpProxy,
       sapConnectivityAuth: config.sapConnectivityAuth,
       ppProxyAuth: config.ppProxyAuth,

--- a/src/adt/config.ts
+++ b/src/adt/config.ts
@@ -57,6 +57,10 @@ export interface AdtClientConfig {
   insecure: boolean;
   /** Cookie-based auth (alternative to basic auth) */
   cookies: Record<string, string>;
+  /** Path to cookie file — enables hot-reload on stale auth */
+  cookieFile?: string;
+  /** Inline cookie string — stored for config awareness (no hot-reload) */
+  cookieString?: string;
   /** Safety configuration */
   safety: SafetyConfig;
   /** Feature detection config */

--- a/src/adt/crud.ts
+++ b/src/adt/crud.ts
@@ -39,33 +39,7 @@ export async function lockObject(
       Accept: 'application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.lock.result, application/*;q=0.8',
     });
   } catch (err) {
-    // NW 7.50 quirk: the LOCK endpoint returns 400 or 401 with an HTML login page when
-    // the object is already locked by another session (Eclipse, SE80). This is not an auth
-    // failure — a GET on the same object succeeds moments earlier with the same credentials.
-    // Reclassify as a clear lock-conflict error so the LLM doesn't chase auth red herrings.
-    // CX_ADT_RES_NO_ACCESS maps to 403 server-side, but with cookie auth (no Basic Auth
-    // header) ICM transforms it to 401 "no logon data". ARC-1's 401 retry handler then
-    // clears the cookie jar and retries without cookies, which returns 400. So we see
-    // 400, 401, or 403 depending on timing — all with the same HTML login page body.
-    //
-    // The "Logon Error Message" HTML body is the de-facto NW 7.50 gate — S/4 returns
-    // structured XML with <exc:exception> here (no "Logon Error Message" string), and
-    // S/4's auth-failure HTML is "Anmeldung fehlgeschlagen" (also no match). So this
-    // branch self-scopes without an explicit detectSystemCapabilities() check.
-    if (
-      err instanceof AdtApiError &&
-      (err.statusCode === 400 || err.statusCode === 401 || err.statusCode === 403) &&
-      err.responseBody?.includes('Logon Error Message')
-    ) {
-      const name = objectUrl.split('/').pop() ?? objectUrl;
-      // Throw as 409 with "locked by" in the message so classifySapDomainError routes
-      // to the 'lock-conflict' category (not the 423 'enqueue-error' / invalid-handle path).
-      throw new AdtApiError(
-        `Object ${name} is locked by another session. Close the editor (Eclipse, SE80) or release the lock in SM12, then retry.`,
-        409,
-        objectUrl,
-      );
-    }
+    rethrowIfNw750LockConflict(err, objectUrl);
     throw err;
   }
 
@@ -134,6 +108,7 @@ export async function createObject(
     const resp = await http.post(url, body, contentType);
     return resp.body;
   } catch (err) {
+    rethrowIfNw750LockConflict(err, objectUrl);
     const fallback = CONTENT_TYPE_FALLBACKS[contentType];
     if (fallback && isUnsupportedMediaTypeError(err)) {
       const resp = await http.post(url, body, fallback);
@@ -266,6 +241,26 @@ export async function safeUpdateObject(
       await unlockObject(session, objectUrl, lock.lockHandle);
     }
   });
+}
+
+// NW 7.50 quirk: several ADT endpoints return 400/401/403 with an HTML login page
+// when an object is locked or already exists. This is not an auth failure — a GET on
+// the same object succeeds moments earlier with the same credentials.
+// The "Logon Error Message" body marker self-scopes to NW 7.50 (S/4 uses structured
+// XML or "Anmeldung fehlgeschlagen" — neither contains this string).
+function rethrowIfNw750LockConflict(err: unknown, objectUrl: string): void {
+  if (
+    err instanceof AdtApiError &&
+    (err.statusCode === 400 || err.statusCode === 401 || err.statusCode === 403) &&
+    err.responseBody?.includes('Logon Error Message')
+  ) {
+    const name = objectUrl.split('/').pop() ?? objectUrl;
+    throw new AdtApiError(
+      `Object ${name} is locked by another session (or already exists). Close the editor (Eclipse, SE80) or release the lock in SM12, then retry.`,
+      409,
+      objectUrl,
+    );
+  }
 }
 
 /** Simple XML value extractor (for lock responses) */

--- a/src/adt/errors.ts
+++ b/src/adt/errors.ts
@@ -40,7 +40,8 @@ export interface SapErrorClassification {
     | 'transport-issue'
     | 'object-exists'
     | 'method-not-supported'
-    | 'icf-handler-not-bound';
+    | 'icf-handler-not-bound'
+    | 'deletion-blocked';
   hint: string;
   transaction?: string;
   details?: Record<string, string>;
@@ -407,6 +408,16 @@ export function classifySapDomainError(statusCode: number, responseBody?: string
         '(often caused by incomplete activation after an upgrade or on minimally-configured ' +
         'systems). Consult your Basis admin or SAP KBA 3128830 (Troubleshooting ICF 404 Errors).',
       transaction: 'SICF',
+      details: typeId ? { exceptionType: typeId } : undefined,
+    };
+  }
+
+  if (statusCode === 404 && /\bcannot be deleted\b.*\breferenced\b/i.test(bodyRaw)) {
+    return {
+      category: 'deletion-blocked',
+      hint:
+        'The object cannot be deleted because other objects still reference it. ' +
+        'Use SAPNavigate(action="where_used") to find referencing objects, remove or update those references first, then retry the deletion.',
       details: typeId ? { exceptionType: typeId } : undefined,
     };
   }

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -30,6 +30,7 @@
 import { Agent, Client, type Dispatcher, fetch as undiciFetch } from 'undici';
 import { logger } from '../server/logger.js';
 import type { BTPProxyConfig } from './btp.js';
+import { resolveCookies } from './cookies.js';
 import { resolveAcceptType, resolveContentType } from './discovery.js';
 import { AdtApiError, AdtNetworkError } from './errors.js';
 import type { Semaphore } from './semaphore.js';
@@ -108,6 +109,10 @@ export interface AdtHttpConfig {
   language?: string;
   insecure?: boolean;
   cookies?: Record<string, string>;
+  /** Path to cookie file — enables hot-reload on stale auth */
+  cookieFile?: string;
+  /** Inline cookie string — stored for config awareness (no hot-reload) */
+  cookieString?: string;
   sessionType?: SessionType;
   /** BTP Connectivity proxy (Cloud Connector) */
   btpProxy?: BTPProxyConfig;
@@ -166,6 +171,8 @@ export class AdtHttpClient {
   private cookieJar: Map<string, string> = new Map();
   /** Guard to prevent infinite retry loops for DB connection errors */
   private dbRetryInProgress = false;
+  /** Set after a 401 clears stale cookies — triggers file reload on the next request */
+  private cookiesCleared = false;
   constructor(config: AdtHttpConfig) {
     this.config = config;
 
@@ -311,6 +318,12 @@ export class AdtHttpClient {
     if (this.config.bearerTokenProvider) {
       const token = await this.config.bearerTokenProvider();
       headers.Authorization = `Bearer ${token}`;
+    }
+
+    // Lazy cookie reload: if cookies were cleared on a previous 401,
+    // re-read the cookie file before this request.
+    if (this.cookiesCleared && this.isCookieAuthMode()) {
+      this.reloadCookiesFromSource();
     }
 
     // Build cookie header from: config cookies + cookie jar (jar takes precedence)
@@ -516,6 +529,15 @@ export class AdtHttpClient {
           durationMs: Date.now() - httpStart,
           errorBody: '401 session retry completed',
         });
+
+        if (response.status === 401 && this.isCookieAuthMode()) {
+          this.config.cookies = {};
+          this.cookiesCleared = true;
+          logger.warn(
+            'Cookie auth: 401 persisted after retry — clearing stale cookies. ' +
+              'Run `arc1-cli extract-cookies` to get fresh cookies; the next SAP call will reload them automatically.',
+          );
+        }
         // Fall through to downstream handlers (403/406/415/normal)
       }
 
@@ -728,6 +750,10 @@ export class AdtHttpClient {
       contentType?.startsWith('text/html') &&
       looksLikeLoginPage(body)
     ) {
+      if (this.isCookieAuthMode()) {
+        this.config.cookies = {};
+        this.cookiesCleared = true;
+      }
       throw new AdtApiError(
         'ADT call returned HTML login page — authentication required. If using cookies, they may have expired. If using Basic auth, credentials may be invalid or not authorized for ADT (S_ADT_RES missing). If on an SSO-only system, try SAP_DISABLE_SAML=true or see docs/enterprise-auth.md. Re-run arc-1 after fixing.',
         401,
@@ -787,6 +813,12 @@ export class AdtHttpClient {
       headers['SAP-Connectivity-Authentication'] = this.config.sapConnectivityAuth;
     }
 
+    // Lazy cookie reload (same guard as request()) — re-read cookie file
+    // before CSRF fetch so a hot-reloaded cookie is used immediately.
+    if (this.cookiesCleared && this.isCookieAuthMode()) {
+      this.reloadCookiesFromSource();
+    }
+
     // Include existing cookies (config + jar) so session is maintained
     const cookieParts: string[] = [];
     if (this.config.cookies) {
@@ -843,6 +875,10 @@ export class AdtHttpClient {
       const token = response.headers.get('x-csrf-token');
       if (!token || token === 'Required') {
         if (response.status === 401) {
+          if (this.isCookieAuthMode()) {
+            this.config.cookies = {};
+            this.cookiesCleared = true;
+          }
           throw new AdtApiError(
             `Authentication failed (401) using sap-client=${this.config.client ?? '100'}. Check SAP_CLIENT, SAP_USER, and SAP_PASSWORD.`,
             401,
@@ -878,6 +914,35 @@ export class AdtHttpClient {
    */
   private isDbConnectionError(body: string): boolean {
     return body.toLowerCase().includes('database connection is not open');
+  }
+
+  private isCookieAuthMode(): boolean {
+    return !!(this.config.cookieFile || this.config.cookieString);
+  }
+
+  /**
+   * Re-read cookies from the original source (file or string).
+   * Called lazily on the NEXT request after a 401 cleared stale cookies.
+   */
+  private reloadCookiesFromSource(): void {
+    this.cookiesCleared = false;
+    if (!this.config.cookieFile && this.config.cookieString) {
+      logger.warn('SAP_COOKIE_STRING cannot be refreshed without restart. Use SAP_COOKIE_FILE for automatic reload.');
+      return;
+    }
+    try {
+      const fresh = resolveCookies(this.config.cookieFile, this.config.cookieString);
+      if (fresh && Object.keys(fresh).length > 0) {
+        this.config.cookies = fresh;
+        logger.info('Reloaded cookies from file', { cookieCount: Object.keys(fresh).length });
+      } else {
+        logger.warn('Cookie reload returned empty result');
+      }
+    } catch (err) {
+      logger.warn('Failed to reload cookies from source', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -375,8 +375,14 @@ function getWriteInfrastructureHint(err: AdtApiError, tool: string, args: Record
 }
 
 /** Format error messages with LLM-friendly remediation hints */
-function formatErrorForLLM(err: unknown, message: string, tool: string, args: Record<string, unknown>): string {
-  const base = buildBaseErrorMessage(err, message, tool, args);
+function formatErrorForLLM(
+  err: unknown,
+  message: string,
+  tool: string,
+  args: Record<string, unknown>,
+  config: ServerConfig,
+): string {
+  const base = buildBaseErrorMessage(err, message, tool, args, config);
   // Handler-attached remediation hints (e.g., CDS delete blocker list) always
   // appear last so the message reads "what happened → diagnostics → how to fix".
   if (err instanceof AdtApiError && err.extraHint && !base.includes(err.extraHint)) {
@@ -385,7 +391,13 @@ function formatErrorForLLM(err: unknown, message: string, tool: string, args: Re
   return base;
 }
 
-function buildBaseErrorMessage(err: unknown, message: string, tool: string, args: Record<string, unknown>): string {
+function buildBaseErrorMessage(
+  err: unknown,
+  message: string,
+  tool: string,
+  args: Record<string, unknown>,
+  config: ServerConfig,
+): string {
   if (err instanceof AdtApiError) {
     // Append additional SAP messages (line numbers, secondary errors) if available
     const enriched = enrichWithSapDetails(err, message);
@@ -407,6 +419,14 @@ function buildBaseErrorMessage(err: unknown, message: string, tool: string, args
       return `${enriched}\n\nHint: Object "${name}" (type ${type}) was not found. Use SAPSearch with query "${name}" to verify the name exists and check the correct type.`;
     }
     if (err.isUnauthorized || err.isForbidden) {
+      if (config.cookieFile || config.cookieString) {
+        return (
+          `${enriched}\n\n` +
+          'Hint: SAP cookies have expired. Ask the user to re-extract cookies ' +
+          'with `arc1-cli extract-cookies`. The next SAP call after extraction ' +
+          'will automatically reload the fresh cookies — no restart needed.'
+        );
+      }
       return `${enriched}\n\nHint: Authorization error. Check SAP_CLIENT (default: '100'), SAP_USER, and SAP_PASSWORD. The configured SAP user may lack permissions for this object.`;
     }
     // Transport / corrNr specific hints
@@ -1121,7 +1141,7 @@ export async function handleToolCall(
           result = await handleSAPWrite(client, args, config, cachingLayer);
           break;
         case 'SAPActivate':
-          result = await handleSAPActivate(client, args);
+          result = await handleSAPActivate(client, args, cachingLayer);
           break;
         case 'SAPNavigate':
           result = await handleSAPNavigate(client, args);
@@ -1209,7 +1229,7 @@ export async function handleToolCall(
         errorMessage: message,
       });
 
-      return errorResult(formatErrorForLLM(err, message, toolName, args));
+      return errorResult(formatErrorForLLM(err, message, toolName, args, config));
     }
   });
 }
@@ -1219,6 +1239,13 @@ export async function handleToolCall(
 /** Check if the connected system is BTP ABAP Environment */
 function isBtpSystem(): boolean {
   return cachedFeatures?.systemType === 'btp';
+}
+
+/** Check if the connected system is NW 7.50 (missing several ADT endpoints) */
+function isRelease750(): boolean {
+  const r = cachedFeatures?.abapRelease?.replace(/\D/g, '') ?? '';
+  const num = Number.parseInt(r, 10);
+  return Number.isFinite(num) && num >= 750 && num < 751;
 }
 
 /** BTP-specific error messages for unavailable operations */
@@ -1233,6 +1260,115 @@ const BTP_HINTS: Record<string, string> = {
   TRAN: 'Transaction codes (TRAN) are not available on BTP ABAP Environment. Use SAPSearch to find apps and services instead.',
 };
 
+/** Static release-gating tables: minimum SAP_BASIS release required for each type/action.
+ *  Values from probe catalog + empirical verification. Separated by operation because
+ *  read and write endpoints for the same type may have different minimum releases. */
+interface ReleaseGate {
+  minRelease: number;
+  hint: string;
+}
+
+const READ_RELEASE_GATES: Record<string, ReleaseGate> = {
+  DOMA: {
+    minRelease: 751,
+    hint:
+      'Structured domain reads (DOMA) are not available on this system. ' +
+      'Alternative: use SAPQuery to read domain metadata from DD01L (type, length, value table) ' +
+      'and fixed values from DD07T. Example: SELECT DOMNAME, DATATYPE, LENG, OUTPUTLEN, ENTITYTAB ' +
+      "FROM DD01L WHERE DOMNAME = '<name>' AND AS4LOCAL = 'A'",
+  },
+  DDLX: {
+    minRelease: 751,
+    hint: 'CDS metadata extensions (DDLX) are not available on this system. Requires SAP_BASIS >= 7.51.',
+  },
+  AUTH: {
+    minRelease: 751,
+    hint: 'Authorization field metadata (AUTH) is not available on this system. Use transaction SU20/SU21 instead.',
+  },
+  ENHO: {
+    minRelease: 751,
+    hint: 'Enhancement implementation reads (ENHO) are not available on this system. Use SE18/SE19 instead.',
+  },
+  FTG2: {
+    minRelease: 752,
+    hint: 'Feature toggles (FTG2) are not available on this system. Use transaction SFW5 instead.',
+  },
+  API_STATE: {
+    minRelease: 752,
+    hint: 'API release state checking is not available on this system. Use SE24 to check API deprecation.',
+  },
+  SKTD: {
+    minRelease: 754,
+    hint: 'Knowledge Transfer Documents (SKTD) are not available on this system. Requires SAP_BASIS >= 7.54.',
+  },
+  BDEF: {
+    minRelease: 754,
+    hint: 'Behavior definitions (BDEF) are not available on this system. Requires SAP_BASIS >= 7.54 (S/4HANA).',
+  },
+  SRVD: {
+    minRelease: 754,
+    hint: 'Service definitions (SRVD) are not available on this system. Requires SAP_BASIS >= 7.54 (S/4HANA).',
+  },
+  SRVB: {
+    minRelease: 754,
+    hint: 'Service bindings (SRVB) are not available on this system. Requires SAP_BASIS >= 7.54 (S/4HANA).',
+  },
+};
+
+const WRITE_RELEASE_GATES: Record<string, ReleaseGate> = {
+  DOMA: {
+    minRelease: 751,
+    hint: 'Domain (DOMA) writes are not available on this system. Use SE11 to create or modify domains instead.',
+  },
+  DDLX: {
+    minRelease: 751,
+    hint: 'CDS metadata extension (DDLX) writes are not available on this system. Requires SAP_BASIS >= 7.51.',
+  },
+  SKTD: {
+    minRelease: 754,
+    hint: 'Knowledge Transfer Document (SKTD) writes are not available on this system. Requires SAP_BASIS >= 7.54.',
+  },
+  BDEF: {
+    minRelease: 754,
+    hint: 'Behavior definition (BDEF) writes are not available on this system. Requires SAP_BASIS >= 7.54 (S/4HANA).',
+  },
+  SRVD: {
+    minRelease: 754,
+    hint: 'Service definition (SRVD) writes are not available on this system. Requires SAP_BASIS >= 7.54 (S/4HANA).',
+  },
+  SRVB: {
+    minRelease: 754,
+    hint: 'Service binding (SRVB) writes are not available on this system. Requires SAP_BASIS >= 7.54 (S/4HANA).',
+  },
+};
+
+const ACTION_RELEASE_GATES: Record<string, ReleaseGate> = {
+  publish_srvb: {
+    minRelease: 754,
+    hint: 'Service binding publishing is not available on this system. Requires SAP_BASIS >= 7.54.',
+  },
+  unpublish_srvb: {
+    minRelease: 754,
+    hint: 'Service binding unpublishing is not available on this system. Requires SAP_BASIS >= 7.54.',
+  },
+};
+
+/** Parse abapRelease string to a numeric value (e.g. "750" → 750, "7.54" → 754). */
+function parseRelease(abapRelease?: string): number {
+  if (!abapRelease) return 0;
+  const num = Number.parseInt(abapRelease.replace(/\D/g, ''), 10);
+  return Number.isFinite(num) ? num : 0;
+}
+
+/** Check if a type/action is gated by release. Returns the hint string if blocked, undefined if allowed. */
+function checkReleaseGate(gates: Record<string, ReleaseGate>, key: string): string | undefined {
+  const gate = gates[key];
+  if (!gate) return undefined;
+  const release = parseRelease(cachedFeatures?.abapRelease);
+  if (release > 0 && release < gate.minRelease) return gate.hint;
+  return undefined;
+}
+
 async function handleSAPRead(
   client: AdtClient,
   args: Record<string, unknown>,
@@ -1240,10 +1376,38 @@ async function handleSAPRead(
 ): Promise<ToolResult> {
   const type = normalizeObjectType(String(args.type ?? ''));
   const name = String(args.name ?? '');
+  const sourceVersion = args.version as string | undefined;
 
   // BTP: return helpful error for unavailable types
   if (isBtpSystem() && BTP_HINTS[type]) {
     return errorResult(BTP_HINTS[type]);
+  }
+
+  const releaseGateHint = checkReleaseGate(READ_RELEASE_GATES, type);
+  if (releaseGateHint) {
+    return errorResult(releaseGateHint);
+  }
+
+  // When version="active", fetch the active source directly via ?version=active
+  // for source-based types. Handled before the main switch to avoid per-case duplication.
+  const SOURCE_TYPES = new Set([
+    'PROG',
+    'CLAS',
+    'INTF',
+    'FUNC',
+    'INCL',
+    'DDLS',
+    'DCLS',
+    'DDLX',
+    'BDEF',
+    'SRVD',
+    'TABL',
+    'STRU',
+  ]);
+  if (sourceVersion && SOURCE_TYPES.has(type) && name) {
+    const srcUrl = sourceUrlForType(type, name);
+    const resp = await client.http.get(`${srcUrl}${srcUrl.includes('?') ? '&' : '?'}version=${sourceVersion}`);
+    return textResult(resp.body);
   }
 
   // Helper: get source with cache support, returns cache hit status
@@ -1252,7 +1416,7 @@ async function handleSAPRead(
     objName: string,
     fetcher: () => Promise<string>,
   ): Promise<{ source: string; cacheHit: boolean }> => {
-    if (!cachingLayer) return { source: await fetcher(), cacheHit: false };
+    if (sourceVersion || !cachingLayer) return { source: await fetcher(), cacheHit: false };
     const { source, hit } = await cachingLayer.getSource(objType, objName, fetcher);
     return { source, cacheHit: hit };
   };
@@ -1409,7 +1573,8 @@ async function handleSAPRead(
       }
     }
     case 'TABL': {
-      const { source, cacheHit } = await cachedGet('TABL', name, () => client.getTable(name));
+      const tablReader = isRelease750() ? () => client.getStructure(name) : () => client.getTable(name);
+      const { source, cacheHit } = await cachedGet('TABL', name, tablReader);
       return cachedTextResult(source, cacheHit);
     }
     case 'VIEW': {
@@ -1890,6 +2055,7 @@ function needsVendorContentType(type: string): boolean {
 function createContentTypeForType(type: string): string {
   // SRVB creation works with wildcard content type; updates use vendor v2 type.
   if (type === 'SRVB') return 'application/*';
+  if (type === 'STRU') return 'application/vnd.sap.adt.blues.v1+xml';
   return needsVendorContentType(type) ? vendorContentTypeForType(type) : 'application/*';
 }
 
@@ -2264,7 +2430,7 @@ export function buildCreateXml(
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </dcl:dclSource>`;
     case 'TABL':
-      // TABL creation also uses SAP's "blue" framework envelope, then source is written via /source/main.
+    case 'STRU':
       return `<?xml version="1.0" encoding="UTF-8"?>
 <blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue"
                  xmlns:adtcore="http://www.sap.com/adt/core"
@@ -2628,6 +2794,55 @@ async function handleSAPWrite(
     return errorResult('"type" and "name" are required for this action.');
   }
 
+  const releaseGateHint = checkReleaseGate(WRITE_RELEASE_GATES, type);
+  if (releaseGateHint) {
+    return errorResult(releaseGateHint);
+  }
+
+  // SAP object names must be uppercase — mixed-case names cause silent corruption
+  // (e.g. DDLS created as "Zc_MyView" instead of "ZC_MYVIEW" confuses the TADIR registry).
+  // Note: source code inside the object CAN use mixed case (e.g. "define view ZC_MyView").
+  if (action === 'create' && name && name !== name.toUpperCase()) {
+    return errorResult(
+      `Object name "${name}" contains lowercase characters. SAP object names must be uppercase (e.g. "${name.toUpperCase()}").\n\n` +
+        `Note: the object NAME in TADIR must be uppercase, but the source code inside the object can use mixed case ` +
+        `(e.g. for DDLS: name="${name.toUpperCase()}" but source can contain "define view entity ${name}").`,
+    );
+  }
+
+  // STRU update guard: the /ddic/structures/ PUT endpoint silently converts transparent
+  // tables (TABL/DT) into structures (TABL/DS) by creating an inactive INTTAB version.
+  // This corrupts DD02L and confuses SE11. Block STRU updates on objects that are actually tables.
+  if (type === 'STRU' && action === 'update' && name) {
+    try {
+      const searchResults = await client.searchObject(name, 1);
+      const match = searchResults.find((r) => r.objectName.toUpperCase() === name.toUpperCase());
+      if (match && match.objectType !== 'TABL/DS') {
+        if (match.objectType === 'TABL/DT') {
+          const hint = isRelease750()
+            ? 'Use SE11 to modify transparent tables on this system.'
+            : 'Use SAPWrite(type="TABL") instead.';
+          return errorResult(`"${name}" is a transparent table (TABL/DT), not a structure. ${hint}`);
+        }
+        return errorResult(
+          `"${name}" exists as ${match.objectType}, not a structure (TABL/DS). ` +
+            `SAPWrite(type="STRU") only works with DDIC structures.`,
+        );
+      }
+    } catch {
+      // search failed — proceed cautiously (SAP's own 405 on create guards against new collisions)
+    }
+  }
+
+  // NW 7.50: /ddic/tables/ doesn't exist — TABL is hidden from the tool schema,
+  // but guard at runtime too in case an LLM hallucinates the type.
+  if (type === 'TABL' && isRelease750() && (action === 'create' || action === 'update')) {
+    return errorResult(
+      `TABL create/update is not available on this SAP release (NW 7.50). ` +
+        `Use SE11 to create or modify tables and structures. SAPRead(type="TABL") works for reading.`,
+    );
+  }
+
   const objectUrl = objectUrlForType(type, name);
   const srcUrl = sourceUrlForType(type, name);
 
@@ -2746,6 +2961,21 @@ async function handleSAPWrite(
         } catch {
           // If transportInfo check fails (older system, permissions, etc.), proceed without it.
           // SAP will return its own error if a transport is actually needed.
+        }
+      }
+
+      // MSAG create with a task number silently fails — CL_ADT_MESSAGE_CLASS_API=>create()
+      // passes corrNr to CTS_WBO_API_INSERT_OBJECTS which only accepts request numbers.
+      // The TADIR entry is created but T100/T100A are never written (phantom object).
+      // Confirmed on NW 7.50; unclear whether later releases fixed it, so validate everywhere.
+      if (type === 'MSAG' && effectiveTransport) {
+        const tr = await getTransport(client.http, client.safety, effectiveTransport);
+        if (!tr) {
+          return errorResult(
+            `Transport "${effectiveTransport}" is not a valid transport request. ` +
+              `On this SAP release, MSAG creation requires the transport request number, not a task number. ` +
+              `Use SAPTransport(action="get", id="<request>") to verify, or SAPTransport(action="list") to find modifiable requests.`,
+          );
         }
       }
 
@@ -3275,6 +3505,16 @@ async function handleSAPWrite(
         const objSource = obj.source ? String(obj.source) : undefined;
         const objDescription = String(obj.description ?? objName);
 
+        if (objName !== objName.toUpperCase()) {
+          results.push({
+            type: objType,
+            name: objName,
+            status: 'failed',
+            error: `Object name "${objName}" contains lowercase characters. SAP object names must be uppercase (e.g. "${objName.toUpperCase()}"). Source code inside the object can use mixed case.`,
+          });
+          break;
+        }
+
         // AFF header validation per object (if schema available)
         const affResult = validateAffHeader(objType, { description: objDescription, originalLanguage: 'en' });
         if (!affResult.valid) {
@@ -3642,11 +3882,20 @@ async function runPreWriteSyntaxCheck(
 
 // ─── SAPActivate Handler ─────────────────────────────────────────────
 
-async function handleSAPActivate(client: AdtClient, args: Record<string, unknown>): Promise<ToolResult> {
+async function handleSAPActivate(
+  client: AdtClient,
+  args: Record<string, unknown>,
+  cachingLayer?: CachingLayer,
+): Promise<ToolResult> {
   const action = String(args.action ?? 'activate');
   const name = String(args.name ?? '');
   const version = String(args.version ?? '0001');
   const explicitServiceType = args.service_type as string | undefined;
+
+  const releaseGateHint = checkReleaseGate(ACTION_RELEASE_GATES, action);
+  if (releaseGateHint) {
+    return errorResult(releaseGateHint);
+  }
 
   // Resolve the OData service type for publish/unpublish endpoints.
   // Explicit service_type parameter takes precedence; otherwise auto-detect from SRVB metadata.
@@ -3764,6 +4013,7 @@ async function handleSAPActivate(client: AdtClient, args: Record<string, unknown
     const statusDetails = formatBatchActivationStatuses(batchStatuses);
 
     if (result.success) {
+      for (const o of objects) cachingLayer?.invalidate(o.type, o.name);
       return textResult(`Successfully activated ${objects.length} objects: ${names}.${statusDetails}`);
     }
     // On batch failure enrich with per-object inactive-version syntax errors —
@@ -3787,6 +4037,7 @@ async function handleSAPActivate(client: AdtClient, args: Record<string, unknown
   const result = await activate(client.http, client.safety, objectUrl, { ...activateOpts, name });
 
   if (result.success) {
+    cachingLayer?.invalidate(type, name);
     return textResult(`Successfully activated ${type} ${name}.${formatActivationMessages(result)}`);
   }
   // On failure, try to enrich with the actual compiler errors from the inactive version —
@@ -5102,6 +5353,11 @@ async function handleSAPManage(
   const action = String(args.action ?? '');
   const flpUnavailableMessage =
     'FLP customization service (PAGE_BUILDER_CUST) is not available on this system. Check ICF service activation in SICF.';
+
+  const releaseGateHint = checkReleaseGate(ACTION_RELEASE_GATES, action);
+  if (releaseGateHint) {
+    return errorResult(releaseGateHint);
+  }
 
   switch (action) {
     case 'features': {

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -170,6 +170,7 @@ export const SAPReadSchema = z
     sqlFilter: z.string().optional(),
     objectType: z.string().optional(),
     versionUri: z.string().optional(),
+    version: z.enum(['active', 'inactive']).optional(),
   })
   .superRefine((input, ctx) => validateSapReadInput(input, ctx));
 
@@ -185,6 +186,7 @@ export const SAPReadSchemaBtp = z
     sqlFilter: z.string().optional(),
     objectType: z.string().optional(),
     versionUri: z.string().optional(),
+    version: z.enum(['active', 'inactive']).optional(),
   })
   .superRefine((input, ctx) => validateSapReadInput(input, ctx));
 
@@ -226,6 +228,7 @@ const SAPWRITE_TYPES_ONPREM = [
   'SRVB',
   'SKTD',
   'TABL',
+  'STRU',
   'DOMA',
   'DTEL',
   'MSAG',

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -32,6 +32,59 @@ function isBtpMode(config: ServerConfig): boolean {
   return config.systemType === 'btp';
 }
 
+// ─── Release-gated types/actions ───────────────────────────────────
+
+/** Minimum SAP_BASIS release for SAPRead types. Mirrors READ_RELEASE_GATES in intent.ts. */
+const READ_RELEASE_GATES: Record<string, number> = {
+  DOMA: 751,
+  DDLX: 751,
+  AUTH: 751,
+  ENHO: 751,
+  FTG2: 752,
+  API_STATE: 752,
+  SKTD: 754,
+  BDEF: 754,
+  SRVD: 754,
+  SRVB: 754,
+};
+
+/** Minimum SAP_BASIS release for SAPWrite types. Mirrors WRITE_RELEASE_GATES in intent.ts. */
+const WRITE_RELEASE_GATES: Record<string, number> = {
+  DOMA: 751,
+  DDLX: 751,
+  TABL: 751,
+  SKTD: 754,
+  BDEF: 754,
+  SRVD: 754,
+  SRVB: 754,
+};
+
+/** Minimum SAP_BASIS release for SAPActivate/SAPManage actions. Mirrors ACTION_RELEASE_GATES in intent.ts. */
+const ACTION_RELEASE_GATES: Record<string, number> = {
+  publish_srvb: 754,
+  unpublish_srvb: 754,
+};
+
+function parseReleaseNum(resolvedFeatures?: ResolvedFeatures): number {
+  const release = resolvedFeatures?.abapRelease?.replace(/\D/g, '') ?? '';
+  const num = Number.parseInt(release, 10);
+  return Number.isFinite(num) ? num : 0;
+}
+
+/** Filter an array of type/action strings, removing entries gated above the detected release. */
+function filterByRelease<T extends string>(
+  items: readonly T[],
+  gates: Record<string, number>,
+  resolvedFeatures?: ResolvedFeatures,
+): T[] {
+  const release = parseReleaseNum(resolvedFeatures);
+  if (release === 0) return [...items];
+  return items.filter((item) => {
+    const min = gates[item];
+    return !min || release >= min;
+  });
+}
+
 // ─── SAPRead Types ──────────────────────────────────────────────────
 
 /** All SAPRead types available on on-premise */
@@ -436,7 +489,7 @@ export function getToolDefinitions(
         properties: {
           type: {
             type: 'string',
-            enum: btp ? SAPREAD_TYPES_BTP : SAPREAD_TYPES_ONPREM,
+            enum: filterByRelease(btp ? SAPREAD_TYPES_BTP : SAPREAD_TYPES_ONPREM, READ_RELEASE_GATES, resolvedFeatures),
             description: btp
               ? 'Object type to read (BTP): CLAS, INTF, FUNC, FUGR, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD, TABL, STRU, DOMA, DTEL, TABLE_CONTENTS, DEVC, SYSTEM, COMPONENTS, MESSAGES, BSP, BSP_DEPLOY, API_STATE, INACTIVE_OBJECTS.'
               : 'Object type to read (on-prem): PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD, TABL, VIEW, STRU, DOMA, DTEL, TRAN, TABLE_CONTENTS, DEVC, SOBJ, SYSTEM, COMPONENTS, MESSAGES, TEXT_ELEMENTS, VARIANTS, BSP, BSP_DEPLOY, API_STATE, INACTIVE_OBJECTS, AUTH, FTG2, ENHO, VERSIONS, VERSION_SOURCE.',
@@ -493,6 +546,12 @@ export function getToolDefinitions(
             description:
               'For VERSION_SOURCE: URI of a specific revision from SAPRead(type="VERSIONS") response (.revisions[].uri). Must start with /sap/bc/adt/.',
           },
+          version: {
+            type: 'string',
+            enum: ['active', 'inactive'],
+            description:
+              'Source version to read. Omit to get the default (latest, possibly inactive). Set to "active" to get the last activated version, or "inactive" to explicitly get the pending inactive version. Do not set this routinely — only when you need to compare active vs inactive state.',
+          },
         },
         required: ['type'],
       },
@@ -522,7 +581,18 @@ export function getToolDefinitions(
           },
           type: {
             type: 'string',
-            enum: btp ? SAPWRITE_TYPES_BTP : SAPWRITE_TYPES_ONPREM,
+            enum: (() => {
+              const types = filterByRelease(
+                [...(btp ? SAPWRITE_TYPES_BTP : SAPWRITE_TYPES_ONPREM)],
+                WRITE_RELEASE_GATES,
+                resolvedFeatures,
+              );
+              // TABL filtered out by WRITE_RELEASE_GATES (751) — add STRU as replacement
+              if (!types.includes('TABL') && !types.includes('STRU')) {
+                types.push('STRU');
+              }
+              return types;
+            })(),
             description: btp
               ? 'Object type (for create/update/delete/edit_method). Supported: CLAS, INTF, DDLS, DDLX, BDEF, SRVD, TABL, DOMA, DTEL.'
               : 'Object type (for create/update/delete/edit_method). Supported: PROG, CLAS, INTF, FUNC, INCL, DDLS, DDLX, BDEF, SRVD, TABL, DOMA, DTEL.',
@@ -599,6 +669,18 @@ export function getToolDefinitions(
           setGetParameter: { type: 'string', description: 'DTEL: SET/GET parameter ID' },
           defaultComponentName: { type: 'string', description: 'DTEL: default component name' },
           changeDocument: { type: 'boolean', description: 'DTEL: enable change document flag' },
+          messages: {
+            type: 'array',
+            description: 'MSAG: message entries for create/update',
+            items: {
+              type: 'object',
+              properties: {
+                number: { type: 'string', description: 'Message number (e.g., "001")' },
+                shortText: { type: 'string', description: 'Message short text (use & for placeholders: "&1", "&2")' },
+              },
+              required: ['number', 'shortText'],
+            },
+          },
           serviceDefinition: { type: 'string', description: 'SRVB: service definition name (SRVD) to bind to' },
           bindingType: {
             type: 'string',
@@ -652,7 +734,17 @@ export function getToolDefinitions(
               properties: {
                 type: {
                   type: 'string',
-                  enum: btp ? SAPWRITE_TYPES_BTP : SAPWRITE_TYPES_ONPREM,
+                  enum: (() => {
+                    const types = filterByRelease(
+                      [...(btp ? SAPWRITE_TYPES_BTP : SAPWRITE_TYPES_ONPREM)],
+                      WRITE_RELEASE_GATES,
+                      resolvedFeatures,
+                    );
+                    if (!types.includes('TABL') && !types.includes('STRU')) {
+                      types.push('STRU');
+                    }
+                    return types;
+                  })(),
                   description: 'Object type (includes TABL for RAP stack bootstrapping)',
                 },
                 name: { type: 'string', description: 'Object name' },
@@ -691,6 +783,18 @@ export function getToolDefinitions(
                 setGetParameter: { type: 'string', description: 'DTEL: SET/GET parameter ID' },
                 defaultComponentName: { type: 'string', description: 'DTEL: default component name' },
                 changeDocument: { type: 'boolean', description: 'DTEL: change document flag' },
+                messages: {
+                  type: 'array',
+                  description: 'MSAG: message entries',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      number: { type: 'string', description: 'Message number (e.g., "001")' },
+                      shortText: { type: 'string', description: 'Message short text' },
+                    },
+                    required: ['number', 'shortText'],
+                  },
+                },
                 serviceDefinition: { type: 'string', description: 'SRVB: service definition (SRVD)' },
                 bindingType: {
                   type: 'string',
@@ -734,7 +838,11 @@ export function getToolDefinitions(
         properties: {
           action: {
             type: 'string',
-            enum: ['activate', 'publish_srvb', 'unpublish_srvb'],
+            enum: filterByRelease(
+              ['activate', 'publish_srvb', 'unpublish_srvb'],
+              ACTION_RELEASE_GATES,
+              resolvedFeatures,
+            ),
             description:
               'Action to perform. "activate" (default): activate ABAP objects. ' +
               '"publish_srvb": publish a service binding to make OData service available. ' +
@@ -1069,7 +1177,7 @@ export function getToolDefinitions(
       properties: {
         action: {
           type: 'string',
-          enum: sapManageActions,
+          enum: filterByRelease(sapManageActions, ACTION_RELEASE_GATES, resolvedFeatures),
           description:
             'Action to execute. Read actions: features, probe, cache_stats, flp_list_catalogs, flp_list_groups, flp_list_tiles. ' +
             'Mutating package/FLP actions require writable safety config and write scope in authenticated mode.',

--- a/src/probe/catalog.ts
+++ b/src/probe/catalog.ts
@@ -104,7 +104,8 @@ export const CATALOG: CatalogEntry[] = [
     collectionUrl: '/sap/bc/adt/ddic/domains',
     objectUrlTemplate: '/sap/bc/adt/ddic/domains/{name}',
     knownObjects: ['ABAP_BOOL', 'MANDT', 'XFELD'],
-    minRelease: 700,
+    minRelease: 751,
+    note: 'Structured domain read endpoint confirmed unavailable on NW 7.50 (404 for existing objects)',
   },
   {
     type: 'DTEL',
@@ -191,8 +192,8 @@ export const CATALOG: CatalogEntry[] = [
     collectionUrl: '/sap/bc/adt/enhancements/enhoxhb',
     objectUrlTemplate: '/sap/bc/adt/enhancements/enhoxhb/{name}',
     knownObjects: [],
-    minRelease: 702,
-    note: 'Enhancement implementations — no universally-shipped ENHO',
+    minRelease: 751,
+    note: 'Enhancement implementations — confirmed unavailable on NW 7.50 (404); no universally-shipped ENHO',
   },
 ];
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -201,6 +201,8 @@ export function buildAdtConfig(
     if (cookies) {
       adtConfig.cookies = cookies;
     }
+    adtConfig.cookieFile = config.cookieFile;
+    adtConfig.cookieString = config.cookieString;
   }
 
   return adtConfig;
@@ -362,8 +364,14 @@ export interface StartupAuthPreflightResult {
 
 const STARTUP_AUTH_ENDPOINT = '/sap/bc/adt/core/discovery';
 
-function buildStartupAuthFailureReason(statusCode: number): string {
+function buildStartupAuthFailureReason(statusCode: number, config: ServerConfig): string {
   if (statusCode === 401) {
+    if (config.cookieFile || config.cookieString) {
+      return (
+        'Authentication failed (401) during startup auth preflight. ' +
+        'Your SAP cookies have expired. Re-extract them with `arc1-cli extract-cookies` — no restart needed, the next SAP call will reload them automatically.'
+      );
+    }
     return (
       'Authentication failed (401) during startup auth preflight. ' +
       'Check SAP_USER/SAP_PASSWORD/SAP_CLIENT (or destination/service-key credentials), then restart ARC-1.'
@@ -419,7 +427,12 @@ export async function runStartupAuthPreflight(
     return { status: 'ok', blocking: false, endpoint, checkedAt, reason };
   } catch (err) {
     if (err instanceof AdtApiError && (err.statusCode === 401 || err.statusCode === 403)) {
-      const reason = buildStartupAuthFailureReason(err.statusCode);
+      const reason = buildStartupAuthFailureReason(err.statusCode, config);
+      const isCookieAuth = !!(config.cookieFile || config.cookieString);
+      if (isCookieAuth && err.statusCode === 401) {
+        logger.warn(reason + ' (non-blocking: runtime cookie reload will retry)', { endpoint, statusCode: 401 });
+        return { status: 'inconclusive', blocking: false, endpoint, checkedAt, statusCode: 401, reason };
+      }
       logger.warn(reason, { endpoint, statusCode: err.statusCode });
       return {
         status: 'failed',

--- a/tests/e2e/ddic-write.e2e.test.ts
+++ b/tests/e2e/ddic-write.e2e.test.ts
@@ -194,6 +194,118 @@ describe('E2E DDIC metadata write tests', () => {
     expectToolError(readDomain, domainName);
   });
 
+  it('SAPRead TABL reads a standard table definition', async () => {
+    const result = await callTool(client, 'SAPRead', { type: 'TABL', name: 'T000' });
+    const text = expectToolSuccess(result);
+    expect(text).toContain('mandt');
+  });
+
+  it('SAPWrite STRU full CRUD cycle with version checks', async (ctx) => {
+    const struName = uniqueName('ZARC1_STRU');
+
+    // Create with initial field
+    const createResult = await callTool(client, 'SAPWrite', {
+      action: 'create',
+      type: 'STRU',
+      name: struName,
+      package: '$TMP',
+      description: 'ARC-1 E2E test structure',
+      source: [
+        `@EndUserText.label : 'ARC-1 E2E test structure'`,
+        `@AbapCatalog.enhancementCategory : #NOT_EXTENSIBLE`,
+        `define type ${struName.toLowerCase()} {`,
+        `  key id   : sysuuid_x16 not null;`,
+        `  status  : char1;`,
+        ``,
+        `}`,
+      ].join('\n'),
+    });
+    expectToolSuccessOrSkip(ctx, createResult);
+
+    try {
+      // Activate the initial version
+      const act1 = await callTool(client, 'SAPActivate', {
+        action: 'activate',
+        type: 'STRU',
+        name: struName,
+      });
+      expectToolSuccess(act1);
+
+      // Update — add a field (creates inactive version)
+      const updateResult = await callTool(client, 'SAPWrite', {
+        action: 'update',
+        type: 'STRU',
+        name: struName,
+        source: [
+          `@EndUserText.label : 'ARC-1 E2E test structure'`,
+          `@AbapCatalog.enhancementCategory : #NOT_EXTENSIBLE`,
+          `define type ${struName.toLowerCase()} {`,
+          `  key id   : sysuuid_x16 not null;`,
+          `  status  : char1;`,
+          `  message : char100;`,
+          ``,
+          `}`,
+        ].join('\n'),
+      });
+      expectToolSuccess(updateResult);
+
+      // Default read — should show the new field (inactive version)
+      const readDefault = await callTool(client, 'SAPRead', { type: 'STRU', name: struName });
+      expect(expectToolSuccess(readDefault)).toContain('message');
+
+      // version=inactive — should also show the new field
+      const readInactive = await callTool(client, 'SAPRead', {
+        type: 'STRU',
+        name: struName,
+        version: 'inactive',
+      });
+      expect(expectToolSuccess(readInactive)).toContain('message');
+
+      // version=active — should NOT have the new field (still the old activated version)
+      const readActive = await callTool(client, 'SAPRead', {
+        type: 'STRU',
+        name: struName,
+        version: 'active',
+      });
+      const activeText = expectToolSuccess(readActive);
+      expect(activeText).toContain('status');
+      expect(activeText).not.toContain('message');
+
+      // Activate the update
+      const act2 = await callTool(client, 'SAPActivate', {
+        action: 'activate',
+        type: 'STRU',
+        name: struName,
+      });
+      expectToolSuccess(act2);
+
+      // Now version=active should include the new field
+      const readActiveAfter = await callTool(client, 'SAPRead', {
+        type: 'STRU',
+        name: struName,
+        version: 'active',
+      });
+      expect(expectToolSuccess(readActiveAfter)).toContain('message');
+    } finally {
+      try {
+        await callTool(client, 'SAPWrite', { action: 'delete', type: 'STRU', name: struName });
+      } catch {
+        // best-effort-cleanup
+      }
+    }
+  });
+
+  it('SAPWrite rejects mixed-case object names on create', async () => {
+    const result = await callTool(client, 'SAPWrite', {
+      action: 'create',
+      type: 'DDLS',
+      name: 'Zarc1_Mixed_Case',
+      package: '$TMP',
+      source: 'define view entity Zarc1_Mixed_Case as select from t000 { key mandt }',
+    });
+    expectToolError(result, 'uppercase');
+  });
+
   it('SAPWrite batch_create supports DOMA + DTEL dependency chain', async (ctx) => {
     const domainName = uniqueName('ZARC1_BDOM');
     const dtelName = uniqueName('ZARC1_BDTL');

--- a/tests/unit/adt/crud.test.ts
+++ b/tests/unit/adt/crud.test.ts
@@ -369,6 +369,44 @@ describe('CRUD Operations', () => {
       ).rejects.toThrow(error400);
       expect(http.post).toHaveBeenCalledTimes(1);
     });
+
+    describe('NW 7.50 lock-conflict reclassification on create', () => {
+      const html = '<html><body>Logon Error Message — please log on again.</body></html>';
+
+      function mockHttpThatRejectsCreate(status: number, body: string): AdtHttpClient {
+        const http = mockHttp();
+        (http.post as ReturnType<typeof vi.fn>).mockRejectedValue(new AdtApiError('reject', status, '/url', body));
+        return http;
+      }
+
+      it('reclassifies 401 + "Logon Error Message" as 409 lock-conflict', async () => {
+        const http = mockHttpThatRejectsCreate(401, html);
+        await expect(
+          createObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/ddic/ddl/sources', '<xml/>'),
+        ).rejects.toMatchObject({ statusCode: 409, message: expect.stringContaining('locked by another session') });
+      });
+
+      it('reclassifies 400 + "Logon Error Message" as 409', async () => {
+        const http = mockHttpThatRejectsCreate(400, html);
+        await expect(
+          createObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/ddic/ddl/sources', '<xml/>'),
+        ).rejects.toMatchObject({ statusCode: 409 });
+      });
+
+      it('reclassifies 403 + "Logon Error Message" as 409', async () => {
+        const http = mockHttpThatRejectsCreate(403, html);
+        await expect(
+          createObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/ddic/ddl/sources', '<xml/>'),
+        ).rejects.toMatchObject({ statusCode: 409 });
+      });
+
+      it('does NOT reclassify 401 without "Logon Error Message" body', async () => {
+        const http = mockHttpThatRejectsCreate(401, 'Authentication required');
+        await expect(
+          createObject(http, unrestrictedSafetyConfig(), '/sap/bc/adt/ddic/ddl/sources', '<xml/>'),
+        ).rejects.toMatchObject({ statusCode: 401 });
+      });
+    });
   });
 
   // ─── updateSource ──────────────────────────────────────────────────

--- a/tests/unit/adt/errors.test.ts
+++ b/tests/unit/adt/errors.test.ts
@@ -492,6 +492,15 @@ describe('AdtApiError', () => {
       expect(classification?.category).toBe('method-not-supported');
     });
 
+    it('classifies 404 deletion-blocked when object is still referenced', () => {
+      const classification = classifySapDomainError(
+        404,
+        'Object ZDTEL_EXAMPLE cannot be deleted as it is still referenced by other objects.',
+      );
+      expect(classification?.category).toBe('deletion-blocked');
+      expect(classification?.hint).toContain('where_used');
+    });
+
     it('returns undefined for unclassifiable errors', () => {
       expect(classifySapDomainError(418, 'teapot')).toBeUndefined();
     });

--- a/tests/unit/probe/replay.test.ts
+++ b/tests/unit/probe/replay.test.ts
@@ -195,8 +195,8 @@ describe('probe replay — npl-750-sp02-dev-edition fixture (recorded from real 
 
     expect(q.verdictHistogram['available-high']).toBe(8);
     expect(q.verdictHistogram['available-medium']).toBe(0);
-    expect(q.verdictHistogram['unavailable-high']).toBe(6);
-    expect(q.verdictHistogram['unavailable-likely']).toBe(3);
+    expect(q.verdictHistogram['unavailable-high']).toBe(8);
+    expect(q.verdictHistogram['unavailable-likely']).toBe(1);
     expect(q.verdictHistogram['auth-blocked']).toBe(0);
     expect(q.verdictHistogram.ambiguous).toBe(3);
   });


### PR DESCRIPTION
All these features have been developed based on my real-world ABAP development workflow. To be honest I'm surprised some of these problems existed from VSP. I think there is still a little bit of foundational work to clean up and harden the code against errors (imho your authz rework and extension framework go in the right direction).

1. I've removed the custom dump endpoint (I don't use it yet anyway and it would fit better your extension framework)

2. The release gate is based on a static release map but you mentioned previously you preferred probing. I would suggest starting with the static release map of features, anyway the filtering has been extracted into method filterByRelease so it can be changed easily later.

3. NW 7.50 has many critical bugs because the ADT API does insufficient checks (eg. if you give a task number instead of a transport number it still accepts it but fails halfway with no recovery possible, if you create a CDS view with a mixed case DDIC object name it accepts it etc...) - I've put guards against these in the code.

4. My code introduces the ability to read inactive versions, this might impact your work with caching/ETag which also mentions that feature.

Auto-generated summary of the squashed commits:
- SAPActivate phantom success detection + two-phase activation handshake
- Cookie hot-reload on stale auth (SAP_COOKIE_FILE re-read on 401)
- Release-gated dispatch for unavailable types/actions on older SAP_BASIS
- NW 7.50 TABL read routing, STRU write support, version param
- Mixed-case object name rejection on create
- MSAG create guard against task numbers on NW 7.50
- Activation error formatting (correct line numbers, decode entities, dedup)
- Opt-in pre-write SAP syntax check + inactive-version diagnostics
- 404 deletion-blocked error classification
- Lock-as-401 reclassification on createObject path
- CLI alignment: extract-cookies, cli-args, tool shortcuts