### PR TITLE
feat: cookie hot-reload on stale 401

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,7 @@ HTTP Request (adt/http.ts)
   ├─ ETag / If-None-Match conditional GET for cached source reads
   ├─ CSRF token management (auto-fetch via HEAD, refresh on 403)
   ├─ Content negotiation fallback (one-retry on 406/415 with header mutation)
-  ├─ Cookie/session management
+  ├─ Cookie/session management (hot-reload from file on stale 401)
   ├─ Stateful sessions for lock→modify→unlock sequences
   │
   ▼
@@ -512,7 +512,8 @@ Automated via [release-please](https://github.com/googleapis/release-please). No
 - Sensitive fields (password, token, cookie) are redacted in logs
 - CSRF tokens are auto-managed by `src/adt/http.ts` (fetch via HEAD, refresh on 403)
 - **Safety config is the server ceiling** — per-user scopes (JWT) can only restrict further, never expand beyond server config
-- **Per-user auth never inherits shared credentials.** `buildAdtConfig(config, btpProxy?, bearerTokenProvider?, { perUser: true })` strips `username`/`password`/`cookies`. Any new Layer B field must respect this flag. Never add auth fields directly to `createPerUserClient`'s `adtConfig` without going through `buildAdtConfig`.
+- **Per-user auth never inherits shared credentials.** `buildAdtConfig(config, btpProxy?, bearerTokenProvider?, { perUser: true })` strips `username`/`password`/`cookies`/`cookieFile`/`cookieString`. Any new Layer B field must respect this flag. Never add auth fields directly to `createPerUserClient`'s `adtConfig` without going through `buildAdtConfig`.
+- **Cookie auth hot-reload.** When `SAP_COOKIE_FILE` is set, expired cookies do not require a restart. On persistent 401 the HTTP client clears stale cookies (`cookiesCleared` flag in `src/adt/http.ts`) and re-reads the file lazily on the next request. Startup auth-preflight is non-blocking in cookie-auth mode (downgrades 401 to `inconclusive`) so deployments don't deadlock when cookies are about to be re-extracted out-of-band. `SAP_COOKIE_STRING` cannot hot-reload (logged warning).
 - **All ADT endpoints have safety guards** — every `http.get/post/put/delete` call is preceded by `checkOperation()`. No unguarded HTTP calls.
 - **Error types matter**: `AdtApiError` (SAP HTTP error), `AdtSafetyError` (blocked by config), `AdtNetworkError` (connectivity). `intent.ts` formats these with LLM-friendly hints.
 - **Stateful sessions**: Lock→modify→unlock sequences must use `http.withStatefulSession()` to share cookies/CSRF tokens across requests

--- a/docs/plans/pr-alpha-cookie-hot-reload.md
+++ b/docs/plans/pr-alpha-cookie-hot-reload.md
@@ -1,0 +1,196 @@
+# PR-α — Cookie Hot-Reload on Stale 401
+
+## Overview
+
+Today, when ARC-1 is configured with `SAP_COOKIE_FILE` and the SAP session cookies expire, every subsequent ADT call fails with a 401 until the operator restarts the process. This punishes long-running deployments and forces a service interruption for what is purely a credential-refresh problem.
+
+This PR adds a **lazy cookie-reload mechanism**: on a persistent 401 in cookie-auth mode, the client clears the in-memory cookie jar and re-reads the configured `cookieFile` (or, where applicable, `cookieString`) on the **next** outgoing request. The mechanism never polls, never restarts on its own, and never expands the auth surface — it simply lets `arc1-cli extract-cookies` (or any equivalent refresh) take effect without a process restart.
+
+This PR is the first of three "ship-now" splits of [PR #196](https://github.com/marianfoo/arc-1/pull/196), cherry-picked because the cookie-reload work is fully orthogonal to the NW 7.50 compatibility work in that PR. The architectural decisions and plans for the rest of PR #196 are captured under `docs/adr/0001..0003.md` and `docs/plans/discovery-driven-endpoint-routing.md`.
+
+## Context
+
+### Current State
+
+- [src/adt/http.ts](../../src/adt/http.ts) holds the cookie jar in `AdtHttpClient.cookieJar` plus the configured static cookies in `this.config.cookies`. The 401 retry block at lines 470–540 already resets cookies + CSRF and retries once, but if the second attempt also returns 401 the cookies remain stale until the next process restart.
+- [src/adt/cookies.ts](../../src/adt/cookies.ts) exposes `resolveCookies(cookieFile, cookieString)` — a pure file-and-string parser that returns a `Record<string, name>` or `undefined`.
+- [src/server/server.ts](../../src/server/server.ts) `buildAdtConfig` (line ~170) currently passes `cookies: resolveCookies(...)` to the AdtClient on construction but does **not** pass the original `cookieFile` / `cookieString` paths, so the client cannot reload them later.
+- [src/server/server.ts](../../src/server/server.ts) `runStartupAuthPreflight` treats a 401 on `/sap/bc/adt/core/discovery` as a **blocking** failure and refuses to start the MCP server. Combined with cookie auth, this means an expired-cookie startup hangs the deployment.
+- The cookie-aware 401 hint in [src/handlers/intent.ts](../../src/handlers/intent.ts) `formatErrorForLLM` does not exist — operators see a generic "Authorization error. Check SAP_CLIENT, SAP_USER, SAP_PASSWORD" message that is wrong for cookie auth.
+
+### Target State
+
+- `AdtClientConfig` and `AdtHttpConfig` carry `cookieFile?` and `cookieString?` so the runtime client can reload from the original source.
+- On a persistent 401 in cookie-auth mode (i.e., either `cookieFile` or `cookieString` is configured), the client clears `this.config.cookies` and sets a `cookiesCleared` flag.
+- On the **next** outgoing request, the client checks `cookiesCleared && isCookieAuthMode()` and re-runs `resolveCookies()` to repopulate cookies before sending. Refresh is lazy — never polled, never automatic mid-failed-request.
+- `cookieString`-only configurations log a one-time warning explaining that no automatic refresh is possible (the string is static; use `cookieFile` for hot-reload). The logic still clears stale cookies so the next request emits a clean auth failure.
+- `runStartupAuthPreflight` downgrades to **non-blocking `inconclusive`** when the connector is in cookie-auth mode and the preflight returns 401. The MCP server starts and the runtime cookie-reload path takes over on the first real ADT call.
+- `formatErrorForLLM` emits a cookie-aware hint when `config.cookieFile || config.cookieString` is set: *"Hint: SAP cookies have expired. Ask the user to re-extract cookies with `arc1-cli extract-cookies`. The next SAP call after extraction will automatically reload the fresh cookies — no restart needed."*
+- Every per-user PP client created via `buildAdtConfig({ perUser: true })` continues to **strip** `cookieFile` / `cookieString` (along with the existing `cookies` strip), so per-user clients never inherit shared-cookie auth.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/config.ts` | `AdtClientConfig` — add optional `cookieFile`, `cookieString` |
+| `src/adt/http.ts` | `AdtHttpConfig` — add optional `cookieFile`, `cookieString`. `AdtHttpClient` — `cookiesCleared` flag, `isCookieAuthMode`, `reloadCookiesFromSource`, lazy reload guard in `request()` and `fetchCsrfToken()`, 401-clears-cookies logic in retry path and HTML-login fallback |
+| `src/adt/client.ts` | `AdtClient` constructor passes the new fields through to `AdtHttpClient` |
+| `src/server/server.ts` | `buildAdtConfig` passes `cookieFile`/`cookieString` (and strips them when `perUser=true`); `buildStartupAuthFailureReason` tailors the cookie-auth message; `runStartupAuthPreflight` downgrades to non-blocking on cookie-auth 401 |
+| `src/handlers/intent.ts` | `formatErrorForLLM` / `buildBaseErrorMessage` — emit cookie-aware hint on `isUnauthorized || isForbidden` when cookie auth is configured |
+| `tests/unit/adt/http.test.ts` | Unit tests for the reload state machine (401 → clear → next request reloads → success) |
+| `tests/unit/server/server.test.ts` | `buildAdtConfig` perUser-strip tests for new fields; preflight downgrade test |
+| `tests/unit/handlers/intent.test.ts` | Cookie-auth hint formatting test |
+| `CLAUDE.md` | Architecture: Request Flow note + Security & Architectural Invariants entry for cookie hot-reload + buildAdtConfig perUser strip clause |
+| `docs_page/configuration-reference.md` | Document hot-reload behavior under `SAP_COOKIE_FILE` |
+| `docs_page/cli-guide.md` | Cross-reference: `arc1-cli extract-cookies` is now a runtime refresh, not a restart trigger |
+
+### Design Principles
+
+1. **Lazy reload, no polling.** Reload happens on the next request after a persistent 401 — never on a timer, never during a failed request. This matches the project pattern of "no clock dependency" used elsewhere (cf. etag plan principle 2).
+2. **Reload only when there is a source.** `cookieString` is static (no file to re-read). The implementation logs a one-time warn-level diagnostic when `cookieString` is the only source, then proceeds without reload. `cookieFile` is the only source that supports automatic refresh.
+3. **Preflight stays advisory in cookie mode.** Today's preflight is blocking on 401, which deadlocks deployments where cookies are about to be re-extracted out-of-band. In cookie-auth mode, downgrade to `inconclusive` + non-blocking and let runtime cookie-reload take over on the first real call.
+4. **Per-user PP clients never inherit shared-cookie state.** `buildAdtConfig({ perUser: true })` strips `cookieFile` and `cookieString` exactly the way it already strips `cookies`. This is enforced by the existing `if (!opts?.perUser)` block — the new fields go inside the same block.
+5. **No new env vars / CLI flags.** The mechanism reuses the existing `SAP_COOKIE_FILE` / `SAP_COOKIE_STRING` config surface; no profile or escape hatch is added. The behavior is automatic when cookie auth is detected.
+6. **Hot-reload never expands auth scope.** The reloaded cookies replace the stale cookies in `this.config.cookies`. The cookie jar from the failed session is **not** carried across the reload. This guarantees the post-reload request authenticates with exactly what `cookieFile` says, nothing more.
+
+## Development Approach
+
+Implement in three small passes: types and config plumbing first, then the reload state machine in `http.ts`, then the operator-facing hint in `intent.ts`. Each pass has its own test task. Documentation updates are bundled in the final task.
+
+The hot-reload state machine has three observable transitions to test:
+
+- **A → B**: cookie-auth client + persistent 401 → `cookies = {}`, `cookiesCleared = true`.
+- **B → A**: next request fires, `cookiesCleared` is true → `reloadCookiesFromSource()` runs → `cookiesCleared = false`, `cookies` repopulated from disk.
+- **B → B**: next request fires but `cookieFile` is missing/empty → `cookiesCleared = false`, warn-level diagnostic emitted, request proceeds with empty cookies (and likely fails 401 again, surfacing a clean error).
+
+Tests use the existing `mockResponse()` helper from `tests/helpers/mock-fetch.ts` and the `vi.mock('undici', …)` pattern already used in `tests/unit/adt/http.test.ts`. The cookie-file reload step is mocked at the `resolveCookies` boundary (or by writing a tmp file), per the test's preference.
+
+## Validation Commands
+
+- `npm test`
+- `npm test -- tests/unit/adt/http.test.ts`
+- `npm test -- tests/unit/server/server.test.ts`
+- `npm test -- tests/unit/handlers/intent.test.ts`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Plumb `cookieFile` / `cookieString` through ADT client config
+
+**Files:**
+- Modify: `src/adt/config.ts`
+- Modify: `src/adt/client.ts`
+- Modify: `src/adt/http.ts`
+
+Add the two optional fields so the runtime client can later reload its own cookies. Without this plumbing, the http client cannot reach back to the original source. No behavior change yet — this task is pure type plumbing.
+
+- [ ] Add `cookieFile?: string` and `cookieString?: string` to `AdtClientConfig` in `src/adt/config.ts` with one-line JSDoc each: *"Path to cookie file — enables hot-reload on stale auth"* and *"Inline cookie string — stored for config awareness (no hot-reload)"*.
+- [ ] Mirror the two fields onto `AdtHttpConfig` in `src/adt/http.ts` (interface near the top of the file).
+- [ ] Pass `config.cookieFile` and `config.cookieString` through `AdtClient` constructor in `src/adt/client.ts` to the `AdtHttpClient` config object (alongside the existing `cookies: config.cookies` line).
+- [ ] Run `npm run typecheck` — no errors.
+- [ ] Run `npm test` — all tests must pass (no logic changed; this asserts the type plumbing doesn't break existing tests).
+
+### Task 2: Implement lazy cookie reload on persistent 401
+
+**Files:**
+- Modify: `src/adt/http.ts`
+
+Add the state machine that clears stale cookies on persistent 401 and reloads them lazily on the next request. The reload mechanism is internal to `AdtHttpClient` and does not change any public API.
+
+- [ ] In `AdtHttpClient`, add a private `cookiesCleared = false` flag (alongside existing `dbRetryInProgress`).
+- [ ] Add a private method `isCookieAuthMode(): boolean` that returns `!!(this.config.cookieFile || this.config.cookieString)`.
+- [ ] Add a private method `reloadCookiesFromSource(): void` that:
+    - Sets `this.cookiesCleared = false` first (so the reload is one-shot per cleared transition).
+    - When `!this.config.cookieFile && this.config.cookieString`, emits `logger.warn('SAP_COOKIE_STRING cannot be refreshed without restart. Use SAP_COOKIE_FILE for automatic reload.')` and returns.
+    - Otherwise calls `resolveCookies(this.config.cookieFile, this.config.cookieString)` (importing from `./cookies.js`).
+    - On success with non-empty result, assigns to `this.config.cookies` and emits `logger.info('Reloaded cookies from file', { cookieCount: Object.keys(fresh).length })`.
+    - On empty result, emits `logger.warn('Cookie reload returned empty result')` and leaves `this.config.cookies` unchanged (caller will see the same auth failure cleanly).
+    - On thrown error, emits `logger.warn('Failed to reload cookies from source', { error: <message> })` and leaves `this.config.cookies` unchanged.
+- [ ] In `request()` (the main public method), insert a lazy-reload guard after `Authorization` header is set but before the cookie header is built: `if (this.cookiesCleared && this.isCookieAuthMode()) this.reloadCookiesFromSource();`.
+- [ ] In the existing 401 retry block (around line 533), after the retried response is received: when `response.status === 401 && this.isCookieAuthMode()`, set `this.config.cookies = {}` and `this.cookiesCleared = true`, emit `logger.warn('Cookie auth: 401 persisted after retry — clearing stale cookies. Run \`arc1-cli extract-cookies\` to get fresh cookies; the next SAP call will reload them automatically.')`.
+- [ ] In the HTML-login-page fallback (around line 750), when the response is HTML+text/html and the body looks like a login page: if `isCookieAuthMode()` is true, set `this.config.cookies = {}` and `this.cookiesCleared = true` before throwing the existing AdtApiError(401).
+- [ ] In `fetchCsrfToken()`, mirror the lazy-reload guard at the start of the method (before building the cookie header) so a CSRF fetch on the next request also picks up reloaded cookies.
+- [ ] In `fetchCsrfToken()`'s 401 branch (around line 875), when `isCookieAuthMode()` is true, also clear cookies and set `cookiesCleared = true` before throwing.
+- [ ] Add unit tests (~6 tests) in `tests/unit/adt/http.test.ts` under a new `describe('cookie hot-reload', …)` block:
+    - **Test 1**: 401 retry that also returns 401 in cookie-auth mode sets `cookiesCleared` and clears `config.cookies`. Verify by inspecting public state after the failure (e.g., expose a tiny test-only getter, or assert via the next-request behavior in a follow-up call).
+    - **Test 2**: Next request after `cookiesCleared` re-reads cookies from a tmp file (use `os.tmpdir()` + `fs.writeFileSync` to create a real Netscape-format cookie file). Assert the request's `Cookie` header contains the new cookie value.
+    - **Test 3**: When only `cookieString` is configured (no `cookieFile`), reload emits the documented warn message and proceeds without reload.
+    - **Test 4**: When `resolveCookies()` returns an empty record (cookie file exists but is empty), warn message emitted and `config.cookies` left unchanged.
+    - **Test 5**: When the cookie file is unreadable (e.g., path doesn't exist), warn message emitted and `config.cookies` left unchanged.
+    - **Test 6**: HTML-login fallback path also clears cookies in cookie-auth mode (assert `cookiesCleared = true` after the throw).
+- [ ] Run `npm test -- tests/unit/adt/http.test.ts` — all new and existing tests must pass.
+
+### Task 3: Wire `cookieFile` / `cookieString` through `buildAdtConfig` and strip on perUser
+
+**Files:**
+- Modify: `src/server/server.ts`
+- Modify: `tests/unit/server/server.test.ts`
+
+The server-side config builder must hand the two fields to the AdtClient on shared-client paths and strip them on per-user (PP) paths so per-user clients never inherit shared cookie auth.
+
+- [ ] In `buildAdtConfig` (around line 170), inside the existing `if (!opts?.perUser)` block, after the `cookies` assignment, add:
+    - `adtConfig.cookieFile = config.cookieFile;`
+    - `adtConfig.cookieString = config.cookieString;`
+- [ ] Verify the per-user branch (the `else` of the same `if`) does **not** assign these fields. The default `Partial<AdtClientConfig>` shape already leaves them undefined.
+- [ ] In `tests/unit/server/server.test.ts`, extend the existing `describe('buildAdtConfig', …)` block with two tests:
+    - **Test A**: Shared-client config with `cookieFile: '/tmp/x.txt'` is passed through to the AdtClient config.
+    - **Test B**: Per-user config (`{ perUser: true }`) with `cookieFile` and `cookieString` set on `ServerConfig` strips both fields from the resulting AdtClient config (assert `adtConfig.cookieFile === undefined` and `adtConfig.cookieString === undefined`).
+- [ ] Run `npm test -- tests/unit/server/server.test.ts` — all tests must pass.
+
+### Task 4: Downgrade startup preflight to non-blocking in cookie-auth mode
+
+**Files:**
+- Modify: `src/server/server.ts`
+- Modify: `tests/unit/server/server.test.ts`
+
+A 401 during startup in cookie-auth mode is recoverable at runtime (the next call will reload cookies). Today's behavior — block startup — defeats the purpose of hot-reload because deployment never gets to the point where cookies can be refreshed.
+
+- [ ] Update `buildStartupAuthFailureReason(statusCode: number, config: ServerConfig)` to accept the config so it can branch on cookie-auth mode. When `statusCode === 401 && (config.cookieFile || config.cookieString)`, return: *"Authentication failed (401) during startup auth preflight. Your SAP cookies have expired. Re-extract them with `arc1-cli extract-cookies` — no restart needed, the next SAP call will reload them automatically."*
+- [ ] In `runStartupAuthPreflight`, when `err.statusCode === 401 && (config.cookieFile || config.cookieString)`, log a `warn` audit event and return `{ status: 'inconclusive', blocking: false, endpoint, checkedAt, statusCode: 401, reason }` instead of the existing `{ status: 'failed', blocking: true, … }`.
+- [ ] Other auth-failure paths (no cookie auth configured, or 403) keep the existing blocking behavior — do NOT downgrade those.
+- [ ] Add unit tests (~3 tests) in `tests/unit/server/server.test.ts` under a `describe('runStartupAuthPreflight', …)` block:
+    - **Test 1**: 401 + no cookie auth configured → `{ status: 'failed', blocking: true }` (unchanged behavior).
+    - **Test 2**: 401 + `cookieFile` set → `{ status: 'inconclusive', blocking: false }`.
+    - **Test 3**: 403 + `cookieFile` set → `{ status: 'failed', blocking: true }` (downgrade is 401-only).
+- [ ] Run `npm test -- tests/unit/server/server.test.ts` — all tests must pass.
+
+### Task 5: Cookie-aware error hint in `formatErrorForLLM`
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+A 401/403 raised through the LLM-facing handler must explain the cookie-refresh path when cookie auth is configured. The existing message — "Check SAP_CLIENT, SAP_USER, and SAP_PASSWORD" — is misleading on cookie-auth deployments.
+
+- [ ] In `formatErrorForLLM` and/or its delegate `buildBaseErrorMessage`, after constructing `enriched` and inside the `err.isUnauthorized || err.isForbidden` branch, branch on `config.cookieFile || config.cookieString`:
+    - When cookie auth is configured: return `${enriched}\n\nHint: SAP cookies have expired. Ask the user to re-extract cookies with \`arc1-cli extract-cookies\`. The next SAP call after extraction will automatically reload the fresh cookies — no restart needed.`
+    - Otherwise: return the existing message verbatim.
+- [ ] Update both function signatures to accept `config: ServerConfig` (already required to read `cookieFile`/`cookieString`). Update the single call site in `handleToolCall`'s catch block.
+- [ ] Add unit tests (~2 tests) in `tests/unit/handlers/intent.test.ts`:
+    - **Test 1**: AdtApiError(401) with `config.cookieFile` set → returned message contains "re-extract cookies" and "no restart needed".
+    - **Test 2**: AdtApiError(401) with no cookie auth configured → returned message contains the existing "Check SAP_CLIENT" guidance.
+- [ ] Run `npm test -- tests/unit/handlers/intent.test.ts` — all tests must pass.
+
+### Task 6: Document the hot-reload behavior
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `docs_page/configuration-reference.md`
+- Modify: `docs_page/cli-guide.md`
+
+Make the runtime invariant discoverable for future contributors and clear for operators.
+
+- [ ] In `CLAUDE.md` "Architecture: Request Flow" diagram, change the `Cookie/session management` line to `Cookie/session management (hot-reload from file on stale 401)`.
+- [ ] In `CLAUDE.md` "Security & Architectural Invariants" section, append two bullets:
+    - *"**Per-user auth never inherits shared credentials.** `buildAdtConfig({ perUser: true })` strips `username`, `password`, `cookies`, `cookieFile`, and `cookieString`. Any new Layer B field must respect this flag."* (replace the existing bullet that lists only the first three.)
+    - *"**Cookie auth hot-reload.** When `SAP_COOKIE_FILE` is set, expired cookies do not require a restart. On persistent 401 the HTTP client clears stale cookies and re-reads the file on the next request (`cookiesCleared` flag in `src/adt/http.ts`). Startup preflight is non-blocking in cookie-auth mode. `SAP_COOKIE_STRING` cannot hot-reload (logged warning)."*
+- [ ] In `docs_page/configuration-reference.md` under the `SAP_COOKIE_FILE` entry, add: *"Cookies are reloaded automatically on the next request after a persistent 401, so you can refresh cookies (e.g. via `arc1-cli extract-cookies`) without restarting ARC-1."*
+- [ ] In `docs_page/cli-guide.md` under the `extract-cookies` subcommand, add a sentence: *"When the running ARC-1 process is configured with `SAP_COOKIE_FILE` pointing to the same file, the next SAP call automatically reloads the fresh cookies — no restart needed."*
+- [ ] Run `npm run lint` — no new lint errors.
+
+### Task 7: Final verification
+
+- [ ] Run `npm test` — all unit tests pass (target: at least 6 new tests for the reload state machine, 3 for preflight downgrade, 2 for handler hint, plus existing tests unchanged).
+- [ ] Run `npm run typecheck` — no errors.
+- [ ] Run `npm run lint` — no errors.
+- [ ] Smoke test against A4H: run `arc1-cli serve` with `SAP_COOKIE_FILE` pointing to a valid Netscape cookie file, manually invalidate the cookies (e.g., overwrite the file with an obviously-bad value), confirm a request fails 401, restore the file, confirm the next request succeeds without restarting the process.
+- [ ] Move this plan to `docs/plans/completed/`.

--- a/docs_page/cli-guide.md
+++ b/docs_page/cli-guide.md
@@ -150,6 +150,18 @@ Output format: `line:column [severity] rule: message`
 
 Uses [@abaplint/core](https://github.com/abaplint/abaplint) with sensible defaults.
 
+### extract-cookies
+
+Open a browser, log into SAP, and write a Netscape-format cookie file usable as `SAP_COOKIE_FILE`.
+
+```bash
+arc1-cli extract-cookies --url https://host:44300 --output ~/.config/arc-1/cookies.txt
+```
+
+When the running ARC-1 process is configured with `SAP_COOKIE_FILE` pointing to the same file, the next SAP call automatically reloads the fresh cookies — **no restart needed**. The reload is lazy: it fires on the next outgoing request after a persistent 401, so just re-extract and the next tool invocation picks up the new session.
+
+`SAP_COOKIE_STRING` does not support hot-reload — that env var is read once at startup. Use `SAP_COOKIE_FILE` if you want the no-restart refresh path.
+
 ### version
 
 Show ARC-1 version.

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -114,10 +114,16 @@ Pick one primary method. Combinations that coexist safely are in the [Coexistenc
 
 | Flag | Env Var | Description |
 |---|---|---|
-| `--cookie-file` | `SAP_COOKIE_FILE` | Path to Netscape-format cookie file |
-| `--cookie-string` | `SAP_COOKIE_STRING` | Inline cookies (`k=v; k2=v2`) |
+| `--cookie-file` | `SAP_COOKIE_FILE` | Path to Netscape-format cookie file. **Hot-reloaded** on stale 401: re-extract cookies (e.g. via `arc1-cli extract-cookies`) and the next SAP call picks them up — no restart needed. |
+| `--cookie-string` | `SAP_COOKIE_STRING` | Inline cookies (`k=v; k2=v2`). **Cannot hot-reload** — the value is read once at startup. To refresh, restart the process with a new value, or switch to `SAP_COOKIE_FILE`. |
 
 Not for production. See [local-development.md → SSO cookie extractor](local-development.md#sso-only-on-prem-cookie-extractor).
+
+**Cookie hot-reload (SAP_COOKIE_FILE only).** When the SAP session expires and a request returns 401 after the standard one-shot session-reset retry, ARC-1 clears the in-memory cookie jar (including any session cookies harvested from intermediate responses) and re-reads the configured cookie file lazily on the next outgoing request. Implications:
+
+- The startup auth preflight downgrades a 401 from blocking to non-blocking when `SAP_COOKIE_FILE` is set, so the MCP server starts even if cookies are about to be re-extracted out-of-band. The first real tool call triggers the reload.
+- `SAP_COOKIE_STRING` keeps the existing blocking-401 behavior — ARC-1 cannot refresh a static env var without restart.
+- Per-user Principal Propagation clients never inherit shared cookie state; `cookieFile`/`cookieString` are stripped from per-user configs in `buildAdtConfig`.
 
 ### B3. BTP ABAP Environment (direct OAuth)
 

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -108,6 +108,8 @@ export class AdtClient {
       language: config.language,
       insecure: config.insecure,
       cookies: config.cookies,
+      cookieFile: config.cookieFile,
+      cookieString: config.cookieString,
       btpProxy: config.btpProxy,
       sapConnectivityAuth: config.sapConnectivityAuth,
       ppProxyAuth: config.ppProxyAuth,

--- a/src/adt/config.ts
+++ b/src/adt/config.ts
@@ -57,6 +57,10 @@ export interface AdtClientConfig {
   insecure: boolean;
   /** Cookie-based auth (alternative to basic auth) */
   cookies: Record<string, string>;
+  /** Path to cookie file — enables hot-reload on stale auth */
+  cookieFile?: string;
+  /** Inline cookie string — stored for config awareness (no hot-reload) */
+  cookieString?: string;
   /** Safety configuration */
   safety: SafetyConfig;
   /** Feature detection config */

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -30,6 +30,7 @@
 import { Agent, Client, type Dispatcher, fetch as undiciFetch } from 'undici';
 import { logger } from '../server/logger.js';
 import type { BTPProxyConfig } from './btp.js';
+import { resolveCookies } from './cookies.js';
 import { resolveAcceptType, resolveContentType } from './discovery.js';
 import { AdtApiError, AdtNetworkError } from './errors.js';
 import type { Semaphore } from './semaphore.js';
@@ -108,6 +109,10 @@ export interface AdtHttpConfig {
   language?: string;
   insecure?: boolean;
   cookies?: Record<string, string>;
+  /** Path to cookie file — enables hot-reload on stale auth */
+  cookieFile?: string;
+  /** Inline cookie string — stored for config awareness (no hot-reload) */
+  cookieString?: string;
   sessionType?: SessionType;
   /** BTP Connectivity proxy (Cloud Connector) */
   btpProxy?: BTPProxyConfig;
@@ -166,6 +171,8 @@ export class AdtHttpClient {
   private cookieJar: Map<string, string> = new Map();
   /** Guard to prevent infinite retry loops for DB connection errors */
   private dbRetryInProgress = false;
+  /** Set after a 401 clears stale cookies — triggers file reload on the next request */
+  private cookiesCleared = false;
   constructor(config: AdtHttpConfig) {
     this.config = config;
 
@@ -311,6 +318,12 @@ export class AdtHttpClient {
     if (this.config.bearerTokenProvider) {
       const token = await this.config.bearerTokenProvider();
       headers.Authorization = `Bearer ${token}`;
+    }
+
+    // Lazy cookie reload: if cookies were cleared on a previous 401,
+    // re-read the cookie file before this request.
+    if (this.cookiesCleared && this.isCookieAuthMode()) {
+      this.reloadCookiesFromSource();
     }
 
     // Build cookie header from: config cookies + cookie jar (jar takes precedence)
@@ -516,6 +529,15 @@ export class AdtHttpClient {
           durationMs: Date.now() - httpStart,
           errorBody: '401 session retry completed',
         });
+
+        if (response.status === 401 && this.isCookieAuthMode()) {
+          this.config.cookies = {};
+          this.cookiesCleared = true;
+          logger.warn(
+            'Cookie auth: 401 persisted after retry — clearing stale cookies. ' +
+              'Run `arc1-cli extract-cookies` to get fresh cookies; the next SAP call will reload them automatically.',
+          );
+        }
         // Fall through to downstream handlers (403/406/415/normal)
       }
 
@@ -728,6 +750,10 @@ export class AdtHttpClient {
       contentType?.startsWith('text/html') &&
       looksLikeLoginPage(body)
     ) {
+      if (this.isCookieAuthMode()) {
+        this.config.cookies = {};
+        this.cookiesCleared = true;
+      }
       throw new AdtApiError(
         'ADT call returned HTML login page — authentication required. If using cookies, they may have expired. If using Basic auth, credentials may be invalid or not authorized for ADT (S_ADT_RES missing). If on an SSO-only system, try SAP_DISABLE_SAML=true or see docs/enterprise-auth.md. Re-run arc-1 after fixing.',
         401,
@@ -787,6 +813,12 @@ export class AdtHttpClient {
       headers['SAP-Connectivity-Authentication'] = this.config.sapConnectivityAuth;
     }
 
+    // Lazy cookie reload (same guard as request()) — re-read cookie file
+    // before CSRF fetch so a hot-reloaded cookie is used immediately.
+    if (this.cookiesCleared && this.isCookieAuthMode()) {
+      this.reloadCookiesFromSource();
+    }
+
     // Include existing cookies (config + jar) so session is maintained
     const cookieParts: string[] = [];
     if (this.config.cookies) {
@@ -843,6 +875,10 @@ export class AdtHttpClient {
       const token = response.headers.get('x-csrf-token');
       if (!token || token === 'Required') {
         if (response.status === 401) {
+          if (this.isCookieAuthMode()) {
+            this.config.cookies = {};
+            this.cookiesCleared = true;
+          }
           throw new AdtApiError(
             `Authentication failed (401) using sap-client=${this.config.client ?? '100'}. Check SAP_CLIENT, SAP_USER, and SAP_PASSWORD.`,
             401,
@@ -878,6 +914,35 @@ export class AdtHttpClient {
    */
   private isDbConnectionError(body: string): boolean {
     return body.toLowerCase().includes('database connection is not open');
+  }
+
+  private isCookieAuthMode(): boolean {
+    return !!(this.config.cookieFile || this.config.cookieString);
+  }
+
+  /**
+   * Re-read cookies from the original source (file or string).
+   * Called lazily on the NEXT request after a 401 cleared stale cookies.
+   */
+  private reloadCookiesFromSource(): void {
+    this.cookiesCleared = false;
+    if (!this.config.cookieFile && this.config.cookieString) {
+      logger.warn('SAP_COOKIE_STRING cannot be refreshed without restart. Use SAP_COOKIE_FILE for automatic reload.');
+      return;
+    }
+    try {
+      const fresh = resolveCookies(this.config.cookieFile, this.config.cookieString);
+      if (fresh && Object.keys(fresh).length > 0) {
+        this.config.cookies = fresh;
+        logger.info('Reloaded cookies from file', { cookieCount: Object.keys(fresh).length });
+      } else {
+        logger.warn('Cookie reload returned empty result');
+      }
+    } catch (err) {
+      logger.warn('Failed to reload cookies from source', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -531,8 +531,7 @@ export class AdtHttpClient {
         });
 
         if (response.status === 401 && this.isCookieAuthMode()) {
-          this.config.cookies = {};
-          this.cookiesCleared = true;
+          this.clearCookiesAndMark();
           logger.warn(
             'Cookie auth: 401 persisted after retry — clearing stale cookies. ' +
               'Run `arc1-cli extract-cookies` to get fresh cookies; the next SAP call will reload them automatically.',
@@ -751,8 +750,7 @@ export class AdtHttpClient {
       looksLikeLoginPage(body)
     ) {
       if (this.isCookieAuthMode()) {
-        this.config.cookies = {};
-        this.cookiesCleared = true;
+        this.clearCookiesAndMark();
       }
       throw new AdtApiError(
         'ADT call returned HTML login page — authentication required. If using cookies, they may have expired. If using Basic auth, credentials may be invalid or not authorized for ADT (S_ADT_RES missing). If on an SSO-only system, try SAP_DISABLE_SAML=true or see docs/enterprise-auth.md. Re-run arc-1 after fixing.',
@@ -876,8 +874,7 @@ export class AdtHttpClient {
       if (!token || token === 'Required') {
         if (response.status === 401) {
           if (this.isCookieAuthMode()) {
-            this.config.cookies = {};
-            this.cookiesCleared = true;
+            this.clearCookiesAndMark();
           }
           throw new AdtApiError(
             `Authentication failed (401) using sap-client=${this.config.client ?? '100'}. Check SAP_CLIENT, SAP_USER, and SAP_PASSWORD.`,
@@ -918,6 +915,47 @@ export class AdtHttpClient {
 
   private isCookieAuthMode(): boolean {
     return !!(this.config.cookieFile || this.config.cookieString);
+  }
+
+  /**
+   * Mark stale cookies for hot-reload on the next request.
+   *
+   * Clears EVERY in-memory copy of the failed session: `config.cookies` (the
+   * static set seeded from cookieFile/cookieString at construction), `cookieJar`
+   * (cookies harvested from prior responses, including the 401/HTML-login
+   * response that just triggered this call), and `csrfToken` (bound to the
+   * dead session).
+   *
+   * Without clearing the jar, the next request's cookie-header build path
+   * (`config.cookies` + `cookieJar`) would re-emit the stale Set-Cookie values
+   * harvested from the failed response — overriding the fresh `config.cookies`
+   * we'll repopulate via `reloadCookiesFromSource()`. The jar therefore must
+   * not survive the reload boundary.
+   *
+   * Called from THREE paths: persistent 401 in `request()` retry, HTML-login
+   * fallback in `handleResponse()`, and CSRF 401 in `fetchCsrfToken()`. Also
+   * exposed publicly via `markCookiesStale()` so the startup auth preflight
+   * can propagate "the cookies you started the process with are dead" state
+   * to the long-lived runtime client.
+   */
+  private clearCookiesAndMark(): void {
+    this.config.cookies = {};
+    this.cookieJar.clear();
+    this.csrfToken = '';
+    this.cookiesCleared = true;
+  }
+
+  /**
+   * Public hook so `runStartupAuthPreflight` (which uses a throwaway client)
+   * can mark the long-lived runtime client as having stale cookies. Without
+   * this propagation, the runtime client ignores the preflight 401 and the
+   * first real tool call repeats the failure before lazy reload kicks in.
+   * Caller is expected to be in cookie-auth mode; the method is a no-op
+   * otherwise.
+   */
+  markCookiesStale(): void {
+    if (!this.isCookieAuthMode()) return;
+    this.clearCookiesAndMark();
   }
 
   /**

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -382,8 +382,14 @@ function getWriteInfrastructureHint(err: AdtApiError, tool: string, args: Record
 }
 
 /** Format error messages with LLM-friendly remediation hints */
-function formatErrorForLLM(err: unknown, message: string, tool: string, args: Record<string, unknown>): string {
-  const base = buildBaseErrorMessage(err, message, tool, args);
+function formatErrorForLLM(
+  err: unknown,
+  message: string,
+  tool: string,
+  args: Record<string, unknown>,
+  config: ServerConfig,
+): string {
+  const base = buildBaseErrorMessage(err, message, tool, args, config);
   // Handler-attached remediation hints (e.g., CDS delete blocker list) always
   // appear last so the message reads "what happened → diagnostics → how to fix".
   if (err instanceof AdtApiError && err.extraHint && !base.includes(err.extraHint)) {
@@ -392,7 +398,13 @@ function formatErrorForLLM(err: unknown, message: string, tool: string, args: Re
   return base;
 }
 
-function buildBaseErrorMessage(err: unknown, message: string, tool: string, args: Record<string, unknown>): string {
+function buildBaseErrorMessage(
+  err: unknown,
+  message: string,
+  tool: string,
+  args: Record<string, unknown>,
+  config: ServerConfig,
+): string {
   if (err instanceof AdtApiError) {
     // Append additional SAP messages (line numbers, secondary errors) if available
     const enriched = enrichWithSapDetails(err, message);
@@ -414,6 +426,14 @@ function buildBaseErrorMessage(err: unknown, message: string, tool: string, args
       return `${enriched}\n\nHint: Object "${name}" (type ${type}) was not found. Use SAPSearch with query "${name}" to verify the name exists and check the correct type.`;
     }
     if (err.isUnauthorized || err.isForbidden) {
+      if (config.cookieFile || config.cookieString) {
+        return (
+          `${enriched}\n\n` +
+          'Hint: SAP cookies have expired. Ask the user to re-extract cookies ' +
+          'with `arc1-cli extract-cookies`. The next SAP call after extraction ' +
+          'will automatically reload the fresh cookies — no restart needed.'
+        );
+      }
       return `${enriched}\n\nHint: Authorization error. Check SAP_CLIENT (default: '100'), SAP_USER, and SAP_PASSWORD. The configured SAP user may lack permissions for this object.`;
     }
     // Transport / corrNr specific hints
@@ -1222,7 +1242,7 @@ export async function handleToolCall(
         errorMessage: message,
       });
 
-      return errorResult(formatErrorForLLM(err, message, toolName, args));
+      return errorResult(formatErrorForLLM(err, message, toolName, args, config));
     }
   });
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -366,10 +366,20 @@ const STARTUP_AUTH_ENDPOINT = '/sap/bc/adt/core/discovery';
 
 function buildStartupAuthFailureReason(statusCode: number, config: ServerConfig): string {
   if (statusCode === 401) {
-    if (config.cookieFile || config.cookieString) {
+    // Only SAP_COOKIE_FILE supports hot-reload: the file is re-read on the next request.
+    // SAP_COOKIE_STRING is a static env var read once at process start — it cannot
+    // change in the running process, so we must not promise "no restart needed".
+    if (config.cookieFile) {
       return (
         'Authentication failed (401) during startup auth preflight. ' +
         'Your SAP cookies have expired. Re-extract them with `arc1-cli extract-cookies` — no restart needed, the next SAP call will reload them automatically.'
+      );
+    }
+    if (config.cookieString) {
+      return (
+        'Authentication failed (401) during startup auth preflight. ' +
+        'SAP_COOKIE_STRING is a static value and cannot be hot-reloaded. ' +
+        'Restart ARC-1 with a refreshed SAP_COOKIE_STRING, or switch to SAP_COOKIE_FILE for automatic reload on the next request.'
       );
     }
     return (
@@ -428,8 +438,11 @@ export async function runStartupAuthPreflight(
   } catch (err) {
     if (err instanceof AdtApiError && (err.statusCode === 401 || err.statusCode === 403)) {
       const reason = buildStartupAuthFailureReason(err.statusCode, config);
-      const isCookieAuth = !!(config.cookieFile || config.cookieString);
-      if (isCookieAuth && err.statusCode === 401) {
+      // Non-blocking downgrade only applies to cookieFile mode — that's the path
+      // the runtime client can actually recover from via the lazy reload. cookieString
+      // is static; downgrading there would just defer the same failure to the first
+      // tool call without giving the operator a way to fix it without restart.
+      if (config.cookieFile && err.statusCode === 401) {
         logger.warn(`${reason} (non-blocking: runtime cookie reload will retry)`, { endpoint, statusCode: 401 });
         return { status: 'inconclusive', blocking: false, endpoint, checkedAt, statusCode: 401, reason };
       }
@@ -488,6 +501,15 @@ export function createServer(
   // Create default ADT client (shared, uses startup-time credentials or OAuth bearer)
   const defaultClient = new AdtClient(buildAdtConfig(config, btpProxy, bearerTokenProvider));
 
+  // Cookie-auth preflight propagation: when startup preflight returned a non-blocking
+  // 401 in SAP_COOKIE_FILE mode, the throwaway preflight client marked itself stale —
+  // but the long-lived defaultClient was constructed independently with cookies read at
+  // startup and is unaware. Without explicit propagation, the first real tool call would
+  // re-emit the same stale cookies and hit 401 again before the lazy reload triggers,
+  // wasting one round-trip per startup-stale-cookie cycle. We propagate the stale state
+  // once on first tool call — idempotent flag keeps later calls O(1).
+  let preflightStalePropagated = false;
+
   // Register tool listing — filtered by user's scopes when auth is active
   server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
     // Wait for the startup probe (if provided), but with a timeout so a slow/unreachable
@@ -524,6 +546,13 @@ export function createServer(
           ],
           isError: true,
         } as Record<string, unknown>;
+      }
+      // Non-blocking 401 from cookie-auth preflight → mark the runtime client's cookies
+      // stale so its first call goes straight to the lazy reload path instead of repeating
+      // the failure. Fires once per process; subsequent calls early-return.
+      if (!preflightStalePropagated && startupAuth.status === 'inconclusive' && startupAuth.statusCode === 401) {
+        defaultClient.http.markCookiesStale();
+        preflightStalePropagated = true;
       }
     }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -201,6 +201,8 @@ export function buildAdtConfig(
     if (cookies) {
       adtConfig.cookies = cookies;
     }
+    adtConfig.cookieFile = config.cookieFile;
+    adtConfig.cookieString = config.cookieString;
   }
 
   return adtConfig;
@@ -362,8 +364,14 @@ export interface StartupAuthPreflightResult {
 
 const STARTUP_AUTH_ENDPOINT = '/sap/bc/adt/core/discovery';
 
-function buildStartupAuthFailureReason(statusCode: number): string {
+function buildStartupAuthFailureReason(statusCode: number, config: ServerConfig): string {
   if (statusCode === 401) {
+    if (config.cookieFile || config.cookieString) {
+      return (
+        'Authentication failed (401) during startup auth preflight. ' +
+        'Your SAP cookies have expired. Re-extract them with `arc1-cli extract-cookies` — no restart needed, the next SAP call will reload them automatically.'
+      );
+    }
     return (
       'Authentication failed (401) during startup auth preflight. ' +
       'Check SAP_USER/SAP_PASSWORD/SAP_CLIENT (or destination/service-key credentials), then restart ARC-1.'
@@ -419,7 +427,12 @@ export async function runStartupAuthPreflight(
     return { status: 'ok', blocking: false, endpoint, checkedAt, reason };
   } catch (err) {
     if (err instanceof AdtApiError && (err.statusCode === 401 || err.statusCode === 403)) {
-      const reason = buildStartupAuthFailureReason(err.statusCode);
+      const reason = buildStartupAuthFailureReason(err.statusCode, config);
+      const isCookieAuth = !!(config.cookieFile || config.cookieString);
+      if (isCookieAuth && err.statusCode === 401) {
+        logger.warn(`${reason} (non-blocking: runtime cookie reload will retry)`, { endpoint, statusCode: 401 });
+        return { status: 'inconclusive', blocking: false, endpoint, checkedAt, statusCode: 401, reason };
+      }
       logger.warn(reason, { endpoint, statusCode: err.statusCode });
       return {
         status: 'failed',

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AdtApiError, AdtNetworkError } from '../../../src/adt/errors.js';
 import { mockResponse } from '../../helpers/mock-fetch.js';
 
@@ -1383,6 +1383,196 @@ describe('AdtHttpClient', () => {
       await Promise.all([client.get('/path1'), client.get('/path2'), client.get('/path3')]);
 
       expect(maxConcurrent).toBe(1);
+    });
+  });
+
+  // ─── Cookie hot-reload on stale 401 ─────────────────────────────────
+  //
+  // Verifies the lazy reload state machine: persistent 401 in cookie-auth
+  // mode clears the cookie jar and re-reads the configured cookieFile on
+  // the NEXT request, with no restart. See docs/plans/pr-alpha-cookie-hot-reload.md
+  // and docs/adr/0001-discovery-driven-endpoint-routing.md (architectural context).
+
+  describe('cookie hot-reload', () => {
+    let tmpFile = '';
+
+    function writeNetscapeCookieFile(cookies: Record<string, string>): string {
+      const fs = require('node:fs');
+      const os = require('node:os');
+      const path = require('node:path');
+      const file = path.join(os.tmpdir(), `arc1-test-cookies-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`);
+      const lines = ['# Netscape HTTP Cookie File'];
+      for (const [k, v] of Object.entries(cookies)) {
+        lines.push(`sap.example.com\tFALSE\t/\tFALSE\t0\t${k}\t${v}`);
+      }
+      fs.writeFileSync(file, `${lines.join('\n')}\n`);
+      return file;
+    }
+
+    afterEach(() => {
+      if (tmpFile) {
+        const fs = require('node:fs');
+        try {
+          fs.unlinkSync(tmpFile);
+        } catch {
+          // best-effort-cleanup
+        }
+        tmpFile = '';
+      }
+    });
+
+    it('clears cookies on persistent 401 in cookie-auth mode', async () => {
+      tmpFile = writeNetscapeCookieFile({ MYSAPSSO2: 'stale-value' });
+      // First GET → 401, retry GET → still 401 (persistent)
+      mockFetch.mockResolvedValueOnce(mockResponse(401, 'Unauthorized'));
+      mockFetch.mockResolvedValueOnce(mockResponse(401, 'Unauthorized'));
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { MYSAPSSO2: 'stale-value' },
+        cookieFile: tmpFile,
+      });
+      await expect(client.get('/sap/bc/adt/programs/programs/ZTEST/source/main')).rejects.toThrow();
+
+      // After persistent 401 in cookie-auth mode: cookies cleared, flag set.
+      expect((client as any).config.cookies).toEqual({});
+      expect((client as any).cookiesCleared).toBe(true);
+    });
+
+    it('reloads cookies from file on the next request after clearing', async () => {
+      tmpFile = writeNetscapeCookieFile({ MYSAPSSO2: 'fresh-value' });
+      // Pre-set the client into cleared state.
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: {},
+        cookieFile: tmpFile,
+      });
+      (client as any).cookiesCleared = true;
+      (client as any).csrfToken = 'T';
+
+      await client.get('/sap/bc/adt/discovery');
+
+      // Inspect the fetch call: the Cookie header must contain the reloaded value.
+      const headers = (mockFetch.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+      expect(headers.Cookie).toContain('MYSAPSSO2=fresh-value');
+      // After reload, the cleared flag is reset.
+      expect((client as any).cookiesCleared).toBe(false);
+      // config.cookies has the reloaded entry.
+      expect((client as any).config.cookies).toEqual({ MYSAPSSO2: 'fresh-value' });
+    });
+
+    it('warns and skips reload when only cookieString is configured (no cookieFile)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const warnSpy = vi.spyOn((await import('../../../src/server/logger.js')).logger, 'warn');
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { MYSAPSSO2: 'stale' },
+        cookieString: 'MYSAPSSO2=stale',
+      });
+      (client as any).cookiesCleared = true;
+      (client as any).csrfToken = 'T';
+
+      await client.get('/sap/bc/adt/discovery');
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('SAP_COOKIE_STRING cannot be refreshed'));
+      // Cleared flag is still reset (one-shot semantics).
+      expect((client as any).cookiesCleared).toBe(false);
+      // config.cookies is unchanged (no source to reload from).
+      expect((client as any).config.cookies).toEqual({ MYSAPSSO2: 'stale' });
+      warnSpy.mockRestore();
+    });
+
+    it('warns when cookieFile reload returns empty result', async () => {
+      tmpFile = writeNetscapeCookieFile({}); // Empty cookie file (only the header comment)
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const warnSpy = vi.spyOn((await import('../../../src/server/logger.js')).logger, 'warn');
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { OLD: 'x' },
+        cookieFile: tmpFile,
+      });
+      (client as any).cookiesCleared = true;
+      (client as any).csrfToken = 'T';
+
+      await client.get('/sap/bc/adt/discovery');
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Cookie reload returned empty result'));
+      // config.cookies should be left unchanged on empty reload.
+      expect((client as any).config.cookies).toEqual({ OLD: 'x' });
+      warnSpy.mockRestore();
+    });
+
+    it('warns when cookieFile is unreadable (path does not exist)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const warnSpy = vi.spyOn((await import('../../../src/server/logger.js')).logger, 'warn');
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { OLD: 'x' },
+        cookieFile: '/no/such/path/that/exists.txt',
+      });
+      (client as any).cookiesCleared = true;
+      (client as any).csrfToken = 'T';
+
+      await client.get('/sap/bc/adt/discovery');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to reload cookies from source'),
+        expect.any(Object),
+      );
+      // config.cookies left unchanged.
+      expect((client as any).config.cookies).toEqual({ OLD: 'x' });
+      warnSpy.mockRestore();
+    });
+
+    it('clears cookies in HTML-login fallback when in cookie-auth mode', async () => {
+      tmpFile = writeNetscapeCookieFile({ MYSAPSSO2: 'stale' });
+      // 200 with HTML body that looks like a login page.
+      const loginHtml = '<html><head><title>Logon Error Message</title></head><body>Logon ticket invalid</body></html>';
+      mockFetch.mockResolvedValueOnce(mockResponse(200, loginHtml, { 'content-type': 'text/html' }));
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { MYSAPSSO2: 'stale' },
+        cookieFile: tmpFile,
+      });
+      (client as any).csrfToken = 'T';
+
+      await expect(client.get('/sap/bc/adt/discovery')).rejects.toThrow();
+
+      expect((client as any).config.cookies).toEqual({});
+      expect((client as any).cookiesCleared).toBe(true);
+    });
+
+    it('does NOT clear cookies on 401 when not in cookie-auth mode (basic auth)', async () => {
+      // Persistent 401 with basic auth — should not clear anything cookie-related.
+      mockFetch.mockResolvedValueOnce(mockResponse(401, 'Unauthorized'));
+      mockFetch.mockResolvedValueOnce(mockResponse(401, 'Unauthorized'));
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        cookies: { OLD: 'x' },
+      });
+      await expect(client.get('/sap/bc/adt/programs/programs/ZTEST/source/main')).rejects.toThrow();
+
+      expect((client as any).config.cookies).toEqual({ OLD: 'x' });
+      expect((client as any).cookiesCleared).toBe(false);
     });
   });
 });

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -1574,5 +1574,119 @@ describe('AdtHttpClient', () => {
       expect((client as any).config.cookies).toEqual({ OLD: 'x' });
       expect((client as any).cookiesCleared).toBe(false);
     });
+
+    // ─── P1: cookieJar + csrfToken cleared alongside config.cookies ─────
+    // Without this, the cookieJar (populated from response Set-Cookie headers
+    // during the failed login round-trip) would override the freshly-reloaded
+    // SAP_COOKIE_FILE values on the next request — see codex review of PR #200.
+    it('clears cookieJar and csrfToken on persistent 401 (P1: jar leak fix)', async () => {
+      tmpFile = writeNetscapeCookieFile({ MYSAPSSO2: 'fresh' });
+      // First GET → 401 with a Set-Cookie that lands in the jar; retry → 401 again.
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(401, 'Unauthorized', {}, ['SAP_SESSIONID_NPL_001=stale-jar-cookie; path=/']),
+      );
+      mockFetch.mockResolvedValueOnce(mockResponse(401, 'Unauthorized'));
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { MYSAPSSO2: 'old' },
+        cookieFile: tmpFile,
+      });
+      // Pre-set a CSRF token to verify it's cleared.
+      (client as any).csrfToken = 'STALE_CSRF';
+      await expect(client.get('/sap/bc/adt/discovery')).rejects.toThrow();
+
+      // All three in-memory copies of the dead session must be cleared.
+      expect((client as any).config.cookies).toEqual({});
+      expect((client as any).cookieJar.size).toBe(0);
+      expect((client as any).csrfToken).toBe('');
+      expect((client as any).cookiesCleared).toBe(true);
+    });
+
+    it('clears cookieJar in HTML-login fallback path (P1)', async () => {
+      tmpFile = writeNetscapeCookieFile({ MYSAPSSO2: 'fresh' });
+      const loginHtml = '<html><head><title>Logon Error Message</title></head><body>Logon ticket invalid</body></html>';
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(200, loginHtml, { 'content-type': 'text/html' }, ['SAP_SESSIONID_X=jar-stale; path=/']),
+      );
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { MYSAPSSO2: 'old' },
+        cookieFile: tmpFile,
+      });
+      (client as any).csrfToken = 'STALE_CSRF';
+      await expect(client.get('/sap/bc/adt/discovery')).rejects.toThrow();
+
+      expect((client as any).config.cookies).toEqual({});
+      expect((client as any).cookieJar.size).toBe(0);
+      expect((client as any).csrfToken).toBe('');
+      expect((client as any).cookiesCleared).toBe(true);
+    });
+
+    // ─── P2: markCookiesStale() public hook for preflight propagation ────
+    it('markCookiesStale() in cookie-auth mode clears jar+config+csrf and arms reload', async () => {
+      tmpFile = writeNetscapeCookieFile({ MYSAPSSO2: 'fresh' });
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { MYSAPSSO2: 'old' },
+        cookieFile: tmpFile,
+      });
+      (client as any).cookieJar.set('SAP_SESSIONID_X', 'jar-stale');
+      (client as any).csrfToken = 'STALE_CSRF';
+
+      client.markCookiesStale();
+
+      expect((client as any).config.cookies).toEqual({});
+      expect((client as any).cookieJar.size).toBe(0);
+      expect((client as any).csrfToken).toBe('');
+      expect((client as any).cookiesCleared).toBe(true);
+    });
+
+    it('markCookiesStale() is a no-op when not in cookie-auth mode', async () => {
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        cookies: { MYSAPSSO2: 'old' },
+      });
+      (client as any).csrfToken = 'CSRF';
+
+      client.markCookiesStale();
+
+      // Basic-auth mode: nothing changes.
+      expect((client as any).config.cookies).toEqual({ MYSAPSSO2: 'old' });
+      expect((client as any).csrfToken).toBe('CSRF');
+      expect((client as any).cookiesCleared).toBe(false);
+    });
+
+    it('after markCookiesStale + reload, request emits ONLY fresh cookies (jar does not leak)', async () => {
+      tmpFile = writeNetscapeCookieFile({ MYSAPSSO2: 'fresh-from-file' });
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { MYSAPSSO2: 'stale-config' },
+        cookieFile: tmpFile,
+      });
+      // Simulate a leftover jar entry that codex's bug would have re-emitted.
+      (client as any).cookieJar.set('MYSAPSSO2', 'stale-jar');
+      (client as any).csrfToken = 'T';
+
+      client.markCookiesStale();
+      await client.get('/sap/bc/adt/discovery');
+
+      const headers = (mockFetch.mock.calls[0]?.[1] as RequestInit).headers as Record<string, string>;
+      // Only the fresh value from the file — no stale-config, no stale-jar.
+      expect(headers.Cookie).toBe('MYSAPSSO2=fresh-from-file');
+      expect(headers.Cookie).not.toContain('stale-config');
+      expect(headers.Cookie).not.toContain('stale-jar');
+    });
   });
 });

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -9679,4 +9679,52 @@ ENDCLASS.`;
       expect(result.content[0]?.text).toContain('[line 5] Unknown annotation');
     });
   });
+
+  // ─── cookie-aware error hint in formatErrorForLLM ───────────────────
+  describe('cookie-aware error hint in formatErrorForLLM', () => {
+    it('emits cookie refresh hint on 401 when cookieFile is configured', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(401, 'Unauthorized'));
+      const result = await handleToolCall(
+        createClient(),
+        { ...DEFAULT_CONFIG, cookieFile: '/path/to/cookies.txt' },
+        'SAPRead',
+        { type: 'PROG', name: 'ZTEST' },
+      );
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('SAP cookies have expired');
+      expect(text).toContain('arc1-cli extract-cookies');
+      expect(text).toContain('no restart needed');
+      expect(text).not.toContain('Check SAP_CLIENT');
+    });
+
+    it('emits cookie refresh hint on 401 when cookieString is configured', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(401, 'Unauthorized'));
+      const result = await handleToolCall(
+        createClient(),
+        { ...DEFAULT_CONFIG, cookieString: 'MYSAPSSO2=xyz' },
+        'SAPRead',
+        { type: 'PROG', name: 'ZTEST' },
+      );
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('SAP cookies have expired');
+      expect(text).toContain('arc1-cli extract-cookies');
+    });
+
+    it('falls back to standard auth hint on 401 when no cookie auth is configured', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(401, 'Unauthorized'));
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'PROG',
+        name: 'ZTEST',
+      });
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('Check SAP_CLIENT');
+      expect(text).not.toContain('SAP cookies have expired');
+    });
+  });
 });

--- a/tests/unit/server/server.test.ts
+++ b/tests/unit/server/server.test.ts
@@ -111,17 +111,17 @@ describe('MCP Server', () => {
   });
 });
 
-describe('buildAdtConfig', () => {
-  function writeCookieFixture(content: string): { file: string; cleanup: () => void } {
-    const dir = mkdtempSync(join(tmpdir(), 'arc1-server-cookies-test-'));
-    const file = join(dir, 'cookies.txt');
-    writeFileSync(file, content, 'utf-8');
-    return {
-      file,
-      cleanup: () => rmSync(dir, { recursive: true, force: true }),
-    };
-  }
+function writeCookieFixture(content: string): { file: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'arc1-server-cookies-test-'));
+  const file = join(dir, 'cookies.txt');
+  writeFileSync(file, content, 'utf-8');
+  return {
+    file,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
 
+describe('buildAdtConfig', () => {
   it('includes username/password in shared config', () => {
     const cfg = buildAdtConfig({
       ...DEFAULT_CONFIG,
@@ -211,6 +211,44 @@ describe('buildAdtConfig', () => {
     });
 
     expect(cfg.disableSaml).toBe(true);
+  });
+
+  it('passes cookieFile and cookieString through to shared ADT config', () => {
+    const fixture = writeCookieFixture('.example.com\tTRUE\t/\tFALSE\t0\tSAP_SESSIONID\txyz789\n');
+    const cfg = buildAdtConfig({
+      ...DEFAULT_CONFIG,
+      url: 'http://sap.example.com:8000',
+      cookieFile: fixture.file,
+      cookieString: 'EXTRA=v',
+    });
+    try {
+      expect(cfg.cookieFile).toBe(fixture.file);
+      expect(cfg.cookieString).toBe('EXTRA=v');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('strips cookieFile and cookieString in per-user config', () => {
+    const fixture = writeCookieFixture('.example.com\tTRUE\t/\tFALSE\t0\tSAP_SESSIONID\txyz789\n');
+    const cfg = buildAdtConfig(
+      {
+        ...DEFAULT_CONFIG,
+        url: 'http://sap.example.com:8000',
+        cookieFile: fixture.file,
+        cookieString: 'EXTRA=v',
+      },
+      undefined,
+      undefined,
+      { perUser: true },
+    );
+    try {
+      expect(cfg.cookieFile).toBeUndefined();
+      expect(cfg.cookieString).toBeUndefined();
+      expect(cfg.cookies).toBeUndefined();
+    } finally {
+      fixture.cleanup();
+    }
   });
 });
 
@@ -348,5 +386,67 @@ describe('startup auth preflight', () => {
 
     expect(result.status).toBe('inconclusive');
     expect(result.blocking).toBe(false);
+  });
+
+  it('downgrades 401 to inconclusive (non-blocking) when in cookie-auth mode', async () => {
+    const fixture = writeCookieFixture('.example.com\tTRUE\t/\tFALSE\t0\tSAP_SESSIONID\txyz789\n');
+    vi.spyOn(AdtHttpClient.prototype, 'get').mockRejectedValue(
+      new AdtApiError('Unauthorized', 401, '/sap/bc/adt/core/discovery', 'stale cookie'),
+    );
+
+    try {
+      const result = await runStartupAuthPreflight({
+        ...DEFAULT_CONFIG,
+        ppEnabled: false,
+        url: 'http://sap.example.com:8000',
+        cookieFile: fixture.file,
+      });
+
+      expect(result.status).toBe('inconclusive');
+      expect(result.blocking).toBe(false);
+      expect(result.statusCode).toBe(401);
+      expect(result.reason).toContain('arc1-cli extract-cookies');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('keeps 403 blocking even in cookie-auth mode', async () => {
+    const fixture = writeCookieFixture('.example.com\tTRUE\t/\tFALSE\t0\tSAP_SESSIONID\txyz789\n');
+    vi.spyOn(AdtHttpClient.prototype, 'get').mockRejectedValue(
+      new AdtApiError('Forbidden', 403, '/sap/bc/adt/core/discovery', 'forbidden'),
+    );
+
+    try {
+      const result = await runStartupAuthPreflight({
+        ...DEFAULT_CONFIG,
+        ppEnabled: false,
+        url: 'http://sap.example.com:8000',
+        cookieFile: fixture.file,
+      });
+
+      expect(result.status).toBe('failed');
+      expect(result.blocking).toBe(true);
+      expect(result.statusCode).toBe(403);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('keeps 401 blocking when not in cookie-auth mode', async () => {
+    vi.spyOn(AdtHttpClient.prototype, 'get').mockRejectedValue(
+      new AdtApiError('Unauthorized', 401, '/sap/bc/adt/core/discovery', 'wrong creds'),
+    );
+
+    const result = await runStartupAuthPreflight({
+      ...DEFAULT_CONFIG,
+      ppEnabled: false,
+      url: 'http://sap.example.com:8000',
+      username: 'TECH_USER',
+      password: 'wrong',
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.blocking).toBe(true);
   });
 });

--- a/tests/unit/server/server.test.ts
+++ b/tests/unit/server/server.test.ts
@@ -449,4 +449,54 @@ describe('startup auth preflight', () => {
     expect(result.status).toBe('failed');
     expect(result.blocking).toBe(true);
   });
+
+  // ─── P2 (codex review): cookieString-only stays blocking on 401 ────────
+  // SAP_COOKIE_STRING is read once at startup and cannot change in the
+  // running process — the runtime client cannot recover via lazy reload, so
+  // promising "no restart needed" would be a lie. Only SAP_COOKIE_FILE gets
+  // the non-blocking downgrade.
+  it('keeps 401 blocking when only cookieString is set (no hot-reload promise)', async () => {
+    vi.spyOn(AdtHttpClient.prototype, 'get').mockRejectedValue(
+      new AdtApiError('Unauthorized', 401, '/sap/bc/adt/core/discovery', 'stale cookie'),
+    );
+
+    const result = await runStartupAuthPreflight({
+      ...DEFAULT_CONFIG,
+      ppEnabled: false,
+      url: 'http://sap.example.com:8000',
+      cookieString: 'MYSAPSSO2=abc123',
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.blocking).toBe(true);
+    expect(result.statusCode).toBe(401);
+    // Reason must NOT promise hot-reload for cookieString.
+    expect(result.reason).not.toContain('no restart needed');
+    expect(result.reason).toContain('SAP_COOKIE_STRING');
+    expect(result.reason).toContain('static');
+  });
+
+  it('downgrade applies even when both cookieFile and cookieString are set (file wins)', async () => {
+    const fixture = writeCookieFixture('.example.com\tTRUE\t/\tFALSE\t0\tSAP_SESSIONID\txyz789\n');
+    vi.spyOn(AdtHttpClient.prototype, 'get').mockRejectedValue(
+      new AdtApiError('Unauthorized', 401, '/sap/bc/adt/core/discovery', 'stale cookie'),
+    );
+
+    try {
+      const result = await runStartupAuthPreflight({
+        ...DEFAULT_CONFIG,
+        ppEnabled: false,
+        url: 'http://sap.example.com:8000',
+        cookieFile: fixture.file,
+        cookieString: 'MYSAPSSO2=also-set',
+      });
+
+      // Presence of cookieFile makes the deployment hot-reloadable.
+      expect(result.status).toBe('inconclusive');
+      expect(result.blocking).toBe(false);
+      expect(result.reason).toContain('arc1-cli extract-cookies');
+    } finally {
+      fixture.cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

When `SAP_COOKIE_FILE` is configured and the SAP session cookies expire, ARC-1 no longer requires a restart to refresh them. On persistent 401 in cookie-auth mode, the HTTP client clears the in-memory cookie jar and **lazily** re-reads the configured `cookieFile` on the **next** outgoing request — never polled, never automatic mid-failed-request.

This is **PR-α**, the first of three "ship-now" splits from [PR #196](https://github.com/marianfoo/arc-1/pull/196). Plan and architectural decisions are recorded in [PR #199](https://github.com/marianfoo/arc-1/pull/199) (`docs/plans/pr-alpha-cookie-hot-reload.md`, `docs/adr/0001..0003.md`). This PR is fully orthogonal to NW 7.50 / release-gating work, and ships independently.

## State machine

- **A → B**: cookie-auth client + persistent 401 (after the existing 401 retry already fired) → `config.cookies = {}`, `cookiesCleared = true`, warn-level log telling the operator to run `arc1-cli extract-cookies`.
- **B → A**: next request (`request()` or CSRF fetch) → `reloadCookiesFromSource()` re-reads the file, repopulates `config.cookies`, resets the flag.
- **B → B**: `cookieFile` missing / empty / unreadable → warn-level log, request proceeds with cleared cookies (next 401 surfaces a clean auth failure rather than silently retrying with stale data).

`SAP_COOKIE_STRING` cannot hot-reload (string is static) — emits a one-time warn explaining `SAP_COOKIE_FILE` is the auto-refresh path.

## Other behavior changes

- **Startup auth preflight downgrade.** On 401 in cookie-auth mode, preflight returns `{ status: 'inconclusive', blocking: false, statusCode: 401 }` so the MCP server starts and the runtime cookie-reload path takes over on the first real ADT call. Other auth-failure paths (basic auth 401, any 403) keep their existing blocking behavior.
- **Cookie-aware LLM error hint.** `formatErrorForLLM` emits *"SAP cookies have expired. Ask the user to re-extract cookies with `arc1-cli extract-cookies`. The next SAP call after extraction will automatically reload the fresh cookies — no restart needed."* on 401/403 when `cookieFile` or `cookieString` is configured. Without cookie auth, the existing *"Check SAP_CLIENT, SAP_USER, SAP_PASSWORD"* hint is preserved.
- **Per-user PP strip extended.** `buildAdtConfig({ perUser: true })` now strips `cookieFile` and `cookieString` alongside the existing `cookies` strip, so per-user clients never inherit shared-cookie auth.

## Files

| File | Change |
|---|---|
| [src/adt/config.ts](https://github.com/marianfoo/arc-1/blob/feat/cookie-hot-reload/src/adt/config.ts) | +`cookieFile?`, +`cookieString?` |
| [src/adt/client.ts](https://github.com/marianfoo/arc-1/blob/feat/cookie-hot-reload/src/adt/client.ts) | Pass-through to AdtHttpClient |
| [src/adt/http.ts](https://github.com/marianfoo/arc-1/blob/feat/cookie-hot-reload/src/adt/http.ts) | `cookiesCleared` flag, `isCookieAuthMode`, `reloadCookiesFromSource`, lazy-reload guards in `request()` and `fetchCsrfToken()`, 401-clears-cookies on retry-fail/HTML-login/CSRF-fail |
| [src/server/server.ts](https://github.com/marianfoo/arc-1/blob/feat/cookie-hot-reload/src/server/server.ts) | `buildAdtConfig` plumbs the new fields and strips on `perUser=true`; preflight downgrade |
| [src/handlers/intent.ts](https://github.com/marianfoo/arc-1/blob/feat/cookie-hot-reload/src/handlers/intent.ts) | Cookie-aware error hint in `formatErrorForLLM`; signature update to receive `config` |
| CLAUDE.md | Architecture: Request Flow note + Security & Architectural Invariants entries |

## Tests added (15 new)

- **`tests/unit/adt/http.test.ts`** (7 tests, new `cookie hot-reload` describe block):
  - Clears cookies on persistent 401 in cookie-auth mode
  - Reloads cookies from file on next request after clearing
  - Warns and skips reload when only `cookieString` is configured
  - Warns when `cookieFile` reload returns empty
  - Warns when `cookieFile` is unreadable
  - Clears cookies in HTML-login fallback when in cookie-auth mode
  - Does NOT clear cookies on 401 when not in cookie-auth mode (basic auth)
- **`tests/unit/server/server.test.ts`** (5 tests):
  - `buildAdtConfig` passes `cookieFile`/`cookieString` to shared config
  - `buildAdtConfig` strips them in per-user config
  - Preflight downgrades 401 to `inconclusive` non-blocking when in cookie-auth mode
  - Preflight keeps 403 blocking even in cookie-auth mode
  - Preflight keeps 401 blocking when not in cookie-auth mode
- **`tests/unit/handlers/intent.test.ts`** (3 tests, new `cookie-aware error hint in formatErrorForLLM` describe block):
  - Emits cookie refresh hint on 401 when `cookieFile` is configured
  - Emits cookie refresh hint on 401 when `cookieString` is configured
  - Falls back to standard auth hint on 401 when no cookie auth is configured

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2419 pass (was 2404; +15)
- [x] `npm run lint` — clean

## Related

- Cherry-picked + refined from PR [#196](https://github.com/marianfoo/arc-1/pull/196) (samibouge)
- Plan and ADRs landed in PR [#199](https://github.com/marianfoo/arc-1/pull/199) (docs-only)
- Sibling ship-now PRs to follow: PR-β (three-file sync + universal write guards), PR-γ (NW 7.50 quirks refined)

## Test plan

- [x] Unit tests cover the state machine + perUser strip + preflight downgrade + LLM hint
- [ ] Manual smoke: configure `SAP_COOKIE_FILE` against A4H, invalidate cookies, refresh file, confirm next request succeeds without restart (described in plan Task 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)