### PR TITLE
docs: troubleshoot Copilot Studio expired-token symptom

### DIFF
--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -230,6 +230,11 @@ The user doesn't have the required role collection assigned. Go to BTP Cockpit �
 ### "Invalid client_id" (Copilot Studio)
 DCR registrations are in-memory and lost on restart. Switch to **Manual** OAuth mode (see above) to avoid this.
 
+### "Token validation failed: not a valid XSUAA, OIDC, or API key token" (Copilot Studio)
+Copilot Studio caches the access token from the initial sign-in. XSUAA tokens expire after 1 hour and Copilot Studio does not always refresh them automatically — the connector keeps sending the expired token, which ARC-1 correctly rejects.
+
+Fix: re-authenticate the connection. In your bot, open **Test** → **Connections** → ⋮ next to the ARC-1 connection → **Authenticate**, or delete and re-add the connection from the connector page.
+
 ### OAuth flow hangs or returns 400
 Check that the XSUAA client ID matches. Run `cf env <app-name>` and look for the `clientid` in the XSUAA binding credentials.
 


### PR DESCRIPTION
## Summary
- Adds a troubleshooting entry to `docs_page/xsuaa-setup.md` for the "Token validation failed: not a valid XSUAA, OIDC, or API key token" error in Copilot Studio.
- Documents that Copilot Studio caches the initial access token, doesn't always refresh after the 1-hour XSUAA expiry, and the fix is to re-authenticate the connection.

Hit while wiring ARC-1 (deployed on a BTP CF subaccount) into Copilot Studio via Generic OAuth 2 — initial sign-in worked, then "Reload tools" later started returning the validation error. Server logs showed `XSUAA failed, trying next {"error":"Token is expired."}` — re-authenticating the connection fixed it immediately.

## Test plan
- [ ] Render the docs site and confirm the new entry appears under the existing Copilot Studio troubleshooting section in `xsuaa-setup.md`.
- [ ] Spot-check the surrounding entries still flow correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)