### PR TITLE
fix(ci): pin Trivy --platform to matrix platform on arm64 runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,6 +61,13 @@ jobs:
       # The release workflow gates HIGH/CRITICAL (exit-code: 1).
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        # Pin the scan to the matrix platform. buildx with provenance attestation
+        # wraps each push-by-digest output in an OCI index; without TRIVY_PLATFORM,
+        # Trivy defaults to linux/amd64 and fails on the arm64 runner with
+        # "no child with platform linux/amd64 in index" (a fatal error that exits
+        # non-zero regardless of the scan's --exit-code setting).
+        env:
+          TRIVY_PLATFORM: ${{ matrix.platform }}
         with:
           image-ref: ghcr.io/marianfoo/arc-1@${{ steps.build.outputs.digest }}
           format: sarif

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,12 @@ jobs:
       # but non-gating, so iteration isn't blocked.)
       - name: Scan image with Trivy (gating)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        # Pin the scan to the matrix platform. buildx with provenance attestation
+        # wraps each push-by-digest output in an OCI index; without TRIVY_PLATFORM,
+        # Trivy defaults to linux/amd64 and fails on the arm64 runner with
+        # "no child with platform linux/amd64 in index".
+        env:
+          TRIVY_PLATFORM: ${{ matrix.platform }}
         with:
           image-ref: ghcr.io/marianfoo/arc-1@${{ steps.build.outputs.digest }}
           format: sarif


### PR DESCRIPTION
## Summary

The v0.9.1 [release workflow](https://github.com/marianfoo/arc-1/actions/runs/25582293344) failed on the arm64 leg with:

```
FATAL  Fatal error  image scan error: scan error: unable to initialize a scan service: …
  remote error: no child with platform linux/amd64 in index
  ghcr.io/marianfoo/arc-1@sha256:a0e1ce65a9d76674c0293bb10149962150f73c41bdd7ae7fa4321c8c51d3355a
```

`docker/build-push-action@v7` with provenance enabled wraps each `push-by-digest` push in an OCI **index**, even for a single platform. The amd64 runner's index has a `linux/amd64` child, so Trivy's default platform happens to match. The arm64 runner's index has only a `linux/arm64` child plus an `unknown/unknown` provenance attestation, so Trivy's default `linux/amd64` lookup fails fatally — and a fatal error exits non-zero regardless of the action's `exit-code` setting.

This was masked in v0.9.0 because the amd64 leg failed first on the picomatch CVE (#240) and `fail-fast` cancelled the arm64 leg before it reached the Trivy step. Now that #240 cleared the amd64 path, the arm64 issue is exposed.

## Fix

Set `TRIVY_PLATFORM=${{ matrix.platform }}` on the Trivy step. Trivy maps the `TRIVY_*` env-var prefix onto `--platform`, so each runner asks the registry for its own arch's child manifest. Applied to both:

- `release.yml` -> gating scan (was failing, blocks Docker publish)
- `docker.yml` -> non-gating dev scan (would also have errored on arm64; SARIF was missing on the previous run)

## Why not other approaches

- **`provenance: false` on the build** — works, but loses SLSA attestations. Targeted env var keeps the attestation chain intact.
- **`load: true` then scan local** — buildx can't `push=true,push-by-digest=true,load=true` simultaneously; would require a second build.
- **Separate per-arch tags + scan tags** — defeats the digest-pinned merge step.

## Release impact

- v0.9.0 -> npm only (no Docker tag) — partial release, by design now superseded
- v0.9.1 -> npm + amd64 image pushed to GHCR by digest, but no merged manifest because arm64 failed -> no `:0.9.1` / `:0.9` / `:latest` tag, no MCP-Registry entry
- Once this PR merges, release-please will cut **v0.9.2**, which will be the first end-to-end clean release after the Trivy gate landed in #236.

## Test plan

- [ ] CI: `Docker (dev)` workflow's Trivy step succeeds on **both** amd64 and arm64 on this PR / on `main` after merge.
- [ ] CI: `Docker (dev)` Trivy SARIF gets uploaded for both platforms (previous arm64 run reported `Path does not exist: trivy-results.sarif`).
- [ ] CI: Release workflow on the v0.9.2 commit completes the `publish-docker` matrix without `FATAL Fatal error`.
- [ ] Spot-check: Trivy still reports findings as expected (sanity-test by temporarily lowering severity to MEDIUM in dev workflow if needed — not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)