### PR TITLE
fix(diagnostics): defensive dumpId encoding + endpoint-aware 403 hints

### DIFF
--- a/src/adt/diagnostics.ts
+++ b/src/adt/diagnostics.ts
@@ -81,22 +81,40 @@ export async function listDumps(
  * 1. XML metadata (chapters, links, attributes)
  * 2. Formatted plain text (full dump content)
  *
- * The dump ID is the URL-encoded path segment from the listing.
+ * The dump ID from `listDumps` already arrives URL-encoded (the SAP feed
+ * encodes spaces in `paimup_MUP_05 ZEISMA 100 70` as `%20`). When a caller
+ * passes a raw ID (e.g. copied from ST22 with literal whitespace), we
+ * encode it ourselves so the path stays valid. The detail payload keeps
+ * the caller's original ID for round-tripping.
  */
 export async function getDump(http: AdtHttpClient, safety: SafetyConfig, dumpId: string): Promise<DumpDetail> {
   checkOperation(safety, OperationType.Read, 'GetDump');
 
+  const safeId = normalizeDumpId(dumpId);
+
   // Fetch XML metadata and formatted text in parallel
   const [xmlResp, textResp] = await Promise.all([
-    http.get(`/sap/bc/adt/runtime/dump/${dumpId}`, {
+    http.get(`/sap/bc/adt/runtime/dump/${safeId}`, {
       Accept: 'application/vnd.sap.adt.runtime.dump.v1+xml',
     }),
-    http.get(`/sap/bc/adt/runtime/dump/${dumpId}/formatted`, {
+    http.get(`/sap/bc/adt/runtime/dump/${safeId}/formatted`, {
       Accept: 'text/plain',
     }),
   ]);
 
   return parseDumpDetail(xmlResp.body, textResp.body, dumpId);
+}
+
+/**
+ * Idempotently URL-encode a dump ID. If the value already contains a `%`
+ * sequence we treat it as already-encoded (the listing endpoint emits
+ * `%20` for spaces); otherwise we encode it once. Trims surrounding
+ * whitespace which would otherwise be encoded as `%20` and break lookup.
+ */
+function normalizeDumpId(dumpId: string): string {
+  const trimmed = String(dumpId ?? '').trim();
+  if (!trimmed) return '';
+  return trimmed.includes('%') ? trimmed : encodeURIComponent(trimmed);
 }
 
 // ─── System Messages + Gateway Errors ──────────────────────────────

--- a/src/adt/diagnostics.ts
+++ b/src/adt/diagnostics.ts
@@ -82,10 +82,10 @@ export async function listDumps(
  * 2. Formatted plain text (full dump content)
  *
  * The dump ID from `listDumps` already arrives URL-encoded (the SAP feed
- * encodes spaces in `paimup_MUP_05 ZEISMA 100 70` as `%20`). When a caller
- * passes a raw ID (e.g. copied from ST22 with literal whitespace), we
- * encode it ourselves so the path stays valid. The detail payload keeps
- * the caller's original ID for round-tripping.
+ * encodes spaces in the server/user/client/dump-number suffix as `%20`).
+ * When a caller passes a raw ID (e.g. copied from ST22 with literal
+ * whitespace), we encode it ourselves so the path stays valid. The
+ * detail payload keeps the caller's original ID for round-tripping.
  */
 export async function getDump(http: AdtHttpClient, safety: SafetyConfig, dumpId: string): Promise<DumpDetail> {
   checkOperation(safety, OperationType.Read, 'GetDump');

--- a/src/adt/errors.ts
+++ b/src/adt/errors.ts
@@ -472,13 +472,14 @@ export function classifySapDomainError(
 }
 
 /**
- * Build an endpoint-specific 403 hint for diagnostics endpoints. We've seen
- * cases (e.g. ZEISMA in MUP) where the dump *list* succeeds but the dump
- * *detail* is forbidden, and the generic "Authorization error" message hid
- * which auth object was actually missing. Naming the typical S_ADMI_FCD /
- * S_ADT_RES values for each path lets the LLM tell the user which role to
- * request — and which transaction (ST22, /IWFND/ERROR_LOG) it maps to —
- * without speculating beyond what the tool just tried to read.
+ * Build an endpoint-specific 403 hint for diagnostics endpoints. The dump
+ * list and dump detail sit on different SAP authorization objects, so a
+ * user can have access to one but not the other; the generic
+ * "Authorization error" message hides which auth object is missing.
+ * Naming the typical S_ADMI_FCD / S_ADT_RES values for each path lets the
+ * LLM tell the user which role to request — and which transaction (ST22,
+ * /IWFND/ERROR_LOG) it maps to — without speculating beyond what the tool
+ * just tried to read.
  *
  * Returns `undefined` for paths that aren't recognized so the generic
  * authorization hint kicks in for everything else.

--- a/src/adt/errors.ts
+++ b/src/adt/errors.ts
@@ -341,7 +341,11 @@ export function extractLockOwner(text: string): { user?: string; transport?: str
 }
 
 /** Classify SAP ADT errors into actionable domain categories with remediation hints. */
-export function classifySapDomainError(statusCode: number, responseBody?: string): SapErrorClassification | undefined {
+export function classifySapDomainError(
+  statusCode: number,
+  responseBody?: string,
+  path?: string,
+): SapErrorClassification | undefined {
   const bodyRaw = responseBody ?? '';
   const bodyLower = bodyRaw.toLowerCase();
   const typeId = extractExceptionType(bodyRaw);
@@ -413,9 +417,12 @@ export function classifySapDomainError(statusCode: number, responseBody?: string
 
   const authPattern = /\bauthorization\b|not authorized|s_develop|s_adt_res|s_transprt/i.test(bodyRaw);
   if (typeId === 'ExceptionNotAuthorized' || (statusCode === 403 && authPattern)) {
+    const endpointHint = describeAuthEndpoint(path);
     return {
       category: 'authorization',
-      hint: 'The SAP user lacks required authorization. Run transaction SU53 in SAP GUI to inspect the last failed authorization check. Common objects: S_DEVELOP (development), S_ADT_RES (ADT resources), S_TRANSPRT (transports). Contact your basis admin or review PFCG role assignments.',
+      hint: endpointHint
+        ? `${endpointHint} Run transaction SU53 in SAP GUI immediately after the failed call to see the exact missing authorization object.`
+        : 'The SAP user lacks required authorization. Run transaction SU53 in SAP GUI to inspect the last failed authorization check. Common objects: S_DEVELOP (development), S_ADT_RES (ADT resources), S_TRANSPRT (transports). Contact your basis admin or review PFCG role assignments.',
       transaction: 'SU53',
       details: typeId ? { exceptionType: typeId } : undefined,
     };
@@ -459,6 +466,56 @@ export function classifySapDomainError(statusCode: number, responseBody?: string
       hint: 'The ADT endpoint rejected this HTTP method. Verify the operation is supported on this SAP release and retry with the correct tool action.',
       details: typeId ? { exceptionType: typeId } : undefined,
     };
+  }
+
+  return undefined;
+}
+
+/**
+ * Build an endpoint-specific 403 hint for diagnostics endpoints. We've seen
+ * cases (e.g. ZEISMA in MUP) where the dump *list* succeeds but the dump
+ * *detail* is forbidden, and the generic "Authorization error" message hid
+ * which auth object was actually missing. Naming the typical S_ADMI_FCD /
+ * S_ADT_RES values for each path lets the LLM tell the user which role to
+ * request — and which transaction (ST22, /IWFND/ERROR_LOG) it maps to —
+ * without speculating beyond what the tool just tried to read.
+ *
+ * Returns `undefined` for paths that aren't recognized so the generic
+ * authorization hint kicks in for everything else.
+ */
+function describeAuthEndpoint(path?: string): string | undefined {
+  if (!path) return undefined;
+
+  // Dump detail: /sap/bc/adt/runtime/dump/{id}[/formatted]
+  if (/\/sap\/bc\/adt\/runtime\/dump\/[^/?#]+/.test(path)) {
+    return (
+      'Reading the short-dump detail was forbidden, even if listing dumps works. ' +
+      'The forbidden resource is `/sap/bc/adt/runtime/dump/{id}` (transaction ST22). ' +
+      'Typical authorization objects to check: `S_ADMI_FCD` with value `ST22` ' +
+      '(ABAP runtime error analysis) and `S_ADT_RES` (ACTVT 03) on the ' +
+      '`/sap/bc/adt/runtime/dump/*` resource path.'
+    );
+  }
+
+  // Dump list: /sap/bc/adt/runtime/dumps
+  if (/\/sap\/bc\/adt\/runtime\/dumps(\?|$|\/)/.test(path)) {
+    return (
+      'Listing short dumps was forbidden. The forbidden resource is ' +
+      '`/sap/bc/adt/runtime/dumps` (transaction ST22). Typical authorization ' +
+      'objects to check: `S_ADMI_FCD` with value `ST22` and `S_ADT_RES` ' +
+      '(ACTVT 03) on the `/sap/bc/adt/runtime/dumps` resource path.'
+    );
+  }
+
+  // Gateway error log (list or detail)
+  if (/\/sap\/bc\/adt\/gw\/errorlog/.test(path)) {
+    return (
+      'Reading the SAP Gateway error log was forbidden. The forbidden resource is ' +
+      '`/sap/bc/adt/gw/errorlog/*` (transaction `/IWFND/ERROR_LOG`). Typical ' +
+      'authorization objects to check: `S_ADT_RES` (ACTVT 03) on ' +
+      '`/sap/bc/adt/gw/errorlog/*`, plus the OData Gateway role that grants ' +
+      'access to `/IWFND/ERROR_LOG`.'
+    );
   }
 
   return undefined;

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -396,7 +396,7 @@ function buildBaseErrorMessage(err: unknown, message: string, tool: string, args
     // Append additional SAP messages (line numbers, secondary errors) if available
     const enriched = enrichWithSapDetails(err, message);
     const argType = String(args.type ?? '').toUpperCase();
-    const classification = classifySapDomainError(err.statusCode, err.responseBody);
+    const classification = classifySapDomainError(err.statusCode, err.responseBody, err.path);
 
     if (classification) {
       const transactionLine = classification.transaction ? `\nSAP Transaction: ${classification.transaction}` : '';
@@ -985,7 +985,7 @@ function getBehaviorPoolSaveFailureHint(err: AdtApiError, args: Record<string, u
 
 function classifyError(err: unknown): string {
   if (err instanceof AdtApiError) {
-    const classification = classifySapDomainError(err.statusCode, err.responseBody);
+    const classification = classifySapDomainError(err.statusCode, err.responseBody, err.path);
     return classification ? `AdtApiError:${classification.category}` : 'AdtApiError';
   }
   if (err instanceof AdtNetworkError) return 'AdtNetworkError';

--- a/tests/unit/adt/diagnostics.test.ts
+++ b/tests/unit/adt/diagnostics.test.ts
@@ -198,6 +198,69 @@ describe('Runtime Diagnostics', () => {
       // Formatted text request
       expect(calls).toContainEqual(['/sap/bc/adt/runtime/dump/DUMP_123/formatted', { Accept: 'text/plain' }]);
     });
+
+    it('passes already-encoded dump IDs through unchanged', async () => {
+      // The listing endpoint emits IDs like "...paimup_MUP_05%20%20%20ZEISMA%20100%2070".
+      // Re-encoding would double-encode the %20 to %2520 and break the lookup.
+      const encodedId = '20260504092539paimup_MUP_05%20%20%20ZEISMA%20100%2070';
+      const http = mockHttp('');
+      try {
+        await getDump(http, unrestrictedSafetyConfig(), encodedId);
+      } catch {
+        // empty response → parse failure, irrelevant for this assertion
+      }
+      const urls = (http.get as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0] as string);
+      expect(urls).toContain(`/sap/bc/adt/runtime/dump/${encodedId}`);
+      expect(urls).toContain(`/sap/bc/adt/runtime/dump/${encodedId}/formatted`);
+      // Defensive: nothing got double-encoded.
+      expect(urls.some((url) => url.includes('%2520'))).toBe(false);
+    });
+
+    it('encodes raw dump IDs that contain literal whitespace', async () => {
+      // Caller copy/pasted from ST22: literal spaces, no percent encoding yet.
+      const rawId = '20260504092539paimup_MUP_05   ZEISMA 100 70';
+      const http = mockHttp('');
+      try {
+        await getDump(http, unrestrictedSafetyConfig(), rawId);
+      } catch {
+        // empty response → parse failure, irrelevant for this assertion
+      }
+      const urls = (http.get as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0] as string);
+      // Spaces must be percent-encoded; underscores stay literal.
+      const encoded = '20260504092539paimup_MUP_05%20%20%20ZEISMA%20100%2070';
+      expect(urls).toContain(`/sap/bc/adt/runtime/dump/${encoded}`);
+      expect(urls).toContain(`/sap/bc/adt/runtime/dump/${encoded}/formatted`);
+      // No literal space leaked into the path.
+      expect(urls.some((url) => url.includes(' '))).toBe(false);
+    });
+
+    it('returns the original dump ID in the parsed detail (round-trip)', async () => {
+      // Even when we re-encode for the HTTP path, the response payload should
+      // surface the ID exactly as the caller passed it — otherwise downstream
+      // round-trips (e.g. saving an ID for follow-up) break.
+      const xmlDetail = readFileSync(join(FIXTURES_DIR, 'dump-detail.xml'), 'utf-8');
+      const formattedText = readFileSync(join(FIXTURES_DIR, 'dump-formatted.txt'), 'utf-8');
+      const http = mockHttpMulti({
+        formatted: formattedText,
+        'runtime/dump/': xmlDetail,
+      });
+      const rawId = 'literal id with spaces';
+      const result = await getDump(http, unrestrictedSafetyConfig(), rawId);
+      expect(result.id).toBe(rawId);
+    });
+
+    it('trims surrounding whitespace before encoding', async () => {
+      const http = mockHttp('');
+      try {
+        await getDump(http, unrestrictedSafetyConfig(), '  DUMP_42  ');
+      } catch {
+        // ignore parse failure
+      }
+      const urls = (http.get as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0] as string);
+      // Whitespace would otherwise become %20%20 prefix/suffix and cause a 404.
+      expect(urls).toContain('/sap/bc/adt/runtime/dump/DUMP_42');
+      expect(urls).toContain('/sap/bc/adt/runtime/dump/DUMP_42/formatted');
+    });
   });
 
   // ─── parseDumpList ──────────────────────────────────────────────────

--- a/tests/unit/adt/diagnostics.test.ts
+++ b/tests/unit/adt/diagnostics.test.ts
@@ -200,9 +200,9 @@ describe('Runtime Diagnostics', () => {
     });
 
     it('passes already-encoded dump IDs through unchanged', async () => {
-      // The listing endpoint emits IDs like "...paimup_MUP_05%20%20%20ZEISMA%20100%2070".
+      // The listing endpoint emits IDs of the form "{timestamp}{server}%20%20%20{user}%20{client}%20{seq}".
       // Re-encoding would double-encode the %20 to %2520 and break the lookup.
-      const encodedId = '20260504092539paimup_MUP_05%20%20%20ZEISMA%20100%2070';
+      const encodedId = '20260101120000app01_SYS_00%20%20%20DEVUSER%20100%2042';
       const http = mockHttp('');
       try {
         await getDump(http, unrestrictedSafetyConfig(), encodedId);
@@ -218,7 +218,7 @@ describe('Runtime Diagnostics', () => {
 
     it('encodes raw dump IDs that contain literal whitespace', async () => {
       // Caller copy/pasted from ST22: literal spaces, no percent encoding yet.
-      const rawId = '20260504092539paimup_MUP_05   ZEISMA 100 70';
+      const rawId = '20260101120000app01_SYS_00   DEVUSER 100 42';
       const http = mockHttp('');
       try {
         await getDump(http, unrestrictedSafetyConfig(), rawId);
@@ -227,7 +227,7 @@ describe('Runtime Diagnostics', () => {
       }
       const urls = (http.get as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0] as string);
       // Spaces must be percent-encoded; underscores stay literal.
-      const encoded = '20260504092539paimup_MUP_05%20%20%20ZEISMA%20100%2070';
+      const encoded = '20260101120000app01_SYS_00%20%20%20DEVUSER%20100%2042';
       expect(urls).toContain(`/sap/bc/adt/runtime/dump/${encoded}`);
       expect(urls).toContain(`/sap/bc/adt/runtime/dump/${encoded}/formatted`);
       // No literal space leaked into the path.

--- a/tests/unit/adt/errors.test.ts
+++ b/tests/unit/adt/errors.test.ts
@@ -453,12 +453,12 @@ describe('AdtApiError', () => {
     });
 
     it('emits a dump-detail-specific 403 hint when path is /runtime/dump/{id}', () => {
-      // Real SAP body when ZEISMA in MUP tries to read the dump detail.
+      // Typical SAP body when a user can list dumps but lacks read on the detail resource.
       const body = 'No authorization to access the resource /sap/bc/adt/runtime/dump/...';
       const classification = classifySapDomainError(
         403,
         body,
-        '/sap/bc/adt/runtime/dump/20260504092539paimup_MUP_05%20%20%20ZEISMA%20100%2070',
+        '/sap/bc/adt/runtime/dump/20260101120000app01_SYS_00%20%20%20DEVUSER%20100%2042',
       );
       expect(classification?.category).toBe('authorization');
       expect(classification?.transaction).toBe('SU53');

--- a/tests/unit/adt/errors.test.ts
+++ b/tests/unit/adt/errors.test.ts
@@ -452,6 +452,76 @@ describe('AdtApiError', () => {
       expect(classification?.transaction).toBe('SU53');
     });
 
+    it('emits a dump-detail-specific 403 hint when path is /runtime/dump/{id}', () => {
+      // Real SAP body when ZEISMA in MUP tries to read the dump detail.
+      const body = 'No authorization to access the resource /sap/bc/adt/runtime/dump/...';
+      const classification = classifySapDomainError(
+        403,
+        body,
+        '/sap/bc/adt/runtime/dump/20260504092539paimup_MUP_05%20%20%20ZEISMA%20100%2070',
+      );
+      expect(classification?.category).toBe('authorization');
+      expect(classification?.transaction).toBe('SU53');
+      // Names the dump-detail resource and the typical SAP authorization objects.
+      expect(classification?.hint).toContain('short-dump detail');
+      expect(classification?.hint).toContain('S_ADMI_FCD');
+      expect(classification?.hint).toContain('ST22');
+      expect(classification?.hint).toContain('S_ADT_RES');
+      expect(classification?.hint).toContain('/sap/bc/adt/runtime/dump/');
+      expect(classification?.hint).toContain('SU53');
+    });
+
+    it('emits a dump-list-specific 403 hint when path is /runtime/dumps', () => {
+      const classification = classifySapDomainError(
+        403,
+        'No authorization to access the resource /sap/bc/adt/runtime/dumps',
+        '/sap/bc/adt/runtime/dumps?$top=50',
+      );
+      expect(classification?.category).toBe('authorization');
+      // Different wording from the detail case: "Listing" not "Reading the ... detail".
+      expect(classification?.hint).toContain('Listing short dumps');
+      expect(classification?.hint).toContain('S_ADMI_FCD');
+      expect(classification?.hint).toContain('ST22');
+      expect(classification?.hint).toContain('S_ADT_RES');
+      expect(classification?.hint).not.toContain('short-dump detail');
+    });
+
+    it('emits a gateway-error-log-specific 403 hint when path is /gw/errorlog', () => {
+      const classification = classifySapDomainError(
+        403,
+        'No authorization to access the resource /sap/bc/adt/gw/errorlog/...',
+        '/sap/bc/adt/gw/errorlog/FrontendError/0050568D-8DF7-1ED0-AABB-CCDDEEFF0011',
+      );
+      expect(classification?.category).toBe('authorization');
+      expect(classification?.hint).toContain('SAP Gateway error log');
+      expect(classification?.hint).toContain('/IWFND/ERROR_LOG');
+      expect(classification?.hint).toContain('S_ADT_RES');
+      expect(classification?.hint).toContain('/sap/bc/adt/gw/errorlog/');
+    });
+
+    it('falls back to the generic authorization hint when the path is unknown', () => {
+      const classification = classifySapDomainError(
+        403,
+        'No authorization for S_DEVELOP',
+        '/sap/bc/adt/programs/programs/ZSOMETHING/source/main',
+      );
+      expect(classification?.category).toBe('authorization');
+      // Generic hint mentions S_DEVELOP / S_ADT_RES / S_TRANSPRT; no endpoint-specific advice.
+      expect(classification?.hint).toContain('S_DEVELOP');
+      expect(classification?.hint).toContain('S_TRANSPRT');
+      expect(classification?.hint).not.toContain('short-dump');
+      expect(classification?.hint).not.toContain('/IWFND/ERROR_LOG');
+    });
+
+    it('falls back to the generic authorization hint when path is not provided', () => {
+      // Backwards compatibility: callers that don't pass `path` still work.
+      const xml = `<exc:exception><type id="ExceptionNotAuthorized"/></exc:exception>`;
+      const classification = classifySapDomainError(403, xml);
+      expect(classification?.category).toBe('authorization');
+      expect(classification?.hint).toContain('S_DEVELOP');
+      expect(classification?.hint).not.toContain('short-dump');
+    });
+
     it('classifies object-exists errors', () => {
       const classification = classifySapDomainError(
         409,


### PR DESCRIPTION
## Summary

Two narrow fixes for short-dump fetching:

- **Defensive `dumpId` re-encoding** in `getDump()` — if the ID is already URL-encoded (the listing endpoint emits `%20`), pass through; otherwise encode once. Trims whitespace. Caller's original ID still surfaces in `DumpDetail.id` for round-tripping.
- **Endpoint-aware 403 hints** — `classifySapDomainError()` now accepts an optional `path`. When a 403 lands on `/runtime/dump/{id}`, `/runtime/dumps`, or `/gw/errorlog/*`, the hint names the typical SAP authorization objects (`S_ADMI_FCD = ST22`, `S_ADT_RES` on the resource path, `/IWFND/ERROR_LOG` for the gateway log) and still points to SU53 for the definitive answer.

## Why

Two adjacent papercuts when fetching short dumps:

1. The dump *list* and dump *detail* sit on different SAP authorization objects. A user can have list access but get a 403 on `/sap/bc/adt/runtime/dump/{id}` — the generic "Authorization error" hint hides which auth object is actually missing.
2. Pasting a dump ID with literal whitespace (e.g. directly from ST22 ALV display) breaks the URL because the path interpolation didn't encode it.

Both fixes are conservative: wording stays in "typical objects to check" territory rather than asserting absolute auth requirements (which vary by SAP release), and the encoding heuristic is idempotent so already-encoded IDs from `listDumps()` aren't double-encoded into `%2520`.

## Files

- `src/adt/diagnostics.ts` — `normalizeDumpId()` helper + applied in `getDump()`
- `src/adt/errors.ts` — `path?` parameter on `classifySapDomainError()` + `describeAuthEndpoint()` helper
- `src/handlers/intent.ts` — pass `err.path` through at both classifier call sites
- `tests/unit/adt/diagnostics.test.ts` — 4 new tests (already-encoded passthrough, raw-spaces encoding, original-ID round-trip, whitespace trim)
- `tests/unit/adt/errors.test.ts` — 5 new tests (dump-detail, dump-list, gateway-log, unknown-path fallback, no-path backward compat)

## Reviewer notes

- The encoding heuristic uses `id.includes('%')` to detect already-encoded IDs. There's a theoretical hole if an ID contains both `%xx` sequences and literal spaces, but listing-emitted IDs are uniformly encoded so this isn't observable in practice.
- `classifySapDomainError()` signature change is backwards-compatible (new param is optional); existing tests exercise the no-path path.
- Wording for the new 403 hints intentionally avoids prescribing exact ACTVT values beyond `03` (read) since SAP releases differ. Users still land on SU53 for the canonical answer.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 2,450 unit tests pass
- [ ] Manual verification against a system where the SAP user lacks `S_ADT_RES` on `/sap/bc/adt/runtime/dump/*` (left to reviewer if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
