### PR TITLE
feat: add TADIR lookup and batch package overrides

### DIFF
--- a/compare/00-feature-matrix.md
+++ b/compare/00-feature-matrix.md
@@ -122,6 +122,7 @@ Tier 2 (CycloneDX SBOM, Cosign image signing, OpenSSF Scorecard) and Tier 3 (Soc
 | Source version history | ✅ (`VERSIONS` list + `VERSION_SOURCE` fetch via `GET {sourceUrl}/versions` Atom feed) | ✅ (3 tools: list/compare/get) | ✅ (`revisions()` + `getObjectSource(url, {version})`) | ❌ | ❌ | ❌ | N/A | ✅ (`abap_get_revisions` list-only) | ❌ |
 | Transactions | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | N/A | ❌ | ❌ |
 | Free SQL | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | N/A | ✅ | ✅ |
+| Exact object-directory lookup | ✅ (`SAPSearch searchType=tadir_lookup`; ADT quick search, grouped by requested name) | ❌ | ✅ (quickSearch primitive) | ✅ (search) | ❌ | ✅ | N/A | ✅ | ✅ |
 | System info / components | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | ❌ | ✅ |
 | BOR business objects | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
 | Messages (T100, `MSAG`; deprecated alias `MESSAGES`) | ✅ (read+write; canonical short type `MSAG` from audit Plan B) | ✅ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
@@ -148,7 +149,7 @@ Tier 2 (CycloneDX SBOM, Cosign image signing, OpenSSF Scorecard) and Tier 3 (Soc
 | RAP CRUD (BDEF, SRVD, DDLX, SRVB) | ✅ (DDLS, DDLX, DCLS, BDEF, SRVD, SRVB write) | ⚠️ (some) | ❌ | ❌ | ✅ (BDEF, SRVD, SRVB) | ✅ (all incl. DDLX) | N/A | ⚠️ (BDEF create, SRVB publish) | ⚠️ (DDLS, DCL, BDEF write; SRVB publish) |
 | Domain write (DOMA) | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | N/A | ❌ | ✅ (PR #149 merged) |
 | Data element write (DTEL) | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | N/A | ❌ | ✅ |
-| Multi-object batch creation | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
+| Multi-object batch creation | ✅ (item-level package/transport overrides) | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
 | Deterministic RAP preflight (TABL/BDEF/DDLX/DDLS static checks) | ⚠️ (in-flight PR [#173](https://github.com/marianfoo/arc-1/pull/173) — `preflightBeforeWrite` toggle) | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
 | RAP behavior-pool handler scaffolding | ✅ (`SAPWrite action=scaffold_rap_handlers` dry-run/autoApply, native CLAS include writes, auto-creates missing `lhc_*` CCDEF/CCIMP skeletons) | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |
 | AFF schema validation (pre-create) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | N/A | ❌ | ❌ |

--- a/docs/plans/completed/pr-e-tadir-lookup-batch-create-package.md
+++ b/docs/plans/completed/pr-e-tadir-lookup-batch-create-package.md
@@ -1,0 +1,141 @@
+# PR-E TADIR Lookup And Batch Create Package Fix
+
+## Overview
+
+This plan implements PR-E from the RAP migration run notes: add a reliable cross-package TADIR-style object lookup and fix `SAPWrite(action="batch_create")` so package and transport values supplied on individual objects are honored. The lookup should use ADT repository quick search instead of `SAPQuery` against `TADIR`, because the S/4 7.58 test system rejects long `WHERE OBJ_NAME IN (...)` lists once the SQL literal grows past 255 characters.
+
+The key design decision is to expose lookup through `SAPSearch` as `searchType="tadir_lookup"`, backed by `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch`. Eclipse ADT apidoc 3.58.1 describes quick search as a lightweight direct TADIR-based search when search providers are not requested, and live S/4 7.58 probes returned exact object type, package, description, and URI for `ZDM_PROJECT_D`, `ZR_DM_PROJECT`, and `ZUI_DM_PROJECTS_O4`.
+
+## Context
+
+### Current State
+
+`SAPSearch` supports object-name search and source-code search, but it has no exact batch lookup mode. The migration skill therefore fell back to `SAPQuery` against `TADIR`; on S/4 7.58, a 12-name `IN (...)` query failed with a 400 parser error about a text literal longer than 255 characters. `batch_create` also reads only top-level `package` and `transport`, while the migration skill naturally emits per-object `{ package, transport }` entries; Zod currently strips those unknown object fields, so the handler defaults the whole batch to `$TMP`.
+
+### Target State
+
+`SAPSearch(searchType="tadir_lookup", names=[...], objectTypes=[...])` returns exact per-name lookup results with matches grouped by requested name and missing names called out. It uses repository search, not free SQL, and supports optional type narrowing. `SAPWrite(action="batch_create")` accepts per-object package and transport values, checks every target package against safety allowlists before mutating, performs transport preflight per effective package, and uses the effective object package in create XML, `_package` query parameters where required, source writes, and result summaries.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/client.ts` | Add repository-search backed lookup helper and optional object type query parameter support. |
+| `src/handlers/intent.ts` | Route `SAPSearch searchType="tadir_lookup"` and apply per-object package/transport in `batch_create`. |
+| `src/handlers/schemas.ts` | Add `tadir_lookup`, `names`, `objectTypes`, and per-object `package`/`transport` validation. |
+| `src/handlers/tools.ts` | Update MCP tool descriptions and JSON schema properties. |
+| `tests/unit/adt/client.test.ts` | Cover lookup URL construction and parsing. |
+| `tests/unit/handlers/intent.test.ts` | Cover lookup response shape and batch per-object package/transport propagation. |
+| `tests/unit/handlers/schemas.test.ts` | Cover new schema acceptance/rejection cases. |
+| `tests/unit/handlers/tools.test.ts` | Cover exposed tool properties and descriptions. |
+| `docs_page/tools.md` | Document TADIR lookup and batch object package behavior. |
+| `docs_page/mcp-usage.md` | Update batch_create examples and TADIR lookup guidance. |
+| `docs_page/roadmap.md` | Mark PR-E items as implemented or add a completed note. |
+| `compare/00-feature-matrix.md` | Add/update the object lookup capability if needed. |
+| `skills/generate-rap-service-researched.md` | Update RAP creation guidance to use object-level package/transport and lookup. |
+
+### Design Principles
+
+1. Prefer ADT repository search for object directory lookup because it is available without enabling freestyle SQL and matches Eclipse ADT's quick search contract.
+2. Preserve existing `SAPSearch(query="Z*")` behavior; `tadir_lookup` is opt-in and exact-match filtered.
+3. Preserve existing top-level `batch_create` package and transport behavior; per-object fields override the top-level defaults only for that object.
+4. Fail before mutating if any effective package is disallowed or clearly requires a transport that is not available.
+5. Keep the response compact but structured enough for agents to decide whether to delete, update, or create objects.
+
+## Development Approach
+
+Implement the lookup helper first so handler tests can mock a single parser contract. Then adjust schemas/tools, wire `SAPSearch`, and fix `batch_create` package propagation. Add focused unit tests around exact behavior and update docs/skills. Use live S/4 7.58 probes as research evidence, but keep CI tests mocked and deterministic; NW 7.50 compatibility is covered by existing probe fixtures proving repository search exists on supported 7.50 landscapes.
+
+## Validation Commands
+
+- `npm test -- tests/unit/adt/client.test.ts tests/unit/handlers/intent.test.ts tests/unit/handlers/schemas.test.ts tests/unit/handlers/tools.test.ts`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add Repository Search Lookup Helper
+
+**Files:**
+- Modify: `src/adt/client.ts`
+- Modify: `src/adt/types.ts` if a shared lookup result type is useful
+- Modify: `tests/unit/adt/client.test.ts`
+
+Add a client helper that runs quick search for exact object names and optional object types, returning grouped lookup results without using `SAPQuery`.
+
+- [x] Add `lookupObjects(names, options)` or equivalent to `AdtClient`, using `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch`.
+- [x] Support optional `objectTypes` by adding `objectType=<type>` to the search URL; when no types are provided, use the default quick-search mode.
+- [x] Exact-filter returned references by object name after parsing so wildcard or substring hits do not count as found.
+- [x] Dedupe duplicate references by type, name, package, and URI.
+- [x] Add unit tests for default lookup, typed lookup, exact-match filtering, URL encoding, and missing results.
+- [x] Run `npm test -- tests/unit/adt/client.test.ts`.
+
+### Task 2: Wire SAPSearch TADIR Lookup
+
+**Files:**
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/tools.ts`
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+- Modify: `tests/unit/handlers/schemas.test.ts`
+- Modify: `tests/unit/handlers/tools.test.ts`
+
+Expose exact lookup through `SAPSearch(searchType="tadir_lookup")`, accepting either `names` or a comma/whitespace-separated `query`.
+
+- [x] Extend `SAPSearchSchema` and no-source variant with `searchType="tadir_lookup"`, optional `names: string[]`, and optional `objectTypes: string[]`.
+- [x] Keep `query` required for `object` and `source_code`; require at least one lookup name for `tadir_lookup`.
+- [x] Update `buildSAPSearchTool()` so tool descriptions and JSON schema explain `tadir_lookup`, `names`, and `objectTypes`.
+- [x] In `handleSAPSearch`, route `tadir_lookup` to the new client helper and return JSON with `count`, `lookups`, and `missing`.
+- [x] Add handler/schema/tool tests for names-array lookup, query-string lookup, typed lookup, missing names, and validation errors.
+- [x] Run `npm test -- tests/unit/handlers/intent.test.ts tests/unit/handlers/schemas.test.ts tests/unit/handlers/tools.test.ts`.
+
+### Task 3: Fix batch_create Per-Object Package And Transport
+
+**Files:**
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/tools.ts`
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+- Modify: `tests/unit/handlers/schemas.test.ts`
+- Modify: `tests/unit/handlers/tools.test.ts`
+
+Honor `package` and `transport` supplied on each `objects[]` item while preserving top-level defaults.
+
+- [x] Add optional `package` and `transport` fields to batch object schemas and tool JSON schema.
+- [x] Compute `effectivePackage = object.package ?? args.package ?? "$TMP"` and `effectiveTransport = object.transport ?? args.transport ?? autoDetectedTransportForPackage`.
+- [x] Check every unique effective package with `checkPackage()` before creating the first object.
+- [x] Run transport preflight per unique non-`$TMP` effective package when no explicit transport is available for that package.
+- [x] Use `effectivePackage` in `buildCreateXml()`, `_package` query parameters for BDEF/TABL, and success/failure summaries.
+- [x] Use `effectiveTransport` for create, post-create metadata update, source write, and MSAG transport-vs-task validation.
+- [x] Add tests for object-level package without top-level package, object-level transport overriding top-level transport, mixed packages in one batch, and package allowlist rejection before mutation.
+- [x] Run `npm test -- tests/unit/handlers/intent.test.ts tests/unit/handlers/schemas.test.ts tests/unit/handlers/tools.test.ts`.
+
+### Task 4: Update Documentation And Skills
+
+**Files:**
+- Modify: `docs_page/tools.md`
+- Modify: `docs_page/mcp-usage.md`
+- Modify: `docs_page/roadmap.md`
+- Modify: `compare/00-feature-matrix.md` if the matrix has a suitable lookup row
+- Modify: `skills/generate-rap-service-researched.md`
+- Modify: `CLAUDE.md` if the Key Files table should mention TADIR lookup
+
+Document the new user-visible behavior so agents stop using fragile long `SAPQuery` `IN` lists for object-existence checks.
+
+- [x] Add `SAPSearch(searchType="tadir_lookup", names=[...])` examples to tool and MCP usage docs.
+- [x] Update `batch_create` docs to state that object-level `package` and `transport` are accepted and override top-level defaults.
+- [x] Update the RAP generation skill to use `tadir_lookup` in reset/preflight and to allow per-object package/transport in `batch_create`.
+- [x] Update roadmap/matrix only where an existing PR-E or object-lookup capability entry exists.
+- [x] Run `npm test -- tests/unit/handlers/tools.test.ts`.
+
+### Task 5: Final Verification And Review
+
+**Files:**
+- Review: all modified files
+
+Run focused and broad verification, then review the implementation for edge cases before opening the PR.
+
+- [x] Run focused unit tests: `npm test -- tests/unit/adt/client.test.ts tests/unit/handlers/intent.test.ts tests/unit/handlers/schemas.test.ts tests/unit/handlers/tools.test.ts`.
+- [x] Run `npm run typecheck`.
+- [x] Run `npm run lint`.
+- [x] Run live S/4 7.58 smoke checks if credentials are available: `SAPSearch(searchType="tadir_lookup", names=["ZDM_PROJECT_D","ZR_DM_PROJECT","ZUI_DM_PROJECTS_O4"])` and a dry batch package URL/unit-level check.
+- [x] Review the diff for accidental schema regressions, safety bypasses, and unrelated changes.
+- [x] Move this plan to `docs/plans/completed/`.

--- a/docs_page/mcp-usage.md
+++ b/docs_page/mcp-usage.md
@@ -232,7 +232,7 @@ Step 3: SAPWrite(action="create", type="CLAS", name="ZCL_ORDER", source="...", p
 
 **Shortcut:** If you skip the check step, ARC-1's pre-flight check will detect the missing transport and return an actionable error with existing transports listed — you can then pick one and retry.
 
-**Batch creation:** The same flow applies to `batch_create`. Provide the `transport` parameter at the top level — all objects in the batch use the same transport.
+**Batch creation:** The same flow applies to `batch_create`. Provide `package` and `transport` at the top level when all objects share them, or set `package`/`transport` per object when a mixed batch needs item-level overrides.
 
 ```
 SAPWrite(action="batch_create", package="ZDEV", transport="A4HK900123", objects=[
@@ -240,6 +240,14 @@ SAPWrite(action="batch_create", package="ZDEV", transport="A4HK900123", objects=
   {type:"BDEF", name:"ZI_TRAVEL", source:"..."},
   {type:"CLAS", name:"ZBP_I_TRAVEL", source:"..."}
 ])
+```
+
+Before reset/create workflows that need to detect existing objects across packages, prefer exact object-directory lookup over long freestyle TADIR SQL:
+
+```
+SAPSearch(searchType="tadir_lookup",
+  names=["ZDM_PROJECT_D","ZR_DM_PROJECT","ZUI_DM_PROJECTS_O4"],
+  objectTypes=["TABL","BDEF","SRVB"])
 ```
 
 ### 5. Investigate Runtime Errors

--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -1,6 +1,6 @@
 # ARC-1 Roadmap
 
-**Last Updated:** 2026-05-10 (PR-A CLAS include writes + RAP handler auto-skeletons)
+**Last Updated:** 2026-05-10 (PR-E TADIR lookup + batch_create item-level package/transport)
 **Project:** ARC-1 (ABAP Relay Connector) — MCP Server for SAP ABAP Systems
 **Repository:** https://github.com/marianfoo/arc-1
 
@@ -117,6 +117,7 @@ SORT RULES for this table — DO NOT BREAK when adding rows:
 
 | ID | Feature | Completed | Category |
 |----|---------|-----------|----------|
+| — | PR-E TADIR lookup + batch_create package fix — `SAPSearch(searchType="tadir_lookup")` adds exact cross-package object-directory lookup via ADT quick search, avoiding brittle long TADIR `IN (...)` SQL preflights. `SAPWrite(action="batch_create")` now honors item-level `package` and `transport` overrides, including TABL/BDEF `_package` query parameters and per-package safety/transport preflights. Plan: `docs/plans/completed/pr-e-tadir-lookup-batch-create-package.md`. | 2026-05-10 | Features |
 | — | PR-A native CLAS include writes + RAP behavior handler auto-skeletons — `SAPWrite(action="update", type="CLAS", include="definitions"|"implementations"|"macros"|"testclasses")` writes local class includes via the parent class lock instead of corrupting `/source/main`; `scaffold_rap_handlers(autoApply=true)` now creates missing `lhc_*` CCDEF/CCIMP skeletons before injecting RAP handler signatures and empty implementation stubs. | 2026-05-10 | Features |
 | — | Function-group (FUGR) and function-module (FUNC) write support — `SAPWrite create/update/delete` for both types with `group` parameter for FM (issue [#250](https://github.com/marianfoo/arc-1/issues/250)). FUGR routes through standard `objectBasePath`; FUNC bypasses with a dedicated URL pre-resolution branch in `handleSAPWrite` and `handleSAPActivate` (group from args; auto-resolved via search for update/delete). New `case 'FUGR'`/`case 'FUNC'` in `buildCreateXml`; `stripFmParamCommentBlock` helper auto-strips SAPGUI `*"…"*` parameter comment blocks (SAP rejects them with `FUNC_ADT028`). FM signature/parameters explicitly out of scope — managed via SAPGUI/SE37 or Eclipse. Verified live on a4h S/4HANA 2023 (full lifecycle); 132/132 E2E pass. Closes the "latent FUNC-update gap" flagged in 2026-04-27 competitor scan. | 2026-05-09 | Features |
 | — | CF deployment hardening (Node `--max-old-space-size=448` heap flag on mta.yaml + `application-logs` lite binding) and XSUAA `ARC-1 Viewer + SQL` role-collection parity with the `viewer-sql` API-key profile. Config-only — no source changes. | 2026-05-09 | Ops |

--- a/docs_page/tools.md
+++ b/docs_page/tools.md
@@ -153,24 +153,28 @@ The full caching architecture (per-version cache keys, conditional GET, dependen
 
 ## SAPSearch
 
-Search for ABAP objects by name pattern with wildcards.
+Search for ABAP objects by name pattern, exact object-directory names, or ABAP source text.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `query` | string | Yes | Search pattern (e.g., `ZCL_ORDER*`, `Z*TEST*`) or text to search in source code |
+| `query` | string | No | Search pattern (e.g., `ZCL_ORDER*`, `Z*TEST*`), source text, or comma/whitespace-separated names for `tadir_lookup` |
 | `maxResults` | number | No | Maximum results (default 100) |
-| `searchType` | string | No | `object` (default, name search) or `source_code` (text search within ABAP source) |
-| `objectType` | string | No | For `source_code` search: filter by object type |
+| `searchType` | string | No | `object` (default, name search), `tadir_lookup` (exact cross-package object lookup), or `source_code` (text search within ABAP source) |
+| `names` | array | No | For `tadir_lookup`: exact object names to resolve across packages |
+| `objectTypes` | array | No | For `tadir_lookup`: optional ADT/TADIR type filters such as `TABL`, `DDLS`, `BDEF`, `SRVB`, `CLAS/OC` |
+| `objectType` | string | No | For `source_code`: filter by object type. For `tadir_lookup`: single type filter |
 | `packageName` | string | No | For `source_code` search: filter by package |
 
-**Returns:** Object type, name, package, and description for each match. Source code search also returns line numbers and code snippets.
+**Returns:** Object type, name, package, and description for each match. `tadir_lookup` groups exact matches by requested name and includes a `missing` list. Source code search also returns line numbers and code snippets.
 
 **Examples:**
 ```
 SAPSearch(query="ZCL_ORDER*")
 SAPSearch(query="Z*INVOICE*", maxResults=20)
+SAPSearch(searchType="tadir_lookup", names=["ZDM_PROJECT_D","ZR_DM_PROJECT"], objectTypes=["TABL","BDEF"])
+SAPSearch(searchType="tadir_lookup", query="ZDM_PROJECT_D ZUI_DM_PROJECTS_O4")
 SAPSearch(query="SY-SUBRC", searchType="source_code")
 SAPSearch(query="SELECT * FROM mara", searchType="source_code", objectType="CLAS", packageName="ZDEV")
 ```
@@ -178,6 +182,8 @@ SAPSearch(query="SELECT * FROM mara", searchType="source_code", objectType="CLAS
 **Umlaut handling:** Object name queries containing non-ASCII characters (ä, ö, ü, ß) are automatically transliterated to ASCII equivalents (AE, OE, UE, SS). SAP object names are ASCII-only. Source code search preserves non-ASCII characters.
 
 **Field names:** If searching for a field/column name (e.g., MATNR, BUKRS), use SAPQuery against DD03L instead — SAPSearch only searches object names.
+
+**TADIR lookup:** Use `searchType="tadir_lookup"` for reset/create preflights that need to know whether objects exist anywhere, regardless of package. It uses ADT repository quick search instead of freestyle SQL against TADIR, so it avoids long `IN (...)` parser limits and works in read/search-only configurations.
 
 **Source code search availability:** Not available on all SAP systems. Requires SICF service activation. If unavailable, falls back with an error suggesting SAPQuery as an alternative.
 
@@ -278,7 +284,7 @@ This helps pinpoint the exact failing field/annotation instead of retrying blind
 
 **Batch creation:**
 
-`batch_create` creates and activates multiple objects in sequence via a single tool call. Objects are processed in array order — put dependencies first (e.g., domain before data element, TABL before DDLS, DCLS after DDLS, BDEF after CDS views). Each object in the array has: `type` (string, required), `name` (string, required), `source` (string, optional), `description` (string, optional), plus optional DOMA/DTEL metadata fields.
+`batch_create` creates and activates multiple objects in sequence via a single tool call. Objects are processed in array order — put dependencies first (e.g., domain before data element, TABL before DDLS, DCLS after DDLS, BDEF after CDS views). Each object in the array has: `type` (string, required), `name` (string, required), `source` (string, optional), `description` (string, optional), optional `package` and `transport` overrides, plus optional DOMA/DTEL metadata fields. Item-level `package` and `transport` override the top-level values for that object.
 
 If any object fails, processing stops and the response reports which objects succeeded and which failed. AFF metadata validation runs automatically for supported types (CLAS, INTF, PROG, DDLS, BDEF, SRVD, SRVB) — invalid metadata is rejected before hitting SAP.
 
@@ -300,6 +306,11 @@ SAPWrite(action="batch_create", package="ZDEV", transport="K900123", objects=[
   {type:"SRVD", name:"ZSD_TRAVEL", source:"define service..."},
   {type:"CLAS", name:"ZBP_I_TRAVEL", source:"CLASS zbp_i_travel..."},
   {type:"SRVB", name:"ZSB_TRAVEL_O4", serviceDefinition:"ZSD_TRAVEL", category:"0"}
+])
+
+SAPWrite(action="batch_create", objects=[
+  {type:"TABL", name:"ZTRAVEL", package:"ZDEV", transport:"K900123", source:"define table ztravel {...}"},
+  {type:"DDLS", name:"ZI_TRAVEL", package:"ZDEV", transport:"K900123", source:"define root view..."}
 ])
 
 SAPWrite(action="create", type="TABL", name="ZTRAVEL", package="$TMP",

--- a/skills/generate-rap-service-researched.md
+++ b/skills/generate-rap-service-researched.md
@@ -648,6 +648,15 @@ After approval, create the artifacts. Use batch creation when possible.
 SAPWrite(action="batch_create", objects=[...], package="<package>", transport="<transport>")
 ```
 
+If some generated objects need explicit per-item routing, put `package` and `transport` on the individual objects. Item-level values override the top-level batch values and are required when a recovered plan mixes packages:
+
+```
+SAPWrite(action="batch_create", objects=[
+  {type: "TABL", name: "<table>", package: "<package>", transport: "<transport>", source: "<ddl>"},
+  {type: "DDLS", name: "ZI_<entity>", package: "<package>", transport: "<transport>", source: "<ddl>"}
+])
+```
+
 Only fall back to sequential creation (Phase 4b) if `batch_create` returns an error. If batch fails: read the error, fix the SPECIFIC failing object's source, and retry `batch_create`. Do NOT switch to sequential mode after one batch failure.
 
 ### 4-pre. Pre-Implementation Check
@@ -661,6 +670,16 @@ SAPRead(type="INACTIVE_OBJECTS")
 **Note:** This may return 404 on some systems where the `/sap/bc/adt/activation/inactive` endpoint is not available. If so, skip this check and proceed — it's a convenience check, not a requirement.
 
 If inactive objects with conflicting names exist, resolve them first (activate or delete).
+
+For reset/create preflights that need to know whether target names exist anywhere in the repository, use exact object-directory lookup instead of a long `SAPQuery` against TADIR:
+
+```
+SAPSearch(searchType="tadir_lookup",
+  names=["<table>","ZI_<entity>","ZC_<entity>","ZSB_<entity>_V4"],
+  objectTypes=["TABL","DDLS","BDEF","SRVD","SRVB","CLAS"])
+```
+
+The lookup groups exact matches by requested name and returns `missing`; do not build large `WHERE OBJ_NAME IN (...)` SQL lists for this check.
 
 ### 4-doma. Create Domains and Data Elements (if approved in Phase 2)
 

--- a/skills/generate-rap-service.md
+++ b/skills/generate-rap-service.md
@@ -210,6 +210,8 @@ SAPWrite(action="batch_create", objects=[
 
 Objects are created and activated in array order — put dependencies first (table before CDS views, DCLS after DDLS, CDS views before BDEFs, behavior pool before interface BDEF). The batch stops on the first failure and reports which objects succeeded and which failed.
 
+Set `package` and `transport` at the top level when every artifact shares them. If a batch item needs to override either value, put `package` and/or `transport` on that object; item-level values win.
+
 If batch creation fails, fall back to the sequential approach below (Steps 4-13).
 
 ## Step 4: Create Database Table (Sequential Fallback)

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -23,6 +23,7 @@ import { AdtHttpClient, type AdtHttpConfig } from './http.js';
 import { checkOperation, OperationType, type SafetyConfig } from './safety.js';
 import { Semaphore } from './semaphore.js';
 import type {
+  AdtObjectLookupResult,
   AdtSearchResult,
   ApiReleaseStateInfo,
   AuthorizationFieldInfo,
@@ -573,6 +574,73 @@ export class AdtClient {
       `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=${encodeURIComponent(query)}&maxResults=${maxResults}`,
     );
     return parseSearchResults(resp.body);
+  }
+
+  /**
+   * Exact object-directory lookup for one or more names.
+   *
+   * Uses ADT repository quick search instead of freestyle SQL against TADIR. This
+   * keeps the lookup available in read/search-only configurations and avoids ADT
+   * SQL parser limits on long IN-lists.
+   */
+  async lookupObjects(
+    names: string[],
+    options: { maxResults?: number; objectTypes?: string[] } = {},
+  ): Promise<AdtObjectLookupResult[]> {
+    checkOperation(this.safety, OperationType.Search, 'LookupObjects');
+
+    const cleanedNames = [
+      ...new Set(
+        names
+          .map((n) => n.trim())
+          .filter(Boolean)
+          .map((n) => n.toUpperCase()),
+      ),
+    ];
+    const objectTypes = [
+      ...new Set(
+        (options.objectTypes ?? [])
+          .map((t) => t.trim())
+          .filter(Boolean)
+          .map((t) => t.toUpperCase()),
+      ),
+    ];
+    const limit = Math.max(1, Math.min(options.maxResults ?? 100, 1000));
+
+    const searchOnce = async (name: string, objectType?: string): Promise<AdtSearchResult[]> => {
+      const params = new URLSearchParams({
+        operation: 'quickSearch',
+        query: name,
+        maxResults: String(limit),
+      });
+      if (objectType) {
+        params.set('objectType', objectType);
+      }
+      const resp = await this.http.get(`/sap/bc/adt/repository/informationsystem/search?${params.toString()}`);
+      return parseSearchResults(resp.body);
+    };
+
+    const results: AdtObjectLookupResult[] = [];
+    for (const name of cleanedNames) {
+      const rawMatches =
+        objectTypes.length > 0
+          ? (await Promise.all(objectTypes.map((objectType) => searchOnce(name, objectType)))).flat()
+          : await searchOnce(name);
+
+      const seen = new Set<string>();
+      const matches = rawMatches
+        .filter((r) => r.objectName.toUpperCase() === name)
+        .filter((r) => {
+          const key = `${r.objectType}\u0000${r.objectName}\u0000${r.packageName}\u0000${r.uri}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+
+      results.push({ name, found: matches.length > 0, matches });
+    }
+
+    return results;
   }
 
   /** Search within ABAP source code (full-text search) */

--- a/src/adt/types.ts
+++ b/src/adt/types.ts
@@ -15,6 +15,13 @@ export interface AdtSearchResult {
   uri: string;
 }
 
+/** Exact object-directory lookup grouped by requested object name */
+export interface AdtObjectLookupResult {
+  name: string;
+  found: boolean;
+  matches: AdtSearchResult[];
+}
+
 /** Object structure node */
 export interface AdtObjectNode {
   type: string;

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -1837,7 +1837,16 @@ async function handleSAPSearch(client: AdtClient, args: Record<string, unknown>)
     const lookups = await client.lookupObjects(names, { maxResults, objectTypes });
     const missing = lookups.filter((l) => !l.found).map((l) => l.name);
     const matchCount = lookups.reduce((count, lookup) => count + lookup.matches.length, 0);
-    return textResult(JSON.stringify({ count: matchCount, lookups, missing }, null, 2));
+    const wildcardNames = names.filter((name) => name.includes('*'));
+    const warnings =
+      wildcardNames.length > 0
+        ? [
+            `tadir_lookup performs exact-name lookup; wildcard characters are treated literally for: ${wildcardNames.join(', ')}`,
+          ]
+        : undefined;
+    return textResult(
+      JSON.stringify({ count: matchCount, lookups, missing, ...(warnings ? { warnings } : {}) }, null, 2),
+    );
   }
 
   if (searchType === 'source_code') {
@@ -3938,12 +3947,24 @@ async function handleSAPWrite(
                 existingList,
             );
           }
-        } catch {
+        } catch (err) {
+          logger.warn('SAPWrite batch_create transport preflight failed; continuing without auto transport', {
+            package: pkg,
+            type: plan.type,
+            name: plan.name,
+            error: err instanceof Error ? err.message : String(err),
+          });
           // If transportInfo check fails, proceed — SAP will return its own error if needed.
         }
       }
 
-      const results: Array<{ type: string; name: string; status: 'success' | 'failed'; error?: string }> = [];
+      const results: Array<{
+        type: string;
+        name: string;
+        packageName: string;
+        status: 'success' | 'failed';
+        error?: string;
+      }> = [];
       const batchWarnings: string[] = [];
       // Per-batch cache for the MSAG transport-vs-task guard. The bug is universal so the
       // guard fires for every MSAG entry, but a batch typically shares one transport — cache
@@ -3964,6 +3985,7 @@ async function handleSAPWrite(
           results.push({
             type: objType,
             name: objName,
+            packageName: objPackage,
             status: 'failed',
             error: `Object name "${objName}" contains lowercase characters. SAP object names must be uppercase (e.g. "${objName.toUpperCase()}"). Source code inside the object can use mixed case.`,
           });
@@ -3981,6 +4003,7 @@ async function handleSAPWrite(
             results.push({
               type: objType,
               name: objName,
+              packageName: objPackage,
               status: 'failed',
               error: `Transport "${objTransport}" is not a valid transport request. MSAG creation requires a transport request number, not a task number.`,
             });
@@ -3994,6 +4017,7 @@ async function handleSAPWrite(
           results.push({
             type: objType,
             name: objName,
+            packageName: objPackage,
             status: 'failed',
             error: `AFF metadata validation failed:\n- ${(affResult.errors ?? []).join('\n- ')}`,
           });
@@ -4016,6 +4040,7 @@ async function handleSAPWrite(
               results.push({
                 type: objType,
                 name: objName,
+                packageName: objPackage,
                 status: 'failed',
                 error: preflightWarnings.result!.content[0].text,
               });
@@ -4030,6 +4055,7 @@ async function handleSAPWrite(
               results.push({
                 type: objType,
                 name: objName,
+                packageName: objPackage,
                 status: 'failed',
                 error: `source rejected by lint: ${lintWarnings.result!.content[0].text}`,
               });
@@ -4098,6 +4124,7 @@ async function handleSAPWrite(
             results.push({
               type: objType,
               name: objName,
+              packageName: objPackage,
               status: 'failed',
               error: `activation failed: ${activationResult.messages.join('; ')}`,
             });
@@ -4105,11 +4132,12 @@ async function handleSAPWrite(
           }
 
           invalidateWrittenObject(objType, objName);
-          results.push({ type: objType, name: objName, status: 'success' });
+          results.push({ type: objType, name: objName, packageName: objPackage, status: 'success' });
         } catch (err) {
           results.push({
             type: objType,
             name: objName,
+            packageName: objPackage,
             status: 'failed',
             error: err instanceof Error ? err.message : String(err),
           });
@@ -4119,17 +4147,23 @@ async function handleSAPWrite(
 
       // Add 'skipped' entries for objects that were never attempted due to early break
       for (let i = results.length; i < objects.length; i++) {
-        const skipped = objects[i];
+        const skippedPlan = batchPlan[i];
+        const skipped = skippedPlan?.obj ?? objects[i];
         results.push({
-          type: normalizeObjectType(String(skipped?.type ?? '')),
-          name: String(skipped.name ?? ''),
+          type: skippedPlan?.type ?? normalizeObjectType(String(skipped?.type ?? '')),
+          name: skippedPlan?.name ?? String(skipped?.name ?? ''),
+          packageName: skippedPlan?.packageName ?? normalizePackageOverride(skipped?.package, defaultPackage),
           status: 'failed',
           error: 'skipped — stopped after previous failure',
         });
       }
 
       const summary = results
-        .map((r) => `${r.name} (${r.type}) ${r.status === 'success' ? '✓' : `✗ — ${r.error}`}`)
+        .map((r) =>
+          r.status === 'success'
+            ? `${r.name} (${r.type}) ✓ [${r.packageName}]`
+            : `${r.name} (${r.type}) ✗ [${r.packageName}] — ${r.error}`,
+        )
         .join(', ');
       const successCount = results.filter((r) => r.status === 'success').length;
       const hasFailure = results.some((r) => r.status === 'failed');
@@ -4137,7 +4171,11 @@ async function handleSAPWrite(
         batchWarnings.length > 0 ? `\n\nRAP preflight warnings:\n- ${batchWarnings.join('\n- ')}` : '';
       const packageNames = [...new Set(batchPlan.map((item) => item.packageName))];
       const packageSummary =
-        packageNames.length === 1 ? `in package ${packageNames[0]}` : `across ${packageNames.length} packages`;
+        packageNames.length === 1
+          ? `in package ${packageNames[0]}`
+          : packageNames.length <= 3
+            ? `across packages [${packageNames.join(', ')}]`
+            : `across ${packageNames.length} packages`;
 
       if (hasFailure) {
         const cleanupHint =

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -1828,6 +1828,18 @@ async function handleSAPSearch(client: AdtClient, args: Record<string, unknown>)
   const maxResults = Number(args.maxResults ?? 100);
   const searchType = String(args.searchType ?? 'object');
 
+  if (searchType === 'tadir_lookup') {
+    const names = extractLookupNames(rawQuery, args.names);
+    if (names.length === 0) {
+      return errorResult('SAPSearch(searchType="tadir_lookup") requires names[] or query with at least one name.');
+    }
+    const objectTypes = extractLookupObjectTypes(args.objectType, args.objectTypes);
+    const lookups = await client.lookupObjects(names, { maxResults, objectTypes });
+    const missing = lookups.filter((l) => !l.found).map((l) => l.name);
+    const matchCount = lookups.reduce((count, lookup) => count + lookup.matches.length, 0);
+    return textResult(JSON.stringify({ count: matchCount, lookups, missing }, null, 2));
+  }
+
   if (searchType === 'source_code') {
     // Source code search: do NOT transliterate — source can contain umlauts in strings/comments
     if (cachedFeatures?.textSearch && !cachedFeatures.textSearch.available) {
@@ -1877,6 +1889,41 @@ async function handleSAPSearch(client: AdtClient, args: Record<string, unknown>)
     return textResult(hint);
   }
   return textResult(transliterationNote + JSON.stringify(results, null, 2));
+}
+
+function extractLookupNames(query: string, rawNames: unknown): string[] {
+  const fromNames = Array.isArray(rawNames) ? rawNames.map((n) => String(n).trim()).filter(Boolean) : [];
+  const fromQuery = query
+    .split(/[,\s]+/)
+    .map((n) => n.trim())
+    .filter(Boolean);
+  return [...new Set([...fromNames, ...fromQuery].map((n) => n.toUpperCase()))];
+}
+
+function extractLookupObjectTypes(rawObjectType: unknown, rawObjectTypes: unknown): string[] {
+  const types = Array.isArray(rawObjectTypes)
+    ? rawObjectTypes.map((t) => normalizeObjectType(String(t))).filter(Boolean)
+    : [];
+  if (typeof rawObjectType === 'string' && rawObjectType.trim()) {
+    types.push(normalizeObjectType(rawObjectType));
+  }
+  return [...new Set(types)];
+}
+
+function normalizePackageOverride(rawPackage: unknown, fallback: string): string {
+  if (rawPackage === undefined || rawPackage === null) {
+    return fallback;
+  }
+  const value = String(rawPackage).trim();
+  return value || fallback;
+}
+
+function normalizeTransportOverride(rawTransport: unknown): string | undefined {
+  if (rawTransport === undefined || rawTransport === null) {
+    return undefined;
+  }
+  const value = String(rawTransport).trim();
+  return value || undefined;
 }
 
 function classifySapQueryParserError(err: AdtApiError, sql: string): string | undefined {
@@ -3840,22 +3887,40 @@ async function handleSAPWrite(
         return errorResult('"objects" array is required and must be non-empty for batch_create action.');
       }
 
-      const pkg = String(args.package ?? '$TMP');
+      const defaultPackage = normalizePackageOverride(args.package, '$TMP');
 
-      // Check package is allowed before starting any creates
-      checkPackage(client.safety, pkg);
+      const batchPlan = objects.map((obj) => {
+        const objType = normalizeObjectType(String(obj.type ?? ''));
+        const objName = String(obj.name ?? '');
+        const objPackage = normalizePackageOverride(obj.package, defaultPackage);
+        const explicitTransport = normalizeTransportOverride(obj.transport) ?? transport;
+        return { obj, type: objType, name: objName, packageName: objPackage, explicitTransport };
+      });
 
-      // Pre-flight transport check for batch_create (same logic as single create)
-      let batchTransport = transport;
-      if (!transport && pkg.toUpperCase() !== '$TMP') {
+      // Check every target package before starting any creates.
+      for (const pkg of new Set(batchPlan.map((item) => item.packageName))) {
+        checkPackage(client.safety, pkg);
+      }
+
+      // Pre-flight transport check for batch_create (same logic as single create),
+      // but keyed by each effective package because objects can override package.
+      const autoTransportByPackage = new Map<string, string | undefined>();
+      const firstPlanNeedingTransportByPackage = new Map<string, (typeof batchPlan)[number]>();
+      for (const plan of batchPlan) {
+        if (
+          !plan.explicitTransport &&
+          plan.packageName.toUpperCase() !== '$TMP' &&
+          !firstPlanNeedingTransportByPackage.has(plan.packageName)
+        ) {
+          firstPlanNeedingTransportByPackage.set(plan.packageName, plan);
+        }
+      }
+      for (const [pkg, plan] of firstPlanNeedingTransportByPackage) {
         try {
-          // Use first object's URL for the transport check
-          const firstObj = objects[0];
-          const firstType = normalizeObjectType(String(firstObj?.type ?? ''));
-          const firstUrl = objectUrlForType(firstType, String(firstObj?.name ?? ''));
+          const firstUrl = objectUrlForType(plan.type, plan.name);
           const transportInfo = await getTransportInfo(client.http, client.safety, firstUrl, pkg, 'I');
           if (transportInfo.lockedTransport) {
-            batchTransport = transportInfo.lockedTransport;
+            autoTransportByPackage.set(pkg, transportInfo.lockedTransport);
           } else if (!transportInfo.isLocal && transportInfo.recording) {
             const existingList =
               transportInfo.existingTransports.length > 0
@@ -3885,9 +3950,9 @@ async function handleSAPWrite(
       // the lookup result to avoid one HTTP roundtrip per object.
       const transportLookupCache = new Map<string, Awaited<ReturnType<typeof getTransport>>>();
 
-      for (const obj of objects) {
-        const objType = normalizeObjectType(String(obj.type ?? ''));
-        const objName = String(obj.name ?? '');
+      for (const plan of batchPlan) {
+        const { obj, type: objType, name: objName, packageName: objPackage } = plan;
+        const objTransport = plan.explicitTransport ?? autoTransportByPackage.get(objPackage);
         const metadataObject = isMetadataWriteType(objType);
         const objSource = obj.source ? String(obj.source) : undefined;
         const objDescription = String(obj.description ?? objName);
@@ -3906,18 +3971,18 @@ async function handleSAPWrite(
         }
 
         // MSAG transport-vs-task guard (per-batch cache to avoid per-object roundtrip).
-        if (objType === 'MSAG' && batchTransport) {
-          let tr = transportLookupCache.get(batchTransport);
+        if (objType === 'MSAG' && objTransport) {
+          let tr = transportLookupCache.get(objTransport);
           if (tr === undefined) {
-            tr = await getTransport(client.http, client.safety, batchTransport);
-            transportLookupCache.set(batchTransport, tr);
+            tr = await getTransport(client.http, client.safety, objTransport);
+            transportLookupCache.set(objTransport, tr);
           }
           if (!tr) {
             results.push({
               type: objType,
               name: objName,
               status: 'failed',
-              error: `Transport "${batchTransport}" is not a valid transport request. MSAG creation requires a transport request number, not a task number.`,
+              error: `Transport "${objTransport}" is not a valid transport request. MSAG creation requires a transport request number, not a task number.`,
             });
             break;
           }
@@ -3976,7 +4041,7 @@ async function handleSAPWrite(
           const objUrl = objectUrlForType(objType, objName);
           const createUrl = objUrl.replace(/\/[^/]+$/, '');
           const objMetadataProps = getMetadataWriteProperties(obj);
-          const body = buildCreateXml(objType, objName, pkg, objDescription, objMetadataProps);
+          const body = buildCreateXml(objType, objName, objPackage, objDescription, objMetadataProps);
           const contentType = createContentTypeForType(objType);
           const needsPackageParam = objType === 'BDEF' || objType === 'TABL';
           try {
@@ -3986,8 +4051,8 @@ async function handleSAPWrite(
               createUrl,
               body,
               contentType,
-              batchTransport,
-              needsPackageParam ? pkg : undefined,
+              objTransport,
+              needsPackageParam ? objPackage : undefined,
               cachedFeatures?.abapRelease,
             );
           } catch (createErr) {
@@ -4004,7 +4069,7 @@ async function handleSAPWrite(
           if (objType === 'DTEL' && dtelNeedsPostCreateUpdate(objMetadataProps)) {
             await client.http.withStatefulSession(async (session) => {
               const lock = await lockObject(session, client.safety, objUrl, 'MODIFY', cachedFeatures?.abapRelease);
-              const lockTransport = batchTransport ?? (lock.corrNr || undefined);
+              const lockTransport = objTransport ?? (lock.corrNr || undefined);
               try {
                 await updateObject(session, client.safety, objUrl, body, lock.lockHandle, contentType, lockTransport);
               } finally {
@@ -4022,7 +4087,7 @@ async function handleSAPWrite(
               objUrl,
               srcUrl,
               objSource,
-              batchTransport,
+              objTransport,
               cachedFeatures?.abapRelease,
             );
           }
@@ -4070,6 +4135,9 @@ async function handleSAPWrite(
       const hasFailure = results.some((r) => r.status === 'failed');
       const warningSuffix =
         batchWarnings.length > 0 ? `\n\nRAP preflight warnings:\n- ${batchWarnings.join('\n- ')}` : '';
+      const packageNames = [...new Set(batchPlan.map((item) => item.packageName))];
+      const packageSummary =
+        packageNames.length === 1 ? `in package ${packageNames[0]}` : `across ${packageNames.length} packages`;
 
       if (hasFailure) {
         const cleanupHint =
@@ -4077,10 +4145,10 @@ async function handleSAPWrite(
             ? ` Note: ${successCount} already-created object(s) remain on the SAP system and may need manual cleanup.`
             : '';
         return errorResult(
-          `Batch created ${successCount}/${objects.length} objects in package ${pkg}: ${summary}${cleanupHint}${warningSuffix}`,
+          `Batch created ${successCount}/${objects.length} objects ${packageSummary}: ${summary}${cleanupHint}${warningSuffix}`,
         );
       }
-      return textResult(`Batch created ${successCount} objects in package ${pkg}: ${summary}${warningSuffix}`);
+      return textResult(`Batch created ${successCount} objects ${packageSummary}: ${summary}${warningSuffix}`);
     }
     default:
       return errorResult(

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -207,18 +207,70 @@ export const SAPReadSchemaBtp = z
 
 // ─── SAPSearch ──────────────────────────────────────────────────────
 
-export const SAPSearchSchema = z.object({
-  query: z.string(),
-  maxResults: z.coerce.number().optional(),
-  searchType: z.enum(['object', 'source_code']).optional(),
-  objectType: z.string().optional(),
-  packageName: z.string().optional(),
-});
+export const SAPSearchSchema = z
+  .object({
+    query: z.string().optional(),
+    maxResults: z.coerce.number().optional(),
+    searchType: z.enum(['object', 'source_code', 'tadir_lookup']).optional(),
+    objectType: z.string().optional(),
+    objectTypes: z.array(z.string()).optional(),
+    packageName: z.string().optional(),
+    names: z.array(z.string()).optional(),
+  })
+  .superRefine((input, ctx) => {
+    const searchType = input.searchType ?? 'object';
+    if (searchType === 'tadir_lookup') {
+      const hasNames = Array.isArray(input.names) && input.names.some((n) => n.trim());
+      const hasQuery = typeof input.query === 'string' && input.query.trim().length > 0;
+      if (!hasNames && !hasQuery) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['names'],
+          message: 'tadir_lookup requires either names[] or query.',
+        });
+      }
+      return;
+    }
+    if (!input.query || input.query.trim().length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['query'],
+        message: `${searchType} search requires query.`,
+      });
+    }
+  });
 
-export const SAPSearchSchemaNoSource = z.object({
-  query: z.string(),
-  maxResults: z.coerce.number().optional(),
-});
+export const SAPSearchSchemaNoSource = z
+  .object({
+    query: z.string().optional(),
+    maxResults: z.coerce.number().optional(),
+    searchType: z.enum(['object', 'tadir_lookup']).optional(),
+    objectType: z.string().optional(),
+    objectTypes: z.array(z.string()).optional(),
+    names: z.array(z.string()).optional(),
+  })
+  .superRefine((input, ctx) => {
+    const searchType = input.searchType ?? 'object';
+    if (searchType === 'tadir_lookup') {
+      const hasNames = Array.isArray(input.names) && input.names.some((n) => n.trim());
+      const hasQuery = typeof input.query === 'string' && input.query.trim().length > 0;
+      if (!hasNames && !hasQuery) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['names'],
+          message: 'tadir_lookup requires either names[] or query.',
+        });
+      }
+      return;
+    }
+    if (!input.query || input.query.trim().length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['query'],
+        message: 'object search requires query.',
+      });
+    }
+  });
 
 // ─── SAPQuery ───────────────────────────────────────────────────────
 
@@ -305,6 +357,8 @@ const batchObjectSchemaOnprem = z.object({
   name: z.string(),
   source: z.string().optional(),
   description: z.string().optional(),
+  package: z.string().optional(),
+  transport: z.string().optional(),
   dataType: z.string().optional(),
   length: z.coerce.number().optional(),
   decimals: z.coerce.number().optional(),
@@ -339,6 +393,8 @@ const batchObjectSchemaBtp = z.object({
   name: z.string(),
   source: z.string().optional(),
   description: z.string().optional(),
+  package: z.string().optional(),
+  transport: z.string().optional(),
   dataType: z.string().optional(),
   length: z.coerce.number().optional(),
   decimals: z.coerce.number().optional(),

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -245,15 +245,17 @@ const SAPQUERY_DESC_BTP =
 // ─── SAPSearch ──────────────────────────────────────────────────────
 
 const SAPSEARCH_DESC_ONPREM =
-  'Search for ABAP objects or search within source code. Two modes:\n' +
+  'Search for ABAP objects, exact object-directory entries, or source code. Three modes:\n' +
   '1. Object search (default): Search by name pattern with wildcards (* for any characters). Returns object type, name, package, description, and ADT URI. Use this to find classes, programs, function modules, tables, etc.\n' +
-  '2. Source code search (searchType="source_code"): Full-text search within ABAP source code across the system. Use this to find all objects containing a specific string (e.g., a method call, variable name, or class reference). Requires SAP_BASIS >= 7.51.\n\n' +
+  '2. TADIR lookup (searchType="tadir_lookup"): Exact cross-package object lookup for one or more names via ADT repository quick search. Use this before create/reset workflows instead of long SAPQuery TADIR IN-lists.\n' +
+  '3. Source code search (searchType="source_code"): Full-text search within ABAP source code across the system. Use this to find all objects containing a specific string (e.g., a method call, variable name, or class reference). Requires SAP_BASIS >= 7.51.\n\n' +
   "Tips: BOR business objects appear as SOBJ type in results. The uri field from results can be used directly with SAPNavigate for references. The objectType field from results can be passed directly to SAPRead/SAPWrite/SAPActivate (ARC-1 auto-normalizes slash suffixes like DDLS/DF, CLAS/OC, PROG/P).\n\nNote: Searches object names only (classes, tables, CDS views, etc.) — field/column names are not searchable here. To find fields by name, use SAPRead(type='DDLS', include='elements') for CDS views or SAPQuery against DD03L.";
 
 const SAPSEARCH_DESC_BTP =
-  'Search for ABAP objects or search within source code (BTP ABAP Environment). Two modes:\n' +
+  'Search for ABAP objects, exact object-directory entries, or source code (BTP ABAP Environment). Three modes:\n' +
   '1. Object search (default): Search by name pattern with wildcards. Returns released SAP objects and custom Z/Y objects. Classic programs, includes, and DDIC views are not searchable on BTP.\n' +
-  '2. Source code search (searchType="source_code"): Full-text search within ABAP source code.\n\n' +
+  '2. TADIR lookup (searchType="tadir_lookup"): Exact object lookup for one or more names via ADT repository quick search.\n' +
+  '3. Source code search (searchType="source_code"): Full-text search within ABAP source code.\n\n' +
   "Tips: On BTP, focus on classes (CL_*), interfaces (IF_*), CDS views (I_*), and custom Z/Y objects.\n\nNote: Searches object names only (classes, CDS views, etc.) — field/column names are not searchable here. To find fields by name, use SAPRead(type='DDLS', include='elements') for CDS views.";
 
 // ─── SAPTransport ───────────────────────────────────────────────────
@@ -371,9 +373,14 @@ function stripSourceCodeLines(desc: string): string {
       (line) =>
         !line.includes('source_code') &&
         !line.includes('Source code search') &&
-        !line.startsWith('2. Source code search'),
+        !line.startsWith('2. Source code search') &&
+        !line.startsWith('3. Source code search'),
     )
     .join('\n')
+    .replace(
+      /, exact object-directory entries, or source code[^.]*\. Three modes:\n1\. Object search \(default\): /i,
+      '. ',
+    )
     .replace(/ or search within source code[^.]*\. Two modes:\n1\. Object search \(default\): /i, '. ')
     .replace(/\n{3,}/g, '\n\n')
     .trim();
@@ -391,8 +398,8 @@ function buildSAPSearchTool(btp: boolean, textSearchAvailable?: boolean): ToolDe
     query: {
       type: 'string',
       description: hideSourceCode
-        ? 'Search pattern: name pattern with wildcards (e.g., ZCL_ORDER*, Z*TEST*).'
-        : 'Search pattern. For object search: name pattern with wildcards (e.g., ZCL_ORDER*, Z*TEST*). For source_code search: text string to find in source (e.g., cl_lsapi_manager, CALL FUNCTION).',
+        ? 'Search pattern for object search, or comma/whitespace-separated names for tadir_lookup.'
+        : 'Search pattern. For object search: name pattern with wildcards (e.g., ZCL_ORDER*, Z*TEST*). For tadir_lookup: exact name or comma/whitespace-separated names. For source_code search: text string to find in source (e.g., cl_lsapi_manager, CALL FUNCTION).',
     },
     maxResults: {
       type: 'number',
@@ -402,17 +409,31 @@ function buildSAPSearchTool(btp: boolean, textSearchAvailable?: boolean): ToolDe
     },
   };
 
+  properties.searchType = {
+    type: 'string',
+    enum: hideSourceCode ? ['object', 'tadir_lookup'] : ['object', 'source_code', 'tadir_lookup'],
+    description: hideSourceCode
+      ? 'Search mode: "object" (default) searches by object name, "tadir_lookup" does exact cross-package object lookup.'
+      : 'Search mode: "object" (default) searches by object name, "source_code" searches within ABAP source code, "tadir_lookup" does exact cross-package object lookup.',
+  };
+  properties.names = {
+    type: 'array',
+    items: { type: 'string' },
+    description:
+      'For tadir_lookup: exact object names to resolve across packages. Prefer this over long SAPQuery TADIR IN-lists.',
+  };
+  properties.objectTypes = {
+    type: 'array',
+    items: { type: 'string' },
+    description: 'For tadir_lookup: optional ADT/TADIR type filters (e.g., TABL, DDLS, BDEF, SRVB, CLAS/OC).',
+  };
+  properties.objectType = {
+    type: 'string',
+    description:
+      'For source_code search: filter by object type (e.g., PROG, CLAS, FUNC). For tadir_lookup: single type filter; use objectTypes for multiple.',
+  };
+
   if (!hideSourceCode) {
-    properties.searchType = {
-      type: 'string',
-      enum: ['object', 'source_code'],
-      description:
-        'Search mode: "object" (default) searches by object name, "source_code" searches within ABAP source code.',
-    };
-    properties.objectType = {
-      type: 'string',
-      description: 'For source_code search: filter by object type (e.g., PROG, CLAS, FUNC)',
-    };
     properties.packageName = { type: 'string', description: 'For source_code search: filter by package name' };
   }
 
@@ -422,7 +443,6 @@ function buildSAPSearchTool(btp: boolean, textSearchAvailable?: boolean): ToolDe
     inputSchema: {
       type: 'object',
       properties,
-      required: ['query'],
     },
   };
 }
@@ -710,6 +730,14 @@ export function getToolDefinitions(
                 name: { type: 'string', description: 'Object name' },
                 source: { type: 'string', description: 'ABAP source code (optional — some objects have no source)' },
                 description: { type: 'string', description: 'Object description (defaults to name if omitted)' },
+                package: {
+                  type: 'string',
+                  description: 'Object-specific package. Overrides top-level package for this item.',
+                },
+                transport: {
+                  type: 'string',
+                  description: 'Object-specific transport request. Overrides top-level transport for this item.',
+                },
                 dataType: { type: 'string', description: 'DOMA/DTEL: ABAP data type' },
                 length: { type: 'number', description: 'DOMA/DTEL: data type length' },
                 decimals: { type: 'number', description: 'DOMA/DTEL: decimal places' },
@@ -777,6 +805,7 @@ export function getToolDefinitions(
             description:
               'For batch_create: ordered list of objects to create and activate. Each object needs type, name, and source (if applicable). ' +
               'Objects are created and activated in array order — put dependencies first (e.g., TABL before DDLS, BDEF after DDLS). ' +
+              'Each item may include package and transport; item-level values override top-level package/transport. ' +
               'Example: [{type:"TABL",name:"ZTRAVEL",source:"..."},{type:"DDLS",name:"ZI_TRAVEL",source:"..."},{type:"BDEF",name:"ZI_TRAVEL",source:"..."},{type:"SRVD",name:"ZSD_TRAVEL",source:"..."}]',
           },
         },

--- a/tests/unit/adt/client.test.ts
+++ b/tests/unit/adt/client.test.ts
@@ -788,6 +788,70 @@ describe('AdtClient', () => {
     });
   });
 
+  describe('lookupObjects', () => {
+    const LOOKUP_RESPONSE = `<?xml version="1.0" encoding="utf-8"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/tables/zdm_project_d" adtcore:type="TABL/DT" adtcore:name="ZDM_PROJECT_D" adtcore:packageName="ZDEMO_MIG_RAP" adtcore:description="Draft table"/>
+  <adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/tables/zdm_project_extra" adtcore:type="TABL/DT" adtcore:name="ZDM_PROJECT_EXTRA" adtcore:packageName="ZDEMO_MIG_RAP" adtcore:description="Substring hit"/>
+</adtcore:objectReferences>`;
+
+    it('uses repository quick search and exact-filters matches', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, LOOKUP_RESPONSE));
+      const client = createClient();
+      const result = await client.lookupObjects(['ZDM_PROJECT_D']);
+
+      const url = String(mockFetch.mock.calls[0]?.[0] ?? '');
+      expect(url).toContain('/sap/bc/adt/repository/informationsystem/search');
+      expect(url).toContain('operation=quickSearch');
+      expect(url).toContain('query=ZDM_PROJECT_D');
+      expect(url).not.toContain('objectType=');
+      expect(result).toEqual([
+        {
+          name: 'ZDM_PROJECT_D',
+          found: true,
+          matches: [
+            {
+              objectType: 'TABL/DT',
+              objectName: 'ZDM_PROJECT_D',
+              packageName: 'ZDEMO_MIG_RAP',
+              description: 'Draft table',
+              uri: '/sap/bc/adt/ddic/tables/zdm_project_d',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('adds objectType filters and deduplicates typed lookup results', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, LOOKUP_RESPONSE));
+      const client = createClient();
+      const result = await client.lookupObjects(['zdm_project_d'], { objectTypes: ['TABL', 'TABL'], maxResults: 5 });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const url = String(mockFetch.mock.calls[0]?.[0] ?? '');
+      expect(url).toContain('objectType=TABL');
+      expect(url).toContain('maxResults=5');
+      expect(result[0]?.name).toBe('ZDM_PROJECT_D');
+      expect(result[0]?.matches).toHaveLength(1);
+    });
+
+    it('returns missing lookup entries when no exact match is found', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          '<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"></adtcore:objectReferences>',
+        ),
+      );
+      const client = createClient();
+      const result = await client.lookupObjects(['ZDOES_NOT_EXIST']);
+
+      expect(result).toEqual([{ name: 'ZDOES_NOT_EXIST', found: false, matches: [] }]);
+    });
+  });
+
   describe('withSafety', () => {
     it('returns a new client with the given safety config', () => {
       const client = createClient();

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -1398,6 +1398,90 @@ describe('Intent Handler', () => {
       expect(result.isError).toBeUndefined();
     });
 
+    it('runs exact TADIR lookup from names array', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          200,
+          `<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/tables/zdm_project_d" adtcore:type="TABL/DT" adtcore:name="ZDM_PROJECT_D" adtcore:packageName="ZDEMO_MIG_RAP" adtcore:description="Draft table"/>
+  <adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/tables/zdm_project_extra" adtcore:type="TABL/DT" adtcore:name="ZDM_PROJECT_EXTRA" adtcore:packageName="ZDEMO_MIG_RAP" adtcore:description="Substring hit"/>
+</adtcore:objectReferences>`,
+        ),
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPSearch', {
+        searchType: 'tadir_lookup',
+        names: ['zdm_project_d'],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const url = String(mockFetch.mock.calls[0]?.[0] ?? '');
+      expect(url).toContain('/sap/bc/adt/repository/informationsystem/search');
+      expect(url).toContain('operation=quickSearch');
+      expect(url).toContain('query=ZDM_PROJECT_D');
+      const payload = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(payload.count).toBe(1);
+      expect(payload.lookups[0]).toMatchObject({
+        name: 'ZDM_PROJECT_D',
+        found: true,
+      });
+      expect(payload.lookups[0].matches[0]).toMatchObject({
+        objectType: 'TABL/DT',
+        objectName: 'ZDM_PROJECT_D',
+        packageName: 'ZDEMO_MIG_RAP',
+      });
+      expect(payload.missing).toEqual([]);
+    });
+
+    it('runs exact TADIR lookup from query and reports missing names', async () => {
+      mockFetch.mockReset();
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse(
+            200,
+            `<objectReferences><objectReference uri="/sap/bc/adt/bo/behaviordefinitions/zr_dm_project" type="BDEF/BDO" name="ZR_DM_PROJECT" packageName="ZDEMO_MIG_RAP" description="Behavior"/></objectReferences>`,
+          ),
+        )
+        .mockResolvedValueOnce(mockResponse(200, '<objectReferences/>'));
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPSearch', {
+        searchType: 'tadir_lookup',
+        query: 'ZR_DM_PROJECT, ZDOES_NOT_EXIST',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const payload = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(payload.count).toBe(1);
+      expect(payload.missing).toEqual(['ZDOES_NOT_EXIST']);
+    });
+
+    it('passes objectTypes as typed TADIR lookup filters', async () => {
+      mockFetch.mockReset();
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse(
+            200,
+            `<objectReferences><objectReference uri="/sap/bc/adt/ddic/tables/zdm_project_d" type="TABL/DT" name="ZDM_PROJECT_D" packageName="ZDEMO_MIG_RAP" description="Draft table"/></objectReferences>`,
+          ),
+        )
+        .mockResolvedValueOnce(mockResponse(200, '<objectReferences/>'));
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPSearch', {
+        searchType: 'tadir_lookup',
+        names: ['ZDM_PROJECT_D'],
+        objectTypes: ['TABL', 'BDEF'],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const urls = mockFetch.mock.calls.map((call) => String(call[0]));
+      expect(urls.some((url) => url.includes('objectType=TABL'))).toBe(true);
+      expect(urls.some((url) => url.includes('objectType=BDEF'))).toBe(true);
+      const payload = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(payload.count).toBe(1);
+    });
+
     // ─── Transliteration ──────────────────────────────────────────────
 
     describe('transliterateQuery', () => {
@@ -8384,6 +8468,81 @@ ENDCLASS.`;
       expect(text).toContain('blocked');
     });
 
+    it('applies package filter to object-specific batch_create packages before mutation', async () => {
+      mockFetch.mockReset();
+      const client = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'admin',
+        password: 'secret',
+        safety: { ...unrestrictedSafetyConfig(), allowedPackages: ['ZALLOWED*'] },
+      });
+
+      const result = await handleToolCall(client, DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'batch_create',
+        objects: [{ type: 'PROG', name: 'ZPROG1', source: 'REPORT zprog1.', package: 'ZBLOCKED' }],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('blocked');
+      expect(mockFetch).toHaveBeenCalledTimes(0);
+    });
+
+    it('uses object-specific package in batch_create when top-level package is omitted', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+
+      const config = { ...DEFAULT_CONFIG, lintBeforeWrite: false };
+      const result = await handleToolCall(createClient(), config, 'SAPWrite', {
+        action: 'batch_create',
+        objects: [
+          {
+            type: 'PROG',
+            name: 'ZPROG1',
+            source: 'REPORT zprog1.',
+            package: 'ZOBJPKG',
+            transport: 'A4HK900123',
+          },
+        ],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const createCall = mockFetch.mock.calls.find(
+        (call) =>
+          String(call[0]).includes('/sap/bc/adt/programs/programs?') &&
+          (call[1] as Record<string, unknown> | undefined)?.method === 'POST',
+      );
+      const body = (createCall?.[1] as Record<string, unknown> | undefined)?.body;
+      expect(body).toContain('<adtcore:packageRef adtcore:name="ZOBJPKG"/>');
+      expect(body).not.toContain('$TMP');
+      expect(result.content[0]?.text).toContain('in package ZOBJPKG');
+    });
+
+    it('uses object-specific transport in batch_create when top-level transport differs', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+
+      const config = { ...DEFAULT_CONFIG, lintBeforeWrite: false };
+      await handleToolCall(createClient(), config, 'SAPWrite', {
+        action: 'batch_create',
+        package: '$TMP',
+        transport: 'TOP900001',
+        objects: [
+          {
+            type: 'PROG',
+            name: 'ZPROG1',
+            source: 'REPORT zprog1.',
+            transport: 'OBJ900001',
+          },
+        ],
+      });
+
+      const createUrl = mockFetch.mock.calls
+        .map((call) => String(call[0]))
+        .find((url) => url.includes('/sap/bc/adt/programs/programs?corrNr='));
+      expect(createUrl).toContain('corrNr=OBJ900001');
+      expect(createUrl).not.toContain('TOP900001');
+    });
+
     it('activates each object after creation', async () => {
       const fetchCalls: string[] = [];
       mockFetch.mockImplementation((_url: string | URL, options?: { method?: string }) => {
@@ -9362,6 +9521,32 @@ ENDCLASS.`;
       expect(result.content[0]?.text).toContain('SAPTransport');
     });
 
+    it('still preflights batch_create package when only some objects provide object transport', async () => {
+      const calls: string[] = [];
+      mockFetch.mockImplementation((url: string) => {
+        calls.push(String(url));
+        if (String(url).includes('/cts/transportchecks')) {
+          return Promise.resolve(
+            mockResponse(200, transportInfoResponse(true, false, ['A4HK900502']), { 'x-csrf-token': 'T' }),
+          );
+        }
+        return Promise.resolve(mockResponse(200, '<xml/>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'batch_create',
+        objects: [
+          { type: 'PROG', name: 'ZPROG1', package: 'Z_MY_PKG', transport: 'A4HK900501', source: 'REPORT zprog1.' },
+          { type: 'PROG', name: 'ZPROG2', package: 'Z_MY_PKG', source: 'REPORT zprog2.' },
+        ],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('requires a transport number');
+      expect(calls.some((url) => url.includes('/cts/transportchecks'))).toBe(true);
+      expect(calls.some((url) => url.includes('/sap/bc/adt/programs/programs?corrNr=A4HK900501'))).toBe(false);
+    });
+
     it('proceeds for local package response even if DLVUNIT is not LOCAL', async () => {
       // Some packages might not require recording even if not strictly "LOCAL"
       mockFetch.mockImplementation((url: string) => {
@@ -10194,6 +10379,39 @@ ENDCLASS.`;
           (c[1] as Record<string, unknown>).method === 'POST',
       );
       expect(createCall).toBeDefined();
+    });
+
+    it('passes object-specific _package query parameter for TABL in batch_create', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+
+      await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'batch_create',
+        objects: [
+          {
+            type: 'TABL',
+            name: 'ZTABL_TEST',
+            package: 'ZOBJPKG',
+            transport: 'A4HK900123',
+            source:
+              "@EndUserText.label : 'T'\n@AbapCatalog.enhancement.category : #NOT_EXTENSIBLE\n@AbapCatalog.tableCategory : #TRANSPARENT\n@AbapCatalog.deliveryClass : #A\n@AbapCatalog.dataMaintenance : #RESTRICTED\ndefine table ZTABL_TEST { key client : abap.clnt not null; }",
+          },
+        ],
+      });
+
+      const createCall = mockFetch.mock.calls.find(
+        (c: unknown[]) =>
+          typeof c[0] === 'string' &&
+          c[0].includes('/sap/bc/adt/ddic/tables') &&
+          c[0].includes('_package=ZOBJPKG') &&
+          !c[0].includes('_package=%24TMP') &&
+          typeof c[1] === 'object' &&
+          (c[1] as Record<string, unknown>).method === 'POST',
+      );
+      expect(createCall).toBeDefined();
+      expect((createCall?.[1] as Record<string, unknown> | undefined)?.body).toContain(
+        '<adtcore:packageRef adtcore:name="ZOBJPKG"/>',
+      );
     });
 
     it('passes _package query parameter for BDEF in batch_create', async () => {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -1457,6 +1457,22 @@ describe('Intent Handler', () => {
       expect(payload.missing).toEqual(['ZDOES_NOT_EXIST']);
     });
 
+    it('warns when exact TADIR lookup names contain wildcards', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(mockResponse(200, '<objectReferences/>'));
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPSearch', {
+        searchType: 'tadir_lookup',
+        names: ['ZDM_PROJECT*'],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const payload = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(payload.missing).toEqual(['ZDM_PROJECT*']);
+      expect(payload.warnings[0]).toContain('exact-name lookup');
+      expect(payload.warnings[0]).toContain('ZDM_PROJECT*');
+    });
+
     it('passes objectTypes as typed TADIR lookup filters', async () => {
       mockFetch.mockReset();
       mockFetch
@@ -8543,6 +8559,62 @@ ENDCLASS.`;
       expect(createUrl).not.toContain('TOP900001');
     });
 
+    it('includes effective packages in mixed-package batch_create summaries', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+
+      const config = { ...DEFAULT_CONFIG, lintBeforeWrite: false };
+      const result = await handleToolCall(createClient(), config, 'SAPWrite', {
+        action: 'batch_create',
+        package: '$TMP',
+        transport: 'A4HK900123',
+        objects: [
+          { type: 'PROG', name: 'ZPROG1', source: 'REPORT zprog1.' },
+          { type: 'PROG', name: 'ZPROG2', source: 'REPORT zprog2.', package: 'ZOBJPKG' },
+        ],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('across packages [$TMP, ZOBJPKG]');
+      expect(text).toContain('ZPROG1 (PROG) ✓ [$TMP]');
+      expect(text).toContain('ZPROG2 (PROG) ✓ [ZOBJPKG]');
+    });
+
+    it('treats empty package and transport overrides as absent in batch_create', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+
+      const config = { ...DEFAULT_CONFIG, lintBeforeWrite: false };
+      const result = await handleToolCall(createClient(), config, 'SAPWrite', {
+        action: 'batch_create',
+        package: 'ZTOPPKG',
+        transport: 'A4HK900123',
+        objects: [
+          {
+            type: 'PROG',
+            name: 'ZPROG1',
+            source: 'REPORT zprog1.',
+            package: '',
+            transport: '',
+          },
+        ],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const createCall = mockFetch.mock.calls.find(
+        (call) =>
+          String(call[0]).includes('/sap/bc/adt/programs/programs?') &&
+          (call[1] as Record<string, unknown> | undefined)?.method === 'POST',
+      );
+      const body = String((createCall?.[1] as Record<string, unknown> | undefined)?.body ?? '');
+      const createUrl = String(createCall?.[0] ?? '');
+      expect(body).toContain('<adtcore:packageRef adtcore:name="ZTOPPKG"/>');
+      expect(body).not.toContain('$TMP');
+      expect(createUrl).toContain('corrNr=A4HK900123');
+      expect(result.content[0]?.text).toContain('in package ZTOPPKG');
+    });
+
     it('activates each object after creation', async () => {
       const fetchCalls: string[] = [];
       mockFetch.mockImplementation((_url: string | URL, options?: { method?: string }) => {
@@ -9379,6 +9451,13 @@ ENDCLASS.`;
         ${transports.length > 0 ? `<TRANSPORTS>${transportEntries}</TRANSPORTS>` : ''}
       </DATA></asx:values></asx:abap>`;
     };
+    const lockedTransportInfoResponse = (transport: string, packageName: string) =>
+      `<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA>
+        <RECORDING>X</RECORDING>
+        <DLVUNIT>SAP</DLVUNIT>
+        <DEVCLASS>${packageName}</DEVCLASS>
+        <LOCKS><HEADER><TRKORR>${transport}</TRKORR></HEADER></LOCKS>
+      </DATA></asx:values></asx:abap>`;
 
     it('returns guidance error when creating in transportable package without transport', async () => {
       const calls: Array<{ url: string; method: string }> = [];
@@ -9498,6 +9577,38 @@ ENDCLASS.`;
       expect(result.content[0]?.text).not.toContain('requires a transport number');
     });
 
+    it('logs and proceeds if batch_create transportInfo check fails', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      try {
+        mockFetch.mockImplementation((url: string) => {
+          if (String(url).includes('/cts/transportchecks')) {
+            return Promise.resolve(mockResponse(500, 'Internal Error', { 'x-csrf-token': 'T' }));
+          }
+          return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+        });
+
+        const config = { ...DEFAULT_CONFIG, lintBeforeWrite: false };
+        const result = await handleToolCall(createClient(), config, 'SAPWrite', {
+          action: 'batch_create',
+          package: 'Z_MY_PKG',
+          objects: [{ type: 'PROG', name: 'ZTEST', source: 'REPORT ztest.' }],
+        });
+
+        expect(result.content[0]?.text).not.toContain('requires a transport number');
+        expect(warnSpy).toHaveBeenCalledWith(
+          'SAPWrite batch_create transport preflight failed; continuing without auto transport',
+          expect.objectContaining({
+            package: 'Z_MY_PKG',
+            type: 'PROG',
+            name: 'ZTEST',
+            error: expect.stringContaining('ADT API error'),
+          }),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it('returns guidance error for batch_create in transportable package without transport', async () => {
       mockFetch.mockImplementation((url: string) => {
         if (String(url).includes('/cts/transportchecks')) {
@@ -9545,6 +9656,50 @@ ENDCLASS.`;
       expect(result.content[0]?.text).toContain('requires a transport number');
       expect(calls.some((url) => url.includes('/cts/transportchecks'))).toBe(true);
       expect(calls.some((url) => url.includes('/sap/bc/adt/programs/programs?corrNr=A4HK900501'))).toBe(false);
+    });
+
+    it('auto-uses locked transports separately for each batch_create package', async () => {
+      let transportCheckCount = 0;
+      const calls: Array<{ url: string; method: string }> = [];
+      mockFetch.mockImplementation((url: string, opts: any) => {
+        const urlStr = String(url);
+        const method = opts?.method ?? 'GET';
+        calls.push({ url: urlStr, method });
+
+        if (urlStr.includes('/cts/transportchecks')) {
+          transportCheckCount++;
+          const transport = transportCheckCount === 1 ? 'A4HK900111' : 'A4HK900222';
+          const packageName = transportCheckCount === 1 ? 'ZPKG1' : 'ZPKG2';
+          return Promise.resolve(
+            mockResponse(200, lockedTransportInfoResponse(transport, packageName), { 'x-csrf-token': 'T' }),
+          );
+        }
+        return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const config = { ...DEFAULT_CONFIG, lintBeforeWrite: false };
+      const result = await handleToolCall(createClient(), config, 'SAPWrite', {
+        action: 'batch_create',
+        objects: [
+          { type: 'PROG', name: 'ZPROG1', package: 'ZPKG1', source: 'REPORT zprog1.' },
+          { type: 'PROG', name: 'ZPROG2', package: 'ZPKG2', source: 'REPORT zprog2.' },
+        ],
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(calls.filter((c) => c.url.includes('/cts/transportchecks'))).toHaveLength(2);
+      const createUrls = calls
+        .filter(
+          (c) =>
+            c.method === 'POST' &&
+            c.url.includes('/sap/bc/adt/programs/programs') &&
+            !c.url.includes('_action=') &&
+            !c.url.includes('/activation'),
+        )
+        .map((c) => c.url);
+      expect(createUrls.some((url) => url.includes('corrNr=A4HK900111'))).toBe(true);
+      expect(createUrls.some((url) => url.includes('corrNr=A4HK900222'))).toBe(true);
+      expect(result.content[0]?.text).toContain('across packages [ZPKG1, ZPKG2]');
     });
 
     it('proceeds for local package response even if DLVUNIT is not LOCAL', async () => {

--- a/tests/unit/handlers/schemas.test.ts
+++ b/tests/unit/handlers/schemas.test.ts
@@ -309,13 +309,29 @@ describe('SAPSearchSchema', () => {
       maxResults: 50,
       searchType: 'source_code',
       objectType: 'CLAS',
+      objectTypes: ['CLAS', 'DDLS'],
       packageName: 'ZTEST',
+      names: ['ZCL_TEST'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts TADIR lookup with names and no query', () => {
+    const result = SAPSearchSchema.safeParse({
+      searchType: 'tadir_lookup',
+      names: ['ZDM_PROJECT_D', 'ZR_DM_PROJECT'],
+      objectTypes: ['TABL', 'BDEF'],
     });
     expect(result.success).toBe(true);
   });
 
   it('rejects missing query', () => {
     const result = SAPSearchSchema.safeParse({ maxResults: 10 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects TADIR lookup without names or query', () => {
+    const result = SAPSearchSchema.safeParse({ searchType: 'tadir_lookup', maxResults: 10 });
     expect(result.success).toBe(false);
   });
 
@@ -331,12 +347,18 @@ describe('SAPSearchSchemaNoSource', () => {
     expect(result.success).toBe(true);
   });
 
-  it('ignores searchType (not in schema)', () => {
+  it('rejects source_code searchType when source search is unavailable', () => {
     const result = SAPSearchSchemaNoSource.safeParse({ query: 'test', searchType: 'source_code' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts TADIR lookup when source search is unavailable', () => {
+    const result = SAPSearchSchemaNoSource.safeParse({
+      searchType: 'tadir_lookup',
+      names: ['ZDM_PROJECT_D'],
+      objectTypes: ['TABL'],
+    });
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect('searchType' in result.data).toBe(false);
-    }
   });
 });
 
@@ -544,11 +566,20 @@ describe('SAPWriteSchema', () => {
       action: 'batch_create',
       package: '$TMP',
       objects: [
-        { type: 'DDLS', name: 'ZI_TRAVEL', source: 'define view entity ZI_TRAVEL {}' },
-        { type: 'BDEF', name: 'ZI_TRAVEL' },
+        {
+          type: 'DDLS',
+          name: 'ZI_TRAVEL',
+          source: 'define view entity ZI_TRAVEL {}',
+          package: 'ZDEV',
+          transport: 'A4HK900123',
+        },
+        { type: 'BDEF', name: 'ZI_TRAVEL', package: 'ZDEV' },
       ],
     });
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.objects?.[0]).toMatchObject({ package: 'ZDEV', transport: 'A4HK900123' });
+    }
   });
 
   it('accepts scaffold_rap_handlers action fields', () => {

--- a/tests/unit/handlers/tools.test.ts
+++ b/tests/unit/handlers/tools.test.ts
@@ -353,6 +353,9 @@ describe('Tool Definitions', () => {
       const schema = sapSearch.inputSchema as Record<string, any>;
       expect(schema.properties.searchType).toBeDefined();
       expect(schema.properties.searchType.enum).toContain('source_code');
+      expect(schema.properties.searchType.enum).toContain('tadir_lookup');
+      expect(schema.properties.names).toBeDefined();
+      expect(schema.properties.objectTypes).toBeDefined();
       expect(schema.properties.objectType).toBeDefined();
       expect(schema.properties.packageName).toBeDefined();
     });
@@ -361,8 +364,12 @@ describe('Tool Definitions', () => {
       const tools = getToolDefinitions(DEFAULT_CONFIG, false);
       const sapSearch = tools.find((t) => t.name === 'SAPSearch')!;
       const schema = sapSearch.inputSchema as Record<string, any>;
-      expect(schema.properties.searchType).toBeUndefined();
-      expect(schema.properties.objectType).toBeUndefined();
+      expect(schema.properties.searchType).toBeDefined();
+      expect(schema.properties.searchType.enum).not.toContain('source_code');
+      expect(schema.properties.searchType.enum).toContain('tadir_lookup');
+      expect(schema.properties.objectType).toBeDefined();
+      expect(schema.properties.names).toBeDefined();
+      expect(schema.properties.objectTypes).toBeDefined();
       expect(schema.properties.packageName).toBeUndefined();
     });
 
@@ -372,6 +379,7 @@ describe('Tool Definitions', () => {
       const schema = sapSearch.inputSchema as Record<string, any>;
       expect(schema.properties.searchType).toBeDefined();
       expect(schema.properties.searchType.enum).toContain('source_code');
+      expect(schema.properties.searchType.enum).toContain('tadir_lookup');
     });
 
     it('SAPSearch description omits source_code mode when unavailable', () => {
@@ -694,6 +702,15 @@ describe('Tool Definitions', () => {
       expect(item.properties.messages).toBeDefined();
       expect(item.properties.messages.type).toBe('array');
       expect(item.properties.messages.items.required).toEqual(['number', 'shortText']);
+    });
+
+    it('exposes package and transport inside batch_create items (on-prem)', () => {
+      const schema = getSAPWriteSchema(false);
+      const item = schema.properties.objects.items;
+      expect(item.properties.package).toBeDefined();
+      expect(item.properties.package.type).toBe('string');
+      expect(item.properties.transport).toBeDefined();
+      expect(item.properties.transport.type).toBe('string');
     });
 
     it('exposes the messages property at top-level SAPWrite (BTP)', () => {


### PR DESCRIPTION
## Goal

Implement PR-E from the RAP migration run notes: replace brittle long TADIR SQL preflights with an ADT-backed exact lookup, and make `SAPWrite(action="batch_create")` honor package/transport values supplied per object.

## Changes

- Adds `SAPSearch(searchType="tadir_lookup")` with `names[]`, `objectTypes[]`, grouped exact-name results, and a `missing` list.
- Backs lookup with ADT repository quick search, not freestyle SQL.
- Allows `batch_create` objects to carry item-level `package` and `transport` overrides.
- Applies package safety checks before mutation and runs transport preflight per effective package needing transport.
- Uses the effective package/transport for create XML, TABL/BDEF `_package` query params, source writes, metadata follow-up writes, MSAG transport validation, and summaries.
- Updates docs, roadmap, comparison matrix, RAP skills, and the completed implementation plan.

## Validation

- `npm test -- tests/unit/adt/client.test.ts tests/unit/handlers/intent.test.ts tests/unit/handlers/schemas.test.ts tests/unit/handlers/tools.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- Live S/4 7.58 smoke: `SAPSearch(searchType="tadir_lookup", names=["ZDM_PROJECT_D","ZR_DM_PROJECT","ZUI_DM_PROJECTS_O4"], objectTypes=["TABL","BDEF","SRVB"])` returned all 3 objects in `ZDEMO_MIG_RAP` with `missing: []`.