### PR TITLE
chore(security): Dependabot config, SECURITY.md, workflow permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+# Dependabot configuration for ARC-1.
+# Documented in docs/plans/dependency-security-tier1-foundation.md (SEC-11).
+# Three ecosystems: npm (production code), github-actions (CI), docker (base image).
+# Schedule: weekly. Security advisories are handled separately by Dependabot's
+# security-updates feature (enabled in repo Settings → Advanced Security).
+
+version: 2
+updates:
+  # ─── npm dependencies ────────────────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "marianfoo"
+    groups:
+      # Bundle dev-only minor + patch updates into a single PR — low review cost.
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      # @types/* packages are noisy — group them so they don't clutter the PR list.
+      types:
+        patterns:
+          - "@types/*"
+      # SAP SDKs change together; review as a unit.
+      sap-sdk:
+        patterns:
+          - "@sap/*"
+          - "@sap-cloud-sdk/*"
+      # MCP SDK updates often touch protocol behavior — review as a unit.
+      mcp-sdk:
+        patterns:
+          - "@modelcontextprotocol/*"
+      # Biome (linter) bumps need biome.json $schema URL bump too.
+      linting:
+        patterns:
+          - "@biomejs/*"
+          - "biome"
+
+  # ─── GitHub Actions ──────────────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "marianfoo"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # ─── Docker base image (node:22-alpine in Dockerfile) ────────────────────
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "marianfoo"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,13 @@ concurrency:
   group: sap-tests-${{ github.ref }}
   cancel-in-progress: true
 
