### PR TITLE
docs(security): verify and document GitHub-native security toggles

### DIFF
--- a/docs_page/security-guide.md
+++ b/docs_page/security-guide.md
@@ -404,11 +404,27 @@ ARC-1 ships as an [npm package](https://www.npmjs.com/package/arc-1) and a [Dock
 | npm provenance | `.github/workflows/release.yml` (`npm publish --provenance`) | every release tarball is Sigstore-attested |
 | `SECURITY.md` policy | repo root | private vulnerability reporting + severity-tiered response SLAs |
 
-GitHub-native repository toggles that should also be on (verified in Settings → Advanced Security):
+### GitHub-native security features (verified enabled)
 
-- Dependabot alerts + security updates + version updates + grouped security updates + malware alerts
-- Secret scanning + push protection
-- Private vulnerability reporting
+These toggles live on the repo's Settings → Code security page and are checked here so a cold reader can confirm what's on without leaving the docs. Last verified: **2026-05-08**.
+
+| Feature | API verification | Status |
+|---|---|---|
+| Dependabot alerts | `gh api repos/marianfoo/arc-1/vulnerability-alerts -i \| head -1` → `HTTP/2.0 204` | ✅ enabled |
+| Dependabot security updates | `gh api repos/marianfoo/arc-1 --jq '.security_and_analysis.dependabot_security_updates.status'` → `"enabled"` | ✅ enabled |
+| Dependabot version updates | reads `.github/dependabot.yml` (in repo root) — toggled on at the same time as security updates; verify activity in [Insights → Dependency graph → Dependabot](https://github.com/marianfoo/arc-1/network/updates) | ✅ enabled |
+| Dependabot grouped security updates | toggled on in Settings → Code security; no public REST field — verify by inspecting any auto-opened security PR (groups multiple advisories per ecosystem into one PR) | ✅ enabled |
+| Dependabot malware alerts | toggled on in Settings → Code security; no public REST field — verify only via the Security tab when an alert fires | ✅ enabled |
+| Secret scanning | `gh api repos/marianfoo/arc-1 --jq '.security_and_analysis.secret_scanning.status'` → `"enabled"` | ✅ enabled |
+| Push protection | `gh api repos/marianfoo/arc-1 --jq '.security_and_analysis.secret_scanning_push_protection.status'` → `"enabled"` | ✅ enabled |
+| Private vulnerability reporting | `gh api repos/marianfoo/arc-1/private-vulnerability-reporting --jq .enabled` → `true` | ✅ enabled |
+
+Optional toggles **not** enabled (deliberate — listed here so the absence is documented, not silent):
+
+- `secret_scanning_non_provider_patterns` — custom regex patterns. Off by default; only worth turning on if we need to scan for project-specific secret formats (we don't).
+- `secret_scanning_validity_checks` — asks the upstream provider whether a leaked token is still valid. Off because the noise/value tradeoff doesn't justify it for a project our size; revisit if the validity API stabilizes and a customer asks.
+
+User-account-level recommendation (cannot be enforced via repo settings): the project maintainer should also enable push protection at [user level](https://github.com/settings/security_analysis), which catches secrets pushed to *any* repo the maintainer commits to (including private forks of `arc-1`).
 
 ### Verifying the chain as an operator
 


### PR DESCRIPTION
## Summary

Subset of Tier 3 plan Task 2 — verify and document the GitHub-native security toggles. The Socket.dev (§15.1) and vulnerability triage runbook (§15.3) parts of Task 2 stay deferred to Tier 3 Tasks 1 and 3.

Replaces the previous bullet list in `docs_page/security-guide.md` §13 with a **verification table** that pairs every toggle with the exact `gh api` command that confirms its state. All 8 toggles verified enabled on 2026-05-08:

| Feature | API verification | Status |
|---|---|---|
| Dependabot alerts | `gh api repos/marianfoo/arc-1/vulnerability-alerts -i \| head -1` → `HTTP/2.0 204` | ✅ |
| Dependabot security updates | `gh api repos/marianfoo/arc-1 --jq '.security_and_analysis.dependabot_security_updates.status'` → `"enabled"` | ✅ |
| Dependabot version updates | reads `.github/dependabot.yml` | ✅ |
| Dependabot grouped security updates | no REST field — UI verified | ✅ |
| Dependabot malware alerts | no REST field — UI verified | ✅ |
| Secret scanning | `gh api repos/marianfoo/arc-1 --jq '.security_and_analysis.secret_scanning.status'` → `"enabled"` | ✅ |
| Push protection | `gh api repos/marianfoo/arc-1 --jq '.security_and_analysis.secret_scanning_push_protection.status'` → `"enabled"` | ✅ |
| Private Vulnerability Reporting | `gh api repos/marianfoo/arc-1/private-vulnerability-reporting --jq .enabled` → `true` | ✅ |

Also documents two opt-in toggles deliberately **not** enabled (`secret_scanning_non_provider_patterns`, `secret_scanning_validity_checks`) so the absence is visible rather than silent, and a recommendation to enable push protection at user level (which cannot be enforced repo-side).

## Test plan

- [x] Each `gh api` command in the table runs successfully against the live repo and returns the documented value.
- [ ] After merge, `mkdocs build` (run by `pages.yml`) renders §13 with the new subsection cleanly.
- [ ] Future re-verification: re-run the table's commands quarterly (or whenever a maintainer flips a toggle) and update the "Last verified" date.

## Context

This PR is the small, low-risk piece of Tier 3 plan Task 2 that doesn't depend on Socket.dev install or the vulnerability triage runbook. Pulling it forward gives operators / auditors a one-page checklist of what's on at the repo level today, with copy-pasteable verification commands. The remaining Tier 3 work (Socket.dev, runbook, non-adoption memo) stays in [`docs/plans/dependency-security-tier3-defense.md`](https://github.com/marianfoo/arc-1/blob/main/docs/plans/dependency-security-tier3-defense.md) for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)