### PR TITLE
ci: gate test workflow by PR title prefix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual trigger so chore: PRs (and any other skipped PR) can be tested on demand.
+  workflow_dispatch:
 
 # Only one SAP-hitting workflow at a time — prevents parallel runs from
 # different PRs/pushes from exhausting SAP work processes.
@@ -13,7 +15,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Gates the rest of the workflow based on PR title (conventional commit prefix).
+  # Skips on `docs:` and `chore:` PRs to save SAP work processes; auto-runs for
+  # everything else (`fix:`, `feat:`, `test:`, `refactor:`, etc.).
+  # Push to main and manual dispatch always pass — chore PRs can be tested via
+  # the "Run workflow" button when needed.
+  gate:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       !startsWith(github.event.pull_request.title, 'docs:') &&
+       !startsWith(github.event.pull_request.title, 'docs(') &&
+       !startsWith(github.event.pull_request.title, 'chore:') &&
+       !startsWith(github.event.pull_request.title, 'chore('))
+    steps:
+      - name: Tests will run
+        run: |
+          echo "event=${{ github.event_name }}"
+          echo "pr_title=${{ github.event.pull_request.title }}"
+
   test:
+    needs: gate
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -242,9 +266,12 @@ jobs:
           retention-days: 7
 
   reliability-summary:
-    if: always()
+    # Run on success or failure of upstream jobs, but only when the gate allowed
+    # the workflow to run in the first place — avoids a noisy "no results" summary
+    # on docs/chore PRs that skipped the test pipeline.
+    if: ${{ !cancelled() && needs.gate.result == 'success' }}
     runs-on: ubuntu-latest
-    needs: [test, integration, e2e]
+    needs: [gate, test, integration, e2e]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Skip the test workflow on `docs:` and `chore:` PRs (saves SAP work processes — these PRs don't change runtime behavior).
- `chore:` PRs can still be tested on demand via **Actions → Test → Run workflow** (added `workflow_dispatch:` trigger).
- Auto-runs unchanged for `fix:`, `feat:`, `test:`, `refactor:`, `perf:`, etc., and for every push to `main`.

## How it works
A new `gate` job evaluates `github.event.pull_request.title` against the prefixes. The rest of the pipeline (`test`, `integration`, `e2e`, `reliability-summary`) chains off it via `needs:`, so a skipped gate cleanly skips the whole run instead of producing an empty "no results" reliability report.

Matches both `prefix:` and `prefix(scope):` forms (e.g. `chore(release):` is also gated).

## Caveats
- PR title changes after the initial `pull_request` event don't re-trigger the workflow on their own — the next push to the branch (or a manual dispatch) does.
- `reliability-summary` is now gated by `needs.gate.result == 'success'` instead of `always()`, so it won't try to summarize a skipped run. It still runs on test failures.

## Test plan
- [ ] Open this PR (`ci:` prefix) → workflow should still run normally.
- [ ] Verify a `docs:` PR (the docs PR opened just before this one) shows the gate job skipped and downstream jobs not running.
- [ ] On a chore-prefixed PR, confirm auto-run is skipped and **Run workflow** button works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)