### PR TITLE
docs: split PR #196 — ADRs 0001-0003, ARCH-01 plan, PR-α/β/γ plans, roadmap

### DIFF
--- a/docs/adr/0001-discovery-driven-endpoint-routing.md
+++ b/docs/adr/0001-discovery-driven-endpoint-routing.md
@@ -1,0 +1,82 @@
+# ADR 0001 — Discovery-driven endpoint routing replaces release-version gating
+
+**Status:** Proposed
+**Date:** 2026-04-28
+**Related PR:** [#196](https://github.com/marianfoo/arc-1/pull/196) (NW 7.50 compatibility fixes)
+**Supersedes:** N/A
+**Superseded by:** N/A
+
+## Context
+
+[PR #196](https://github.com/marianfoo/arc-1/pull/196) introduced static SAP_BASIS release maps (`READ_RELEASE_GATES`, `WRITE_RELEASE_GATES`, `ACTION_RELEASE_GATES`) duplicated in [src/handlers/intent.ts](../../src/handlers/intent.ts) and [src/handlers/tools.ts](../../src/handlers/tools.ts) to gate types and route TABL→STRU on NW 7.50. Live verification surfaced four problems with this design:
+
+1. **Two sources of truth.** The maps in `intent.ts` and `tools.ts` must stay in sync manually; the PR already had a divergence (`TABL: 751` was in tools.ts but missing from intent.ts).
+2. **Manual maintenance burden.** Every new SAP support pack that back-ports an endpoint to NW 7.50 needs a manual map update. Conversely, S/4HANA endpoints that reach BTP at different times require per-release literals.
+3. **Async-loaded `cachedFeatures` doesn't reach all entry points.** `runStartupProbe()` populates `cachedFeatures` only in MCP-server mode. Live probe confirmed `arc1-cli call SAPRead TABL T000` against NPL still hits `/sap/bc/adt/ddic/tables` (404) because `isRelease750()` returns `false` when features are `undefined`.
+4. **Empirical evidence aligns with discovery, not release literals.** Direct comparison of `/sap/bc/adt/discovery` between A4H 758 SP02 and NPL 750 SP02 shows the discovery feed is already the authoritative answer to "is this collection available on this system?" The release-number heuristic is a proxy for what the discovery feed says directly.
+
+| Collection | A4H discovery | NPL discovery | Release map says |
+|---|---|---|---|
+| `/sap/bc/adt/ddic/tables` | ✅ | ❌ | gate `TABL: 751` (correct outcome, brittle reasoning) |
+| `/sap/bc/adt/ddic/structures` | ✅ | ✅ | always allowed (correct outcome, no gate needed) |
+| `/sap/bc/adt/ddic/domains` | ✅ | ❌ | gate `DOMA: 751` (correct outcome, brittle reasoning) |
+| `/sap/bc/adt/ddic/ddlx/sources` | ✅ | ❌ | gate `DDLX: 751` (correct outcome, brittle reasoning) |
+| `/sap/bc/adt/bo/behaviordefinitions` | ✅ | ❌ | gate `BDEF: 754` (correct outcome, brittle reasoning) |
+| `/sap/bc/adt/businessservices/bindings` | ✅ | ❌ | gate `SRVB: 754` (correct outcome, brittle reasoning) |
+| `/sap/bc/adt/enhancements/enhoxhb` | ✅ | ❌ | gate `ENHO: 751` (NPL has `enhoxh` but not `enhoxhb` — release map can't express this) |
+
+The `enhoxh` vs `enhoxhb` row is decisive: the static release map cannot express that NPL has *one* of two enhancement endpoints but not the other, because the release literal is not a fine-enough discriminator. Discovery answers the right question directly.
+
+## Decision
+
+Replace the two static release-gate tables and `isRelease750()` helper with a **discovery-driven routing primitive** built on the already-cached `/sap/bc/adt/discovery` feed.
+
+Concrete shape:
+
+- A new `discoveryHasCollection(uri: string): boolean` helper in [src/adt/discovery.ts](../../src/adt/discovery.ts) that consults the same cache used today for MIME negotiation, but does not require a `<app:accept>` element on the collection (the current parser drops accept-less collections — useful for MIME, harmful for availability).
+- A new `resolveSourceUrl(type: string, name: string): { url: string } | { unavailable: string }` helper in [src/handlers/intent.ts](../../src/handlers/intent.ts) that maps each ABAP object type to an ordered candidate-URL list and returns the first URL whose collection is published in discovery.
+- `filterByDiscovery(items, typeToCollection, discoveryMap)` replaces `filterByRelease` for tool-enum filtering in [src/handlers/tools.ts](../../src/handlers/tools.ts).
+- All discovery-feed loading paths (MCP server `runStartupProbe`, CLI lazy load, integration tests) populate the same cache, so routing decisions are consistent across entry points.
+
+Out of scope for this ADR (retain release-aware logic where structurally needed):
+
+- The `convertNw750HtmlConflictToProperError` heuristic (covered by ADR-0002) — error reclassification is a different problem from endpoint routing.
+- The `version=active|inactive` query parameter (covered by ADR-0003 + the etag plan).
+
+## Consequences
+
+**Positive:**
+
+- One source of truth (the discovery feed) for "what does this system support."
+- Self-correcting across SAP support packs — when SAP back-ports `/ddic/domains` to NW 7.50 SP15, ARC-1 picks it up automatically.
+- Works identically in MCP-server, stdio, CLI, and integration-test paths.
+- Replaces ~150 lines of duplicated release maps with one ordered candidate-list per type.
+- Existing probe fixtures ([tests/fixtures/probe/npl-750-sp02-dev-edition](../../tests/fixtures/probe/npl-750-sp02-dev-edition), [tests/fixtures/probe/ecc-ehp8-nw750-sp31-onprem-prod](../../tests/fixtures/probe/ecc-ehp8-nw750-sp31-onprem-prod)) become regression tests for the new routing logic.
+
+**Negative:**
+
+- Discovery fetch becomes a hard dependency for routing, not just MIME negotiation. Today's graceful degradation (`fetchDiscoveryDocument` returns an empty map on failure) must be preserved — when discovery is unavailable, fall back to a defensive routing strategy ("try the canonical URL; surface SAP's response unmodified").
+- Adds one additional structural piece to discovery parsing (collection-without-accept tracking).
+- Behavior depends on accuracy of `/sap/bc/adt/discovery`. If a SAP system mis-publishes a collection that is not actually wired in SICF, ARC-1 routes optimistically and surfaces SAP's 404 — this is not a regression vs. the static map (which would also send the request), but it shifts the failure mode.
+
+**Migration path:**
+
+- ARCH-01 ships the primitive (PR-δ); the gates and `isRelease750()` are not touched.
+- PR-ε removes `READ_RELEASE_GATES`, `WRITE_RELEASE_GATES`, `ACTION_RELEASE_GATES`, `parseRelease`, `parseReleaseNum`, `filterByRelease`, the TABL→STRU read fallback, and the TABL write block. Each removal is paired with a discovery-based equivalent.
+
+## Alternatives considered
+
+**Keep the static release map but move to a single source of truth.** Solves the duplication concern but leaves the manual-update burden, the CLI feature-cache gap, and the `enhoxh` vs `enhoxhb` precision gap.
+
+**Run a runtime probe on first use of each type.** Self-correcting like discovery, but adds an HTTP roundtrip per type per session and requires careful caching to avoid storms. Discovery is one HTTP call at startup that already happens.
+
+**Use SAP Note metadata.** Authoritative, but no machine-readable feed exists; would require manual SAP Note research per type.
+
+**Status quo (release literals).** Rejected — see Context.
+
+## References
+
+- Live probe data captured 2026-04-28 against `a4h.marianzeis.de:50000` (S/4HANA 2023, SAP_BASIS 758 SP02) and `npl.marianzeis.de` (NetWeaver 7.50 SP02).
+- [docs/nw750-discovery-gap-analysis.md](../nw750-discovery-gap-analysis.md) — empirical NW 7.50 endpoint inventory contributed by PR [#196](https://github.com/marianfoo/arc-1/pull/196) author.
+- [docs/plans/discovery-driven-endpoint-routing.md](../plans/discovery-driven-endpoint-routing.md) — implementation plan (ARCH-01 / PR-δ).
+- [src/adt/discovery.ts](../../src/adt/discovery.ts), [src/adt/xml-parser.ts](../../src/adt/xml-parser.ts) `parseDiscoveryDocument`.

--- a/docs/adr/0002-structured-exception-lock-conflict-reclassification.md
+++ b/docs/adr/0002-structured-exception-lock-conflict-reclassification.md
@@ -1,0 +1,77 @@
+# ADR 0002 — Lock-conflict reclassification by SAP error structure, not HTML markers
+
+**Status:** Proposed
+**Date:** 2026-04-28
+**Related PR:** [#196](https://github.com/marianfoo/arc-1/pull/196) (NW 7.50 compatibility fixes)
+**Supersedes:** N/A
+**Superseded by:** N/A
+
+## Context
+
+[PR #196](https://github.com/marianfoo/arc-1/pull/196) introduced `rethrowIfNw750LockConflict` in [src/adt/crud.ts](../../src/adt/crud.ts) to reclassify NW 7.50 lock conflicts that the SAP ICM transforms into HTML `401 Logon Error Message` responses. The heuristic checks `responseBody?.includes('Logon Error Message')` and, if matched, throws a synthetic `409 locked by another session` instead of the misleading 401.
+
+The PR comment claims the body marker self-scopes to NW 7.50 because *"S/4 returns Anmeldung fehlgeschlagen, NW 7.50 returns Logon Error Message"*. Live probe of both test systems on 2026-04-28 disproves this:
+
+| System | `<title>` element | Body `<h1>` element |
+|---|---|---|
+| **A4H 758 SP02** (wrong creds → 401) | `Anmeldung fehlgeschlagen` | `Anmeldung fehlgeschlagen` (no "Logon Error Message" anywhere) |
+| **NPL 750 SP02** (wrong creds → 401) | `Logon Error Message` | `Anmeldung fehlgeschlagen` |
+
+The marker happens to fire only on NPL — not because NPL is NW 7.50, but because NPL's ICM uses an English error-page template while A4H's ICM uses a German template. Re-localizing either system breaks the heuristic in a different direction:
+
+- A4H reconfigured with English ICM templates → all auth 401s now match `"Logon Error Message"` and get misreclassified as lock conflicts.
+- NPL reconfigured with non-English ICM templates → real lock conflicts on 7.50 stop matching the heuristic and surface as auth errors again.
+
+The structured-exception variant is more reliable. SAP's ADT error path emits `<exc:exception><type id="…">` for protocol-level failures (already extracted by `extractExceptionType` in [src/adt/errors.ts](../../src/adt/errors.ts)). The known type for the lock-conflict-via-CX_ADT_RES_NO_ACCESS path is `ExceptionResourceNoAccess`. When SAP returns a structured exception, the type ID is the right signal; only when the response is HTML (i.e. the ICM intercepted the response before the ADT handler completed) do we fall back to a body heuristic.
+
+## Decision
+
+Replace the body-marker heuristic with a layered detection strategy:
+
+1. **Primary: structured exception type.** When the response includes `<exc:exception><type id="ExceptionResourceNoAccess"/>` (or known equivalents for lock-conflict semantics), reclassify regardless of HTTP status. This works on every SAP release that emits ADT structured errors.
+2. **Secondary: HTML-based fallback, scoped by feature signal.** When the response is `text/html`, status is 4xx, and `cachedFeatures.abapRelease` parses to `< 751`, treat the response as a likely ICM-level intercept of a real conflict. Use neutral phrasing — *"Operation conflicted on `{name}` — object may be locked or already exist"* — because the ICM intercept does not preserve the original SAP exception type, so we cannot distinguish lock-conflict from already-exists.
+3. **Tertiary: when `cachedFeatures` is undefined**, run the secondary check defensively (the same way the PR's current heuristic would). This preserves CLI/test paths where the startup probe didn't populate features.
+
+Naming and surface changes:
+
+- Rename `rethrowIfNw750LockConflict` → `convertHtmlConflictToProperError`. Caller-side becomes `const conv = convertHtmlConflictToProperError(err, objectUrl); if (conv) throw conv; throw err;` so the control flow is explicit.
+- Reuse this same helper in `createObject` (currently the only other call site in PR #196) — and any future write helper that needs the same reclassification.
+- The synthesized `AdtApiError` carries status `409`, which keeps the existing `classifySapDomainError` `lock-conflict` branch in [src/adt/errors.ts](../../src/adt/errors.ts) firing.
+
+## Consequences
+
+**Positive:**
+
+- Robust against UI-language changes on the SAP server.
+- Works on every SAP release that emits structured ADT exceptions (i.e. all currently-supported releases).
+- The secondary HTML fallback is dormant on modern systems where structured errors are reliable, removing a fragile branch from the hot path.
+- Reuses existing `extractExceptionType` machinery — no new error parsing.
+
+**Negative:**
+
+- Slightly more code than the body-string check (one structured-exception probe + the gated HTML fallback).
+- The HTML-fallback message must be neutral because the ICM intercept loses the original exception type. *"Object locked by another session"* becomes *"Operation conflicted on `{name}` — object may be locked or already exist"*.
+- Requires a small `cachedFeatures.abapRelease`-aware guard. This guard is read-only — it never expands routing, only narrows the fragile heuristic — so it doesn't reintroduce the gating problems in ADR-0001.
+
+## Migration path
+
+- PR-γ (the refined NW 7.50 quirks PR) ships this ADR's behavior immediately, replacing the PR #196 heuristic. The 4 unit tests cherry-picked from PR #196 are extended:
+  - One asserts structured-exception path fires on a `<exc:exception><type id="ExceptionResourceNoAccess"/>` body regardless of status code.
+  - One asserts the HTML-fallback path fires on a 401 HTML body when `cachedFeatures.abapRelease` is `<751`.
+  - One asserts the HTML-fallback path is *skipped* when `cachedFeatures.abapRelease >= 751` (modern system safety).
+  - One asserts a real auth 401 (non-HTML, structured plain-text body, no marker) is not reclassified.
+
+## Alternatives considered
+
+**Keep PR #196's body-marker heuristic.** Rejected — fragile against UI-language reconfiguration; both A4H reconfig (false positives) and NPL reconfig (false negatives) break it.
+
+**Probe SM12 enqueue table on every conflict.** Authoritative, but adds an HTTP roundtrip per failure and requires extra authorization; rejected as too expensive for a hint.
+
+**Always route 4xx + HTML responses through the heuristic.** Catches more cases but produces false positives on non-7.50 systems for normal auth failures.
+
+## References
+
+- Live probe data captured 2026-04-28 against A4H 758 SP02 and NPL 750 SP02.
+- `extractExceptionType` and `classifySapDomainError` in [src/adt/errors.ts](../../src/adt/errors.ts).
+- [src/adt/crud.ts](../../src/adt/crud.ts) `lockObject` and `createObject` (call sites).
+- PR [#202](https://github.com/marianfoo/arc-1/pull/202) — PR-γ ships the layered detection helper, `cachedFeatures?.abapRelease` threading, classifier extension, and MSAG transport guard. The plan file `docs/plans/pr-gamma-nw750-quirks-refined.md` lives on the PR-γ branch and lands in main alongside the implementation when PR #202 merges.

--- a/docs/adr/0003-sapread-version-stays-internal.md
+++ b/docs/adr/0003-sapread-version-stays-internal.md
@@ -1,0 +1,58 @@
+# ADR 0003 — SAPRead `version` parameter stays internal until diff feature is designed
+
+**Status:** **Superseded** — see [PR #186](https://github.com/marianfoo/arc-1/pull/186) (merged 2026-04-28).
+**Original date:** 2026-04-28 (proposed)
+**Superseded date:** 2026-04-28
+**Related PR:** [#196](https://github.com/marianfoo/arc-1/pull/196) (NW 7.50 compatibility fixes — proposed `version` on SAPRead)
+
+## Resolution: superseded by maintainer design choice
+
+PR [#186](https://github.com/marianfoo/arc-1/pull/186) (merged 2026-04-28, the same day this ADR was drafted) shipped the etag-validated source cache and **also** added a user-facing `version: 'active' | 'inactive' | 'auto'` parameter to `SAPRead`. The maintainer judged that surfacing the version axis directly to LLMs was valuable enough to warrant the public-API change despite Principle #6 of the etag plan. ADR-0003 is therefore retained only as a record of the analysis at the time the PR-196 split was being designed; it does not reflect ARC-1's current shipped behavior.
+
+The analysis below is preserved verbatim. Read it as a snapshot of one design option, not a current recommendation. Two of its three claims still hold:
+
+- **Claim 1 (etag plan principle #6):** Correct — the etag plan internally tracked version as a cache-key axis. PR #186 implemented that *and* added the user-facing surface.
+- **Claim 2 (FEAT-DIFF as natural home for `version`):** Open question — FEAT-DIFF is still on the roadmap. SAPRead now has `version`; FEAT-DIFF will need to choose a different parameter name (e.g. `version1`/`version2` for two-revision diff) to avoid collision.
+- **Claim 3 (defer to avoid public-API churn):** Rejected by PR #186. The churn risk was judged smaller than the LLM-discoverability benefit.
+
+## Context (preserved from original draft)
+
+[PR #196](https://github.com/marianfoo/arc-1/pull/196) proposes adding `version: 'active' \| 'inactive'` to `SAPReadSchema` / `SAPReadSchemaBtp`, with an early-return path in [src/handlers/intent.ts](../../src/handlers/intent.ts) that appends `?version=…` to the source URL.
+
+The pre-existing etag-and-inactive-objects plan (commit `c9ebe47`, [docs/plans/etag-conditional-get-and-inactive-objects-fix.md](../plans/etag-conditional-get-and-inactive-objects-fix.md)) explicitly excluded this surface change in Design Principle #6:
+
+> **No breaking changes to the SAPRead schema.** This plan does not add a `version` parameter to the SAPRead Zod schema or tool description. The cache internally tracks versions for correctness; the surface stays exactly as today. A future plan can add the user-facing parameter if there's demand for reading inactive drafts directly.
+
+Live probe of A4H 758 SP02 confirmed both halves of this plan's reasoning are accurate:
+
+- The SAP server already supports `?version=active|inactive` on source URLs and returns different etags per version (DDLS `I_TIMEZONE` returned etag suffix `…0011` for active, `…0001` for inactive — exactly matching the etag plan's predicted cache-key shape).
+- Surfacing `version` on `SAPRead` would design a public API on top of a backend feature the etag plan already plans to consume internally.
+
+The roadmap also already lists [FEAT-24 CompareSource (Diff)](../../docs_page/roadmap.md) as the home for user-facing version-aware reads — *"Client-side diff of two revision sources — ADT has no server-side diff endpoint"*. Adding `version` on `SAPRead` now creates a near-future API churn (add now, possibly remove or restructure when FEAT-DIFF lands).
+
+PR [#179](https://github.com/marianfoo/arc-1/pull/179) (already merged) added `version: 'active' \| 'inactive'` to `SAPDiagnose action=syntax`, scoped to the syntax-check use case where active-vs-inactive matters today (post-write diagnostics on the inactive draft).
+
+## Original decision (not adopted)
+
+Defer surfacing `version` on `SAPRead` until FEAT-DIFF is designed. Concrete actions:
+
+1. Drop the `version` field from `SAPReadSchema` and `SAPReadSchemaBtp` in [src/handlers/schemas.ts](../../src/handlers/schemas.ts).
+2. Drop the early-return `version` branch in `handleSAPRead` (around line 1404 in PR #196's intent.ts) and the associated `SOURCE_TYPES` set.
+3. Drop the `version` property from the SAPRead JSON schema in [src/handlers/tools.ts](../../src/handlers/tools.ts).
+4. Treat the `version` axis as **cache-internal only**, exactly as the etag plan specifies. When the etag plan ships the cache key change to `(type, name, version)`, the existing `version` query parameter becomes part of the conditional-GET layer — invisible to LLMs.
+5. The STRU active/inactive lifecycle e2e test added by PR #196 ([tests/e2e/ddic-write.e2e.test.ts](../../tests/e2e/ddic-write.e2e.test.ts)) is restructured: assert STRU CRUD round-trip (create → activate → update → activate → delete) without a `version` parameter. The active/inactive comparison can be re-added later via `SAPDiagnose action=syntax version=…` (already exposed) if needed for regression coverage.
+
+## What main actually shipped
+
+PR #186 added `version: 'active' | 'inactive' | 'auto'` to both `SAPReadSchema` and `SAPReadSchemaBtp` (default `'active'`). The handler routes through the conditional-GET cache layer with the version axis as the cache key. STRU was independently collapsed into TABL by PR [#219](https://github.com/marianfoo/arc-1/pull/219). The combined effect: LLMs can now read active or inactive sources directly, and the etag-validated cache treats the two as separate cache entries (per the etag plan's internal design).
+
+## Lesson for future ADRs
+
+ADRs that recommend declining a feature are at higher risk of being superseded by parallel implementation work, especially in a fast-moving repo. When drafting an ADR that says "don't do X," check open PRs for in-flight work on the same feature before publishing — and link to those PRs in the ADR so reviewers see the trade-off being made simultaneously elsewhere.
+
+## References
+
+- [PR #186](https://github.com/marianfoo/arc-1/pull/186) — etag-validated source cache + `version` parameter (the change that superseded this ADR).
+- [docs/plans/etag-conditional-get-and-inactive-objects-fix.md](../plans/etag-conditional-get-and-inactive-objects-fix.md) — the pre-existing plan with Principle #6 (now overridden in practice).
+- [docs_page/roadmap.md](../../docs_page/roadmap.md) FEAT-24 CompareSource (Diff) — needs to choose a non-`version` parameter name to avoid collision with the now-shipped SAPRead `version`.
+- PR [#179](https://github.com/marianfoo/arc-1/pull/179) — SAPDiagnose `version` precedent.

--- a/docs/nw750-discovery-gap-analysis.md
+++ b/docs/nw750-discovery-gap-analysis.md
@@ -1,0 +1,185 @@
+# NW 7.50 ADT Discovery — Gap Analysis
+
+Cross-reference of every endpoint in the NW 7.50 ADT discovery document (`tests/fixtures/xml/discovery-nw750.xml`) against what ARC-1 implements. Only endpoints present in the discovery XML are listed — ARC-1 endpoints not in the discovery file (e.g., custom endpoints, OData services) are out of scope.
+
+## Potentially Valuable Gaps
+
+Endpoints present in NW 7.50 discovery but not implemented in ARC-1.
+
+| # | Discovery Endpoint | Title | Notes |
+|---|---|---|---|
+| 1 | `/sap/bc/adt/datapreview/cds` | Data Preview for CDS | Only `freestyle` and `ddic` are used. CDS preview supports association navigation. |
+| 2 | `/sap/bc/adt/abapsource/typehierarchy` | Type Hierarchy | Class/interface inheritance tree |
+| 3 | `/sap/bc/adt/abapsource/cleanup/source` | Source Cleanup | SAP's built-in source cleanup/refactoring |
+| 4 | `/sap/bc/adt/abapsource/codecompletion/elementinfo` | Element Info (code completion) | Hover-style type info for symbols |
+| 5 | `/sap/bc/adt/abapsource/codecompletion/insertion` | Code Insertion | Pattern-based code insertion |
+| 6 | `/sap/bc/adt/ddic/ddl/dependencies/graphdata` | DDL Dependency Graph | Server-computed CDS dependency graph |
+| 7 | `/sap/bc/adt/ddic/ddl/elementinfo` | DDL Element Info | CDS field/annotation metadata |
+| 8 | `/sap/bc/adt/ddic/ddl/elementinfos` | DDL Mass Element Info | Batch CDS field info |
+| 9 | `/sap/bc/adt/ddic/ddl/activeobject` | DDL Active Object | Resolve active CDS entity from data source |
+| 10 | `/sap/bc/adt/ddic/ddl/createstatements` | DDL sqlView Create Statement | Generated SQL view DDL |
+| 11 | `/sap/bc/adt/ddic/ddl/ddicrepositoryaccess` | DDL Dictionary Repository Access | CDS path-based field resolution |
+| 12 | `/sap/bc/adt/ddic/ddl/formatter/identifiers` | DDL Case Preserving Formatter | CDS identifier formatting |
+| 13 | `/sap/bc/adt/ddic/codecompletion` | DDIC Code Completion | Dictionary-level code completion |
+| 14 | `/sap/bc/adt/ddic/elementinfo` | DDIC Element Info | Dictionary element type info |
+| 15 | `/sap/bc/adt/ddic/typegroups` | Type Groups (TYPS) | Missing object type — can't read type group source |
+| 16 | `/sap/bc/adt/ddic/dbprocedureproxies` | Database Procedure Proxies | AMDP proxy objects |
+| 17 | `/sap/bc/adt/repository/informationsystem/usageSnippets` | Usage Snippets | Source snippets for where-used results |
+| 18 | `/sap/bc/adt/repository/informationsystem/messagesearch` | Message Search | Search T100 messages by text |
+| 19 | `/sap/bc/adt/repository/informationsystem/executableObjects` | Executable Objects | Find runnable programs |
+| 20 | `/sap/bc/adt/repository/informationsystem/fullnamemapping` | Full Name Mapping | Map full names to ADT URIs |
+| 21 | `/sap/bc/adt/repository/informationsystem/metadata` | Repository Metadata | Repository-level metadata |
+| 22 | `/sap/bc/adt/repository/informationsystem/objecttypes` | Object Types | Enumerate available object types |
+| 23 | `/sap/bc/adt/repository/informationsystem/releasestates` | Release States | C0/C1/C2 API release state list |
+| 24 | `/sap/bc/adt/repository/informationsystem/executableobjecttypes` | Executable Object Types | Enumerate executable object types |
+| 25 | `/sap/bc/adt/repository/nodepath` | Node Path | Object-to-package path |
+| 26 | `/sap/bc/adt/repository/objectstructure` | Object Structure | Object internal structure |
+| 27 | `/sap/bc/adt/repository/typestructure` | Type Structure | Type component breakdown |
+| 28 | `/sap/bc/adt/repository/proxyurimappings` | Proxy URI Mappings | Proxy URI resolution |
+| 29 | `/sap/bc/adt/oo/classrun` | Class Run | Execute `IF_OO_ADT_CLASSRUN` classes |
+| 30 | `/sap/bc/adt/oo/linenumber` | Line Number | Line mapping across includes |
+| 31 | `/sap/bc/adt/oo/validation/objectname` | OO Name Validation | Validate class/intf name before create |
+| 32 | `/sap/bc/adt/docu/abap/langu` | ABAP Language Help | ABAP keyword documentation |
+| 33 | `/sap/bc/adt/docu/ddl/langu` | DDL Language Help | CDS keyword documentation |
+| 34 | `/sap/bc/adt/docu/dcl/langu` | DCL Language Help | DCL keyword documentation |
+| 35 | `/sap/bc/adt/acm/dcl/parser` | DCL Parser Info | DCL parser metadata |
+| 36 | `/sap/bc/adt/acm/dcl/validation` | DCL Name Validation | Validate DCL name before create |
+| 37 | `/sap/bc/adt/ddic/ddl/parser` | DDL Parser Info | DDL parser metadata |
+| 38 | `/sap/bc/adt/ddic/ddl/validation` | DDL Name Validation | Validate DDL name before create |
+| 39 | `/sap/bc/adt/ddic/ddl/elementmappings` | DDL Element Mappings | CDS element mapping |
+| 40 | `/sap/bc/adt/ddic/ddl/elementmappings/strategies` | DDL Mapping Strategies | CDS mapping strategy options |
+| 41 | `/sap/bc/adt/classifications` | Object Classifications | C0/C1/C2 API release classification |
+| 42 | `/sap/bc/adt/runtime/traces/abaptraces/parameters` | Trace Parameters | Profiler trace configuration |
+| 43 | `/sap/bc/adt/runtime/traces/abaptraces/requests` | Trace Requests | Trigger profiler trace capture |
+| 44 | `/sap/bc/adt/enhancements/enhoxh` | Enhancement Implementation (alt URL) | ARC-1 uses `enhoxhb`, discovery lists `enhoxh` |
+| 45 | `/sap/bc/adt/enhancements/enhsxs` | Enhancement Spots | Enhancement spot definitions (not implementations) |
+| 46 | `/sap/bc/adt/xslt/transformations` | XSLT Transformations | Missing object type — XSLT/ST source |
+| 47 | `/sap/bc/adt/system/users` | Users | Query SAP users |
+| 48 | `/sap/bc/adt/system/clients` | Clients | List SAP clients |
+| 49 | `/sap/bc/adt/system/information` | System Information | System-level metadata |
+| 50 | `/sap/bc/adt/system/landscape/servers` | System Landscape | Application server list |
+| 51 | `/sap/bc/adt/packages/settings` | Package Settings | Package configuration metadata |
+| 52 | `/sap/bc/adt/cts/transportrequests/reference` | Transport Reference | Transport reference data |
+| 53 | `/sap/bc/adt/atc/customizing` | ATC Customizing | ATC check configuration |
+| 54 | `/sap/bc/adt/atc/ccstunnel` | ATC CCS Tunnel | CCS proxy tunnel |
+| 55 | `/sap/bc/adt/atc/results` | ATC Results | Persistent ATC result sets |
+| 56 | `/sap/bc/adt/atc/approvers` | ATC Approvers | Exemption approver list |
+| 57 | `/sap/bc/adt/atc/variants` | ATC Variants | Check variant list |
+| 58 | `/sap/bc/adt/atc/exemptions/apply` | ATC Exemptions | Apply ATC exemptions |
+| 59 | `/sap/bc/adt/checkruns/reporters` | Check Reporters | Available check reporters |
+| 60 | `/sap/bc/adt/basic/object/properties` | Basic Object Properties | Generic object property reader |
+| 61 | `/sap/bc/adt/urifragmentmappings` | URI Fragment Mapper | Map URI fragments to plain text |
+| 62 | `/sap/bc/adt/abapsource/occurencemarkers` | Occurrence Markers | Highlight all occurrences of a symbol |
+| 63 | `/sap/bc/adt/abapsource/parsers/rnd/grammar` | ABAP Parser Grammar | ABAP parser metadata |
+| 64 | `/sap/bc/adt/abapsource/abapdoc/exportjobs` | ABAP Doc Export | Export ABAP documentation |
+| 65 | `/sap/bc/adt/sqlm/data` | SQLM Marker Data | SQL Monitor marker data |
+| 66 | `/sap/bc/adt/security/reentranceticket` | Reentrance Ticket | Security reentrance ticket |
+| 67 | `/sap/bc/adt/ato/settings` | ATO Settings | Adaptation Transport Organizer |
+| 68 | `/sap/bc/adt/sscr/registration/objects` | SSCR Object Registration | Developer key management |
+| 69 | `/sap/bc/adt/sscr/registration/objects/validation` | SSCR Object Validation | SSCR validation |
+| 70 | `/sap/bc/adt/sscr/registration/developers/validation` | SSCR Developer Validation | Developer registration validation |
+| 71 | `/sap/bc/adt/businesslogicextensions/badis` | BAdI Definitions | BAdI read + compatibility check |
+| 72 | `/sap/bc/adt/businesslogicextensions/badinameproposals` | BAdI Name Proposals | BAdI naming suggestions |
+| 73 | `/sap/bc/adt/ddic/dataelements/validation` | Data Element Validation | Validate DTEL name before create |
+| 74 | `/sap/bc/adt/ddic/structures/validation` | Structure Validation | Validate structure name before create |
+| 75 | `/sap/bc/adt/ddic/views/$validation` | View Validation | Validate view name |
+| 76 | `/sap/bc/adt/ddic/validation` | DDIC SQSC Validation | DDIC-level validation |
+| 77 | `/sap/bc/adt/ddic/typegroups/validation` | Type Group Validation | Validate type group name |
+| 78 | `/sap/bc/adt/enhancements/enhoxh/validation` | Enhancement Impl Validation | Validate ENHO name |
+| 79 | `/sap/bc/adt/enhancements/enhsxs/validation` | Enhancement Spot Validation | Validate ENHS name |
+| 80 | `/sap/bc/adt/programs/validation` | Program Validation | Validate program name before create |
+| 81 | `/sap/bc/adt/includes/validation` | Include Validation | Validate include name |
+| 82 | `/sap/bc/adt/functions/validation` | Function Group Validation | Validate FUGR name |
+| 83 | `/sap/bc/adt/messageclass/validation` | Message Class Validation | Validate MSAG name |
+| 84 | `/sap/bc/adt/filestore/ui5-bsp/ui5-rt-version` | SAPUI5 Runtime Version | UI5 runtime version info |
+| 85 | `/sap/bc/adt/filestore/ui5-bsp/deploy-storage` | UI5 Deploy Storage Marker | Deploy storage support flag |
+
+## Eclipse-Only / Not Useful for MCP (excluded)
+
+| Category | Count | Endpoints | Why excluded |
+|---|---|---|---|
+| BOPF | 8 | `/sap/bc/adt/bopf/*` | Legacy BOL/BOPF, Eclipse wizard-specific |
+| Solution Manager CM | 3 | `/sap/bc/adt/solutionmanager/cm/*` | SolMan Change Management integration |
+| UI Flexibility | 1 | `/sap/bc/adt/ui_flex_dta_folder/` | DTA folder deployment |
+| AMDP Debugger | 1 | `/sap/bc/adt/amdp/debugger/main` | Interactive HANA debugging session |
+| Code Composer | 6 | `/sap/bc/adt/cmp_code_composer/*` | Eclipse template wizard |
+| Dummy types | 4 | `/sap/bc/adt/dummygroup/*` | SAP internal test types |
+| Object Type Admin | 4 | `/sap/bc/adt/objtype_admin/*` | Object type registration admin |
+| Enterprise Services | 13 | `/sap/bc/esproxy/*` | SOA proxy management |
+| Feed Repository | 3 | `/sap/bc/adt/dataproviders`, `/feeds` | ADT internal feed framework |
+| Dynamic Logpoints | 3 | `/sap/bc/adt/dlp/*` | Interactive runtime logging |
+| Debugger | 12 | `/sap/bc/adt/debugger/*` | Interactive ABAP debugging |
+| Web Dynpro | 27 | `/sap/bc/adt/wdy/*` | WDA component editor |
+| FPM | 1 | `/sap/bc/adt/fpm/creationtools` | FPM wizard |
+| NHI / HANA Integration | 6 | `/sap/bc/adt/nhi/*` | HANA repository transport |
+| Data Preview AMDP | 2 | `/sap/bc/adt/datapreview/amdp*` | AMDP-specific preview |
+| ADT HTTP Endpoint | 1 | System-specific full URL | ADT framework internal |
+
+## Already Implemented
+
+| Endpoint | ARC-1 Usage |
+|---|---|
+| `/sap/bc/adt/programs/programs` | SAPRead PROG |
+| `/sap/bc/adt/programs/includes` | SAPRead INCL |
+| `/sap/bc/adt/oo/classes` | SAPRead CLAS |
+| `/sap/bc/adt/oo/interfaces` | SAPRead INTF |
+| `/sap/bc/adt/functions/groups` | SAPRead FUGR/FUNC |
+| `/sap/bc/adt/ddic/ddl/sources` | SAPRead DDLS |
+| `/sap/bc/adt/acm/dcl/sources` | SAPRead DCLS |
+| `/sap/bc/adt/ddic/structures` | SAPRead STRU |
+| `/sap/bc/adt/ddic/dataelements` | SAPRead DTEL |
+| `/sap/bc/adt/ddic/views` | SAPRead VIEW |
+| `/sap/bc/adt/messageclass` | SAPRead MSAG |
+| `/sap/bc/adt/repository/informationsystem/search` | SAPSearch (quick search) |
+| `/sap/bc/adt/repository/informationsystem/usageReferences` | Where-used analysis |
+| `/sap/bc/adt/repository/nodestructure` | Package hierarchy browsing |
+| `/sap/bc/adt/datapreview/ddic` | SAPQuery table preview |
+| `/sap/bc/adt/datapreview/freestyle` | SAPQuery free SQL |
+| `/sap/bc/adt/activation` | SAPActivate |
+| `/sap/bc/adt/activation/inactiveobjects` | List inactive objects |
+| `/sap/bc/adt/checkruns` | Pre-write syntax check |
+| `/sap/bc/adt/abapunit/testruns` | Unit test execution |
+| `/sap/bc/adt/atc/runs` + `worklists` | ATC check runs |
+| `/sap/bc/adt/quickfixes/evaluation` | Quick fix proposals |
+| `/sap/bc/adt/abapsource/prettyprinter` + `/settings` | Pretty printer |
+| `/sap/bc/adt/abapsource/codecompletion/proposal` | Code completion |
+| `/sap/bc/adt/navigation/target` | Go-to-definition |
+| `/sap/bc/adt/cts/transports` | Transport info check |
+| `/sap/bc/adt/cts/transportrequests` | Transport management |
+| `/sap/bc/adt/cts/transportchecks` | Transport requirement checks |
+| `/sap/bc/adt/refactorings` | Refactoring framework |
+| `/sap/bc/adt/refactoring/changepackage` | Package move (incorrectly gated at 754) |
+| `/sap/bc/adt/runtime/dumps` + `dump/{id}` | Short dump listing + detail |
+| `/sap/bc/adt/runtime/systemmessages` | SM02 system messages |
+| `/sap/bc/adt/runtime/traces/abaptraces` | Profiler trace listing + detail |
+| `/sap/bc/adt/gw/errorlog` | Gateway error log |
+| `/sap/bc/adt/system/components` | System detection (SAP_BASIS release) |
+| `/sap/bc/adt/filestore/ui5-bsp/objects` | UI5 BSP app listing |
+
+## Top 10 Most Valuable Gaps (ranked by MCP usefulness)
+
+1. **`/sap/bc/adt/ddic/ddl/dependencies/graphdata`** — CDS dependency graph. Would supercharge `SAPContext action="impact"` with server-computed dependency trees instead of client-side where-used traversal.
+
+2. **`/sap/bc/adt/datapreview/cds`** — CDS-aware data preview with association navigation. Currently ARC-1 only has `ddic` (table) and `freestyle` (SQL). CDS preview would enable reading CDS view data directly.
+
+3. **`/sap/bc/adt/abapsource/typehierarchy`** — Inheritance tree. Useful when an LLM needs to understand class hierarchies for refactoring.
+
+4. **`/sap/bc/adt/ddic/typegroups`** — Type groups (TYPS). A missing object type — can't read type group source.
+
+5. **`/sap/bc/adt/classifications`** — API release classification (C0/C1/C2). Important for cloud-readiness checks.
+
+6. **`/sap/bc/adt/repository/informationsystem/messagesearch`** — Search T100 messages by text. Currently requires SQL (`SAPQuery`).
+
+7. **`/sap/bc/adt/xslt/transformations`** — XSLT/Simple Transformations source. A missing object type.
+
+8. **`/sap/bc/adt/oo/classrun`** — Execute `IF_OO_ADT_CLASSRUN` classes. Could enable running console apps.
+
+9. **`/sap/bc/adt/enhancements/enhsxs`** — Enhancement spots. Currently only ENHO (implementations) is supported, not ENHS (spots).
+
+10. **`/sap/bc/adt/businesslogicextensions/badis`** — BAdI definitions. Would let an LLM read BAdI structures and run compatibility checks.
+
+## Known Issues Found
+
+- **`change_package` incorrectly gated at `minRelease: 754`** — The NW 7.50 discovery XML (line 1287) explicitly lists `/sap/bc/adt/refactoring/changepackage` with title "Change Package Assignment". The `ACTION_RELEASE_GATES` entry in `tools.ts` and `intent.ts` should be removed.
+
+- **`enhoxh` vs `enhoxhb` URL mismatch** — Discovery lists `/sap/bc/adt/enhancements/enhoxh`, but ARC-1 uses `/sap/bc/adt/enhancements/enhoxhb`. Both may exist; worth verifying which URL the probe catalog should reference.

--- a/docs/plans/discovery-driven-endpoint-routing.md
+++ b/docs/plans/discovery-driven-endpoint-routing.md
@@ -1,0 +1,282 @@
+# ARCH-01 — Discovery-driven Endpoint Routing
+
+## Overview
+
+Replace the static SAP_BASIS release maps proposed in [PR #196](https://github.com/marianfoo/arc-1/pull/196) with a routing primitive that reads the truth from the SAP system's own `/sap/bc/adt/discovery` feed. The discovery feed already lists every collection the system publishes; the static release maps were a manually-maintained proxy for what the feed says directly.
+
+This plan implements the foundation. A follow-up plan ([discovery-driven-routing-cleanup.md](#) — to be created after this lands) consumes the foundation by removing the release-version literals and the `isRelease750()` helper from PR #196 and rewriting tool-enum filtering.
+
+This plan ships ARCH-01 only (the new helpers + the lazy load path + the test fixtures). The static maps from PR #196 do not touch this PR — they ship in PR-ε after this PR merges.
+
+Context, decision, and consequences are recorded in [docs/adr/0001-discovery-driven-endpoint-routing.md](../adr/0001-discovery-driven-endpoint-routing.md). Live evidence captured 2026-04-28 against A4H 758 SP02 and NPL 750 SP02 confirms the discovery feed is the right authority: A4H lists `/sap/bc/adt/ddic/tables`, NPL doesn't; A4H lists `/ddic/domains`, NPL doesn't; A4H lists both `enhancements/enhoxh` + `enhoxhb`, NPL only `enhoxh` — a precision the SAP_BASIS release literal cannot express.
+
+## Context
+
+### Current State
+
+- [src/adt/discovery.ts](../../src/adt/discovery.ts) `fetchDiscoveryDocument` is called once per startup probe in MCP-server mode (via `runStartupProbe` in [src/server/server.ts](../../src/server/server.ts)). Result is stored as a `DiscoveryMap` (path → accepted MIME types) and consumed by `resolveAcceptType` / `resolveContentType` in the HTTP layer.
+- [src/adt/xml-parser.ts](../../src/adt/xml-parser.ts) `parseDiscoveryDocument` only retains collections that have `<app:accept>` elements (necessary for MIME negotiation). Collections without `<app:accept>` are dropped — but those still indicate an available endpoint. Live counts: A4H 671 total / 232 with-accept / 439 without; NPL 214 total / 32 with-accept / 182 without.
+- The CLI `arc1-cli call …` path does **not** invoke `runStartupProbe`. Discovery is fetched lazily by the HTTP layer's first content-type-resolution call. This means routing decisions that depend on discovery must trigger the lazy load — they cannot rely on `cachedDiscovery` being populated synchronously.
+- [src/handlers/intent.ts](../../src/handlers/intent.ts) `objectBasePath` (the per-type URL mapper) hard-codes one URL per type (e.g., `TABL → /sap/bc/adt/ddic/tables/`). When SAP doesn't publish that endpoint, requests 404 with a misleading "Object not found" hint.
+- [src/handlers/tools.ts](../../src/handlers/tools.ts) `filterByRelease` (introduced by PR #196) prunes types from the SAPRead/SAPWrite enums based on `cachedFeatures.abapRelease`. `cachedFeatures` is populated lazily but does **not** reach the CLI fast path (live verified 2026-04-28: NPL TABL read via CLI hits `/ddic/tables` and 404s because `isRelease750()` returns false).
+- Two probe fixtures in [tests/fixtures/probe/](../../tests/fixtures/probe/) (`npl-750-sp02-dev-edition` and `ecc-ehp8-nw750-sp31-onprem-prod`) capture real SAP responses. They become the regression set for this plan.
+
+### Target State
+
+- A new `discoveryHasCollection(uri: string): boolean` helper consults a per-client `discoveryAvailability` cache (set of normalized hrefs) populated from the discovery feed, including collections without `<app:accept>` elements.
+- A new `resolveSourceUrl(type, name)` helper in [src/handlers/intent.ts](../../src/handlers/intent.ts) returns either `{ url: string }` for the first available candidate URL, or `{ unavailable: string }` with an actionable hint that does not name a SAP_BASIS release literal.
+- A per-type candidate-URL list lives in one place — `RESOLVE_RULES` table in `intent.ts`, structured as `Map<type, OrderedCandidates>` where each candidate is a `{ collectionUri, urlBuilder, hintOnFallback? }`.
+- `filterByDiscovery(items, typeToCollection, discoveryAvailability)` replaces (in PR-ε) `filterByRelease` for tool-enum filtering. This plan ships the new helper; the swap-out happens in PR-ε.
+- A small augmentation to `parseDiscoveryDocument` returns both the existing accept-types map AND a new "all collections" set that includes accept-less collections.
+- CLI mode populates the same discovery cache on first `AdtClient` construction (lazy, single-flight).
+- Tests cover routing decisions against both probe fixtures (NPL 7.50, ECC EHP8) plus a synthesized A4H 758 fixture captured during this plan's verification.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/discovery.ts` | Add `discoveryHasCollection` helper; expose collection-availability set; integrate lazy load on first AdtClient use |
+| `src/adt/xml-parser.ts` | `parseDiscoveryDocument` returns both accept-types map and full collection set |
+| `src/adt/types.ts` | `DiscoveryMap` augmented with `available: Set<string>` (or new sibling type `DiscoveryAvailability`) |
+| `src/adt/http.ts` | `AdtHttpClient` lazy-loads discovery on first construction (single-flight via existing infra), exposes accessor |
+| `src/handlers/intent.ts` | `resolveSourceUrl(type, name)` helper + `RESOLVE_RULES` table |
+| `src/handlers/tools.ts` | New `filterByDiscovery(items, typeToCollection)` (consumed by PR-ε; ships unused but tested here) |
+| `src/server/server.ts` | `runStartupProbe` populates the new availability set in addition to the existing MIME map |
+| `tests/unit/adt/discovery.test.ts` | Unit tests for `discoveryHasCollection` |
+| `tests/unit/adt/xml-parser.test.ts` | Tests for the augmented `parseDiscoveryDocument` (accept-less collections retained) |
+| `tests/unit/handlers/intent.test.ts` | Tests for `resolveSourceUrl` against synthetic discovery maps |
+| `tests/unit/handlers/tools.test.ts` | Tests for `filterByDiscovery` |
+| `tests/fixtures/probe/a4h-758-sp02-onprem/` | New probe fixture from live A4H discovery (capture during plan implementation) |
+| `tests/fixtures/probe/npl-750-sp02-dev-edition/responses/GET__sap_bc_adt_discovery.xml` | Confirm exists; if not, add for tests |
+| `CLAUDE.md` | Architecture: Request Flow note for "discovery-driven URL resolution"; Key Files row for "Add SAP version-quirk workaround" updated to reference `resolveSourceUrl` instead of release literals |
+| `docs_page/architecture.md` | New subsection: how discovery drives endpoint routing |
+
+### Design Principles
+
+1. **Discovery is the source of truth for endpoint availability.** The release literal is a proxy; the discovery feed is the authority. When SAP back-ports a collection to NW 7.50 SP15, ARC-1 picks it up automatically.
+2. **Graceful degradation when discovery is unavailable.** `fetchDiscoveryDocument` already returns an empty map on failure. The new `discoveryHasCollection` returns `false` on an empty set, which routes to "use the canonical URL and surface SAP's response" — defensive default that doesn't worsen current behavior.
+3. **Candidate-list per type, ordered.** When multiple URLs can serve the same type (e.g., `TABL → /ddic/tables` first, fallback `/ddic/structures` second), the order is deterministic and documented in `RESOLVE_RULES`. A4H prefers `/ddic/tables` (richer table metadata); NPL falls through to `/ddic/structures`.
+4. **No SAP_BASIS version literals in routing code.** This plan introduces zero `release < 751` checks. The only place release literals remain is the lock-conflict heuristic (covered by ADR-0002) — entirely separate concern.
+5. **Lazy load preserves CLI parity.** Single-flight discovery fetch on first AdtClient construction means CLI and MCP-server paths see the same routing decisions — the bug surfaced by live probe (NPL TABL via CLI 404s because `cachedFeatures` empty) goes away because routing keys off discovery, which loads on demand.
+6. **Unused-helper smell tolerated for one PR.** `filterByDiscovery` ships in this plan but is consumed by PR-ε. Tests cover it; it sits dormant in `tools.ts` until PR-ε removes the static maps. This is preferable to a giant single PR that mixes foundation with cleanup.
+
+## Development Approach
+
+Implement in five passes:
+
+1. Augment the discovery parser to retain accept-less collections (smallest unit; pure function refactor).
+2. Add the availability accessor to `AdtHttpClient` and the `runStartupProbe` integration.
+3. Implement `resolveSourceUrl` and the `RESOLVE_RULES` table.
+4. Implement `filterByDiscovery` (used by PR-ε but tested here).
+5. Tests, fixtures, and docs.
+
+The capture of an A4H 758 fixture happens during Task 1 — copy `/tmp/probe/a4h-discovery.xml` from the live verification into `tests/fixtures/probe/a4h-758-sp02-onprem/responses/GET__sap_bc_adt_discovery.xml` so the same file drives unit tests.
+
+## Validation Commands
+
+- `npm test`
+- `npm test -- tests/unit/adt/discovery.test.ts`
+- `npm test -- tests/unit/adt/xml-parser.test.ts`
+- `npm test -- tests/unit/handlers/intent.test.ts`
+- `npm test -- tests/unit/handlers/tools.test.ts`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Augment `parseDiscoveryDocument` to retain accept-less collections
+
+**Files:**
+- Modify: `src/adt/xml-parser.ts`
+- Modify: `src/adt/types.ts`
+- Modify: `tests/unit/adt/xml-parser.test.ts`
+- Add: `tests/fixtures/probe/a4h-758-sp02-onprem/responses/GET__sap_bc_adt_discovery.xml` (capture from live A4H system per Approach above)
+
+The current parser drops collections without `<app:accept>` because they're useless for MIME negotiation. For routing-availability, every published collection matters.
+
+- [ ] Add a new exported type in `src/adt/types.ts`:
+    ```ts
+    export interface DiscoveryParseResult {
+      mimeMap: Map<string, string[]>;
+      availableCollections: Set<string>;
+    }
+    ```
+- [ ] Modify `parseDiscoveryDocument(xml: string): DiscoveryParseResult` to return both:
+    - The existing `mimeMap` (path → accept types, only entries with `<app:accept>` retained — preserves current MIME negotiation contract).
+    - A new `availableCollections` Set containing every collection's normalized href, regardless of whether it has accept types.
+- [ ] Update all callers of `parseDiscoveryDocument` to consume the new shape. There is exactly one external caller (`fetchDiscoveryDocument` in `src/adt/discovery.ts`); update it.
+- [ ] Capture the live A4H discovery XML to `tests/fixtures/probe/a4h-758-sp02-onprem/responses/GET__sap_bc_adt_discovery.xml`. Use the file already saved at `/tmp/probe/a4h-discovery.xml` from prior probing, or re-run: `curl -su MARIAN:$SAP_PASSWORD "http://a4h.marianzeis.de:50000/sap/bc/adt/discovery?sap-client=001" -H "Accept: application/atomsvc+xml" > tests/fixtures/probe/a4h-758-sp02-onprem/responses/GET__sap_bc_adt_discovery.xml`. Add a sibling `meta.json` with `{"systemId": "A4H", "release": "758", "spLevel": "0002"}` for documentation.
+- [ ] Add unit tests (~5 tests) in `tests/unit/adt/xml-parser.test.ts`:
+    - **Test 1**: Parse the A4H fixture — `availableCollections.size > 600`, `mimeMap.size` matches the existing assertion (regression check).
+    - **Test 2**: Parse the NPL fixture (use existing `tests/fixtures/probe/npl-750-sp02-dev-edition/...` if discovery XML is captured; otherwise add it now) — `availableCollections.size > 200`.
+    - **Test 3**: A4H fixture contains `/sap/bc/adt/ddic/tables` AND `/sap/bc/adt/ddic/structures` AND `/sap/bc/adt/ddic/domains` AND `/sap/bc/adt/ddic/ddlx/sources` AND `/sap/bc/adt/bo/behaviordefinitions` AND `/sap/bc/adt/businessservices/bindings` in `availableCollections`.
+    - **Test 4**: NPL fixture contains `/sap/bc/adt/ddic/structures` but NOT `/sap/bc/adt/ddic/tables`, NOT `/sap/bc/adt/ddic/domains`, NOT `/sap/bc/adt/ddic/ddlx/sources`, NOT `/sap/bc/adt/bo/behaviordefinitions`.
+    - **Test 5**: Empty XML → `{ mimeMap: empty, availableCollections: empty }` (graceful).
+- [ ] Run `npm test -- tests/unit/adt/xml-parser.test.ts` — all tests must pass.
+
+### Task 2: Expose discovery availability via `discoveryHasCollection`
+
+**Files:**
+- Modify: `src/adt/discovery.ts`
+- Modify: `src/adt/http.ts`
+- Modify: `tests/unit/adt/discovery.test.ts`
+
+A single helper that callers can ask "is this collection published?". Lazy-load semantics already exist for the MIME map; reuse the same cache lifecycle.
+
+- [ ] In `src/adt/discovery.ts`, change `fetchDiscoveryDocument(client)` to return `Promise<DiscoveryParseResult>` (same shape as the new parser). Update all internal callers and the `runStartupProbe` integration in `src/server/server.ts`.
+- [ ] Add `export function discoveryHasCollection(availability: Set<string>, uri: string): boolean`:
+    - Normalizes `uri` (strip trailing slash, ensure leading slash).
+    - Returns `availability.has(normalized)`.
+    - Returns `false` when `availability` is empty (graceful degradation).
+- [ ] In `AdtHttpClient` (in `src/adt/http.ts`), expose the discovery availability as `getDiscoveryAvailability(): Promise<Set<string>>` — single-flight: if cached, return immediately; if not, kick off `fetchDiscoveryDocument` and cache the result.
+- [ ] Add unit tests (~4 tests) in `tests/unit/adt/discovery.test.ts`:
+    - **Test 1**: `discoveryHasCollection(set, '/sap/bc/adt/ddic/tables')` returns `true` when the set contains the path.
+    - **Test 2**: Trailing-slash variant: `discoveryHasCollection(set, '/sap/bc/adt/ddic/tables/')` returns `true` when the set contains either form.
+    - **Test 3**: Empty set → returns `false` for any input.
+    - **Test 4**: Path not in set → returns `false`.
+- [ ] Run `npm test -- tests/unit/adt/discovery.test.ts` — all tests must pass.
+
+### Task 3: Implement `resolveSourceUrl` with `RESOLVE_RULES`
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+The per-type candidate-URL table is the consumer of `discoveryHasCollection`. This is the function PR-ε will call instead of `objectBasePath` for the affected types.
+
+- [ ] Add a `RESOLVE_RULES` table in `src/handlers/intent.ts` near `objectBasePath`. Each entry maps a type to an ordered list of candidates. Initial entries (informed by the live probe data captured in [docs/adr/0001-discovery-driven-endpoint-routing.md](../adr/0001-discovery-driven-endpoint-routing.md)):
+    ```ts
+    type Candidate = {
+      collectionUri: string;
+      buildUrl: (name: string) => string;
+    };
+    const RESOLVE_RULES: Record<string, { candidates: Candidate[]; unavailableHint: string }> = {
+      TABL: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/ddic/tables', buildUrl: (n) => `/sap/bc/adt/ddic/tables/${encodeURIComponent(n)}` },
+          { collectionUri: '/sap/bc/adt/ddic/structures', buildUrl: (n) => `/sap/bc/adt/ddic/structures/${encodeURIComponent(n)}` },
+        ],
+        unavailableHint: 'Neither /ddic/tables nor /ddic/structures is published by this SAP system. Use SE11 in SAP GUI.',
+      },
+      STRU: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/ddic/structures', buildUrl: (n) => `/sap/bc/adt/ddic/structures/${encodeURIComponent(n)}` },
+        ],
+        unavailableHint: '/ddic/structures is not published by this SAP system. Use SE11 in SAP GUI.',
+      },
+      DOMA: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/ddic/domains', buildUrl: (n) => `/sap/bc/adt/ddic/domains/${encodeURIComponent(n)}` },
+        ],
+        unavailableHint: '/ddic/domains is not published by this SAP system. Use SE11 in SAP GUI, or query DD01L via SAPQuery.',
+      },
+      DDLX: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/ddic/ddlx/sources', buildUrl: (n) => `/sap/bc/adt/ddic/ddlx/sources/${encodeURIComponent(n)}` },
+        ],
+        unavailableHint: 'CDS metadata extensions (DDLX) are not published by this SAP system.',
+      },
+      BDEF: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/bo/behaviordefinitions', buildUrl: (n) => `/sap/bc/adt/bo/behaviordefinitions/${encodeURIComponent(n)}` },
+        ],
+        unavailableHint: 'Behavior definitions (BDEF) are not published by this SAP system.',
+      },
+      SRVD: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/ddic/srvd/sources', buildUrl: (n) => `/sap/bc/adt/ddic/srvd/sources/${encodeURIComponent(n)}` },
+        ],
+        unavailableHint: 'Service definitions (SRVD) are not published by this SAP system.',
+      },
+      SRVB: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/businessservices/bindings', buildUrl: (n) => `/sap/bc/adt/businessservices/bindings/${encodeURIComponent(n)}` },
+        ],
+        unavailableHint: 'Service bindings (SRVB) are not published by this SAP system.',
+      },
+      SKTD: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/documentation/ktd/documents', buildUrl: (n) => `/sap/bc/adt/documentation/ktd/documents/${encodeURIComponent(n.toLowerCase())}` },
+        ],
+        unavailableHint: 'Knowledge Transfer Documents (SKTD) are not published by this SAP system.',
+      },
+      AUTH: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/ddic/authorityfields', buildUrl: (n) => `/sap/bc/adt/ddic/authorityfields/${encodeURIComponent(n)}` },
+        ],
+        unavailableHint: 'Authorization fields (AUTH) are not published by this SAP system. Use SU20/SU21 in SAP GUI.',
+      },
+      FTG2: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/ddic/featuretoggles', buildUrl: (n) => `/sap/bc/adt/ddic/featuretoggles/${encodeURIComponent(n)}` },
+        ],
+        unavailableHint: 'Feature toggles (FTG2) are not published by this SAP system. Use SFW5 in SAP GUI.',
+      },
+      ENHO: {
+        candidates: [
+          { collectionUri: '/sap/bc/adt/enhancements/enhoxhb', buildUrl: (n) => `/sap/bc/adt/enhancements/enhoxhb/${encodeURIComponent(n)}` },
+          { collectionUri: '/sap/bc/adt/enhancements/enhoxh', buildUrl: (n) => `/sap/bc/adt/enhancements/enhoxh/${encodeURIComponent(n)}` },
+        ],
+        unavailableHint: 'Enhancement implementations (ENHO) are not published by this SAP system. Use SE18/SE19 in SAP GUI.',
+      },
+    };
+    ```
+    (Note the SKTD `toLowerCase` quirk — copies behavior from the existing `objectUrlForType` special case.)
+- [ ] Add `export async function resolveObjectUrl(client: AdtClient, type: string, name: string): Promise<{ url: string } | { unavailable: string }>`:
+    ```ts
+    const rule = RESOLVE_RULES[type];
+    if (!rule) return { url: objectUrlForType(type, name) }; // fallback to legacy mapper for types not in the table
+    const availability = await client.http.getDiscoveryAvailability();
+    for (const c of rule.candidates) {
+      if (discoveryHasCollection(availability, c.collectionUri)) return { url: c.buildUrl(name) };
+    }
+    return { unavailable: rule.unavailableHint };
+    ```
+- [ ] Add `export async function resolveSourceUrl(client: AdtClient, type: string, name: string): Promise<{ url: string } | { unavailable: string }>` — same as `resolveObjectUrl` but appends `/source/main` to the URL when an object URL is resolved.
+- [ ] Add unit tests (~6 tests) in `tests/unit/handlers/intent.test.ts`:
+    - **Test 1**: A4H availability set → `resolveObjectUrl(client, 'TABL', 'T000')` returns `{ url: '/sap/bc/adt/ddic/tables/T000' }`.
+    - **Test 2**: NPL availability set → `resolveObjectUrl(client, 'TABL', 'T000')` falls through to `{ url: '/sap/bc/adt/ddic/structures/T000' }`.
+    - **Test 3**: NPL availability set → `resolveObjectUrl(client, 'DOMA', 'ABAP_BOOL')` returns `{ unavailable: '...not published by this SAP system. Use SE11...' }`.
+    - **Test 4**: A4H availability set → `resolveObjectUrl(client, 'ENHO', 'ZE_FOO')` prefers `/enhoxhb`.
+    - **Test 5**: NPL availability set → `resolveObjectUrl(client, 'ENHO', 'ZE_FOO')` falls through to `/enhoxh`.
+    - **Test 6**: Empty discovery set → falls through to `unavailable` hints (graceful).
+- [ ] Run `npm test -- tests/unit/handlers/intent.test.ts` — all tests must pass.
+
+### Task 4: Implement `filterByDiscovery` (used by PR-ε)
+
+**Files:**
+- Modify: `src/handlers/tools.ts`
+- Modify: `tests/unit/handlers/tools.test.ts`
+
+The companion to `resolveSourceUrl` for tool-enum filtering. Ships unused in this PR but tested; PR-ε swaps `filterByRelease` → `filterByDiscovery` at the call sites.
+
+- [ ] Add `export function filterByDiscovery<T extends string>(items: readonly T[], typeToCollection: Record<string, string>, availability: Set<string>): T[]`:
+    - For each item: if it's not in `typeToCollection`, keep it (no gating). Otherwise keep iff `availability.has(typeToCollection[item])`.
+    - When `availability` is empty (discovery failed/unloaded), keep all items (defensive — same shape as `filterByRelease` for `release === 0`).
+- [ ] Add a `TYPE_TO_COLLECTION` table near `RESOLVE_RULES` (or import from `intent.ts`), keyed by the same types. The simplest copy is the first-candidate `collectionUri` from each `RESOLVE_RULES` entry.
+- [ ] Add unit tests (~4 tests) in `tests/unit/handlers/tools.test.ts`:
+    - **Test 1**: `filterByDiscovery(['TABL', 'STRU', 'DOMA'], {...}, npl-availability)` returns `['TABL', 'STRU']` (DOMA filtered out because NPL doesn't publish `/ddic/domains` — but TABL is kept because the type-to-collection table maps TABL to `/ddic/structures` for the routing purpose ... NOTE: we may want the gating-collection to be the *required* one, distinct from the routing first-choice. Decide during implementation: gating uses *any* candidate present, not just the first).
+    - **Test 2**: Empty availability set → all items returned.
+    - **Test 3**: Items not in `typeToCollection` → kept (e.g., `'CLAS'` is not gated).
+    - **Test 4**: Items where the gating collection is present → kept.
+- [ ] Run `npm test -- tests/unit/handlers/tools.test.ts` — all tests must pass.
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `docs_page/architecture.md`
+
+Make the new primitive discoverable for future contributors and explain the architectural shift.
+
+- [ ] In `CLAUDE.md` "Architecture: Request Flow" diagram, add a line under HTTP Request: *"Discovery-driven URL routing for selected types — see `RESOLVE_RULES` in `src/handlers/intent.ts`"*.
+- [ ] In the same `CLAUDE.md` Key Files table, replace the row for "Add SAP version-quirk workaround (NW 7.50 / S/4 gating)" with: *"Don't gate by SAP_BASIS release literal. Add an entry to `RESOLVE_RULES` in `src/handlers/intent.ts` listing ordered candidate collection URIs; `resolveObjectUrl` checks the discovery feed for availability. See [docs/adr/0001-discovery-driven-endpoint-routing.md](docs/adr/0001-discovery-driven-endpoint-routing.md)."*
+- [ ] In `docs_page/architecture.md`, add a subsection "Discovery-driven endpoint routing" (~200 words) describing the candidate-list pattern, the `discoveryHasCollection` primitive, and the graceful-degradation contract when discovery is unavailable.
+- [ ] Run `npm run lint` — no new lint errors.
+
+### Task 6: Final verification
+
+- [ ] Run `npm test` — all unit tests pass (target: ~5 parser tests, ~4 discovery helper tests, ~6 resolve helper tests, ~4 filter tests = ~19 new tests).
+- [ ] Run `npm run typecheck` — no errors.
+- [ ] Run `npm run lint` — no errors.
+- [ ] When `TEST_SAP_URL` is configured for both A4H and NPL: run an integration test that exercises `resolveObjectUrl(client, 'TABL', 'T000')` against both and asserts A4H returns `/ddic/tables/...` while NPL returns `/ddic/structures/...`. (Add as `tests/integration/discovery-routing.integration.test.ts` if it doesn't exist.)
+- [ ] Move this plan to `docs/plans/completed/`.
+- [ ] Schedule PR-ε (the cleanup that consumes this foundation) — see `docs/todo.md` "ARCH-01 follow-ups".

--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -1,6 +1,6 @@
 # ARC-1 Roadmap
 
-**Last Updated:** 2026-05-08
+**Last Updated:** 2026-05-08 (added ARCH-01 + PR-ε architecture entries)
 **Project:** ARC-1 (ABAP Relay Connector) — MCP Server for SAP ABAP Systems
 **Repository:** https://github.com/marianfoo/arc-1
 
@@ -51,6 +51,8 @@ SORT RULES for this table — DO NOT BREAK when adding rows:
 | ID | Feature | Priority | Effort | Category |
 |-----|---------|----------|--------|----------|
 | [BUG-01](#bug-01) | SAPActivate phantom success + CLI/server alignment (NW 7.50) — PR [#179](https://github.com/marianfoo/arc-1/pull/179) open | P0 | S | Bugs |
+| [ARCH-01](#arch-01) | Discovery-driven endpoint routing — replaces hard-coded per-type URLs with ordered candidate-list against `/sap/bc/adt/discovery` (TABL already does this via `resolveTablObjectUrl`; extend to DOMA, DDLX, BDEF, SRVD, SRVB, ENHO). Plan: [docs/plans/discovery-driven-endpoint-routing.md](../docs/plans/discovery-driven-endpoint-routing.md) | P1 | M | Architecture |
+| [PR-ε](#pr-epsilon) | Remove static SAP_BASIS release gates and `isRelease750()` helper after ARCH-01 lands; consume `resolveSourceUrl` + `filterByDiscovery` at the call sites that are still hard-coded | P1 | S | Architecture |
 | [FEAT-18](#feat-18) | Function Group Bulk Fetch | P1 | S | Features |
 | [FEAT-24](#feat-24) | CompareSource (Diff) | P1 ↑ (from P2, 2026-04-23 — last piece of code-review workflow trio with FEAT-20 + FEAT-49) | S | Features |
 | [DOC-01](#doc-01) | Copilot Studio Setup Guide | P1 | S | Docs |
@@ -115,6 +117,8 @@ SORT RULES for this table — DO NOT BREAK when adding rows:
 
 | ID | Feature | Completed | Category |
 |----|---------|-----------|----------|
+| — | PR-β three-file sync (MSAG `messages` schema property exposure) + universal write guards (mixed-case object name rejection on create + batch_create). Splits PR [#196](https://github.com/marianfoo/arc-1/pull/196). Plan: `docs/plans/pr-beta-three-file-sync-and-universal-guards.md` (now in `docs/plans/completed/` after merge). PR [#201](https://github.com/marianfoo/arc-1/pull/201). | 2026-05-08 | Features |
+| — | PR-α cookie hot-reload on stale 401 (`SAP_COOKIE_FILE` re-read on persistent 401, no restart needed; non-blocking startup auth-preflight in cookie-auth mode; cookie-aware LLM error hint). Splits PR [#196](https://github.com/marianfoo/arc-1/pull/196). PR [#200](https://github.com/marianfoo/arc-1/pull/200). | 2026-05-08 | Features |
 | [SEC-11](#sec-11) | Dependency & Supply-Chain Security — Tier 1 Foundation (cleared 9 npm audit advisories; Dependabot for npm/actions/docker with grouping + ignore rules; `npm audit` PR gate; GitHub Dependency Review; Trivy container scanning gating on release + advisory on dev; third-party action SHA pinning; workflow-level `permissions: contents: read`; SECURITY.md policy) | 2026-05-08 | Security |
 | — | Audit Plan B: read/write enum symmetry (`MSAG` added to `SAPREAD_TYPES_*`) + `FTG2 → FEATURE_TOGGLE` rename. Issue #218 follow-up; both old aliases (`MESSAGES`, `FTG2`) accepted for one minor with stderr deprecation warning. Verified live on a4h S/4HANA 2023 + npl NW 7.50 SP02. | 2026-05-08 | Features |
 | — | Audit-driven purge of invented ADT slash aliases (issue #218 follow-up, Plan A — PR #223). Removes `FUNC/FM`, `CLAS/LI`, `VIEW/V`, `TRAN/O` from `SLASH_TYPE_MAP`; repoints `FUGR/FF → FUNC` (was `→ FUGR`); adds real `VIEW/DV → VIEW` and `TRAN/T → TRAN`; adds `objectBasePath('VIEW')` (DDIC view reads were silently broken via fallthrough to `/programs/programs/`); adds `KNOWN_BASE_TYPES` exhaustiveness guard + `SLASH_TYPE_EVIDENCE` citation guard so this bug class can't recur. Verified against a4h S/4HANA 2023 + npl NW 7.50. | 2026-05-08 | Compatibility |
@@ -1782,6 +1786,43 @@ For FUGR (function groups), the same pattern applies with `objecttype=FUGR/P` an
 **PR #179 fix summary:** inactive-objects detection in parse result (including owning user from `ioc:transport[@_user]`), endpoint fallback, flat-shape parser support, new `version` parameter plumbed through, `<chkrun:checkMessage>` position extraction, and a new `inactiveSyntaxDiagnostic()` primitive invoked on activation failure to append compiler errors from the inactive version.
 
 **Blast radius:** Every activation path (`SAPActivate`, RAP batch activation, E2E suites). Needs the missing E2E regression test the PR description calls out: create a class with a deliberate type error → attempt `SAPActivate` → assert failure → assert the returned message names the user and includes compiler text.
+
+---
+
+<a id="arch-01"></a>
+### ARCH-01: Discovery-driven Endpoint Routing
+
+| Field | Value |
+|-------|-------|
+| **Priority** | P1 |
+| **Effort** | M (3-5 days) |
+| **Risk** | Medium — touches discovery, intent, tools layers |
+| **Usefulness** | High — replaces brittle hard-coded URLs with self-correcting routing |
+| **Status** | **Plan ready** — [docs/plans/discovery-driven-endpoint-routing.md](../docs/plans/discovery-driven-endpoint-routing.md); decision recorded in [docs/adr/0001-discovery-driven-endpoint-routing.md](../docs/adr/0001-discovery-driven-endpoint-routing.md) |
+| **Blocks** | PR-ε (release-gate cleanup, if any release literals are reintroduced before ARCH-01 lands) |
+
+**What:** Generalize the discovery-driven URL pattern (`resolveTablObjectUrl` already does this for TABL — falls back from `/ddic/tables` to `/ddic/structures` based on what the SAP system publishes in `/sap/bc/adt/discovery`). Extend the same approach to other types where the URL varies across releases or where systems differ in which collections they expose: DOMA, DDLX, BDEF, SRVD, SRVB, ENHO. Adds one helper (`discoveryHasCollection(uri)`) plus a `RESOLVE_RULES` table mapping each type to an ordered candidate-URL list. Eliminates per-version branching in the handler hot path.
+
+**Why P1:** Foundation for replacing brittle release-version literals (`isRelease750()` and similar) anywhere they exist. Also makes the codebase self-correcting across SAP support packs — when SAP back-ports a collection, ARC-1 picks it up automatically. The pattern is already proven in `resolveTablObjectUrl`; this generalizes it.
+
+**Live evidence (captured 2026-04-28 against A4H 758 SP02 + NPL 750 SP02):** A4H discovery publishes `/ddic/{tables, structures, domains, ddlx/sources}, /bo/behaviordefinitions, /businessservices/bindings, /enhancements/{enhoxh, enhoxhb}`. NPL 750 publishes only `/ddic/{structures, dataelements, ddl/sources}, /enhancements/enhoxh, /messageclass, /businesslogicextensions/badis`. Discovery is the precise, machine-readable answer to "is this collection available."
+
+**Empirical input:** [docs/nw750-discovery-gap-analysis.md](../docs/nw750-discovery-gap-analysis.md) — endpoint-by-endpoint inventory contributed by PR [#196](https://github.com/marianfoo/arc-1/pull/196) author.
+
+---
+
+<a id="pr-epsilon"></a>
+### PR-ε: Remove Static Release Gates (consumes ARCH-01)
+
+| Field | Value |
+|-------|-------|
+| **Priority** | P1 |
+| **Effort** | S (1-2 days) |
+| **Risk** | Low — purely deletion + swap-in if release literals are reintroduced |
+| **Usefulness** | Maintenance — keeps the codebase free of `release < 751` literals once ARCH-01 lands |
+| **Status** | **Blocked on ARCH-01.** Currently a placeholder — the static release maps proposed in PR [#196](https://github.com/marianfoo/arc-1/pull/196) were not merged, so there is currently nothing to remove. If any future PR reintroduces release-version branching for endpoint routing, PR-ε replaces it with `resolveSourceUrl` / `filterByDiscovery`. |
+
+**Verification:** Each removal must be paired with a regression test against the NPL-7.50 probe fixture and a 758-class fixture, confirming the routing decision is identical to or better than what the literal would produce.
 
 ---
 


### PR DESCRIPTION
## Summary (after rebase, post-α/β merged)

This PR has been narrowed to its surviving content after the surrounding ship-now PRs landed:

- **PR-α (#200)** cookie hot-reload — **merged 2026-05-08**. Plan went into main with the implementation.
- **PR-β (#201)** three-file sync + universal write guards — **merged 2026-05-08**. Plan went into main with the implementation.
- **PR-γ (#202)** layered lock-conflict + MSAG transport guard — **in flight**, plan lives on its own branch.
- **PR #186** etag + `version=active|inactive` on SAPRead — **merged 2026-04-28**, which supersedes ADR-0003.

What remains in this PR is a tighter set of architectural artifacts:

| File | Purpose |
|---|---|
| `docs/adr/0001-discovery-driven-endpoint-routing.md` | Architectural decision: replace hard-coded URLs with discovery-driven routing. ARCH-01 plan implements it. |
| `docs/adr/0002-structured-exception-lock-conflict-reclassification.md` | Codifies the layered detection design that PR-γ (#202) implements. Reference updated to point at #202. |
| `docs/adr/0003-sapread-version-stays-internal.md` | **Superseded by PR #186.** Reframed with status `Superseded` and an explanation of what the maintainer chose to ship instead. The original analysis is preserved verbatim as a record of the trade-off considered at the time. |
| `docs/plans/discovery-driven-endpoint-routing.md` | ARCH-01 implementation plan (extends the `resolveTablObjectUrl` pattern that already exists in main to DOMA, DDLX, BDEF, SRVD, SRVB, ENHO). |
| `docs/nw750-discovery-gap-analysis.md` | Empirical endpoint inventory contributed by PR #196 author. Input data for ARCH-01. |
| `docs_page/roadmap.md` | Adds ARCH-01 (P1) + PR-ε (P1) to "Not Yet Implemented" with detail anchors. Adds PR-α + PR-β rows to the completed table. |

## What changed during the rebase

- **Reset branch to current `main`** to avoid a messy multi-conflict rebase. Main has had many roadmap updates that would have collided with the original PR #199 entries.
- **Re-added only the surviving content**: 3 ADRs (with ADR-0003 reframed) + ARCH-01 plan + gap analysis + roadmap entries.
- **Dropped**: the original PR's `docs/todo.md` changes (user reverted them locally) and the original roadmap entries that referenced PR-α/β/γ as pending (now historical).

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] All internal markdown links audited:
  - ADR-0001 → ARCH-01 plan + gap analysis ✓
  - ADR-0002 → PR #202 (plan lives on PR-γ's branch until merge) ✓
  - ADR-0003 → PR #186 (the change that superseded it) ✓
  - Roadmap → ADR + plan paths ✓

## Test plan

- [x] Diff matches expected scope (6 files, +726/-1)
- [x] No stale references to plan files that moved to per-PR branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)