### PR TITLE
Feat/add helmet middleware

### DIFF
--- a/manifest-btp-abap.yml
+++ b/manifest-btp-abap.yml
@@ -37,6 +37,8 @@ applications:
       SAP_ALLOW_FREE_SQL: "true"
       SAP_ALLOW_TRANSPORT_WRITES: "true"
       SAP_ALLOW_GIT_WRITES: "false"
+      # CORS: allowed origins for browser-based MCP clients (empty = disabled)
+      # ARC1_ALLOWED_ORIGINS: "https://your-ui.example.com"
       # Logging
       SAP_VERBOSE: "true"
     services:

--- a/manifest.yml
+++ b/manifest.yml
@@ -47,6 +47,8 @@ applications:
       SAP_ALLOW_FREE_SQL: "false"
       SAP_ALLOW_TRANSPORT_WRITES: "false"
       SAP_ALLOW_GIT_WRITES: "false"
+      # CORS: allowed origins for browser-based MCP clients (empty = disabled)
+      # ARC1_ALLOWED_ORIGINS: "https://your-ui.example.com"
       # Logging
       SAP_VERBOSE: "true"
     services:

--- a/mta.yaml
+++ b/mta.yaml
@@ -93,6 +93,9 @@ modules:
       SAP_ALLOW_TRANSPORT_WRITES: "false"
       SAP_ALLOW_GIT_WRITES: "false"
       SAP_ALLOWED_PACKAGES: "$TMP"
+      # CORS: allowed origins for browser-based MCP clients (empty = disabled).
+      # Set per landscape via mtaext or cf set-env.
+      ARC1_ALLOWED_ORIGINS: ""
     requires:
       - name: arc1-xsuaa
       - name: arc1-destination

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "fast-xml-parser": "^5.5.9",
+        "helmet": "^8.1.0",
         "jose": "^6.2.2",
         "undici": "^8.0.2",
         "zod": "^4.3.6"
@@ -2938,6 +2939,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hono": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "ajv": "^8.18.0",
         "better-sqlite3": "^12.8.0",
         "commander": "^14.0.3",
+        "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "fast-xml-parser": "^5.5.9",
@@ -33,6 +34,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
         "@types/better-sqlite3": "^7.6.13",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/node": "^22.0.0",
         "@types/supertest": "^7.2.0",
@@ -1319,6 +1321,16 @@
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.5.9",
+    "helmet": "^8.1.0",
     "jose": "^6.2.2",
     "undici": "^8.0.2",
     "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "ajv": "^8.18.0",
     "better-sqlite3": "^12.8.0",
     "commander": "^14.0.3",
+    "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.5.9",
@@ -96,6 +97,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/node": "^22.0.0",
     "@types/supertest": "^7.2.0",

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -467,6 +467,19 @@ export function resolveConfig(args: string[]): { config: ServerConfig; sources: 
     config.maxConcurrent = Number.isNaN(parsed) || parsed < 1 ? 1 : parsed;
   }
 
