### PR TITLE
chore(deps): ignore @types/node and Docker node major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,14 @@ updates:
         patterns:
           - "@biomejs/*"
           - "biome"
+    ignore:
+      # @types/node major must match `engines.node` minimum (currently
+      # `>=22.0.0`), not Node's latest release line. Bumping to a newer
+      # major surfaces APIs that don't exist on the minimum supported
+      # runtime, allowing accidental use of APIs that crash at runtime.
+      # Bump @types/node major in the same PR that bumps engines.node.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # ─── GitHub Actions ──────────────────────────────────────────────────────
   - package-ecosystem: "github-actions"
@@ -83,3 +91,10 @@ updates:
       - "dependencies"
     reviewers:
       - "marianfoo"
+    ignore:
+      # Stay on Node LTS for the published image. Node 22 is in active
+      # LTS until Apr 2027; next planned bump is to `node:24-alpine`
+      # (LTS from Oct 2026). Dependabot doesn't know the LTS schedule —
+      # block major bumps and bump manually on the LTS cadence.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Two `ignore` rules added to `.github/dependabot.yml` so Dependabot stops opening PRs we always close:

| Ignore | Reason |
|---|---|
| `@types/node` major | Must match `engines.node` minimum (currently `>=22.0.0`), not the latest Node release line. Bumping to a newer major surfaces APIs that don't exist on the minimum supported runtime. Bump in the same PR that bumps `engines.node`. — Closes [#231](https://github.com/marianfoo/arc-1/pull/231). |
| Docker `node` major | Image must stay on Node LTS. Node 22 is in active LTS until Apr 2027; next planned bump is `node:24-alpine` (LTS from Oct 2026). Dependabot doesn't know the LTS schedule. — Closes [#230](https://github.com/marianfoo/arc-1/pull/230). |

TypeScript major bumps are deliberately left without an ignore rule — we want Dependabot to surface them so we know one is available, and then review per-PR.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'` — exits 0.
- [ ] After merge: confirm Dependabot does not re-open the closed `@types/node` and `node:` major-bump PRs in next Monday's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)