### PR TITLE
fix(docker): drop bundled npm CLI from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,16 @@ LABEL io.modelcontextprotocol.server.name="io.github.marianfoo/arc-1"
 # ca-certificates: needed for HTTPS connections to SAP systems
 RUN apk add --no-cache tini ca-certificates
 
+# Drop the bundled npm CLI from the runtime image. We exec `node dist/index.js`
+# directly, so npm/npx are never invoked at runtime — but their transitive
+# bundle (picomatch, brace-expansion, ip-address, …) recurringly raises HIGH
+# CVEs that block the gating Trivy scan in release.yml. Removing them shrinks
+# the image and the CVE surface in one shot.
+RUN rm -rf \
+  /usr/local/lib/node_modules/npm \
+  /usr/local/bin/npm \
+  /usr/local/bin/npx
+
 # Run as non-root user
 RUN addgroup -S arc1 && adduser -S arc1 -G arc1
 WORKDIR /home/arc1


### PR DESCRIPTION
## Summary

- The release-gating Trivy scan in `.github/workflows/release.yml` (added in #236) started failing on the v0.9.0 release because `node:22-alpine` bundles an `npm` CLI whose vendored `picomatch@4.0.3` is flagged by **CVE-2026-33671** (HIGH ReDoS, fixed in 4.0.4).
- The runtime image only execs `node dist/index.js`; `npm`/`npx` are never invoked at runtime, so they are pure CVE surface (and they also pull in `brace-expansion`, `ip-address`, etc., each of which has had its own CVE recently).
- This PR removes `/usr/local/lib/node_modules/npm` plus the `/usr/local/bin/npm` + `/usr/local/bin/npx` symlinks in the runtime stage of the multi-stage Dockerfile. The build stage still uses npm normally to `npm ci` + build + prune dev deps.

## What else can fail with the same root cause

Three other CI steps look at the same image / package set, but only the release path is gating today:

| Workflow | Scope | Gating? | Status |
|---|---|---|---|
| `release.yml` -> `Scan image with Trivy (gating)` | Built release image, HIGH/CRITICAL | **yes (`exit-code: 1`)** | Was failing — this PR fixes it |
| `docker.yml` -> `Scan image with Trivy` | Built dev image, HIGH/CRITICAL | no (`exit-code: 0`) | Surfaces same CVE on `main` pushes; SARIF still uploaded — this PR also clears it |
| `test.yml` -> `Security audit (npm audit)` | `package-lock.json`, HIGH/CRITICAL | yes | Unaffected — only scans our app deps, not the OS-level `npm` bundle |
| `dependency-review.yml` | PR diff against base | yes (HIGH) | Unaffected — same reason |

Net effect after merge: gating Trivy scan goes green, the dev-push Trivy SARIF report stops surfacing the npm-bundle CVEs as alerts on the Security tab.

## Release notes

- The npm publish for v0.9.0 succeeded ([npm view arc-1@0.9.0](https://www.npmjs.com/package/arc-1)). The Docker tag for v0.9.0 was **not** pushed because the gating scan failed before the manifest-merge job. After this PR merges, release-please will cut a v0.9.1 with a clean Docker tag, MCP-Registry entry, and `:latest`. (Re-running the failed jobs in run [25580704239](https://github.com/marianfoo/arc-1/actions/runs/25580704239) is **not** sufficient — the re-run would build from the pre-fix commit `053a652`.)

## Test plan

- [ ] CI: `Docker (dev)` workflow builds amd64 + arm64 successfully on this PR / on `main` after merge.
- [ ] CI: `Docker (dev)` Trivy SARIF on `main` no longer reports `CVE-2026-33671` (or other npm-bundle CVEs).
- [ ] CI: Release workflow on the v0.9.1 release commit completes the `publish-docker` matrix without Trivy `exit-code: 1`.
- [ ] Container smoke: `docker run --rm ghcr.io/marianfoo/arc-1:latest node --version` works (npm absence does not affect node).
- [ ] Container smoke: `docker run --rm ghcr.io/marianfoo/arc-1:latest npm --version` returns "not found" (confirms removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)