### PR TITLE
fix(adt): decode XML entities in parseSearchResults description

### DIFF
--- a/src/adt/xml-parser.ts
+++ b/src/adt/xml-parser.ts
@@ -114,6 +114,14 @@ export function parseXml(xml: string): Record<string, unknown> {
  * <adtcore:objectReferences>
  *   <adtcore:objectReference uri="..." type="PROG/P" name="ZTEST" packageName="$TMP" description="..."/>
  * </adtcore:objectReferences>
+ *
+ * The shared parser runs with `processEntities: false` (intentional — dump XML
+ * can exceed fast-xml-parser's `maxTotalExpansions` cap), so XML attribute
+ * values like descriptions arrive with `&gt;` / `&amp;` / `&lt;` / `&quot;` /
+ * `&apos;` un-decoded. We decode the user-visible free-text field
+ * (`description`) at the boundary via `decodeXmlEntities()`. Object names,
+ * types, URIs, and package names don't carry free text — leaving them
+ * undecoded is intentional.
  */
 export function parseSearchResults(xml: string): AdtSearchResult[] {
   const parsed = parseXml(xml);
@@ -121,7 +129,7 @@ export function parseSearchResults(xml: string): AdtSearchResult[] {
   return refs.map((ref: Record<string, unknown>) => ({
     objectType: String(ref['@_type'] ?? ''),
     objectName: String(ref['@_name'] ?? ''),
-    description: String(ref['@_description'] ?? ''),
+    description: decodeXmlEntities(String(ref['@_description'] ?? '')),
     packageName: String(ref['@_packageName'] ?? ''),
     uri: String(ref['@_uri'] ?? ''),
   }));

--- a/tests/unit/adt/xml-parser.test.ts
+++ b/tests/unit/adt/xml-parser.test.ts
@@ -118,6 +118,61 @@ describe('XML Parser', () => {
       expect(results[0]?.objectName).toBe('');
       expect(results[0]?.objectType).toBe('');
     });
+
+    // Regression for the "literal &gt; in description" bug. The shared parser
+    // runs with processEntities:false (intentional — see xml-parser.ts header
+    // comment). Free-text fields are decoded at the boundary so consumers see
+    // the human-readable form, not the wire-encoded form.
+    describe('decodes standard XML entities in description', () => {
+      function descOf(rawAttr: string): string | undefined {
+        const xml = `<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+          <adtcore:objectReference uri="/u" type="PROG/P" name="ZX" packageName="$TMP" description="${rawAttr}"/>
+        </adtcore:objectReferences>`;
+        return parseSearchResults(xml)[0]?.description;
+      }
+
+      it('decodes &gt; (the original repro)', () => {
+        expect(descOf('Seed data for SEGW-&gt;RAP demo')).toBe('Seed data for SEGW->RAP demo');
+      });
+
+      it('decodes &lt;', () => {
+        expect(descOf('Less &lt; than')).toBe('Less < than');
+      });
+
+      it('decodes &amp;', () => {
+        expect(descOf('Cars &amp; coffee')).toBe('Cars & coffee');
+      });
+
+      it('decodes &quot;', () => {
+        expect(descOf('She said &quot;hi&quot;')).toBe('She said "hi"');
+      });
+
+      it('decodes &apos;', () => {
+        expect(descOf('It&apos;s fine')).toBe("It's fine");
+      });
+
+      it('decodes all five mixed in one description', () => {
+        expect(descOf('a &gt; b &amp; c &lt; d &quot;e&quot; &apos;f&apos;')).toBe('a > b & c < d "e" \'f\'');
+      });
+
+      it('decodes &amp; LAST so &amp;lt; resolves to literal &lt; (CodeQL js/double-escaping)', () => {
+        // If &amp; were decoded first, &amp;lt; → &lt; → < (incorrect).
+        // We decode &amp; last, so &amp;lt; → &lt; (literal text).
+        expect(descOf('a &amp;lt; b')).toBe('a &lt; b');
+      });
+
+      it("leaves names/types/uri/packageName undecoded (they don't carry free text)", () => {
+        // Synthetic — SAP wouldn't produce these — but the contract says we don't touch these fields.
+        const xml = `<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+          <adtcore:objectReference uri="/u&amp;r" type="X&amp;Y" name="N&amp;M" packageName="P&amp;Q" description="d"/>
+        </adtcore:objectReferences>`;
+        const r = parseSearchResults(xml)[0];
+        expect(r?.uri).toBe('/u&amp;r');
+        expect(r?.objectType).toBe('X&amp;Y');
+        expect(r?.objectName).toBe('N&amp;M');
+        expect(r?.packageName).toBe('P&amp;Q');
+      });
+    });
   });
 
   // ─── parseTableContents ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The shared `parseXml` config sets `processEntities: false` (intentional — ST22 dump XML can exceed fast-xml-parser's `maxTotalExpansions=1000` cap). The cost: XML attribute values arrive raw, e.g. `Seed data for SEGW-&gt;RAP demo` stays wire-encoded instead of `Seed data for SEGW->RAP demo`.
- Fix: apply the existing `decodeXmlEntities()` helper to `parseSearchResults.description` (the field that surfaces SAP free text to consumers via `SAPSearch` / `getPackageContents`).
- Other fields (`objectType`, `objectName`, `packageName`, `uri`) don't carry free text on real systems — left undecoded.

## Reproducer (before)

```bash
arc1-cli search ZDM_SEED_DATA
# description: "Seed data for SEGW-&gt;RAP demo"   ← wire-encoded
```

## After

```bash
arc1-cli search ZDM_SEED_DATA
# description: "Seed data for SEGW->RAP demo"   ← decoded
```

Smoke-tested against `a4h.marianzeis.de`.

## Test plan

- [x] 8 new tests in `tests/unit/adt/xml-parser.test.ts > parseSearchResults > decodes standard XML entities in description`:
  - one per standard XML entity (`&gt;`, `&lt;`, `&amp;`, `&quot;`, `&apos;`)
  - mixed-entity case
  - chained-entity case (`&amp;lt;` resolves to `&lt;`, not `<` — CodeQL `js/double-escaping`)
  - contract test that `objectName` / `objectType` / `uri` / `packageName` remain undecoded
- [x] Existing 5 `parseSearchResults` tests stay green
- [x] Full unit suite (81 files) passes
- [x] Live smoke test on `a4h.marianzeis.de`

## Out of scope (potential follow-ups)

Other parsers in `xml-parser.ts` likely have the same gap for any field that carries free SAP text (e.g. `parseSourceSearchResults`, message-related parsers). Sweeping all of them is its own PR — flagged separately.

Pairs naturally with #242 (the DEVC listing fix), but is independent — both ship value on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)