### PR TITLE
fix: harden apply_quickfix payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The 12 tools are designed from real LLM interaction feedback:
 | **SAPGit** | Git-based ABAP workflows across gCTS and abapGit (list/clone/pull/push/commit/branch/unlink) with backend auto-selection and safety gating (`--allow-git-writes`) |
 | **SAPContext** | Compressed dependency context (`action="deps"`), reverse dependency lookup (`action="usages"`), and CDS upstream/downstream impact analysis (`action="impact"` for DDLS) |
 | **SAPLint** | Local ABAP lint (system-aware presets, auto-fix, pre-write validation) + ADT PrettyPrint (server-side formatting) |
-| **SAPDiagnose** | Syntax check, ABAP Unit tests, ATC code quality, short dumps, profiler traces |
+| **SAPDiagnose** | Syntax check, ABAP Unit tests, ATC code quality, SAP quickfix proposals/application deltas, short dumps, profiler traces |
 | **SAPManage** | Feature probing — detect what the system supports before acting |
 
 Tool definitions automatically adapt to the target system (BTP vs on-premise), removing unavailable types and adjusting descriptions so the LLM never attempts unsupported operations.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The 12 tools are designed from real LLM interaction feedback:
 | **SAPGit** | Git-based ABAP workflows across gCTS and abapGit (list/clone/pull/push/commit/branch/unlink) with backend auto-selection and safety gating (`--allow-git-writes`) |
 | **SAPContext** | Compressed dependency context (`action="deps"`), reverse dependency lookup (`action="usages"`), and CDS upstream/downstream impact analysis (`action="impact"` for DDLS) |
 | **SAPLint** | Local ABAP lint (system-aware presets, auto-fix, pre-write validation) + ADT PrettyPrint (server-side formatting) |
-| **SAPDiagnose** | Syntax check, ABAP Unit tests, ATC code quality, SAP quickfix proposals/application deltas, short dumps, profiler traces |
+| **SAPDiagnose** | Syntax check, ABAP Unit tests, ATC code quality, generic ADT quickfix proposals/application deltas, short dumps, profiler traces |
 | **SAPManage** | Feature probing — detect what the system supports before acting |
 
 Tool definitions automatically adapt to the target system (BTP vs on-premise), removing unavailable types and adjusting descriptions so the LLM never attempts unsupported operations.

