### PR TITLE
fix!: use CreateCorrectionRequest endpoint for transport creation

### DIFF
--- a/src/adt/transport.ts
+++ b/src/adt/transport.ts
@@ -76,29 +76,67 @@ export async function getTransport(
   return match ?? null;
 }
 
-/** Create a new transport request */
+/**
+ * Create a new transport request via the ADT CreateCorrectionRequest endpoint.
+ *
+ * Uses POST `/sap/bc/adt/cts/transports` (the same endpoint Eclipse ADT and
+ * marcellourbani/abap-adt-api use). The legacy POST `/cts/transportrequests`
+ * path with a `<tm:root tm:useraction="newrequest">` body is rejected by
+ * NW 7.5x with HTTP 400 "user action  is not supported" because that release's
+ * `CL_ADT_TM_RESOURCE` only accepts `useraction` on PUT operations
+ * (changeowner, release). Verified against NW 7.51 SP02.
+ *
+ * SAP infers the transport type (K/W/T) from the package's transport route
+ * configured in TADIR, so the legacy `transportType` argument is ignored
+ * by the backend and kept here only for API compatibility.
+ *
+ * @param targetPackage required — DEVCLASS the transport is created for
+ * @param objectUrl optional — ADT object URL hint for transport-route lookup;
+ *                  the object is NOT locked or attached to the transport
+ */
 export async function createTransport(
   http: AdtHttpClient,
   safety: SafetyConfig,
   description: string,
-  targetPackage?: string,
-  transportType = 'K',
+  targetPackage: string,
+  _transportType = 'K',
+  objectUrl?: string,
 ): Promise<string> {
   checkTransport(safety, '', 'CreateTransport', true);
 
-  const body = `<?xml version="1.0" encoding="UTF-8"?>
-<tm:root xmlns:tm="${CTS_NAMESPACE_TM}">
-  <tm:request tm:desc="${escapeXmlAttr(description)}" tm:type="${escapeXmlAttr(transportType)}"${targetPackage ? ` tm:target="${escapeXmlAttr(targetPackage)}"` : ''}/>
-</tm:root>`;
+  if (!targetPackage) {
+    throw new Error(
+      'createTransport: targetPackage (DEVCLASS) is required by the ADT CreateCorrectionRequest endpoint.',
+    );
+  }
 
-  const resp = await http.post('/sap/bc/adt/cts/transportrequests', body, CTS_CONTENT_TYPE_ORGANIZER, {
-    Accept: CTS_CONTENT_TYPE_ORGANIZER,
-  });
+  const refXml = objectUrl ? `<REF>${escapeXmlAttr(objectUrl)}</REF>` : '<REF/>';
+  const body = `<?xml version="1.0" encoding="UTF-8"?><asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+    <DATA>
+      <DEVCLASS>${escapeXmlAttr(targetPackage)}</DEVCLASS>
+      <REQUEST_TEXT>${escapeXmlAttr(description)}</REQUEST_TEXT>
+      ${refXml}
+      <OPERATION>I</OPERATION>
+    </DATA>
+  </asx:values>
+</asx:abap>`;
 
-  // Extract transport number from response
-  const parsed = parseXml(resp.body);
-  const requests = findDeepNodes(parsed, 'request');
-  return String(requests[0]?.['@_number'] ?? '');
+  const resp = await http.post(
+    '/sap/bc/adt/cts/transports',
+    body,
+    'application/vnd.sap.as+xml; charset=UTF-8; dataname=com.sap.adt.CreateCorrectionRequest',
+    { Accept: 'text/plain' },
+  );
+
+  // Response body is a path like "/com.sap.cts/object_record/NEDK928884" —
+  // the transport ID is the last path segment.
+  const transportId =
+    String(resp.body ?? '')
+      .trim()
+      .split('/')
+      .pop() ?? '';
+  return transportId;
 }
 
 /** Release a transport request */

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -4752,8 +4752,13 @@ async function handleSAPTransport(client: AdtClient, args: Record<string, unknow
     case 'create': {
       const description = String(args.description ?? '');
       if (!description) return errorResult('Description is required for "create" action.');
+      const targetPackage = String(args.package ?? '');
+      if (!targetPackage)
+        return errorResult(
+          'Package is required for "create" action — SAP needs DEVCLASS to determine the transport route.',
+        );
       const transportType = String(args.type ?? 'K');
-      const id = await createTransport(client.http, client.safety, description, undefined, transportType);
+      const id = await createTransport(client.http, client.safety, description, targetPackage, transportType);
       if (!id)
         return errorResult(
           'Transport creation succeeded but no transport ID was returned. Check the SAP system manually.',

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1196,7 +1196,7 @@ export function getToolDefinitions(
             description:
               'list: show transports (defaults to current user, modifiable only). ' +
               'get: fetch transport details including tasks and objects. ' +
-              'create: create a new transport request. ' +
+              'create: create a new transport request (requires description and package). ' +
               'release: release a single transport or task. ' +
               'delete: delete a transport (use recursive=true to delete tasks first). ' +
               'reassign: change transport owner (use recursive=true for tasks too). ' +
@@ -1211,7 +1211,11 @@ export function getToolDefinitions(
           },
           description: { type: 'string', description: 'Transport description text (required for create)' },
           name: { type: 'string', description: 'Object name (for check or history actions)' },
-          package: { type: 'string', description: 'Package name (for check action)' },
+          package: {
+            type: 'string',
+            description:
+              'Package name. Required for create (DEVCLASS — SAP infers the transport route from the package) and for check.',
+          },
           user: {
             type: 'string',
             description:

--- a/tests/integration/transport.integration.test.ts
+++ b/tests/integration/transport.integration.test.ts
@@ -80,12 +80,14 @@ describe('Transport Integration Tests', () => {
   // ─── getTransport ──────────────────────────────────────────────
 
   describe('getTransport', () => {
-    it('returns transport details with corrected Accept header', async () => {
+    it('returns transport details with corrected Accept header', async (ctx) => {
       // First list transports to find an existing one
       const transports = await listTransports(client.http, client.safety);
       if (transports.length === 0) {
-        // No transports available — create one to test with
-        const id = await createTransport(client.http, client.safety, 'ARC-1 integration test: getTransport');
+        // No transports available — create one to test with (needs a package)
+        const pkg = process.env.TEST_TRANSPORT_PACKAGE;
+        requireOrSkip(ctx, pkg, SkipReason.NO_TRANSPORT_PACKAGE);
+        const id = await createTransport(client.http, client.safety, 'ARC-1 integration test: getTransport', pkg);
         expect(id).toBeTruthy();
         expect(id).toMatch(/^[A-Z0-9]+K\d+$/);
 
@@ -132,21 +134,12 @@ describe('Transport Integration Tests', () => {
       }
     });
 
-    it('creates a transport with corrected namespace and media type', async (ctx) => {
+    it('creates a transport via CreateCorrectionRequest endpoint', async (ctx) => {
+      const pkg = process.env.TEST_TRANSPORT_PACKAGE;
+      requireOrSkip(ctx, pkg, SkipReason.NO_TRANSPORT_PACKAGE);
+
       const desc = `ARC-1 IT ${Date.now()}`;
-      let id: string;
-      try {
-        id = await createTransport(client.http, client.safety, desc);
-      } catch (err) {
-        // NW 7.50 SP02 rejects transport creation with 400
-        // "user action  is not supported" — a backend limitation of this
-        // release, not an ARC-1 bug. Skip rather than fail.
-        if (err instanceof Error && /user action\s+is not supported/i.test(err.message)) {
-          ctx.skip(`${SkipReason.BACKEND_UNSUPPORTED}: transport create not supported on this SAP release`);
-          return;
-        }
-        throw err;
-      }
+      const id = await createTransport(client.http, client.safety, desc, pkg);
 
       expect(id).toBeTruthy();
       // SAP transport IDs follow pattern: <SID>K<number>
@@ -158,17 +151,6 @@ describe('Transport Integration Tests', () => {
       expect(transport).not.toBeNull();
       expect(transport!.id).toBe(id);
       expect(transport!.description).toBe(desc);
-    });
-
-    it('creates a transport with target package', async (ctx) => {
-      const pkg = process.env.TEST_TRANSPORT_PACKAGE;
-      requireOrSkip(ctx, pkg, SkipReason.NO_TRANSPORT_PACKAGE);
-
-      const desc = `ARC-1 IT pkg ${Date.now()}`;
-      const id = await createTransport(client.http, client.safety, desc, pkg);
-      expect(id).toBeTruthy();
-      expect(id).toMatch(/^[A-Z0-9]+K\d+$/);
-      createdTransportIds.push(id);
     });
   });
 
@@ -233,16 +215,9 @@ describe('Transport Integration Tests', () => {
 
   describe('deleteTransport', () => {
     it('creates and deletes a transport', async (ctx) => {
-      let id: string;
-      try {
-        id = await createTransport(client.http, client.safety, `ARC-1 IT delete ${Date.now()}`);
-      } catch (err) {
-        if (err instanceof Error && /user action\s+is not supported/i.test(err.message)) {
-          ctx.skip(`${SkipReason.BACKEND_UNSUPPORTED}: transport create not supported on this SAP release`);
-          return;
-        }
-        throw err;
-      }
+      const pkg = process.env.TEST_TRANSPORT_PACKAGE;
+      requireOrSkip(ctx, pkg, SkipReason.NO_TRANSPORT_PACKAGE);
+      const id = await createTransport(client.http, client.safety, `ARC-1 IT delete ${Date.now()}`, pkg);
       expect(id).toBeTruthy();
 
       await deleteTransport(client.http, client.safety, id);
@@ -257,61 +232,22 @@ describe('Transport Integration Tests', () => {
     }, 30_000);
   });
 
-  // ─── createTransport with type ────────────────────────────────
-
-  describe('createTransport with type', () => {
-    it('creates a Customizing transport (type W)', async (ctx) => {
-      let id = '';
-      try {
-        id = await createTransport(client.http, client.safety, `ARC-1 IT type-W ${Date.now()}`, undefined, 'W');
-        expect(id).toBeTruthy();
-        const transport = await getTransport(client.http, client.safety, id);
-        expect(transport).not.toBeNull();
-        expect(transport!.type).toBe('W');
-      } catch (err) {
-        if (isUnsupportedBackend(err)) return ctx.skip('Backend does not support Customizing transports (type W)');
-        throw err;
-      } finally {
-        if (id) {
-          try {
-            await deleteTransport(client.http, client.safety, id, true);
-          } catch {
-            // best-effort-cleanup
-          }
-        }
-      }
-    }, 30_000);
-
-    it('creates a Transport of Copies (type T)', async (ctx) => {
-      let id = '';
-      try {
-        id = await createTransport(client.http, client.safety, `ARC-1 IT type-T ${Date.now()}`, undefined, 'T');
-        expect(id).toBeTruthy();
-        const transport = await getTransport(client.http, client.safety, id);
-        expect(transport).not.toBeNull();
-        expect(transport!.type).toBe('T');
-      } catch (err) {
-        if (isUnsupportedBackend(err)) return ctx.skip('Backend does not support Transport of Copies (type T)');
-        throw err;
-      } finally {
-        if (id) {
-          try {
-            await deleteTransport(client.http, client.safety, id, true);
-          } catch {
-            // best-effort-cleanup
-          }
-        }
-      }
-    }, 30_000);
-  });
+  // K/W/T transport type is no longer driven by the request body — the
+  // CreateCorrectionRequest endpoint infers the type from the target
+  // package's transport route in TADIR. The legacy `transportType`
+  // parameter is kept on the function signature for backward compatibility
+  // but ignored by the backend, so per-type integration tests would need
+  // separate Customizing/Workbench packages and are not portable.
 
   // ─── reassignTransport ────────────────────────────────────────
 
   describe('reassignTransport', () => {
     it('reassigns a transport to same user', async (ctx) => {
+      const pkg = process.env.TEST_TRANSPORT_PACKAGE;
+      requireOrSkip(ctx, pkg, SkipReason.NO_TRANSPORT_PACKAGE);
       let id = '';
       try {
-        id = await createTransport(client.http, client.safety, `ARC-1 IT reassign ${Date.now()}`);
+        id = await createTransport(client.http, client.safety, `ARC-1 IT reassign ${Date.now()}`, pkg);
         expect(id).toBeTruthy();
 
         const transport = await getTransport(client.http, client.safety, id);
@@ -341,9 +277,11 @@ describe('Transport Integration Tests', () => {
 
   describe('releaseTransportRecursive', () => {
     it('recursively releases a transport', async (ctx) => {
+      const pkg = process.env.TEST_TRANSPORT_PACKAGE;
+      requireOrSkip(ctx, pkg, SkipReason.NO_TRANSPORT_PACKAGE);
       let id = '';
       try {
-        id = await createTransport(client.http, client.safety, `ARC-1 IT recursive-release ${Date.now()}`);
+        id = await createTransport(client.http, client.safety, `ARC-1 IT recursive-release ${Date.now()}`, pkg);
         expect(id).toBeTruthy();
 
         const result = await releaseTransportRecursive(client.http, client.safety, id);

--- a/tests/unit/adt/transport.test.ts
+++ b/tests/unit/adt/transport.test.ts
@@ -196,38 +196,59 @@ describe('Transport Management', () => {
     it('is blocked when transports not enabled', async () => {
       const http = mockHttp();
       const safety = { ...unrestrictedSafetyConfig(), allowTransportWrites: false };
-      await expect(createTransport(http, safety, 'Test')).rejects.toThrow(AdtSafetyError);
+      await expect(createTransport(http, safety, 'Test', 'ZPACKAGE')).rejects.toThrow(AdtSafetyError);
+    });
+
+    it('throws when targetPackage is missing', async () => {
+      const http = mockHttp();
+      // Empty string is treated as "not provided" by the new endpoint contract.
+      await expect(createTransport(http, enabledSafety, 'Test', '')).rejects.toThrow(/targetPackage/);
     });
 
     it('creates transport when fully enabled', async () => {
-      const xml = '<tm:request tm:number="DEVK900002"/>';
-      const http = mockHttp(xml);
-      const id = await createTransport(http, enabledSafety, 'New transport');
+      const http = mockHttp('/com.sap.cts/object_record/DEVK900002');
+      const id = await createTransport(http, enabledSafety, 'New transport', 'ZPACKAGE');
       expect(id).toBe('DEVK900002');
     });
 
-    it('sends correct XML body (Issue #70: wrong content-type)', async () => {
-      const http = mockHttp('<tm:request tm:number="DEV123"/>');
+    it('sends correct CreateCorrectionRequest body (asx:abap envelope)', async () => {
+      const http = mockHttp('/com.sap.cts/object_record/DEV123');
       await createTransport(http, enabledSafety, 'My description', 'ZPACKAGE');
       const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
-      expect(body).toContain('tm:desc="My description"');
-      expect(body).toContain('tm:type="K"');
-      expect(body).toContain('tm:target="ZPACKAGE"');
+      expect(body).toContain('xmlns:asx="http://www.sap.com/abapxml"');
+      expect(body).toContain('<DEVCLASS>ZPACKAGE</DEVCLASS>');
+      expect(body).toContain('<REQUEST_TEXT>My description</REQUEST_TEXT>');
+      expect(body).toContain('<REF/>');
+      expect(body).toContain('<OPERATION>I</OPERATION>');
     });
 
-    it('escapes special characters in description', async () => {
-      const http = mockHttp('<tm:request tm:number="DEV123"/>');
-      await createTransport(http, enabledSafety, 'Test with "quotes" & <brackets>');
+    it('includes <REF> when objectUrl is provided', async () => {
+      const http = mockHttp('/com.sap.cts/object_record/DEV123');
+      await createTransport(http, enabledSafety, 'desc', 'ZPACKAGE', 'K', '/sap/bc/adt/oo/classes/zcl_foo');
+      const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
+      expect(body).toContain('<REF>/sap/bc/adt/oo/classes/zcl_foo</REF>');
+      expect(body).not.toContain('<REF/>');
+    });
+
+    it('escapes special characters in description and package', async () => {
+      const http = mockHttp('/com.sap.cts/object_record/DEV123');
+      await createTransport(http, enabledSafety, 'Test with "quotes" & <brackets>', 'Z&PKG');
       const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
       expect(body).toContain('&amp;');
       expect(body).toContain('&lt;');
       expect(body).toContain('&quot;');
     });
 
-    it('returns empty string when no transport number in response', async () => {
-      const http = mockHttp('<tm:root/>');
-      const id = await createTransport(http, enabledSafety, 'Test');
+    it('returns empty string when response body is empty', async () => {
+      const http = mockHttp('');
+      const id = await createTransport(http, enabledSafety, 'Test', 'ZPACKAGE');
       expect(id).toBe('');
+    });
+
+    it('extracts transport ID as the last path segment', async () => {
+      const http = mockHttp('/com.sap.cts/object_record/A4HK900100');
+      const id = await createTransport(http, enabledSafety, 'Test', 'ZPACKAGE');
+      expect(id).toBe('A4HK900100');
     });
   });
 
@@ -391,30 +412,9 @@ describe('Transport Management', () => {
     });
   });
 
-  // ─── createTransport with type ────────────────────────────────────
-
-  describe('createTransport with transport type', () => {
-    it('defaults to type K when not specified', async () => {
-      const http = mockHttp('<tm:request tm:number="DEV123"/>');
-      await createTransport(http, enabledSafety, 'Test');
-      const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
-      expect(body).toContain('tm:type="K"');
-    });
-
-    it('type W included in XML body', async () => {
-      const http = mockHttp('<tm:request tm:number="DEV123"/>');
-      await createTransport(http, enabledSafety, 'Test', undefined, 'W');
-      const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
-      expect(body).toContain('tm:type="W"');
-    });
-
-    it('type T included in XML body', async () => {
-      const http = mockHttp('<tm:request tm:number="DEV123"/>');
-      await createTransport(http, enabledSafety, 'Test', undefined, 'T');
-      const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
-      expect(body).toContain('tm:type="T"');
-    });
-  });
+  // The legacy K/W/T transportType argument is now ignored: the
+  // CreateCorrectionRequest endpoint infers the request type from the
+  // package's transport route (TADIR), not from the request body.
 
   // ─── releaseTransportRecursive ────────────────────────────────────
 
@@ -547,22 +547,15 @@ describe('Transport Management', () => {
       expect(headers.Accept).toBe(CTS_CONTENT_TYPE_ORGANIZER);
     });
 
-    it('createTransport sends organizer Accept and Content-Type', async () => {
-      const http = mockHttp('<tm:request tm:number="DEV123"/>');
-      await createTransport(http, enabledSafety, 'Test');
+    it('createTransport sends CreateCorrectionRequest Content-Type and text/plain Accept', async () => {
+      const http = mockHttp('/com.sap.cts/object_record/DEV123');
+      await createTransport(http, enabledSafety, 'Test', 'ZPACKAGE');
       const calls = (http.post as ReturnType<typeof vi.fn>).mock.calls[0];
       const contentType = calls?.[2] as string;
       const headers = calls?.[3] as Record<string, string>;
-      expect(contentType).toBe(CTS_CONTENT_TYPE_ORGANIZER);
-      expect(headers.Accept).toBe(CTS_CONTENT_TYPE_ORGANIZER);
-    });
-
-    it('createTransport uses correct TM namespace in payload', async () => {
-      const http = mockHttp('<tm:request tm:number="DEV123"/>');
-      await createTransport(http, enabledSafety, 'Test');
-      const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
-      expect(body).toContain(`xmlns:tm="${CTS_NAMESPACE_TM}"`);
-      expect(body).not.toContain('http://www.sap.com/cts/transports');
+      expect(contentType).toContain('application/vnd.sap.as+xml');
+      expect(contentType).toContain('dataname=com.sap.adt.CreateCorrectionRequest');
+      expect(headers.Accept).toBe('text/plain');
     });
 
     it('releaseTransport sends organizer Accept header', async () => {
@@ -572,11 +565,11 @@ describe('Transport Management', () => {
       expect(headers.Accept).toBe(CTS_CONTENT_TYPE_ORGANIZER);
     });
 
-    it('createTransport endpoint is /sap/bc/adt/cts/transportrequests', async () => {
-      const http = mockHttp('<tm:request tm:number="DEV123"/>');
-      await createTransport(http, enabledSafety, 'Test');
+    it('createTransport endpoint is /sap/bc/adt/cts/transports (CreateCorrectionRequest)', async () => {
+      const http = mockHttp('/com.sap.cts/object_record/DEV123');
+      await createTransport(http, enabledSafety, 'Test', 'ZPACKAGE');
       const url = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
-      expect(url).toBe('/sap/bc/adt/cts/transportrequests');
+      expect(url).toBe('/sap/bc/adt/cts/transports');
     });
 
     it('response parsing handles both old and new namespace attributes', async () => {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -8649,35 +8649,32 @@ ENDCLASS.`;
       expect(result.content[0]?.text).toContain('DEVK900001');
     });
 
-    it('create with type W passes type through', async () => {
-      const responseXml = '<tm:request tm:number="DEVK900099"/>';
-      mockFetch.mockResolvedValue(mockResponse(200, responseXml, { 'x-csrf-token': 'T' }));
+    it('create succeeds with description and package', async () => {
+      // CreateCorrectionRequest endpoint returns a path like /com.sap.cts/object_record/<id>
+      mockFetch.mockResolvedValue(mockResponse(200, '/com.sap.cts/object_record/DEVK900099', { 'x-csrf-token': 'T' }));
       const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
         action: 'create',
-        description: 'Customizing transport',
-        type: 'W',
+        description: 'Workbench transport',
+        package: 'ZTEST',
       });
       expect(result.isError).toBeUndefined();
       expect(result.content[0]?.text).toContain('DEVK900099');
-      // Verify the W type was in the request body
+      // Verify the body uses the asx:abap envelope and embeds DEVCLASS
       const fetchBody = mockFetch.mock.calls.find(
-        (c: unknown[]) => typeof c[1]?.body === 'string' && c[1].body.includes('tm:type'),
+        (c: unknown[]) => typeof c[1]?.body === 'string' && c[1].body.includes('DEVCLASS'),
       );
-      expect(fetchBody?.[1]?.body).toContain('tm:type="W"');
+      expect(fetchBody?.[1]?.body).toContain('<DEVCLASS>ZTEST</DEVCLASS>');
+      expect(fetchBody?.[1]?.body).toContain('<OPERATION>I</OPERATION>');
     });
 
-    it('create without type defaults to K', async () => {
-      const responseXml = '<tm:request tm:number="DEVK900099"/>';
-      mockFetch.mockResolvedValue(mockResponse(200, responseXml, { 'x-csrf-token': 'T' }));
+    it('create errors when package is missing', async () => {
+      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
       const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
         action: 'create',
         description: 'Default transport',
       });
-      expect(result.isError).toBeUndefined();
-      const fetchBody = mockFetch.mock.calls.find(
-        (c: unknown[]) => typeof c[1]?.body === 'string' && c[1].body.includes('tm:type'),
-      );
-      expect(fetchBody?.[1]?.body).toContain('tm:type="K"');
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toMatch(/package.*required/i);
     });
 
     it('list defaults to current SAP user and modifiable status', async () => {


### PR DESCRIPTION
## Summary

`SAPTransport(action="create")` is unusable on NetWeaver 7.5x backends today: SAP rejects the legacy `POST /sap/bc/adt/cts/transportrequests` body with HTTP 400 `user action  is not supported`, and the existing `BACKEND_UNSUPPORTED` skip in the integration suite hides the gap rather than fixing it.

I dug into the SAP response (the message comes from `CL_ADT_TM_RESOURCE`, with empty `<properties/>` so it's not a T100-parameterised message) and confirmed by experiment that NW 7.5x ignores `tm:useraction` on the `POST .../transportrequests` body — that backend only honours `useraction` on PUT operations like `changeowner` / release.

The fix is to switch to the same path that Eclipse ADT, [`marcellourbani/abap-adt-api`](https://github.com/marcellourbani/abap-adt-api/blob/main/src/api/transports.ts), and [`jfilak/sapcli`](https://github.com/jfilak/sapcli/blob/master/sap/adt/cts.py) use: `POST /sap/bc/adt/cts/transports` with the `asx:abap` `CreateCorrectionRequest` schema (`DEVCLASS` / `REQUEST_TEXT` / `REF` / `OPERATION`). SAP infers `K`/`W`/`T` from the package's transport route in TADIR, so the legacy `transportType` argument becomes a no-op kept only for signature compatibility. The response body looks like `/com.sap.cts/object_record/<id>`; the transport ID is the last path segment.

Verified live against NW 7.51 SP02 (an on-prem dev system). Without the fix the `SAPTransport create` call fails 100% of the time; with it, transport creation now works end-to-end via the MCP tool.

## ⚠ Breaking change

`createTransport()` and `SAPTransport(action="create")` now require a target package. Without one the call returns an actionable error (`Package is required for "create" action — SAP needs DEVCLASS to determine the transport route.`) instead of a confusing 400 from SAP. The `package` parameter already existed on the tool schema for `check`; this PR documents it as required for `create` too.

## Test plan

- [x] `npx vitest run tests/unit/adt/transport.test.ts` — 68/68 pass with the rewritten body, response, content-type, and endpoint assertions
- [x] `npx vitest run tests/unit/handlers/intent.test.ts` — 458/458 pass, including a new "create errors when package is missing" case
- [x] `npx tsc --noEmit` — clean
- [x] Manual end-to-end: `SAPTransport(action="create", description="…", package="ZCAO")` now returns a fresh transport ID on NW 7.51 SP02 (verified with `SAPTransport(action="get")`)
- [ ] Re-run the integration suite against a system that exposes both Customizing and Workbench packages — I only had a Workbench-routed package available, so I dropped the per-type integration tests that relied on the legacy `tm:type` body assertion. They could come back later with `TEST_TRANSPORT_PACKAGE_W` / `TEST_TRANSPORT_PACKAGE_K` env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)