+# Minimum required GITHUB_TOKEN permissions — closes CodeQL
+# `actions/missing-workflow-permissions` alerts. All jobs only need to read
+# the repo (artifact upload via `actions/upload-artifact@v4+` does not need
+# additional permissions; SAP secrets are passed via `env:` from `secrets.*`).
+permissions:
+  contents: read
+
 jobs:
   # Smoke check that mta.yaml + the .mtaext.example template are valid MTA
   # descriptors. Runs on every push/PR (no SAP secrets needed) so a broken

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+ARC-1 is an enterprise MCP server for SAP ABAP systems, distributed as an [npm package](https://www.npmjs.com/package/arc-1) and a [Docker image](https://github.com/marianfoo/arc-1/pkgs/container/arc-1) and deployed on SAP BTP Cloud Foundry, Docker hosts, and on-premise servers. Security reports are taken seriously — please follow this policy when reporting.
+
+## Supported Versions
+
+Pre-1.0 (current state): only the latest published minor line receives security fixes.
+
+| Version | Supported              |
+| ------- | ---------------------- |
+| 0.8.x   | :white_check_mark:     |
+| < 0.8   | :x: — please upgrade   |
+
+After 1.0, this table will reflect the documented support window for each major.
+
+## Reporting a Vulnerability
+
+**Preferred — GitHub Private Vulnerability Reporting:**
+[Open a private advisory](https://github.com/marianfoo/arc-1/security/advisories/new). This routes the report directly to the maintainers, keeps it confidential, and gives us a private workspace to coordinate the fix.
+
+**Fallback — email:**
+`marianbsp@gmail.com`. Please include "ARC-1 security" in the subject line. If you need to send encrypted email, request a public key in the first message.
+
+**Please do _not_** open a public GitHub issue, post on the SAP Community, or share details on social media until a fix is published. Coordinated disclosure protects users running affected versions.
+
+## Response Times (best-effort, non-contractual)
+
+| Stage                                  | Target                  |
+| -------------------------------------- | ----------------------- |
+| Acknowledgement of report              | within 3 business days  |
+| Initial triage and severity assessment | within 7 business days  |
+| Critical fix or mitigation             | within 14 days          |
+| High fix or mitigation                 | within 30 days          |
+| Moderate fix or mitigation             | within 60 days          |
+| Low fix or mitigation                  | best-effort             |
+
+Severity follows [CVSS v3.1](https://www.first.org/cvss/v3-1/specification-document) where applicable.
+
+## CVE Handling
+
+Confirmed vulnerabilities receive a [GitHub Security Advisory (GHSA)](https://github.com/marianfoo/arc-1/security/advisories) and, where applicable, a CVE assigned via GitHub's CNA. Patches publish through the normal release flow ([release-please](https://github.com/googleapis/release-please) → npm + ghcr.io); the advisory marks affected versions and the fixed version. Where the patch warrants user action (e.g., config change), the advisory and the release notes call it out explicitly.
+
+## Out of Scope
+
+- **SAP system vulnerabilities.** ARC-1 is a client of SAP ADT APIs. Vulnerabilities in the SAP system itself (NetWeaver, S/4HANA, BTP ABAP Environment, Cloud Connector) belong to SAP — please report via [SAP's responsible-disclosure channel](https://www.sap.com/about/trust-center/security/incident-management.html).
+- **Upstream dependency vulnerabilities** with no ARC-1-specific exposure (i.e. the upstream advisory does not impact how ARC-1 uses the dependency). Please report upstream to the affected project. ARC-1 tracks affected upstream advisories via Dependabot.
+- **Theoretical vulnerabilities** without a concrete exploitation path against ARC-1's documented usage. We're happy to discuss design hardening, but those discussions belong in [GitHub Discussions](https://github.com/marianfoo/arc-1/discussions) or a regular issue, not the private advisory channel.
+- **Issues in unsupported versions** (see Supported Versions above).
+
+## Safe Harbor
+
+ARC-1 supports good-faith security research. Researchers acting in good faith and following this policy will not face legal action.
+
+We commit to:
+- Responding within the timelines above.
+- Working with you to reproduce and understand the issue.
+- Crediting you in the resulting GHSA / CVE if you wish (or honoring an anonymous-disclosure request).
+- Not pursuing legal action against research conducted in accordance with this policy.
+
+## Hardening Recommendations for Operators
+
+This policy covers vulnerability *reporting*. For runtime hardening recommendations (auth modes, safety flags, audit logging, network policy, secrets management, incident-response playbooks), see the [Security Best Practices Guide](https://marianfoo.github.io/arc-1/security-guide/).


### PR DESCRIPTION
## Summary

Three small, self-contained Tier 1 additions from the dependency-security plan ([#226](https://github.com/marianfoo/arc-1/pull/226)):

### 1. `.github/dependabot.yml`
Three ecosystems (`npm`, `github-actions`, `docker`), weekly Monday updates at 06:00 Europe/Berlin, with grouping rules to keep PR volume manageable:
- `dev-dependencies`: dev-only minor + patch bundled
- `types`: `@types/*` together
- `sap-sdk`: `@sap/*` + `@sap-cloud-sdk/*` together
- `mcp-sdk`: `@modelcontextprotocol/*` together
- `linting`: `@biomejs/*` + `biome` together (Biome bumps usually need a `biome.json` `$schema` URL bump too)
- Production deps outside these groups stay individual so they get focused review.

This file is a no-op until **Dependabot version updates** is toggled on in repo Settings → Advanced Security (the toggle you saw in the screenshot).

### 2. `SECURITY.md`
Vulnerability reporting policy. Preferred channel: [GitHub Private Vulnerability Reporting](https://github.com/marianfoo/arc-1/security/advisories/new). Fallback: `marianbsp@gmail.com`. Severity-tiered response SLAs:

| Stage | Target |
|---|---|
| Acknowledgement | 3 business days |
| Triage + severity | 7 business days |
| Critical fix | 14 days |
| High fix | 30 days |
| Moderate fix | 60 days |

Out-of-scope explicitly lists SAP system bugs (route to SAP), upstream-only dep vulns (route upstream), and theoretical issues without an exploitation path. Safe-harbor clause for good-faith research. Renders on the repo's Security tab and raises the OpenSSF Scorecard `Security-Policy` check from missing → satisfied.

### 3. `.github/workflows/test.yml` — top-level `permissions:`
Adds `permissions: contents: read` at the workflow root. **Closes 5 of the 12 open CodeQL alerts** (`actions/missing-workflow-permissions`, MEDIUM, alerts #1–5 — covering the `mta-validate`, `test`, `integration`, `e2e`, and `reliability-summary` jobs). All five jobs only need read access — artifact upload via `actions/upload-artifact@v4+` doesn't need extra permissions, and SAP credentials are injected via `env:` from `secrets.*`, which doesn't require permission grants.

## Operator action required after merge

In repo Settings → Advanced Security, toggle on:
- **Dependabot alerts**
- **Dependabot security updates**
- **Grouped security updates**
- **Dependabot version updates** ← reads the new `.github/dependabot.yml`
- **Private vulnerability reporting** ← referenced by `SECURITY.md`

(All five were `Disabled` in the screenshot you shared.)

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'` — exits 0.
- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/test.yml"))'` — exits 0.
- [ ] After merge: confirm the CodeQL re-run drops the 5 `actions/missing-workflow-permissions` alerts.
- [ ] After Dependabot version-updates toggle is enabled in repo settings: confirm Dependabot Insights show the three ecosystems being tracked.
- [ ] `SECURITY.md` renders on https://github.com/marianfoo/arc-1/security and on the repo landing page.

## Context

This PR addresses Tasks 2 and 8 of the Tier 1 plan in [#226](https://github.com/marianfoo/arc-1/pull/226). Once merged, those tasks should get marked complete in a follow-up plan-update commit (similar to how Task 1 was marked done after [#227](https://github.com/marianfoo/arc-1/pull/227)).

The remaining CodeQL alerts (7 HIGH — clear-text logging, double-escaping, incomplete sanitization, missing rate limiting) need code-level fixes and warrant separate review/PRs — they are not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)