--- a/docs/plans/completed/fix-apply-quickfix-500.md
+++ b/docs/plans/completed/fix-apply-quickfix-500.md
@@ -16,7 +16,7 @@ Research inputs for this PR include the saved chat transcript, `/Users/marianzei
 
 ### Target State
 
-`apply_quickfix` accepts the exact proposal payload returned by `quickfix`, including empty `userContent`, optional affected object references, and an optional exact `sourceUri` for class includes such as `/includes/definitions`. ARC-1 serializes proposal application as valid ADT quickfix XML, posts with `application/xml`, and parses both existing delta fixtures and XSD-native unit deltas. Existing clients that pass `proposalUri` and `proposalUserContent` continue to work.
+`apply_quickfix` accepts the exact proposal payload returned by `quickfix`, including empty `userContent`, optional affected object references, and an optional exact `sourceUri` for class includes such as `/includes/definitions`. ARC-1 serializes proposal application as valid ADT quickfix XML, posts with `application/xml`, and parses both existing delta fixtures and XSD-native unit deltas. The XML body follows `quickfixes.xsd` with a namespaced `quickfixes:proposalRequest` root and unqualified quickfix child elements such as `input`, `content`, `affectedObjects`, `unit`, and `userContent`. Existing clients that pass `proposalUri` and `proposalUserContent` continue to work.
 
 The RAP `create_class_implementation` quickfix may still require a higher-level non-UI wrapper in a later PR because Eclipse's BDEF UI handler opens a wizard before apply. This PR should still eliminate avoidable ARC-1-side 500s and make backend-applicable quickfixes work predictably on S/4HANA 2023 and NW 7.50-compatible systems.
 
@@ -38,7 +38,7 @@ The RAP `create_class_implementation` quickfix may still require a higher-level 
 
 ### Design Principles
 
-1. Follow Eclipse ADT's XML model where observed: `proposalRequest` contains `input` as a quickfix `unit`, optional `affectedObjects`, and optional `userContent`; apply posts as `application/xml`.
+1. Follow Eclipse ADT's XML model where observed: `proposalRequest` contains `input` as a quickfix `unit`, optional `affectedObjects`, and optional `userContent`; apply posts as `application/xml`. Per `quickfixes.xsd` `elementFormDefault="unqualified"`, child elements inside the quickfix namespace are serialized without the `quickfixes:` prefix.
 2. Preserve backwards compatibility: existing `proposalUri` plus `proposalUserContent` calls should keep working, including non-empty legacy user content and the default type/name main-source URI.
 3. Treat empty `proposalUserContent` as valid data, not as a missing required field.
 4. Do not invent a RAP-specific behavior implementation generator in this PR; document that as follow-up because Eclipse's RAP quickfix path has UI-specific pre-apply behavior.

--- a/docs/plans/completed/fix-apply-quickfix-500.md
+++ b/docs/plans/completed/fix-apply-quickfix-500.md
@@ -1,0 +1,122 @@
+# Fix Apply Quickfix 500
+
+## Overview
+
+This plan fixes `SAPDiagnose(action="apply_quickfix")` so ARC-1 sends ADT quickfix application requests in the same XML model shape used by Eclipse ADT instead of the current partial body that can trigger SAP HTTP 500 responses such as "Dereferencing of the NULL reference".
+
+The implementation keeps the existing `quickfix` and `apply_quickfix` tool actions, but hardens the model: `proposalUserContent` may be an empty string, proposals can carry affected object references, apply uses `application/xml`, callers can override the exact ADT `sourceUri` for include-level quickfixes, and delta parsing understands the ADT `proposalResult/deltas/unit` response shape. This PR does not try to replace Eclipse-only RAP behavior implementation wizards; it makes the generic ADT quickfix apply path correct and returns useful results for backend-applicable fixes.
+
+## Context
+
+### Current State
+
+`src/adt/devtools.ts` can evaluate quickfix proposals and `SAPDiagnose(action="quickfix")` returns useful ADT proposals. The apply path currently builds a minimal `<quickfixes:proposalRequest>` body, posts it with `application/*`, drops affected objects returned by evaluation, requires a truthy `proposalUserContent` in `src/handlers/intent.ts`, and parses only legacy-looking `delta` nodes rather than the Eclipse ADT XSD-native `proposalResult/deltas/unit` response.
+
+Research inputs for this PR include the saved chat transcript, `/Users/marianzeis/DEV/arc-1-legacy-ui5-rap-conversion/RUN-NOTES.md`, `/Users/marianzeis/DEV/arc-1-eclipse-adt/pr-review-guide.md`, Eclipse ADT 3.58 bundles under `/Users/marianzeis/eclipse/java-2025-09/Eclipse.app`, the public apidoc folder `/Users/marianzeis/DEV/arc-1-eclipse-adt/com.sap.adt.core.apidoc-3.58.1`, and existing ARC-1 compare notes. `INFRASTRUCTURE.md` was not present in this checkout. The public ADT apidoc does not expose quickfix internals, but the installed Eclipse bundles include `quickfixes.xsd`, `QuickfixService.apply`, and `RefactoringSerializationUtil.serializeQuickfixProposalRequest`, which define the request and response model.
+
+### Target State
+
+`apply_quickfix` accepts the exact proposal payload returned by `quickfix`, including empty `userContent`, optional affected object references, and an optional exact `sourceUri` for class includes such as `/includes/definitions`. ARC-1 serializes proposal application as valid ADT quickfix XML, posts with `application/xml`, and parses both existing delta fixtures and XSD-native unit deltas. Existing clients that pass `proposalUri` and `proposalUserContent` continue to work.
+
+The RAP `create_class_implementation` quickfix may still require a higher-level non-UI wrapper in a later PR because Eclipse's BDEF UI handler opens a wizard before apply. This PR should still eliminate avoidable ARC-1-side 500s and make backend-applicable quickfixes work predictably on S/4HANA 2023 and NW 7.50-compatible systems.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/types.ts` | Defines `FixProposal`, `FixDelta`, and the quickfix data model shared by ADT and handlers. |
+| `src/adt/devtools.ts` | Implements `getFixProposals`, `applyFixProposal`, XML request serialization, and quickfix response parsing. |
+| `src/handlers/intent.ts` | Routes `SAPDiagnose` quickfix actions and validates handler-level required fields. |
+| `src/handlers/schemas.ts` | Defines Zod validation for `SAPDiagnose` input fields. |
+| `src/handlers/tools.ts` | Publishes MCP tool schema and descriptions for quickfix parameters. |
+| `tests/unit/adt/devtools.test.ts` | Unit coverage for ADT quickfix request bodies and XML parsing. |
+| `tests/unit/handlers/intent.test.ts` | Unit coverage for `SAPDiagnose` routing and handler validation. |
+| `tests/unit/handlers/schemas.test.ts` | Unit coverage for accepted `SAPDiagnose` payload shapes. |
+| `tests/unit/handlers/tools.test.ts` | Unit coverage for generated tool schema metadata. |
+| `README.md` | User-facing tool capability table. Dedicated `docs/tools.md`, `docs/index.md`, and `docs/roadmap.md` files are not present in this checkout. |
+| `docs/plans/completed/fix-proposals-auto-fix-from-atc.md` | Prior quickfix implementation plan and historical design notes. |
+
+### Design Principles
+
+1. Follow Eclipse ADT's XML model where observed: `proposalRequest` contains `input` as a quickfix `unit`, optional `affectedObjects`, and optional `userContent`; apply posts as `application/xml`.
+2. Preserve backwards compatibility: existing `proposalUri` plus `proposalUserContent` calls should keep working, including non-empty legacy user content and the default type/name main-source URI.
+3. Treat empty `proposalUserContent` as valid data, not as a missing required field.
+4. Do not invent a RAP-specific behavior implementation generator in this PR; document that as follow-up because Eclipse's RAP quickfix path has UI-specific pre-apply behavior.
+5. Keep SAP safety posture unchanged: this is still a diagnostic/devtools operation routed through existing ADT calls and server-side authorization.
+
+## Development Approach
+
+Implement the ADT model changes first, then wire optional affected-object payloads through `SAPDiagnose`, then update documentation and tests. Use unit tests with mocked `undici` responses for deterministic request-body and parser verification. Live SAP tests are useful as smoke checks only when credentials are available; they are not required for CI because the regression is in request serialization and response parsing.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Harden ADT quickfix serialization and parsing
+
+**Files:**
+- Modify: `src/adt/types.ts`
+- Modify: `src/adt/devtools.ts`
+- Modify: `tests/unit/adt/devtools.test.ts`
+
+This task fixes the ADT-layer contract before tool routing is changed. It should follow Eclipse ADT's quickfix model while preserving the current public method names.
+
+- [x] Extend quickfix types with optional affected object units carrying URI metadata and optional source content.
+- [x] Update `parseFixProposals()` to preserve affected object references returned by quickfix evaluation.
+- [x] Update `applyFixProposal()` to use `application/xml` and serialize `input`, optional `affectedObjects`, and optional `userContent` safely.
+- [x] Update `parseFixDeltas()` to parse ADT `proposalResult/deltas/unit` responses in addition to the existing legacy delta shapes.
+- [x] Add unit tests (~6 tests): affected object parsing, `application/xml` apply content type, empty user content handling, affected object serialization, XSD-native unit delta parsing, and compatibility with the existing delta parser.
+- [x] Run `npm test -- tests/unit/adt/devtools.test.ts` — all ADT quickfix tests must pass.
+
+### Task 2: Wire affected quickfix proposals through SAPDiagnose
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/tools.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+- Modify: `tests/unit/handlers/schemas.test.ts`
+- Modify: `tests/unit/handlers/tools.test.ts`
+
+This task makes `SAPDiagnose(action="apply_quickfix")` accept the complete proposal shape produced by `quickfix`. The most important behavior change is accepting `proposalUserContent: ""` as valid.
+
+- [x] Add optional `proposalAffectedObjects` validation for affected object units with URI metadata and optional content.
+- [x] Change handler validation so `proposalUserContent` is missing only when it is `undefined`, not when it is an empty string.
+- [x] Pass `proposalAffectedObjects` into `client.applyFixProposal()`.
+- [x] Add optional `sourceUri` override for include-level quickfix targets while preserving the type/name default.
+- [x] Update MCP tool schema and descriptions to say `proposalUserContent` may be empty and affected objects should be passed through when returned by `quickfix`.
+- [x] Add unit tests (~5 tests): empty user content accepted, missing user content still rejected, affected objects forwarded into the apply body, schema accepts the new payload shape, and tool schema exposes the new field.
+- [x] Run `npm test -- tests/unit/handlers/intent.test.ts tests/unit/handlers/schemas.test.ts tests/unit/handlers/tools.test.ts` — all handler quickfix tests must pass.
+
+### Task 3: Update docs and plan status
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/plans/completed/fix-proposals-auto-fix-from-atc.md`
+- Modify: `docs/plans/completed/fix-apply-quickfix-500.md`
+
+This task records the externally visible behavior and the boundary discovered during research. It should not overpromise RAP behavior implementation generation because that still needs a separate feature.
+
+- [x] Update `README.md` for `SAPDiagnose` quickfix capability visibility.
+- [x] Add a short hardening note to the completed fix-proposals plan that records the Eclipse ADT `application/xml` and `proposalResult/deltas/unit` findings.
+- [x] Mark this plan's implementation checkboxes as completed after code and docs land.
+- [x] Move this plan to `docs/plans/completed/`.
+- [x] Run `npm test -- tests/unit/adt/devtools.test.ts tests/unit/handlers/intent.test.ts tests/unit/handlers/schemas.test.ts tests/unit/handlers/tools.test.ts` — targeted tests must pass after docs changes.
+
+### Task 4: Final verification and PR
+
+**Files:**
+- Review: all modified files
+- Review: git diff
+
+This task performs the implementation review requested by the user, then prepares the branch for review.
+
+- [x] Run full test suite: `npm test` — all tests pass.
+- [x] Run typecheck: `npm run typecheck` — no errors.
+- [x] Run lint: `npm run lint` — no errors.
+- [x] Review the final diff for accidental secrets, unrelated churn, and compatibility with the PR-B scope.
+- [x] Commit with a conventional `fix:` message.
+- [x] Push branch `codex/fix-apply-quickfix-500`.
+- [x] Create a pull request with a `fix:` title and a description covering goal, content, and validation.

--- a/docs/plans/completed/fix-proposals-auto-fix-from-atc.md
+++ b/docs/plans/completed/fix-proposals-auto-fix-from-atc.md
@@ -83,7 +83,7 @@ The implementation adds two new actions to `SAPDiagnose`: `quickfix` (get propos
 
 ### 2026-05-10 apply_quickfix hardening note
 
-Follow-up research against Eclipse ADT 3.58 showed that the original abap-adt-api-compatible request shape is sufficient for evaluation, but generic proposal application should follow Eclipse's quickfix XML model more closely. `apply_quickfix` now posts `application/xml`, preserves empty `userContent`, can pass through `affectedObjects` source units from evaluation, accepts an exact `sourceUri` override for include-level fixes, and parses the native `<proposalResult><deltas><unit>...` response shape.
+Follow-up research against Eclipse ADT 3.58 showed that the original abap-adt-api-compatible request shape is sufficient for evaluation, but generic proposal application should follow Eclipse's quickfix XML model more closely. `apply_quickfix` now posts `application/xml`, preserves empty `userContent`, can pass through `affectedObjects` source units from evaluation, accepts an exact `sourceUri` override for include-level fixes, and parses the native `<proposalResult><deltas><unit>...` response shape. The request keeps only the root `quickfixes:proposalRequest` namespaced; `input`, `content`, `affectedObjects`, `unit`, and `userContent` remain unqualified because `quickfixes.xsd` declares `elementFormDefault="unqualified"`.
 
 The RAP `create_class_implementation` proposal remains a separate higher-level feature candidate: Eclipse's behavior-definition UI handler opens a wizard and transforms the proposal request before apply, so generic `apply_quickfix` should not claim to fully replace "Generate Behavior Implementation" yet.
 

--- a/docs/plans/completed/fix-proposals-auto-fix-from-atc.md
+++ b/docs/plans/completed/fix-proposals-auto-fix-from-atc.md
@@ -81,6 +81,12 @@ The implementation adds two new actions to `SAPDiagnose`: `quickfix` (get propos
 
 **Discovery:** The endpoint exists in ADT discovery as `Quickfixes` workspace with `application/vnd.sap.adt.quickfixes.evaluation+xml;version=1.0.0` accept type. Additionally, an `Autoquickfix` endpoint exists at `/sap/bc/adt/atc/autoqf/worklist` for batch ATC fixes.
 
+### 2026-05-10 apply_quickfix hardening note
+
+Follow-up research against Eclipse ADT 3.58 showed that the original abap-adt-api-compatible request shape is sufficient for evaluation, but generic proposal application should follow Eclipse's quickfix XML model more closely. `apply_quickfix` now posts `application/xml`, preserves empty `userContent`, can pass through `affectedObjects` source units from evaluation, accepts an exact `sourceUri` override for include-level fixes, and parses the native `<proposalResult><deltas><unit>...` response shape.
+
+The RAP `create_class_implementation` proposal remains a separate higher-level feature candidate: Eclipse's behavior-definition UI handler opens a wizard and transforms the proposal request before apply, so generic `apply_quickfix` should not claim to fully replace "Generate Behavior Implementation" yet.
+
 ## Development Approach
 
 Tasks are ordered foundation-first: types → core functions → handler wiring → schema/tool definitions → tests → documentation → skills. Each task includes its own tests and validation step.

--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -541,14 +541,16 @@ export async function applyFixProposal(
     proposal.userContent === undefined
       ? ''
       : `
-  <quickfixes:userContent>${escapeXmlText(proposal.userContent)}</quickfixes:userContent>`;
+  <userContent>${escapeXmlText(proposal.userContent)}</userContent>`;
   const affectedObjects = serializeAffectedObjects(proposal.affectedObjects);
+  // quickfixes.xsd uses elementFormDefault="unqualified"; only the root and imported adtcore
+  // elements are prefixed.
   const body = `<?xml version="1.0" encoding="UTF-8"?>
 <quickfixes:proposalRequest xmlns:quickfixes="http://www.sap.com/adt/quickfixes" xmlns:adtcore="http://www.sap.com/adt/core">
-  <quickfixes:input>
-    <quickfixes:content>${escapeXmlText(source)}</quickfixes:content>
+  <input>
+    <content>${escapeXmlText(source)}</content>
     <adtcore:objectReference adtcore:uri="${escapeXmlAttr(uriWithStart)}"/>
-  </quickfixes:input>${affectedObjects}${userContent}
+  </input>${affectedObjects}${userContent}
 </quickfixes:proposalRequest>`;
 
   const resp = await http.post(proposal.uri, body, 'application/xml', {
@@ -887,17 +889,17 @@ function serializeAffectedObjects(affectedObjects: FixAffectedObject[] | undefin
   const units = (affectedObjects ?? [])
     .filter((affected) => affected.uri && affected.content !== undefined)
     .map(
-      (affected) => `    <quickfixes:unit>
-      <quickfixes:content>${escapeXmlText(affected.content ?? '')}</quickfixes:content>
+      (affected) => `    <unit>
+      <content>${escapeXmlText(affected.content ?? '')}</content>
       <adtcore:objectReference ${serializeObjectReferenceAttrs(affected)}/>
-    </quickfixes:unit>`,
+    </unit>`,
     );
 
   if (units.length === 0) return '';
   return `
-  <quickfixes:affectedObjects>
+  <affectedObjects>
 ${units.join('\n')}
-  </quickfixes:affectedObjects>`;
+  </affectedObjects>`;
 }
 
 function parseFixProposals(xml: string): FixProposal[] {

--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -12,7 +12,14 @@ import { logger } from '../server/logger.js';
 import { AdtApiError } from './errors.js';
 import type { AdtHttpClient } from './http.js';
 import { checkOperation, OperationType, type SafetyConfig } from './safety.js';
-import type { FixDelta, FixProposal, SyntaxCheckResult, SyntaxMessage, UnitTestResult } from './types.js';
+import type {
+  FixAffectedObject,
+  FixDelta,
+  FixProposal,
+  SyntaxCheckResult,
+  SyntaxMessage,
+  UnitTestResult,
+} from './types.js';
 import { decodeXmlEntities, escapeXmlAttr, findDeepNodes, parseXml } from './xml-parser.js';
 
 /** Run syntax check on an ABAP object.
@@ -530,17 +537,22 @@ export async function applyFixProposal(
   checkOperation(safety, OperationType.Read, 'ApplyFixProposal');
 
   const uriWithStart = `${sourceUri}#start=${line},${column}`;
+  const userContent =
+    proposal.userContent === undefined
+      ? ''
+      : `
+  <quickfixes:userContent>${escapeXmlText(proposal.userContent)}</quickfixes:userContent>`;
+  const affectedObjects = serializeAffectedObjects(proposal.affectedObjects);
   const body = `<?xml version="1.0" encoding="UTF-8"?>
 <quickfixes:proposalRequest xmlns:quickfixes="http://www.sap.com/adt/quickfixes" xmlns:adtcore="http://www.sap.com/adt/core">
-  <input>
-    <content>${escapeXmlText(source)}</content>
+  <quickfixes:input>
+    <quickfixes:content>${escapeXmlText(source)}</quickfixes:content>
     <adtcore:objectReference adtcore:uri="${escapeXmlAttr(uriWithStart)}"/>
-  </input>
-  <userContent>${escapeXmlText(proposal.userContent)}</userContent>
+  </quickfixes:input>${affectedObjects}${userContent}
 </quickfixes:proposalRequest>`;
 
-  const resp = await http.post(proposal.uri, body, 'application/*', {
-    Accept: 'application/*',
+  const resp = await http.post(proposal.uri, body, 'application/xml', {
+    Accept: 'application/xml',
   });
 
   return parseFixDeltas(resp.body);
@@ -820,6 +832,74 @@ function readNodeText(node: unknown): string {
     .join('');
 }
 
+function nodeRecords(value: unknown): Array<Record<string, unknown>> {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.filter((item): item is Record<string, unknown> => item != null && typeof item === 'object');
+  }
+  return typeof value === 'object' ? [value as Record<string, unknown>] : [];
+}
+
+function readObjectReference(value: unknown): FixAffectedObject | undefined {
+  const objectRef = toNodeRecord(value);
+  const uri = String(objectRef?.['@_uri'] ?? '');
+  if (!uri) return undefined;
+
+  const affected: FixAffectedObject = { uri };
+  const type = objectRef?.['@_type'];
+  const name = objectRef?.['@_name'];
+  const description = objectRef?.['@_description'];
+  if (type != null) affected.type = String(type);
+  if (name != null) affected.name = String(name);
+  if (description != null) affected.description = String(description);
+  return affected;
+}
+
+function parseAffectedObjects(value: unknown): FixAffectedObject[] | undefined {
+  const affectedNode = toNodeRecord(value);
+  if (!affectedNode) return undefined;
+
+  const affected: FixAffectedObject[] = [];
+  for (const unit of nodeRecords(affectedNode.unit)) {
+    const ref = readObjectReference(unit.objectReference);
+    if (!ref) continue;
+    if (unit.content !== undefined) ref.content = readNodeText(unit.content);
+    affected.push(ref);
+  }
+
+  for (const objectRef of nodeRecords(affectedNode.objectReference)) {
+    const ref = readObjectReference(objectRef);
+    if (ref) affected.push(ref);
+  }
+
+  return affected.length > 0 ? affected : undefined;
+}
+
+function serializeObjectReferenceAttrs(ref: FixAffectedObject): string {
+  const attrs = [`adtcore:uri="${escapeXmlAttr(ref.uri)}"`];
+  if (ref.type !== undefined) attrs.push(`adtcore:type="${escapeXmlAttr(ref.type)}"`);
+  if (ref.name !== undefined) attrs.push(`adtcore:name="${escapeXmlAttr(ref.name)}"`);
+  if (ref.description !== undefined) attrs.push(`adtcore:description="${escapeXmlAttr(ref.description)}"`);
+  return attrs.join(' ');
+}
+
+function serializeAffectedObjects(affectedObjects: FixAffectedObject[] | undefined): string {
+  const units = (affectedObjects ?? [])
+    .filter((affected) => affected.uri && affected.content !== undefined)
+    .map(
+      (affected) => `    <quickfixes:unit>
+      <quickfixes:content>${escapeXmlText(affected.content ?? '')}</quickfixes:content>
+      <adtcore:objectReference ${serializeObjectReferenceAttrs(affected)}/>
+    </quickfixes:unit>`,
+    );
+
+  if (units.length === 0) return '';
+  return `
+  <quickfixes:affectedObjects>
+${units.join('\n')}
+  </quickfixes:affectedObjects>`;
+}
+
 function parseFixProposals(xml: string): FixProposal[] {
   const parsed = parseXml(xml);
   const results = findDeepNodes(parsed, 'evaluationResult');
@@ -828,12 +908,14 @@ function parseFixProposals(xml: string): FixProposal[] {
   return results
     .map((result) => {
       const objectRef = toNodeRecord(result.objectReference);
+      const affectedObjects = parseAffectedObjects(result.affectedObjects);
       return {
         uri: String(objectRef?.['@_uri'] ?? ''),
         type: String(objectRef?.['@_type'] ?? ''),
         name: String(objectRef?.['@_name'] ?? ''),
         description: String(objectRef?.['@_description'] ?? ''),
         userContent: readNodeText(result.userContent),
+        ...(affectedObjects ? { affectedObjects } : {}),
       } satisfies FixProposal;
     })
     .filter((proposal) => proposal.uri.length > 0);
@@ -846,7 +928,7 @@ function parseIntOrUndefined(value: unknown): number | undefined {
 }
 
 function parsePositionFragment(uri: string, key: 'start' | 'end'): { line: number; column: number } | undefined {
-  const re = key === 'start' ? /#start=(\d+),(\d+)/ : /#end=(\d+),(\d+)/;
+  const re = key === 'start' ? /(?:#|[;&])start=(\d+),(\d+)/ : /(?:#|[;&])end=(\d+),(\d+)/;
   const match = uri.match(re);
   if (!match?.[1] || !match[2]) return undefined;
   return {
@@ -855,8 +937,62 @@ function parsePositionFragment(uri: string, key: 'start' | 'end'): { line: numbe
   };
 }
 
+function parseFixDeltaNode(node: Record<string, unknown>): FixDelta {
+  const objectRef = toNodeRecord(node.objectReference);
+  const startNode = toNodeRecord(node.start ?? node.from ?? node.sourceStart);
+  const endNode = toNodeRecord(node.end ?? node.to ?? node.sourceEnd);
+
+  const uri = String(node['@_uri'] ?? objectRef?.['@_uri'] ?? '');
+
+  const startFromUri = parsePositionFragment(uri, 'start');
+  const endFromUri = parsePositionFragment(uri, 'end');
+
+  const startLine =
+    parseIntOrUndefined(node['@_startLine']) ??
+    parseIntOrUndefined(node['@_startline']) ??
+    parseIntOrUndefined(startNode?.['@_line']) ??
+    startFromUri?.line ??
+    0;
+  const startColumn =
+    parseIntOrUndefined(node['@_startColumn']) ??
+    parseIntOrUndefined(node['@_startCol']) ??
+    parseIntOrUndefined(node['@_startcolumn']) ??
+    parseIntOrUndefined(startNode?.['@_column']) ??
+    parseIntOrUndefined(startNode?.['@_col']) ??
+    startFromUri?.column ??
+    0;
+  const endLine =
+    parseIntOrUndefined(node['@_endLine']) ??
+    parseIntOrUndefined(node['@_endline']) ??
+    parseIntOrUndefined(endNode?.['@_line']) ??
+    endFromUri?.line ??
+    startLine;
+  const endColumn =
+    parseIntOrUndefined(node['@_endColumn']) ??
+    parseIntOrUndefined(node['@_endCol']) ??
+    parseIntOrUndefined(node['@_endcolumn']) ??
+    parseIntOrUndefined(endNode?.['@_column']) ??
+    parseIntOrUndefined(endNode?.['@_col']) ??
+    endFromUri?.column ??
+    startColumn;
+
+  const content = readNodeText(node.content ?? node.replacement ?? node.newText ?? node.text ?? node['#text']);
+
+  return {
+    uri,
+    range: {
+      start: { line: startLine, column: startColumn },
+      end: { line: endLine, column: endColumn },
+    },
+    content,
+  };
+}
+
 function parseFixDeltas(xml: string): FixDelta[] {
   const parsed = parseXml(xml);
+  const unitNodes = findDeepNodes(parsed, 'deltas').flatMap((deltas) => nodeRecords(deltas.unit));
+  if (unitNodes.length > 0) return unitNodes.map(parseFixDeltaNode);
+
   const candidateKeys = ['delta', 'edit', 'textEdit', 'replacement', 'replace'] as const;
   let nodes: Array<Record<string, unknown>> = [];
 
@@ -865,58 +1001,7 @@ function parseFixDeltas(xml: string): FixDelta[] {
     if (nodes.length > 0) break;
   }
 
-  if (nodes.length === 0) return [];
-
-  return nodes.map((node) => {
-    const objectRef = toNodeRecord(node.objectReference);
-    const startNode = toNodeRecord(node.start ?? node.from ?? node.sourceStart);
-    const endNode = toNodeRecord(node.end ?? node.to ?? node.sourceEnd);
-
-    const uri = String(node['@_uri'] ?? objectRef?.['@_uri'] ?? '');
-
-    const startFromUri = parsePositionFragment(uri, 'start');
-    const endFromUri = parsePositionFragment(uri, 'end');
-
-    const startLine =
-      parseIntOrUndefined(node['@_startLine']) ??
-      parseIntOrUndefined(node['@_startline']) ??
-      parseIntOrUndefined(startNode?.['@_line']) ??
-      startFromUri?.line ??
-      0;
-    const startColumn =
-      parseIntOrUndefined(node['@_startColumn']) ??
-      parseIntOrUndefined(node['@_startCol']) ??
-      parseIntOrUndefined(node['@_startcolumn']) ??
-      parseIntOrUndefined(startNode?.['@_column']) ??
-      parseIntOrUndefined(startNode?.['@_col']) ??
-      startFromUri?.column ??
-      0;
-    const endLine =
-      parseIntOrUndefined(node['@_endLine']) ??
-      parseIntOrUndefined(node['@_endline']) ??
-      parseIntOrUndefined(endNode?.['@_line']) ??
-      endFromUri?.line ??
-      startLine;
-    const endColumn =
-      parseIntOrUndefined(node['@_endColumn']) ??
-      parseIntOrUndefined(node['@_endCol']) ??
-      parseIntOrUndefined(node['@_endcolumn']) ??
-      parseIntOrUndefined(endNode?.['@_column']) ??
-      parseIntOrUndefined(endNode?.['@_col']) ??
-      endFromUri?.column ??
-      startColumn;
-
-    const content = readNodeText(node.content ?? node.replacement ?? node.newText ?? node.text ?? node['#text']);
-
-    return {
-      uri,
-      range: {
-        start: { line: startLine, column: startColumn },
-        end: { line: endLine, column: endColumn },
-      },
-      content,
-    };
-  });
+  return nodes.map(parseFixDeltaNode);
 }
 
 function parseAtcFindings(xml: string): AtcFinding[] {

--- a/src/adt/types.ts
+++ b/src/adt/types.ts
@@ -266,7 +266,7 @@ export interface FixProposal {
   name: string;
   /** Human-readable description (may contain HTML entities) */
   description: string;