+  // ── CORS (browser-based MCP clients) ───────────────────────────────
+  const originsRaw = getFlag('allowed-origins') ?? process.env.ARC1_ALLOWED_ORIGINS;
+  if (originsRaw !== undefined) {
+    config.allowedOrigins = originsRaw
+      .split(',')
+      .map((o) => o.trim())
+      .filter((o) => o.length > 0);
+    sources.allowedOrigins =
+      getFlag('allowed-origins') !== undefined ? { flag: '--allowed-origins' } : { env: 'ARC1_ALLOWED_ORIGINS' };
+  } else {
+    sources.allowedOrigins = 'default';
+  }
+
   // ── Logging ────────────────────────────────────────────────────────
   config.logFile = resolveOptionalStr('log-file', 'ARC1_LOG_FILE', 'logFile');
   const logLevel = resolveStr('log-level', 'ARC1_LOG_LEVEL', 'info', 'logLevel');

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -27,6 +27,7 @@
 
 import type { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import cors from 'cors';
 import type { Request, Response } from 'express';
 import express from 'express';
 import helmet from 'helmet';
@@ -122,8 +123,41 @@ export async function startHttpServer(
   // Trust first proxy (CF gorouter) — required for express-rate-limit
   // and correct client IP detection behind CF's reverse proxy.
   app.set('trust proxy', 1);
-  // Security headers via helmet (applied before all routes).
-  app.use(helmet());
+  // Security headers via helmet. When CORS is enabled (browser-based clients),
+  // relax cross-origin policies so that browser fetch() and OAuth popup flows work.
+  const hasCorsOrigins = config.allowedOrigins.length > 0;
+  app.use(
+    helmet({
+      // Allow cross-origin reads when browser clients are configured
+      crossOriginResourcePolicy: hasCorsOrigins ? { policy: 'cross-origin' as const } : undefined,
+      // Keep OAuth popup/redirect window.opener relationship intact
+      crossOriginOpenerPolicy: hasCorsOrigins ? { policy: 'same-origin-allow-popups' as const } : undefined,
+      // Allow inline styles used by OAuth consent/error pages served by mcpAuthRouter
+      contentSecurityPolicy: hasCorsOrigins
+        ? {
+            directives: {
+              defaultSrc: ["'self'"],
+              scriptSrc: ["'self'"],
+              styleSrc: ["'self'", "'unsafe-inline'"],
+            },
+          }
+        : undefined,
+    }),
+  );
+  // CORS — only enabled when admin explicitly configures allowed origins.
+  // Without this, every browser-originated fetch() is silently blocked.
+  if (hasCorsOrigins) {
+    app.use(
+      cors({
+        origin: config.allowedOrigins,
+        methods: ['GET', 'POST', 'DELETE'],
+        allowedHeaders: ['Content-Type', 'Authorization', 'mcp-session-id'],
+        exposedHeaders: ['mcp-session-id'],
+        credentials: true,
+      }),
+    );
+    logger.info('CORS enabled', { origins: config.allowedOrigins });
+  }
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   const mcpHandler = createMcpHandler(serverFactory);

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -29,6 +29,7 @@ import type { Server as McpServer } from '@modelcontextprotocol/sdk/server/index
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { Request, Response } from 'express';
 import express from 'express';
+import helmet from 'helmet';
 import { expandScopes } from '../authz/policy.js';
 import { API_KEY_PROFILES } from './config.js';
 import { logger } from './logger.js';
@@ -121,6 +122,8 @@ export async function startHttpServer(
   // Trust first proxy (CF gorouter) — required for express-rate-limit
   // and correct client IP detection behind CF's reverse proxy.
   app.set('trust proxy', 1);
+  // Security headers via helmet (applied before all routes).
+  app.use(helmet());
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   const mcpHandler = createMcpHandler(serverFactory);

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -124,6 +124,10 @@ export interface ServerConfig {
   /** Maximum concurrent SAP HTTP requests (default: 10). Prevents work process exhaustion. */
   maxConcurrent: number;
 
+  // --- CORS (browser-based MCP clients) ---
+  /** Allowed origins for CORS (empty = CORS disabled). */
+  allowedOrigins: string[];
+
   // --- Misc ---
   verbose: boolean;
 }
@@ -170,6 +174,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   cacheWarmup: false,
   cacheWarmupPackages: '',
   maxConcurrent: 10,
+  allowedOrigins: [],
   logLevel: 'info',
   logFormat: 'text',
   verbose: false,


### PR DESCRIPTION
## feat: add security headers (helmet) + optional CORS

### Summary

* Add helmet (v8.1.0) for standard security headers (CSP, HSTS, X-Frame-Options, etc.)
* Add optional CORS via `ARC1_ALLOWED_ORIGINS` (env / CLI / mta.yaml)
* CORS disabled by default (requires explicit allowlist)

### Browser Compatibility (when CORS enabled)

* Cross-Origin-Resource-Policy: cross-origin
* Cross-Origin-Opener-Policy: same-origin-allow-popups
* CSP allows inline styles (OAuth flows)

### Configuration

```bash
ARC1_ALLOWED_ORIGINS="https://app.example.com,https://client.example.com"
```

Override via `mta.yaml`, `mtaext`, or `cf set-env`.

### Testing

**Automated**

* build, typecheck, lint: clean
* tests: 2450/2450 passing

**Manual (BTP CF)**

* No origins → no CORS headers
* With origins:

  * Preflight → 204 + CORS headers
  * Allowed origin → Access-Control-Allow-Origin set
  * Disallowed origin → no CORS headers
* Helmet headers always present

### Changes

* `server/types.ts` → add `allowedOrigins`
* `server/config.ts` → parse config
* `server/http.ts` → helmet + CORS middleware
* `mta.yaml` → add config property
* manifests → add examples
* deps → add helmet
