### PR TITLE
chore: drop Claude Code plugin distribution files

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,0 @@
-{
-  "name": "arc-1",
-  "description": "SAP ABAP Development Tools (ADT) MCP integration. Read, write, search, activate, and manage ABAP objects, run syntax checks, unit tests, and manage CTS transports.",
-  "author": {
-    "name": "Marian Zeis"
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,7 @@ INFRASTRUCTURE.md
 MEMORY.md
 
 # MCP config (contains credentials)
-# Note: root .mcp.json is excluded from this rule — it's the Claude Code plugin
-# config and contains no credentials (uses env var references only).
 .mcp*.json
-!/.mcp.json
 ./claude/abap-adt-api-lib/
 
 # Binaries

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,0 @@
-{
-  "arc-1": {
-    "command": "npx",
-    "args": ["-y", "arc-1@latest"]
-  }
-}

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -14,7 +14,6 @@ biome.json
 # Config/CI
 .github/
 .claude/
-.claude-plugin/
 .cursor-plugin/
 scripts/
 docs/

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -12,7 +12,6 @@ This document describes how to publish ARC-1 to various MCP server registries, m
 | [VS Code / GitHub Copilot](#4-vs-code--github-copilot) | Via MCP Registry | Automatic | VS Code Extensions `@mcp` gallery |
 | [Cursor Marketplace](#5-cursor-marketplace) | Manual | Ready | Cursor IDE built-in marketplace |
 | [Claude Desktop Extensions](#6-claude-desktop-extensions) | Manual (CI builds .mcpb) | Ready | Claude Desktop Extensions directory |
-| [Claude Code Plugins](#7-claude-code-plugins) | Manual | Ready | Claude Code `/plugin` discovery |
 
 ## Files in This Repository
 
@@ -24,8 +23,6 @@ This document describes how to publish ARC-1 to various MCP server registries, m
 | `.cursor-plugin/plugin.json` | Cursor Marketplace plugin manifest |
 | `mcpb-manifest.json` | Claude Desktop Extension (MCPB) manifest |
 | `.mcpbignore` | Files excluded from MCPB bundle |
-| `.claude-plugin/plugin.json` | Claude Code plugin manifest |
-| `.mcp.json` | Claude Code MCP server config |
 
 ---
 
@@ -321,40 +318,7 @@ Add to `.github/workflows/release.yml` to build and attach `.mcpb` to releases:
 
 ---
 
-## 7. Claude Code Plugins
-
-**URL:** Claude Code → `/plugin` → Discover  
-**Impact:** Medium-high. Native Claude Code integration.
-
-### Files Already in Repo
-
-- `.claude-plugin/plugin.json` — Plugin manifest
-- `.mcp.json` — MCP server configuration (auto-discovered by Claude Code)
-
-### Steps
-
-1. **Submit via the plugin directory form:**
-   https://claude.ai/settings/plugins/submit
-   (or https://platform.claude.com/plugins/submit)
-
-2. **Provide:**
-   - Repository URL: `https://github.com/marianfoo/arc-1`
-   - The form triggers automated security scanning and review
-
-3. **Once approved**, users install via:
-   ```bash
-   claude plugin install arc-1
-   ```
-
-### Community Directory Alternative
-
-If the official directory is slow to process:
-- The community plugins repository at `anthropics/claude-plugins-community` is synced from Anthropic's internal pipeline
-- PRs directly to the community repo are auto-closed — use the submission form
-
----
-
-## 8. Additional Directories (Manual, Lower Priority)
+## 7. Additional Directories (Manual, Lower Priority)
 
 These don't require files in the repo — just web submissions:
 


### PR DESCRIPTION
## Summary

- Delete `.claude-plugin/plugin.json` and `.mcp.json` — the Claude Code plugin distribution channel prepared in #102 was never submitted, and the tracked `.mcp.json` shipped in a malformed shape (missing the `mcpServers` wrapper) that would not have worked anyway.
- Drop the `!/.mcp.json` un-ignore in `.gitignore`. Contributors who want a local `.mcp.json` pointing at `node bin/arc1.js` now just create one — it falls under the existing `.mcp*.json` rule with no `skip-worktree` ceremony.
- Remove the now-stale `.claude-plugin/` line from `.mcpbignore` and § 7 + table rows from `docs/publishing-guide.md`.

## Why not fix the file instead?

Two routes were considered first:

1. **Repair the wrapper and add env-var refs.** Keeps the file tracked but leaves the contributor-conflict pain (every pull overwrites local edits) and forces a `git update-index --skip-worktree` workaround.
2. **Move `mcpServers` inline into `.claude-plugin/plugin.json` and untrack root `.mcp.json`.** Cleaner, but Claude Code currently drops the inline `mcpServers` field during manifest parsing — see [anthropics/claude-code#16143](https://github.com/anthropics/claude-code/issues/16143). The plugin distribution would silently ship without a server.

Since the plugin was never actually submitted and Claude Code's project-level `.mcp.json` (documented in [`docs_page/index.md`](docs_page/index.md)) covers the same end-user install path, removing the channel beats maintaining a broken/conflicting one. Other distribution channels are unaffected: npm, Docker, [Official MCP Registry](server.json), [Glama](glama.json), [Cursor Marketplace](mcp.json), [Claude Desktop Extensions](mcpb-manifest.json), VS Code `@mcp`.

Closes #194.

## Test plan

- [ ] `git pull` no longer overwrites a contributor's local `.mcp.json` (verify on a fresh clone)
- [ ] `docs/publishing-guide.md` § 1‑7 are sequential, no broken anchor links
- [ ] No remaining references to `.claude-plugin/` or the deleted `.mcp.json` in repo (`grep -r 'claude-plugin\|"\.mcp\.json"' --include='*.md' --include='*.json'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)