-  /** Opaque SAP quickfix state blob, pass through unchanged. Can be an empty string. */
+  /** Opaque SAP quickfix state blob, pass through unchanged. May be an empty string or omitted by SAP. */
   userContent: string;
   /** Additional source units that ADT needs to evaluate/apply this proposal. */
   affectedObjects?: FixAffectedObject[];

--- a/src/adt/types.ts
+++ b/src/adt/types.ts
@@ -242,6 +242,20 @@ export interface UnitTestResult {
   duration?: number;
 }
 
+/** Source unit affected by a quick fix proposal/application. */
+export interface FixAffectedObject {
+  /** ADT source URI for this affected unit. May include #start/#end range fragments. */
+  uri: string;
+  /** Optional ADT object type metadata from the proposal payload. */
+  type?: string;
+  /** Optional ADT object name metadata from the proposal payload. */
+  name?: string;
+  /** Optional human-readable description from the proposal payload. */
+  description?: string;
+  /** Current source content for this affected unit. Needed when applying multi-object quick fixes. */
+  content?: string;
+}
+
 /** Quick fix proposal from /sap/bc/adt/quickfixes/evaluation */
 export interface FixProposal {
   /** Proposal endpoint URI (used for apply step) */
@@ -252,8 +266,10 @@ export interface FixProposal {
   name: string;
   /** Human-readable description (may contain HTML entities) */
   description: string;
-  /** Opaque SAP quickfix state blob, pass through unchanged */
+  /** Opaque SAP quickfix state blob, pass through unchanged. Can be an empty string. */
   userContent: string;
+  /** Additional source units that ADT needs to evaluate/apply this proposal. */
+  affectedObjects?: FixAffectedObject[];
 }
 
 /** Text delta returned when applying a quick fix proposal */

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -150,6 +150,7 @@ import {
 import type {
   ClassHierarchy,
   DumpDetail,
+  FixAffectedObject,
   InactiveObject,
   ObjectTransportHistory,
   ResolvedFeatures,
@@ -4829,6 +4830,7 @@ async function handleSAPDiagnose(client: AdtClient, args: Record<string, unknown
     }
     case 'quickfix': {
       const source = args.source as string | undefined;
+      const sourceUri = args.sourceUri as string | undefined;
       if (!name || !type) return errorResult('"name" and "type" are required for "quickfix" action.');
       if (!source) return errorResult('"source" is required for "quickfix" action.');
       if (args.line == null) return errorResult('"line" is required for "quickfix" action.');
@@ -4841,7 +4843,7 @@ async function handleSAPDiagnose(client: AdtClient, args: Record<string, unknown
       const proposals = await getFixProposals(
         client.http,
         client.safety,
-        sourceUrlForType(type, name),
+        sourceUri ?? sourceUrlForType(type, name),
         source,
         line,
         column,
@@ -4850,13 +4852,16 @@ async function handleSAPDiagnose(client: AdtClient, args: Record<string, unknown
     }
     case 'apply_quickfix': {
       const source = args.source as string | undefined;
+      const sourceUri = args.sourceUri as string | undefined;
       const proposalUri = args.proposalUri as string | undefined;
       const proposalUserContent = args.proposalUserContent as string | undefined;
+      const proposalAffectedObjects = args.proposalAffectedObjects as FixAffectedObject[] | undefined;
       if (!name || !type) return errorResult('"name" and "type" are required for "apply_quickfix" action.');
       if (!source) return errorResult('"source" is required for "apply_quickfix" action.');
       if (args.line == null) return errorResult('"line" is required for "apply_quickfix" action.');
       if (!proposalUri) return errorResult('"proposalUri" is required for "apply_quickfix" action.');
-      if (!proposalUserContent) return errorResult('"proposalUserContent" is required for "apply_quickfix" action.');
+      if (proposalUserContent === undefined)
+        return errorResult('"proposalUserContent" is required for "apply_quickfix" action.');
 
       const line = Number(args.line);
       const column = Number(args.column ?? 0);
@@ -4872,8 +4877,9 @@ async function handleSAPDiagnose(client: AdtClient, args: Record<string, unknown
           name: '',
           description: '',
           userContent: proposalUserContent,
+          ...(proposalAffectedObjects ? { affectedObjects: proposalAffectedObjects } : {}),
         },
-        sourceUrlForType(type, name),
+        sourceUri ?? sourceUrlForType(type, name),
         source,
         line,
         column,

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -490,6 +490,14 @@ export const SAPLintSchema = z.object({
 
 // ─── SAPDiagnose ────────────────────────────────────────────────────
 
+const QuickfixAffectedObjectSchema = z.object({
+  uri: z.string(),
+  type: z.string().optional(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  content: z.string().optional(),
+});
+
 export const SAPDiagnoseSchema = z.object({
   action: z.enum([
     'syntax',
@@ -505,11 +513,13 @@ export const SAPDiagnoseSchema = z.object({
   name: z.string().optional(),
   type: z.string().optional(),
   source: z.string().optional(),
+  sourceUri: z.string().optional(),
   line: z.coerce.number().optional(),
   column: z.coerce.number().optional(),
   version: z.enum(['active', 'inactive']).optional(),
   proposalUri: z.string().optional(),
   proposalUserContent: z.string().optional(),
+  proposalAffectedObjects: z.array(QuickfixAffectedObjectSchema).optional(),
   variant: z.string().optional(),
   id: z.string().optional(),
   detailUrl: z.string().optional(),

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -935,8 +935,8 @@ export function getToolDefinitions(
         '- "syntax": Syntax check an ABAP object. Requires name + type. Optional: version ("active" or "inactive", defaults to active). Optional: source — when supplied, SAP compiles the given content as if it lived at the object\'s URI (pre-write dry-run, nothing is written). Omit source to check what is stored.\n' +
         '- "unittest": Run ABAP unit tests. Requires name + type.\n' +
         '- "atc": Run ATC code quality checks. Requires name + type. Optional: variant.\n' +
-        '- "quickfix": Get SAP quick fix proposals for a specific source position. Requires name + type + source + line. Optional: column.\n' +
-        '- "apply_quickfix": Apply one quick fix proposal and return text deltas (does not write source). Requires name + type + source + line + proposalUri + proposalUserContent. Optional: column.\n' +
+        '- "quickfix": Get SAP quick fix proposals for a specific source position. Requires name + type + source + line. Optional: column, sourceUri for exact ADT include/source targets.\n' +
+        '- "apply_quickfix": Apply one quick fix proposal and return text deltas (does not write source). Requires name + type + source + line + proposalUri + proposalUserContent. Optional: column, sourceUri, proposalAffectedObjects. proposalUserContent may be an empty string; pass it through exactly from quickfix.\n' +
         '- "dumps": List or read ABAP short dumps (ST22). Without id: lists recent dumps (filter by user, maxResults). With id: returns focused chapter sections by default; set includeFullText=true to include the full formatted dump blob. Optional sections=[kap0,kap3,...] to request specific chapter IDs.\n' +
         '- "traces": List or analyze ABAP profiler traces. Without id: lists trace files. With id + analysis: returns trace analysis (hitlist = hot spots, statements = call tree, dbAccesses = database access statistics).\n\n' +
         '- "system_messages": List SM02 system messages via ADT feed (filter by user, maxResults, from, to).\n' +
@@ -966,6 +966,11 @@ export function getToolDefinitions(
             type: 'string',
             description: 'Current source code (required for quickfix/apply_quickfix).',
           },
+          sourceUri: {
+            type: 'string',
+            description:
+              'Exact ADT source URI for quickfix/apply_quickfix. Defaults to the type/name main source; use this for class includes such as /includes/definitions.',
+          },
           line: {
             type: 'number',
             description: 'Source line number for quickfix evaluation (required for quickfix/apply_quickfix).',
@@ -986,7 +991,24 @@ export function getToolDefinitions(
           },
           proposalUserContent: {
             type: 'string',
-            description: 'Opaque userContent from quickfix action (required for apply_quickfix).',
+            description:
+              'Opaque userContent from quickfix action (required for apply_quickfix). May be an empty string; pass through exactly.',
+          },
+          proposalAffectedObjects: {
+            type: 'array',
+            description:
+              'Optional affectedObjects array from quickfix action. Include content for each affected source unit when applying multi-object quickfixes.',
+            items: {
+              type: 'object',
+              required: ['uri'],
+              properties: {
+                uri: { type: 'string', description: 'Affected ADT source URI, optionally with #start/#end range.' },
+                type: { type: 'string', description: 'Optional ADT object type metadata.' },
+                name: { type: 'string', description: 'Optional ADT object name metadata.' },
+                description: { type: 'string', description: 'Optional affected object description.' },
+                content: { type: 'string', description: 'Current source content for this affected unit.' },
+              },
+            },
           },
           variant: { type: 'string', description: 'ATC check variant (for atc action)' },
           id: {

--- a/tests/unit/adt/devtools.test.ts
+++ b/tests/unit/adt/devtools.test.ts
@@ -1218,7 +1218,7 @@ describe('DevTools', () => {
       const xml = `<?xml version="1.0" encoding="utf-8"?>
 <quickfixes:applicationResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes">
   <quickfixes:delta uri="/sap/bc/adt/oo/classes/ZCL_TEST/source/main" startLine="7" startColumn="3" endLine="7" endColumn="8">
-    <quickfixes:content>DATA(lv_count)</quickfixes:content>
+    <content>DATA(lv_count)</content>
   </quickfixes:delta>
 </quickfixes:applicationResult>`;
       const http = mockHttp(xml);
@@ -1251,12 +1251,12 @@ describe('DevTools', () => {
     it('applyFixProposal parses ADT proposalResult unit deltas', async () => {
       const xml = `<?xml version="1.0" encoding="utf-8"?>
 <quickfixes:proposalResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes" xmlns:adtcore="http://www.sap.com/adt/core">
-  <quickfixes:deltas>
-    <quickfixes:unit>
-      <quickfixes:content>METHODS approve_project FOR MODIFY.</quickfixes:content>
+  <deltas>
+    <unit>
+      <content>METHODS approve_project FOR MODIFY.</content>
       <adtcore:objectReference adtcore:uri="/sap/bc/adt/oo/classes/ZBP_DM_PROJECT/includes/definitions#start=4,2;end=4,2"/>
-    </quickfixes:unit>
-  </quickfixes:deltas>
+    </unit>
+  </deltas>
 </quickfixes:proposalResult>`;
       const http = mockHttp(xml);
 
@@ -1328,7 +1328,7 @@ describe('DevTools', () => {
       );
 
       const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
-      expect(body).toContain('<quickfixes:userContent>opaque-state</quickfixes:userContent>');
+      expect(body).toContain('<userContent>opaque-state</userContent>');
     });
 
     it('applyFixProposal preserves empty userContent in request XML', async () => {
@@ -1350,7 +1350,7 @@ describe('DevTools', () => {
       );
 
       const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
-      expect(body).toContain('<quickfixes:userContent></quickfixes:userContent>');
+      expect(body).toContain('<userContent></userContent>');
     });
 
     it('applyFixProposal serializes affected object units with content', async () => {
@@ -1381,9 +1381,9 @@ describe('DevTools', () => {
       );
 
       const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
-      expect(body).toContain('<quickfixes:affectedObjects>');
-      expect(body).toContain('<quickfixes:unit>');
-      expect(body).toContain('<quickfixes:content>CLASS zcl_helper DEFINITION. ENDCLASS.</quickfixes:content>');
+      expect(body).toContain('<affectedObjects>');
+      expect(body).toContain('<unit>');
+      expect(body).toContain('<content>CLASS zcl_helper DEFINITION. ENDCLASS.</content>');
       expect(body).toContain('adtcore:uri="/sap/bc/adt/oo/classes/ZCL_HELPER/source/main"');
       expect(body).toContain('adtcore:type="CLAS/OC"');
       expect(body).toContain('adtcore:name="ZCL_HELPER"');

--- a/tests/unit/adt/devtools.test.ts
+++ b/tests/unit/adt/devtools.test.ts
@@ -1098,6 +1098,43 @@ describe('DevTools', () => {
       expect(proposals[1]?.name).toBe('Inline DATA');
     });
 
+    it('getFixProposals preserves affected object units from evaluation response', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+<qf:evaluationResults xmlns:qf="http://www.sap.com/adt/quickfixes" xmlns:adtcore="http://www.sap.com/adt/core">
+  <qf:evaluationResult>
+    <adtcore:objectReference adtcore:uri="/sap/bc/adt/quickfixes/1" adtcore:type="quickfix/proposal" adtcore:name="Apply multi-object fix" adtcore:description="Updates helper include"/>
+    <qf:affectedObjects>
+      <qf:unit>
+        <qf:content>CLASS helper DEFINITION. ENDCLASS.</qf:content>
+        <adtcore:objectReference adtcore:uri="/sap/bc/adt/oo/classes/ZCL_TEST/source/main#start=1,0;end=1,5" adtcore:type="CLAS/OC" adtcore:name="ZCL_TEST" adtcore:description="Main class"/>
+      </qf:unit>
+    </qf:affectedObjects>
+    <qf:userContent></qf:userContent>
+  </qf:evaluationResult>
+</qf:evaluationResults>`;
+      const http = mockHttp(xml);
+
+      const proposals = await getFixProposals(
+        http,
+        unrestrictedSafetyConfig(),
+        '/sap/bc/adt/oo/classes/ZCL_TEST/source/main',
+        'CLASS zcl_test IMPLEMENTATION. ENDCLASS.',
+        1,
+        0,
+      );
+
+      expect(proposals[0]?.userContent).toBe('');
+      expect(proposals[0]?.affectedObjects).toEqual([
+        {
+          uri: '/sap/bc/adt/oo/classes/ZCL_TEST/source/main#start=1,0;end=1,5',
+          type: 'CLAS/OC',
+          name: 'ZCL_TEST',
+          description: 'Main class',
+          content: 'CLASS helper DEFINITION. ENDCLASS.',
+        },
+      ]);
+    });
+
     it('getFixProposals returns empty array for empty evaluation response', async () => {
       const http = mockHttp('<qf:evaluationResults xmlns:qf="http://www.sap.com/adt/quickfixes"/>');
       const proposals = await getFixProposals(
@@ -1211,6 +1248,43 @@ describe('DevTools', () => {
       ]);
     });
 
+    it('applyFixProposal parses ADT proposalResult unit deltas', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+<quickfixes:proposalResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes" xmlns:adtcore="http://www.sap.com/adt/core">
+  <quickfixes:deltas>
+    <quickfixes:unit>
+      <quickfixes:content>METHODS approve_project FOR MODIFY.</quickfixes:content>
+      <adtcore:objectReference adtcore:uri="/sap/bc/adt/oo/classes/ZBP_DM_PROJECT/includes/definitions#start=4,2;end=4,2"/>
+    </quickfixes:unit>
+  </quickfixes:deltas>
+</quickfixes:proposalResult>`;
+      const http = mockHttp(xml);
+
+      const deltas = await applyFixProposal(
+        http,
+        unrestrictedSafetyConfig(),
+        {
+          uri: '/sap/bc/adt/quickfixes/1',
+          type: 'quickfix/proposal',
+          name: 'Create implementation',
+          description: 'Creates handler methods',
+          userContent: '',
+        },
+        '/sap/bc/adt/oo/classes/ZBP_DM_PROJECT/includes/definitions',
+        'CLASS lhc_project DEFINITION. ENDCLASS.',
+        4,
+        2,
+      );
+
+      expect(deltas).toEqual([
+        {
+          uri: '/sap/bc/adt/oo/classes/ZBP_DM_PROJECT/includes/definitions#start=4,2;end=4,2',
+          range: { start: { line: 4, column: 2 }, end: { line: 4, column: 2 } },
+          content: 'METHODS approve_project FOR MODIFY.',
+        },
+      ]);
+    });
+
     it('applyFixProposal posts to proposal URI', async () => {
       const http = mockHttp('<quickfixes:applicationResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes"/>');
       await applyFixProposal(
@@ -1231,6 +1305,8 @@ describe('DevTools', () => {
 
       const target = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
       expect(target).toBe('/sap/bc/adt/quickfixes/123');
+      expect((http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[2]).toBe('application/xml');
+      expect((http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[3]).toEqual({ Accept: 'application/xml' });
     });
 
     it('applyFixProposal includes userContent in request XML', async () => {
@@ -1252,7 +1328,65 @@ describe('DevTools', () => {
       );
 
       const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
-      expect(body).toContain('<userContent>opaque-state</userContent>');
+      expect(body).toContain('<quickfixes:userContent>opaque-state</quickfixes:userContent>');
+    });
+
+    it('applyFixProposal preserves empty userContent in request XML', async () => {
+      const http = mockHttp('<quickfixes:proposalResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes"/>');
+      await applyFixProposal(
+        http,
+        unrestrictedSafetyConfig(),
+        {
+          uri: '/sap/bc/adt/quickfixes/123',
+          type: 'quickfix/proposal',
+          name: 'Fix',
+          description: 'Fix',
+          userContent: '',
+        },
+        '/sap/bc/adt/programs/programs/ZTEST/source/main',
+        'REPORT ztest.',
+        1,
+        0,
+      );
+
+      const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
+      expect(body).toContain('<quickfixes:userContent></quickfixes:userContent>');
+    });
+
+    it('applyFixProposal serializes affected object units with content', async () => {
+      const http = mockHttp('<quickfixes:proposalResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes"/>');
+      await applyFixProposal(
+        http,
+        unrestrictedSafetyConfig(),
+        {
+          uri: '/sap/bc/adt/quickfixes/123',
+          type: 'quickfix/proposal',
+          name: 'Fix',
+          description: 'Fix',
+          userContent: 'opaque-state',
+          affectedObjects: [
+            {
+              uri: '/sap/bc/adt/oo/classes/ZCL_HELPER/source/main',
+              type: 'CLAS/OC',
+              name: 'ZCL_HELPER',
+              description: 'Helper class',
+              content: 'CLASS zcl_helper DEFINITION. ENDCLASS.',
+            },
+          ],
+        },
+        '/sap/bc/adt/programs/programs/ZTEST/source/main',
+        'REPORT ztest.',
+        1,
+        0,
+      );
+
+      const body = (http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as string;
+      expect(body).toContain('<quickfixes:affectedObjects>');
+      expect(body).toContain('<quickfixes:unit>');
+      expect(body).toContain('<quickfixes:content>CLASS zcl_helper DEFINITION. ENDCLASS.</quickfixes:content>');
+      expect(body).toContain('adtcore:uri="/sap/bc/adt/oo/classes/ZCL_HELPER/source/main"');
+      expect(body).toContain('adtcore:type="CLAS/OC"');
+      expect(body).toContain('adtcore:name="ZCL_HELPER"');
     });
 
     it('applyFixProposal XML-escapes source and userContent', async () => {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -1948,6 +1948,47 @@ ENDCLASS.`;
       expect(result.content[0]?.text).toContain('"line" is required for "quickfix" action.');
     });
 
+    it('quickfix action uses sourceUri override for include targets', async () => {
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockImplementation(
+        (
+          url: string | URL,
+          opts?: { method?: string; body?: string | Buffer | null; headers?: Record<string, string> },
+        ) => {
+          const method = opts?.method ?? 'GET';
+          calls.push({
+            method,
+            url: String(url),
+            body: typeof opts?.body === 'string' ? opts.body : undefined,
+          });
+          if (method === 'POST' && String(url).includes('/sap/bc/adt/quickfixes/evaluation')) {
+            return Promise.resolve(
+              mockResponse(200, '<qf:evaluationResults xmlns:qf="http://www.sap.com/adt/quickfixes"/>', {
+                'x-csrf-token': 'T',
+              }),
+            );
+          }
+          return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+        },
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPDiagnose', {
+        action: 'quickfix',
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        sourceUri: '/sap/bc/adt/oo/classes/ZCL_TEST/includes/definitions',
+        source: 'CLASS lhc_test DEFINITION. ENDCLASS.',
+        line: 1,
+        column: 45,
+      });
+
+      expect(result.isError).toBeUndefined();
+      const evalCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/quickfixes/evaluation'));
+      expect(evalCall?.url).toContain('%2Fsap%2Fbc%2Fadt%2Foo%2Fclasses%2FZCL_TEST%2Fincludes%2Fdefinitions');
+      expect(evalCall?.url).toContain('%23start%3D1%2C45');
+    });
+
     it('apply_quickfix action posts to proposal URI and returns deltas JSON', async () => {
       mockFetch.mockReset();
       const calls: Array<{ method: string; url: string; body?: string }> = [];
@@ -1984,6 +2025,7 @@ ENDCLASS.`;
         action: 'apply_quickfix',
         type: 'CLAS',
         name: 'ZCL_TEST',
+        sourceUri: '/sap/bc/adt/oo/classes/ZCL_TEST/includes/definitions',
         source: 'CLASS zcl_test DEFINITION. ENDCLASS.',
         line: 3,
         column: 1,
@@ -2003,7 +2045,60 @@ ENDCLASS.`;
 
       const applyCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/quickfixes/1'));
       expect(applyCall).toBeDefined();
-      expect(applyCall?.body).toContain('<userContent>opaque-state</userContent>');
+      expect(applyCall?.body).toContain('<quickfixes:userContent>opaque-state</quickfixes:userContent>');
+    });
+
+    it('apply_quickfix action accepts empty userContent and forwards affected objects', async () => {
+      mockFetch.mockReset();
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockImplementation(
+        (
+          url: string | URL,
+          opts?: { method?: string; body?: string | Buffer | null; headers?: Record<string, string> },
+        ) => {
+          const method = opts?.method ?? 'GET';
+          calls.push({
+            method,
+            url: String(url),
+            body: typeof opts?.body === 'string' ? opts.body : undefined,
+          });
+          return Promise.resolve(
+            mockResponse(200, '<quickfixes:proposalResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes"/>', {
+              'x-csrf-token': 'T',
+            }),
+          );
+        },
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPDiagnose', {
+        action: 'apply_quickfix',
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        sourceUri: '/sap/bc/adt/oo/classes/ZCL_TEST/includes/definitions',
+        source: 'CLASS zcl_test DEFINITION. ENDCLASS.',
+        line: 3,
+        column: 1,
+        proposalUri: '/sap/bc/adt/quickfixes/1',
+        proposalUserContent: '',
+        proposalAffectedObjects: [
+          {
+            uri: '/sap/bc/adt/oo/classes/ZCL_HELPER/source/main',
+            type: 'CLAS/OC',
+            name: 'ZCL_HELPER',
+            content: 'CLASS zcl_helper DEFINITION. ENDCLASS.',
+          },
+        ],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const applyCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/quickfixes/1'));
+      expect(applyCall?.body).toContain('<quickfixes:userContent></quickfixes:userContent>');
+      expect(applyCall?.body).toContain('/sap/bc/adt/oo/classes/ZCL_TEST/includes/definitions#start=3,1');
+      expect(applyCall?.body).toContain('<quickfixes:affectedObjects>');
+      expect(applyCall?.body).toContain('adtcore:uri="/sap/bc/adt/oo/classes/ZCL_HELPER/source/main"');
+      expect(applyCall?.body).toContain(
+        '<quickfixes:content>CLASS zcl_helper DEFINITION. ENDCLASS.</quickfixes:content>',
+      );
     });
 
     it('apply_quickfix action returns error when proposalUri is missing', async () => {
@@ -2017,6 +2112,19 @@ ENDCLASS.`;
       });
       expect(result.isError).toBe(true);
       expect(result.content[0]?.text).toContain('"proposalUri" is required for "apply_quickfix" action.');
+    });
+
+    it('apply_quickfix action returns error when proposalUserContent is missing', async () => {
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPDiagnose', {
+        action: 'apply_quickfix',
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        source: 'CLASS zcl_test DEFINITION. ENDCLASS.',
+        line: 3,
+        proposalUri: '/sap/bc/adt/quickfixes/1',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('"proposalUserContent" is required for "apply_quickfix" action.');
     });
 
     it('schema validation rejects unknown SAPDiagnose actions', async () => {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -2010,7 +2010,7 @@ ENDCLASS.`;
                 200,
                 `<quickfixes:applicationResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes">
                   <quickfixes:delta uri="/sap/bc/adt/oo/classes/ZCL_TEST/source/main" startLine="3" startColumn="1" endLine="3" endColumn="4">
-                    <quickfixes:content>DATA</quickfixes:content>
+                    <content>DATA</content>
                   </quickfixes:delta>
                 </quickfixes:applicationResult>`,
                 { 'x-csrf-token': 'T' },
@@ -2045,7 +2045,7 @@ ENDCLASS.`;
 
       const applyCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/quickfixes/1'));
       expect(applyCall).toBeDefined();
-      expect(applyCall?.body).toContain('<quickfixes:userContent>opaque-state</quickfixes:userContent>');
+      expect(applyCall?.body).toContain('<userContent>opaque-state</userContent>');
     });
 
     it('apply_quickfix action accepts empty userContent and forwards affected objects', async () => {
@@ -2092,13 +2092,11 @@ ENDCLASS.`;
 
       expect(result.isError).toBeUndefined();
       const applyCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/quickfixes/1'));
-      expect(applyCall?.body).toContain('<quickfixes:userContent></quickfixes:userContent>');
+      expect(applyCall?.body).toContain('<userContent></userContent>');
       expect(applyCall?.body).toContain('/sap/bc/adt/oo/classes/ZCL_TEST/includes/definitions#start=3,1');
-      expect(applyCall?.body).toContain('<quickfixes:affectedObjects>');
+      expect(applyCall?.body).toContain('<affectedObjects>');
       expect(applyCall?.body).toContain('adtcore:uri="/sap/bc/adt/oo/classes/ZCL_HELPER/source/main"');
-      expect(applyCall?.body).toContain(
-        '<quickfixes:content>CLASS zcl_helper DEFINITION. ENDCLASS.</quickfixes:content>',
-      );
+      expect(applyCall?.body).toContain('<content>CLASS zcl_helper DEFINITION. ENDCLASS.</content>');
     });
 
     it('apply_quickfix action returns error when proposalUri is missing', async () => {

--- a/tests/unit/handlers/schemas.test.ts
+++ b/tests/unit/handlers/schemas.test.ts
@@ -744,11 +744,40 @@ describe('SAPDiagnoseSchema', () => {
       name: 'ZCL_TEST',
       type: 'CLAS',
       source: 'CLASS zcl_test DEFINITION. ENDCLASS.',
+      sourceUri: '/sap/bc/adt/oo/classes/ZCL_TEST/includes/definitions',
       line: 12,
       proposalUri: '/sap/bc/adt/quickfixes/1',
       proposalUserContent: 'opaque-state',
     });
     expect(result.success).toBe(true);
+  });
+
+  it('accepts apply_quickfix with empty userContent and affected objects', () => {
+    const result = SAPDiagnoseSchema.safeParse({
+      action: 'apply_quickfix',
+      name: 'ZCL_TEST',
+      type: 'CLAS',
+      source: 'CLASS zcl_test DEFINITION. ENDCLASS.',
+      sourceUri: '/sap/bc/adt/oo/classes/ZCL_TEST/includes/definitions',
+      line: 12,
+      proposalUri: '/sap/bc/adt/quickfixes/1',
+      proposalUserContent: '',
+      proposalAffectedObjects: [
+        {
+          uri: '/sap/bc/adt/oo/classes/ZCL_HELPER/source/main',
+          type: 'CLAS/OC',
+          name: 'ZCL_HELPER',
+          description: 'Helper class',
+          content: 'CLASS zcl_helper DEFINITION. ENDCLASS.',
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.proposalUserContent).toBe('');
+      expect(result.data.sourceUri).toBe('/sap/bc/adt/oo/classes/ZCL_TEST/includes/definitions');
+      expect(result.data.proposalAffectedObjects?.[0]?.uri).toBe('/sap/bc/adt/oo/classes/ZCL_HELPER/source/main');
+    }
   });
 });
 

--- a/tests/unit/handlers/tools.test.ts
+++ b/tests/unit/handlers/tools.test.ts
@@ -331,10 +331,13 @@ describe('Tool Definitions', () => {
     expect(actionEnum).toContain('system_messages');
     expect(actionEnum).toContain('gateway_errors');
     expect(schema.properties.source).toBeDefined();
+    expect(schema.properties.sourceUri).toBeDefined();
     expect(schema.properties.line).toBeDefined();
     expect(schema.properties.column).toBeDefined();
     expect(schema.properties.proposalUri).toBeDefined();
     expect(schema.properties.proposalUserContent).toBeDefined();
+    expect(schema.properties.proposalAffectedObjects).toBeDefined();
+    expect(schema.properties.proposalAffectedObjects.items.required).toContain('uri');
     expect(schema.properties.sections).toBeDefined();
     expect(schema.properties.includeFullText).toBeDefined();
     expect(schema.properties.detailUrl).toBeDefined();


### PR DESCRIPTION
## Goal
Fix PR-B for `SAPDiagnose(action="apply_quickfix")` by aligning ARC-1's quickfix application payloads with Eclipse ADT's quickfix XML model and removing the empty-userContent blocker that contributed to backend 500s.

## Content
- Serialize quickfix apply requests as `application/xml` with namespaced input, optional affected source units, and preserved empty `userContent`.
- Parse ADT-native `<proposalResult><deltas><unit>...` responses while preserving the existing delta parser.
- Add `proposalAffectedObjects` and `sourceUri` pass-through fields so include-level RAP quickfixes can target exact ADT source URIs such as `/includes/definitions`.
- Document the remaining boundary: Eclipse's RAP `create_class_implementation` path still has UI-specific pre-apply behavior, so a dedicated generator remains a follow-up.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`