### PR TITLE
docs: restructure config reference and document env precedence

### DIFF
--- a/docs_page/configuration-precedence.md
+++ b/docs_page/configuration-precedence.md
@@ -1,0 +1,85 @@
+# Configuration Precedence
+
+How ARC-1 resolves config values from CLI args, environment variables, `.env` files, and defaults — and what changes when you run via `npx`, a local clone, Docker, or BTP Cloud Foundry.
+
+This page is short on purpose. For the full list of what each env var does, see [configuration-reference.md](configuration-reference.md).
+
+---
+
+## The universal rule
+
+For every config field, ARC-1 looks at four sources in this order and uses the first one that's set:
+
+```
+CLI flag   >   process.env   >   .env file (in CWD)   >   built-in default
+```
+
+- **CLI flag** — `--allow-writes`, `--port`, etc. Highest precedence. Always wins.
+- **`process.env`** — anything already in the running process's environment when ARC-1 starts. This includes shell exports, `docker run -e`, Cloud Foundry env, and the `env` block of an `mcp.json` (because the MCP client launches ARC-1 as a subprocess with that block as its environment).
+- **`.env` file** — loaded by [dotenv](https://github.com/motdotla/dotenv) from `process.cwd()` at startup ([src/index.ts:16](https://github.com/marianfoo/arc-1/blob/main/src/index.ts#L16)). **Dotenv never overrides values that are already set in `process.env`** — it only fills in missing keys.
+- **Built-in default** — defined in [src/server/config.ts](https://github.com/marianfoo/arc-1/blob/main/src/server/config.ts).
+
+That last point is the one most people miss: if `SAP_URL` is set in your shell and also in `.env`, the shell value wins. Putting something in `.env` doesn't "override" anything — it's a fallback.
+
+---
+
+## What changes per deployment mode
+
+The rule above is universal. What differs across modes is **where `process.env` comes from** and **whether `.env` even exists in the CWD**.
+
+| Mode | `process.env` source | `.env` in CWD? | Practical winner |
+|---|---|---|---|
+| `npx arc-1` from a shell | shell exports | usually no (CWD is wherever you ran npx, not the package cache) | shell exports > defaults |
+| `npx arc-1` launched by an MCP client (stdio) | the client subprocess env (set from the `env` block in mcp.json / claude_desktop_config.json) | no | mcp.json `env` > defaults |
+| `npm run dev` / `npm start` from a local clone | shell exports | yes, the repo's `.env` | shell exports > repo `.env` > defaults |
+| `node dist/index.js` launched by an MCP client (stdio) | client subprocess env from mcp.json | only if you set the client's `cwd` to a directory that has one | mcp.json `env` > .env in `cwd` (if set) > defaults |
+| Remote HTTP — client connects via `"url"` | the **server's** env at startup (set when you launched the server) | the server's CWD | server-side env > server's `.env` > defaults. **Client-side mcp.json `env` does nothing.** |
+| `docker run -e KEY=VAL ...` | the `-e` flags + `--env-file` | not in the image; only present if you bind-mount one | `-e` / `--env-file` > defaults |
+| BTP Cloud Foundry (`cf push` / `cf deploy`) | `manifest.yml` / `mta.yaml` `properties:` + `cf set-env` + bound services via `VCAP_SERVICES` | not in the droplet; not deployed | manifest/cf-set-env/VCAP > defaults |
+
+### The one that surprises people: HTTP mode
+
+When an MCP client connects to a remote ARC-1 instance over HTTP — i.e. the client config is
+
+```json
+{ "servers": { "sap": { "url": "https://arc1.example.com/mcp" } } }
+```
+
+— **the `env` block in mcp.json is not sent to the server**. The server is already running with whatever environment was set when it was started (`docker run -e ...`, `cf set-env ...`, or your shell). Only the URL and any auth headers (API key / OAuth token) travel from the client.
+
+If you need to change a config value on a remote ARC-1, change it where the server runs and restart, not in mcp.json.
+
+---
+
+## How to debug "which value am I actually using?"
+
+ARC-1 logs an effective-config summary on startup. The most useful lines are:
+
+```
+INFO: auth: MCP=[…] SAP=[…] (shared|per-user) [disable-saml=on?]
+INFO: safety: writes=… data=… freeSQL=… transports=… git=… packages=…
+```
+
+Each value is recorded with its source (flag / env / .env / default) internally; the `arc1 config show` CLI command (when run with the same args / env as your server) prints the resolved value plus the source for every field. Use it whenever the runtime behaviour disagrees with what you thought `.env` said.
+
+For BTP CF deploys, `cf env <app>` shows you the final environment as the container sees it (manifest values, `cf set-env` values, and `VCAP_*` injected by bound services).
+
+---
+
+## Common pitfalls
+
+- **`.env` not being read.** Dotenv loads from `process.cwd()`. If you `cd /tmp && arc1 …`, the `.env` in your project root is ignored. Either `cd` into the project or use absolute env vars.
+- **Shell exports shadowing `.env`.** `export SAP_URL=…` in your `~/.zshrc` will silently win over a `.env` file. Unset the shell variable or change `.env` (or just use the CLI flag for one-off overrides).
+- **Quoting glob patterns.** `SAP_ALLOWED_PACKAGES=*` in a shell expands to the contents of the current directory. Use single quotes: `SAP_ALLOWED_PACKAGES='*'` or `-e SAP_ALLOWED_PACKAGES='Z*,$TMP'`. Inside `.env` files no extra quoting is needed.
+- **Changing mcp.json on a remote server.** As noted above, the `env` block only applies when the client is *spawning* the server. For `url`-based remote connections, change config on the server side.
+- **Container `.env` files.** `docker run` doesn't read `.env` from your host. Use `--env-file path/to/.env` or `-e` flags.
+- **`ARC1_LOG_HTTP_DEBUG=1` doesn't work.** Most boolean env vars accept either `"true"` or `"1"`, but this one only accepts `"true"` (a known inconsistency — see the note in [configuration-reference.md → Logging and observability](configuration-reference.md#logging-and-observability)).
+
+---
+
+## See also
+
+- [Configuration Reference](configuration-reference.md) — every env var, grouped by purpose, with effects.
+- [Local Development](local-development.md) — `.env`, `npm run dev:http`, MCP client configs for local clones.
+- [Docker Guide](docker.md) — `-e`, `--env-file`, and CA cert mounts.
+- [BTP Cloud Foundry Deployment](phase4-btp-deployment.md) — `mta.yaml` properties, `cf set-env`, `VCAP_SERVICES`.

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -1,239 +1,322 @@
 # Configuration Reference
 
-Every flag, env var, and default in one place.
+Every environment variable and CLI flag that ARC-1 reads, grouped by what it configures and what it actually does at runtime.
 
-Global precedence: **CLI flag > env var > `.env` file > built-in default**.
+This page is the flat reference. For the mental model (three-layer authorization, scope semantics), start with [Authorization & Roles](authorization.md). For *where values come from* across `npx` / local / Docker / BTP, see [Configuration Precedence](configuration-precedence.md).
 
-!!! tip "Looking for the big picture?"
-    This page is a flat reference. For the mental model (three-layer authorization, two-gate rule, scope implications, recipes), start with the [Authorization & Roles](authorization.md) overview.
-
-For the grouped template with inline commentary, see [`.env.example`](https://github.com/marianfoo/arc-1/blob/main/.env.example).
+The full grouped template with inline commentary is [`.env.example`](https://github.com/marianfoo/arc-1/blob/main/.env.example).
 
 ---
 
-## Mental model (short version)
+## Sections
 
-ARC-1 has **three independent gates** that all must pass for a mutation:
-
-1. **Server safety config** (Layer 1) — e.g. `SAP_ALLOW_WRITES`, `SAP_ALLOW_TRANSPORT_WRITES`. Positive opt-ins, defaults restrictive.
-2. **User scope** (Layer 2) — from JWT (XSUAA/OIDC) or API-key profile. Scopes: `read`, `write`, `data`, `sql`, `transports`, `git`, `admin`. `admin` implies all.
-3. **SAP authorization** (Layer 3) — the underlying SAP user's PFCG roles / S_DEVELOP checks. Per-user via principal propagation.
-
-Reads of SAP object source/metadata only need Layer 2 (`read` scope) — no server opt-out. Data preview and freestyle SQL each need both layers. Transport/Git mutations need `write` plus their specialized `transports` / `git` scope because users without `write` are treated as no-mutation users.
-
-See [Authorization & Roles](authorization.md) for the full model.
+1. [How values are resolved](#how-values-are-resolved) — precedence summary
+2. [SAP connection](#sap-connection) — URL, client, language, TLS, system type, ABAP release
+3. [Authentication](#authentication) — Layer B (ARC-1 → SAP) and Layer A (MCP Client → ARC-1)
+4. [Authorization and safety](#authorization-and-safety) — what tool calls are allowed
+5. [Server runtime](#server-runtime) — transport, bind address, CORS, concurrency
+6. [Caching](#caching) — source cache, warmup
+7. [Logging and observability](#logging-and-observability) — log file, level, format, HTTP debug
+8. [ABAP feature toggles](#abap-feature-toggles) — abapGit, gCTS, RAP, AMDP, UI5, HANA, FLP
+9. [Code-quality gates](#code-quality-gates) — pre-write lint/check, abaplint config, tool mode
 
 ---
 
-## Safety flags (Layer 1)
+## How values are resolved
 
-**Every flag below defaults to the restrictive setting.** ARC-1 starts read-only: no writes, no free SQL, no named table preview, no transport writes, no git writes, writes confined to `$TMP`.
+```
+CLI flag   >   process.env   >   .env file (in CWD)   >   built-in default
+```
 
-!!! warning "`SAP_ALLOW_DATA_PREVIEW` and `SAP_ALLOW_FREE_SQL` sit outside the SAP API Policy FAQ envelope"
-    The April 2026 [SAP API Policy](https://help.sap.com/doc/sap-api-policy/latest/en-US/API_Policy_latest.pdf) and its accompanying [SAP API Policy FAQ](https://www.sap.com/documents/2026/04/e2a0665e-4c7f-0010-bca6-c68f7e60039b.html) endorse ADT-based developer tooling for internal development automation. The same FAQ excludes "programmatic reading of application tables or export of business data" and "SQL execution against SAP backend systems". Both `SAP_ALLOW_DATA_PREVIEW` and `SAP_ALLOW_FREE_SQL` map directly onto these excluded capabilities, which is why they are off by default and gated behind explicit env vars. Keep them off on systems where you want to stay aligned with the FAQ's endorsed-development-tooling scope. See [authorization.md](authorization.md#sap-api-policy-data-preview-and-free-sql-are-gated-for-a-reason) for the full policy alignment.
+`process.env` covers shell exports, `docker run -e`, `cf set-env`, and the `env` block in mcp.json (because that block becomes the environment of the subprocess the MCP client spawns). `.env` is loaded via dotenv and **only fills in keys that aren't already set** — it never overrides existing env values.
 
-| Flag                             | Env Var                       | Default | What it enables                                                                                                              |
-| -------------------------------- | ----------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `--allow-writes`                 | `SAP_ALLOW_WRITES`            | `false` | Object mutations (`SAPWrite`, `SAPActivate`, package CRUD, FLP mutations). Also required for transport/git writes.            |
-| `--allow-data-preview`           | `SAP_ALLOW_DATA_PREVIEW`      | `false` | Named table preview (`SAPRead(type=TABLE_CONTENTS)`). **Outside SAP API Policy FAQ endorsed-development-tooling scope** — explicit opt-in required. |
-| `--allow-free-sql`               | `SAP_ALLOW_FREE_SQL`          | `false` | Freestyle SQL via `SAPQuery`. **Outside SAP API Policy FAQ endorsed-development-tooling scope** — explicit opt-in required. |
-| `--allow-transport-writes`       | `SAP_ALLOW_TRANSPORT_WRITES`  | `false` | Transport mutations (`SAPTransport.create`/`release`/`delete`/`reassign`). **Also requires** `allowWrites=true`.              |
-| `--allow-git-writes`             | `SAP_ALLOW_GIT_WRITES`        | `false` | Git mutations (`SAPGit.clone`/`pull`/`push`/`commit`). **Also requires** `allowWrites=true`.                                 |
-| `--allowed-packages`             | `SAP_ALLOWED_PACKAGES`        | `$TMP`  | Package allowlist for writes. Comma-separated. `Z*` prefix wildcard. `*` = unrestricted. **Reads are never package-gated.**   |
-| `--allowed-transports`           | `SAP_ALLOWED_TRANSPORTS`      | `[]`    | Advanced: specific CTS transport ID whitelist.                                                                               |
-| `--deny-actions`                 | `SAP_DENY_ACTIONS`            | `[]`    | Fine-grained per-action denial. Tool-qualified grammar. See [deny actions](authorization.md#advanced-deny-actions).          |
-| `--tool-mode`                    | `ARC1_TOOL_MODE`              | `standard` | `standard` (12 tools) / `hyperfocused` (1 universal tool, ~200 tokens).                                                  |
-| `--abaplint-config`              | `SAP_ABAPLINT_CONFIG`         | —       | Path to custom `abaplint.jsonc`.                                                                                             |
-| `--lint-before-write`            | `SAP_LINT_BEFORE_WRITE`       | `true`  | Pre-write lint validation (block syntax errors before save).                                                                 |
+For the full per-deployment-mode breakdown (npx vs local vs Docker vs BTP, and the gotcha where mcp.json `env` does nothing for `url`-based remote connections), see [Configuration Precedence](configuration-precedence.md).
 
-### Recipes
+**Boolean values.** Most boolean flags accept either `"true"` or `"1"`. One exception: `ARC1_LOG_HTTP_DEBUG` accepts only `"true"` ([known inconsistency](#logging--observability)).
 
-| Goal                                           | Set these flags                                                                          |
-| ---------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Read/search only                               | (nothing — defaults are restrictive)                                                     |
-| Read + table preview                           | `SAP_ALLOW_DATA_PREVIEW=true`                                                             |
-| Read + table preview + freestyle SQL           | `SAP_ALLOW_DATA_PREVIEW=true`, `SAP_ALLOW_FREE_SQL=true`                                  |
-| Writes to `$TMP`/`Z*`                          | `SAP_ALLOW_WRITES=true`, `SAP_ALLOWED_PACKAGES='$TMP,Z*'`                                 |
-| Writes + CTS transports                        | `SAP_ALLOW_WRITES=true`, `SAP_ALLOW_TRANSPORT_WRITES=true`                                |
-| Writes + Git mutations                         | `SAP_ALLOW_WRITES=true`, `SAP_ALLOW_GIT_WRITES=true`                                      |
-| Full local dev (everything)                    | All `SAP_ALLOW_*=true`, `SAP_ALLOWED_PACKAGES='*'`                                        |
-| Deny specific actions (fine-grained)           | e.g. `SAP_DENY_ACTIONS=SAPWrite.delete,SAPManage.flp_*`                                   |
-
-Shell-quote package patterns with `*` or `$TMP`: `-e SAP_ALLOWED_PACKAGES='*'` or `-e SAP_ALLOWED_PACKAGES='Z*,$TMP'`. In `.env` files, no extra quoting needed.
-
-API-key profile note: `developer`, `developer-data`, and `developer-sql` profiles are intentionally capped to `$TMP`. If you use API keys and need Z-package writes, use a tightly scoped `admin` key with a narrow server-side `SAP_ALLOWED_PACKAGES`, or use OIDC/XSUAA for per-user scopes.
-
-### Internal classification (for developers)
-
-ARC-1 classifies each action internally using an `OperationType` enum (Read, Search, Query, FreeSQL, Create, Update, Delete, Activate, Workflow, Test, Lock, Intelligence, Transport). This classification drives the `isOperationAllowed` safety check. The enum is **internal** — admins configure via the `SAP_ALLOW_*` flags and `SAP_DENY_ACTIONS`, not directly.
-
-The single source of truth for `(tool, action) → (scope, opType)` lives at `src/authz/policy.ts`. The CI validator (`npm run validate:policy`) asserts every action declared in `src/handlers/schemas.ts` has a matching policy entry.
-
-### Operation summary
-
-| Op type     | Admin-facing flag           | Example tool actions                                       |
-| ----------- | --------------------------- | ---------------------------------------------------------- |
-| Read        | (always allowed)             | `SAPRead` (except TABLE_CONTENTS), `SAPSearch`, many others |
-| Search      | (always allowed)             | `SAPSearch`                                                 |
-| Intelligence | (always allowed)             | `SAPNavigate`, `SAPLint`, `SAPContext`                     |
-| Test        | (always allowed)             | `SAPDiagnose(action=unittest)`                             |
-| Lock        | (always allowed)             | Internal CRUD lock step                                     |
-| Query       | `SAP_ALLOW_DATA_PREVIEW`     | `SAPRead(type=TABLE_CONTENTS)`                             |
-| FreeSQL     | `SAP_ALLOW_FREE_SQL`         | `SAPQuery`                                                  |
-| Create      | `SAP_ALLOW_WRITES`           | `SAPWrite(action=create)`, `SAPManage.create_package`      |
-| Update      | `SAP_ALLOW_WRITES`           | `SAPWrite(action=update)`, `SAPLint.set_formatter_settings` |
-| Delete      | `SAP_ALLOW_WRITES`           | `SAPWrite(action=delete)`, `SAPManage.delete_package`      |
-| Activate    | `SAP_ALLOW_WRITES`           | `SAPActivate`                                               |
-| Workflow    | `SAP_ALLOW_WRITES`           | FLP mutations in `SAPManage`                               |
-| Transport   | `SAP_ALLOW_WRITES` + `SAP_ALLOW_TRANSPORT_WRITES` | `SAPTransport.create`/`release`/`delete`                 |
+**Comma-separated lists.** `SAP_ALLOWED_PACKAGES`, `SAP_ALLOWED_TRANSPORTS`, `SAP_DENY_ACTIONS`, and `ARC1_ALLOWED_ORIGINS` are split on `,` and `.trim()`-ed. Quote shell-sensitive entries (`*`, `$TMP`, glob characters): `-e SAP_ALLOWED_PACKAGES='Z*,$TMP'`. In `.env` files no extra quoting is needed.
 
 ---
 
 ## SAP connection
 
-| Flag | Env Var | Default | Description |
+The bare minimum needed to reach a SAP system. None of these affect what tool calls are allowed — that's the [Authorization and safety](#authorization-and-safety) section.
+
+| Flag | Env var | Default | Effect |
 |---|---|---|---|
-| `--url` | `SAP_URL` | — | SAP system URL (required) |
-| `--client` | `SAP_CLIENT` | `100` | SAP client number |
-| `--language` | `SAP_LANGUAGE` | `EN` | SAP logon language |
-| `--insecure` | `SAP_INSECURE` | `false` | Skip TLS verification (dev only) |
-| `--system-type` | `SAP_SYSTEM_TYPE` | `auto` | `auto` / `btp` / `onprem` |
+| `--url` | `SAP_URL` | — (required) | Base URL ARC-1 uses for every ADT call. Include the scheme and port (e.g. `https://host:44300`). Required unless you use a BTP Destination or service key, which supply the URL. |
+| `--client` | `SAP_CLIENT` | `100` | Logon client number. Sent as `sap-client` in every ADT request and as the `client` field during authentication. Wrong value → "Logon not possible (incorrect client)". |
+| `--language` | `SAP_LANGUAGE` | `EN` | SAP logon language. Affects message texts, DDIC short descriptions, and any other language-dependent server response. |
+| `--insecure` | `SAP_INSECURE` | `false` | When `true`, skips TLS certificate verification on the SAP HTTP client. **Dev only** — masks man-in-the-middle attacks and corp-CA misconfiguration in production. |
+| `--system-type` | `SAP_SYSTEM_TYPE` | `auto` | Forces ARC-1's release/feature gating to behave as if the target is `btp` (Steampunk/Public Cloud) or `onprem`. `auto` (default) lets ARC-1 detect via probes. Override when auto-detection is wrong (e.g. mirrored systems). |
+| `--abap-release` | `SAP_ABAP_RELEASE` | — | Manual `SAP_BASIS` release override for local tooling that needs a release number (e.g. abaplint's syntax-feature gating). Example: `758` for S/4HANA 2023. ARC-1's runtime probe still wins when available — this is the fallback. |
 
-## Layer B — ARC-1 → SAP authentication
+### TLS / proxy notes
 
-Pick one primary method. Combinations that coexist safely are in the [Coexistence Matrix](enterprise-auth.md#coexistence-matrix).
-
-### B1. Basic Auth
-
-| Flag | Env Var | Description |
-|---|---|---|
-| `--user` | `SAP_USER` | SAP username |
-| `--password` | `SAP_PASSWORD` | SAP password |
-
-### B2. Cookie Auth (dev-only, SSO on-prem)
-
-| Flag | Env Var | Description |
-|---|---|---|
-| `--cookie-file` | `SAP_COOKIE_FILE` | Path to Netscape-format cookie file. **Hot-reloaded** on stale 401: re-extract cookies (e.g. via `arc1-cli extract-cookies`) and the next SAP call picks them up — no restart needed. |
-| `--cookie-string` | `SAP_COOKIE_STRING` | Inline cookies (`k=v; k2=v2`). **Cannot hot-reload** — the value is read once at startup. To refresh, restart the process with a new value, or switch to `SAP_COOKIE_FILE`. |
-
-Not for production. See [local-development.md → SSO cookie extractor](local-development.md#sso-only-on-prem-cookie-extractor).
-
-**Cookie hot-reload (SAP_COOKIE_FILE only).** When the SAP session expires and a request returns 401 after the standard one-shot session-reset retry, ARC-1 clears the in-memory cookie jar (including any session cookies harvested from intermediate responses) and re-reads the configured cookie file lazily on the next outgoing request. Implications:
-
-- The startup auth preflight downgrades a 401 from blocking to non-blocking when `SAP_COOKIE_FILE` is set, so the MCP server starts even if cookies are about to be re-extracted out-of-band. The first real tool call triggers the reload.
-- `SAP_COOKIE_STRING` keeps the existing blocking-401 behavior — ARC-1 cannot refresh a static env var without restart.
-- Per-user Principal Propagation clients never inherit shared cookie state; `cookieFile`/`cookieString` are stripped from per-user configs in `buildAdtConfig`.
-
-### B3. BTP ABAP Environment (direct OAuth)
-
-| Flag | Env Var | Description |
-|---|---|---|
-| `--btp-service-key-file` | `SAP_BTP_SERVICE_KEY_FILE` | Path to BTP service key JSON |
-| `--btp-service-key` | `SAP_BTP_SERVICE_KEY` | Inline BTP service key JSON |
-| `--btp-oauth-callback-port` | `SAP_BTP_OAUTH_CALLBACK_PORT` | `0` (auto) |
-
-Full reference: [btp-abap-environment.md](btp-abap-environment.md).
-
-### B4. BTP Destination Service
-
-| Env Var | Description |
-|---|---|
-| `SAP_BTP_DESTINATION` | Destination name (shared/Basic) |
-| `SAP_BTP_PP_DESTINATION` | Destination name (`PrincipalPropagation` type) |
-
-Full reference: [btp-destination-setup.md](btp-destination-setup.md).
-
-### B5. Principal Propagation
-
-| Flag | Env Var | Default | Description |
-|---|---|---|---|
-| `--pp-enabled` | `SAP_PP_ENABLED` | `false` | Per-user SAP identity |
-| `--pp-strict` | `SAP_PP_STRICT` | `false` | PP failure = error, no fallback |
-| `--pp-allow-shared-cookies` | `SAP_PP_ALLOW_SHARED_COOKIES` | `false` | Escape hatch: allow cookies to coexist with PP (cookies stay on shared client only) |
-
-Full reference: [principal-propagation-setup.md](principal-propagation-setup.md).
-
-### Layer B extras
-
-| Flag | Env Var | Default | Description |
-|---|---|---|---|
-| `--disable-saml` | `SAP_DISABLE_SAML` | `false` | Emit `X-SAP-SAML2: disabled` + `?saml2=disabled` (SAP Note 3456236). **Breaks BTP ABAP / S/4 Public Cloud.** |
+ARC-1 uses [undici](https://github.com/nodejs/undici) for all SAP HTTP. It respects standard `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` env vars. For custom CA certificates, set `NODE_EXTRA_CA_CERTS=/path/to/ca.pem` (read by Node, not by ARC-1 directly). For Docker mounts of CA bundles, see [docker.md](docker.md#self-signed-or-internal-ca-certificates).
 
 ---
 
-## Layer A — MCP Client → ARC-1 authentication
+## Authentication
 
-Multiple methods chain — API Key + OIDC + XSUAA can all be active on one instance.
+ARC-1 has two independent authentication boundaries:
 
-### A1. No auth (stdio only, local dev)
+- **Layer B** — how ARC-1 itself authenticates to SAP (cookies, basic auth, OAuth, principal propagation…).
+- **Layer A** — how MCP clients authenticate to ARC-1 (none for stdio, API key / OIDC / XSUAA for HTTP).
 
-Set nothing.
+The full coexistence matrix is in [enterprise-auth.md](enterprise-auth.md#coexistence-matrix). Below is what each env var does.
 
-### A2. API Key(s)
+### Layer B — ARC-1 → SAP
 
-| Flag | Env Var | Description |
+Pick one primary method. Combining methods that conflict (e.g. basic + cookies + PP) fails fast at startup unless an escape-hatch flag is set.
+
+#### B1. Basic auth
+
+| Flag | Env var | Effect |
 |---|---|---|
-| `--api-keys` | `ARC1_API_KEYS` | Multi-key with profiles: `key1:viewer,key2:developer`. Valid profiles: `viewer`, `viewer-data`, `viewer-sql`, `developer`, `developer-data`, `developer-sql`, `admin`. Each profile maps to a scope set AND a partial SafetyConfig intersected with the server ceiling. |
+| `--user` | `SAP_USER` | Username sent in `Authorization: Basic` on every ADT request. With `SAP_PP_ENABLED=true`, this becomes the *fallback* technical user used only when per-user PP is unavailable. |
+| `--password` | `SAP_PASSWORD` | Password for the above. Redacted from all logs. |
 
-Full reference: [api-key-setup.md](api-key-setup.md). Single `--api-key` / `ARC1_API_KEY` was removed in v0.7 — see [updating.md](updating.md#v07-authorization-refactor-breaking-change).
+#### B2. Cookie auth (dev-only SSO bridge)
 
-### A3. OIDC / JWT
+| Flag | Env var | Effect |
+|---|---|---|
+| `--cookie-file` | `SAP_COOKIE_FILE` | Netscape-format cookie jar. ARC-1 sends these cookies on every SAP request. **Hot-reloaded**: when a request returns 401 after the standard session-reset retry, the jar is cleared and the file is re-read on the next request — no restart needed. |
+| `--cookie-string` | `SAP_COOKIE_STRING` | Inline cookies (`k=v; k2=v2`) read once at startup. **Cannot hot-reload** — restart with a new value or switch to `SAP_COOKIE_FILE`. |
 
-| Flag | Env Var | Default | Description |
+Cookie auth is not for production. See [local-development.md → SSO cookie extractor](local-development.md#sso-only-on-prem-cookie-extractor). On startup, the auth preflight is non-blocking when `SAP_COOKIE_FILE` is set, so the server starts even if cookies are about to be re-extracted out-of-band. Per-user PP clients never inherit cookie state — `cookieFile`/`cookieString` are stripped from per-user configs.
+
+#### B3. BTP ABAP Environment (direct OAuth)
+
+| Flag | Env var | Default | Effect |
 |---|---|---|---|
-| `--oidc-issuer` | `SAP_OIDC_ISSUER` | — | OIDC issuer URL |
-| `--oidc-audience` | `SAP_OIDC_AUDIENCE` | — | Expected audience claim |
-| `--oidc-clock-tolerance` | `SAP_OIDC_CLOCK_TOLERANCE` | `0` | JWT clock skew seconds |
+| `--btp-service-key-file` | `SAP_BTP_SERVICE_KEY_FILE` | — | Path to a BTP ABAP service key JSON. ARC-1 reads `url` and `uaa` from it and performs an OAuth 2.0 Authorization Code flow on first use (browser opens). |
+| `--btp-service-key` | `SAP_BTP_SERVICE_KEY` | — | Same as above but inline JSON. Useful when the key can't live on disk (e.g. CF deploys via `cf set-env`). |
+| `--btp-oauth-callback-port` | `SAP_BTP_OAUTH_CALLBACK_PORT` | `0` (auto) | Local TCP port the OAuth callback listener binds to. `0` picks any free port. Pin it when you need a fixed redirect URI registered in BTP. |
+
+Full reference: [btp-abap-environment.md](btp-abap-environment.md).
+
+#### B4. BTP Destination Service
+
+| Env var | Effect |
+|---|---|
+| `SAP_BTP_DESTINATION` | Name of the BTP Destination ARC-1 reads to obtain SAP URL + credentials. Used for the shared technical client and as a fallback for per-user PP. Bypasses `SAP_URL` / `SAP_USER` / `SAP_PASSWORD` — those are ignored when a destination is set. |
+| `SAP_BTP_PP_DESTINATION` | Destination of type `PrincipalPropagation`. When set, per-user PP requests use this; when unset, ARC-1 falls back to `SAP_BTP_DESTINATION`. Set this when shared and PP traffic must route via different destinations (different Cloud Connector subaccount mapping, different authorization model, etc.). |
+
+Full reference: [btp-destination-setup.md](btp-destination-setup.md).
+
+#### B5. Principal Propagation
+
+| Flag | Env var | Default | Effect |
+|---|---|---|---|
+| `--pp-enabled` | `SAP_PP_ENABLED` | `false` | Enables per-user identity to SAP: incoming JWT `email`/`user_name` is used to mint a per-user SAP session via BTP Destination Service. Without PP, every SAP call uses the shared technical user. |
+| `--pp-strict` | `SAP_PP_STRICT` | `false` | When PP fails (token mapping missing, destination unavailable), `false` falls back to the shared technical client. `true` returns an error to the MCP caller — no shared-client fallback. Production should use `true`. |
+| `--pp-allow-shared-cookies` | `SAP_PP_ALLOW_SHARED_COOKIES` | `false` | Escape hatch. Without it, setting `SAP_COOKIE_FILE`/`SAP_COOKIE_STRING` together with `SAP_PP_ENABLED=true` fails at startup (cookies belong to one user, PP wants per-user). With `true`, cookies stay on the shared client only and PP traffic runs cookie-free. |
+
+Full reference: [principal-propagation-setup.md](principal-propagation-setup.md).
+
+#### Layer B extras
+
+| Flag | Env var | Default | Effect |
+|---|---|---|---|
+| `--disable-saml` | `SAP_DISABLE_SAML` | `false` | Emits `X-SAP-SAML2: disabled` header + `?saml2=disabled` query on every ADT request (SAP Note 3456236). Stops on-prem systems from redirecting to SAML IdP when Basic Auth is intended. **Breaks BTP ABAP Environment and S/4 Public Cloud — only enable for on-prem with SAML enforcement.** |
+
+### Layer A — MCP Client → ARC-1
+
+These only apply to HTTP transport. Stdio has no authentication boundary — the client *is* the spawner.
+
+Methods chain: any combination of API Key + OIDC + XSUAA is valid and active simultaneously.
+
+#### A1. No auth
+
+Set nothing. Stdio only. Anyone who can pipe stdin to the process is "authenticated" by being the spawner.
+
+#### A2. API Key(s)
+
+| Flag | Env var | Effect |
+|---|---|---|
+| `--api-keys` | `ARC1_API_KEYS` | Comma-separated `key:profile` pairs. Each profile maps to a scope set (read/write/data/sql/transports/git/admin) **and** a partial SafetyConfig intersected with the server ceiling. Valid profiles: `viewer`, `viewer-data`, `viewer-sql`, `developer`, `developer-data`, `developer-sql`, `admin`. Caller sends `Authorization: Bearer <key>` (or `X-API-Key: <key>`); ARC-1 looks the key up and applies that profile's scopes for the request. |
+
+Full reference: [api-key-setup.md](api-key-setup.md). The single-key `ARC1_API_KEY` env var was removed in v0.7 — see [updating.md](updating.md#v07-authorization-refactor-breaking-change).
+
+#### A3. OIDC / JWT
+
+| Flag | Env var | Default | Effect |
+|---|---|---|---|
+| `--oidc-issuer` | `SAP_OIDC_ISSUER` | — | OIDC issuer URL (e.g. Entra ID, Auth0). ARC-1 fetches JWKS from `{issuer}/.well-known/openid-configuration` and validates incoming JWTs against it. |
+| `--oidc-audience` | `SAP_OIDC_AUDIENCE` | — | Expected `aud` claim. Tokens whose `aud` doesn't match are rejected. |
+| `--oidc-clock-tolerance` | `SAP_OIDC_CLOCK_TOLERANCE` | `0` | Seconds of clock skew tolerated when checking `exp`/`nbf`/`iat`. Set 30–60 if your auth server and ARC-1 host clocks drift. |
 
 Full reference: [oauth-jwt-setup.md](oauth-jwt-setup.md).
 
-### A4. XSUAA OAuth (BTP)
+#### A4. XSUAA OAuth (BTP)
 
-| Flag | Env Var | Default | Description |
+| Flag | Env var | Default | Effect |
 |---|---|---|---|
-| `--xsuaa-auth` | `SAP_XSUAA_AUTH` | `false` | Enable XSUAA token validation |
-| `--oauth-dcr-ttl-seconds` | `ARC1_OAUTH_DCR_TTL_SECONDS` | `2592000` (30 d) | Lifetime of an OAuth Dynamic Client Registration `client_id`. Min 60 s, max 90 d. Lower bounds blast radius if the signing key leaks; higher reduces re-auth churn. Only consulted when `--xsuaa-auth=true`. |
+| `--xsuaa-auth` | `SAP_XSUAA_AUTH` | `false` | When `true`, ARC-1 reads XSUAA credentials from `VCAP_SERVICES`, validates incoming JWTs against XSUAA's keys, and exposes RFC 9449 OAuth metadata + Dynamic Client Registration endpoints. Required for BTP CF deployments. |
+| `--oauth-dcr-ttl-seconds` | `ARC1_OAUTH_DCR_TTL_SECONDS` | `2592000` (30d) | Lifetime of a dynamically-registered OAuth `client_id` (Anthropic-style stateless DCR). Lower it to bound blast radius if the signing key leaks; raise it to reduce re-auth churn for long-lived agents. Clamped to `[60, 7776000]` (1 min – 90 d). Only consulted when XSUAA auth is on. |
 
 Full reference: [xsuaa-setup.md](xsuaa-setup.md).
 
 ---
 
-## Transport & logging
+## Authorization and safety
 
-| Flag | Env Var | Default | Description |
+ARC-1 starts **fully restrictive**. Every capability below is a positive opt-in. Per-user scopes (from JWT or API-key profile) can only restrict further — they never expand beyond what these flags allow. This is the server ceiling.
+
+!!! warning "Two flags sit outside the SAP API Policy FAQ envelope"
+    The April 2026 [SAP API Policy FAQ](https://www.sap.com/documents/2026/04/e2a0665e-4c7f-0010-bca6-c68f7e60039b.html) endorses ADT-based developer tooling, but excludes "programmatic reading of application tables or export of business data" and "SQL execution against SAP backend systems". `SAP_ALLOW_DATA_PREVIEW` and `SAP_ALLOW_FREE_SQL` map directly onto these excluded capabilities — that's why they're off by default and gated behind explicit env vars. Keep them off on systems where you want to stay aligned with the FAQ. See [authorization.md](authorization.md#sap-api-policy-data-preview-and-free-sql-are-gated-for-a-reason).
+
+### Capability flags
+
+| Flag | Env var | Default | Effect |
 |---|---|---|---|
-| `--transport` | `SAP_TRANSPORT` | `stdio` | `stdio` / `http-streamable` |
-| `--http-addr` | `ARC1_HTTP_ADDR` / `SAP_HTTP_ADDR` | `0.0.0.0:8080` | HTTP bind address |
-| `--port` | `ARC1_PORT` | `8080` | HTTP port (simpler alternative to `--http-addr`) |
-| `--allowed-origins` | `ARC1_ALLOWED_ORIGINS` | (empty) | Comma-separated CORS allowlist for **browser-based** MCP clients. Empty disables CORS entirely. Native clients (Claude Desktop / Cursor / VS Code Copilot / Copilot Studio) don't need this. Exact match only (no wildcards) because the response sets `credentials: true`. See [Security headers & CORS](security-guide.md#11-network-security). |
-| — | `ARC1_PUBLIC_URL` | (auto from `VCAP_APPLICATION`) | Public URL ARC-1 advertises in OAuth metadata (issuer, `authorize` / `token` / `register` / `revoke`, protected-resource metadata, and the `WWW-Authenticate: ... resource_metadata=` URL). Set this when ARC-1 is reached through a reverse proxy on a different hostname or under a base-path prefix than the bound route — without it, MCP clients receive metadata pointing at the underlying host and bypass the proxy. Path prefix supported (e.g. `https://gateway.example.com/arc1`); when present, the well-known endpoints are also served at that prefix so OAuth discovery works through the proxy. Trailing slash stripped. |
-| `--log-file` | `ARC1_LOG_FILE` | — | File sink path |
-| `--log-level` | `ARC1_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
-| `--log-format` | `ARC1_LOG_FORMAT` | `text` | `text` / `json` |
-| `--verbose` | `SAP_VERBOSE` | `false` | Debug-level logging |
+| `--allow-writes` | `SAP_ALLOW_WRITES` | `false` | Master switch for every mutation: `SAPWrite` (create/update/delete), `SAPActivate`, package CRUD, FLP mutations. When `false`, every mutating tool call is rejected at the safety layer regardless of caller scopes. Also required (in addition to the specific flag below) for transport and git writes. |
+| `--allow-data-preview` | `SAP_ALLOW_DATA_PREVIEW` | `false` | Enables `SAPRead(type=TABLE_CONTENTS)`. When off, that one read action is rejected — every other SAPRead type still works. |
+| `--allow-free-sql` | `SAP_ALLOW_FREE_SQL` | `false` | Enables `SAPQuery` (freestyle ABAP SQL via `/sap/bc/adt/datapreview/freestyle`). When off, `SAPQuery` is rejected. |
+| `--allow-transport-writes` | `SAP_ALLOW_TRANSPORT_WRITES` | `false` | Enables `SAPTransport.create` / `release` / `delete` / `reassign`. **Requires `SAP_ALLOW_WRITES=true`** — without it, transport mutations fail even with this flag on, because users without `write` scope are treated as no-mutation users. Transport *reads* (list / get / check / history) are always available. |
+| `--allow-git-writes` | `SAP_ALLOW_GIT_WRITES` | `false` | Enables `SAPGit.clone` / `pull` / `push` / `commit` against gCTS and abapGit. Same `SAP_ALLOW_WRITES` precondition as transport writes. Git reads always available. |
+| `--allowed-packages` | `SAP_ALLOWED_PACKAGES` | `$TMP` | Glob allowlist for **writes only**. Comma-separated, supports `Z*` / `Y*` / `/COMPANY/*` prefix wildcards, and `*` for unrestricted. Writes to a package outside this list fail at the safety layer. **Reads are never package-gated.** |
+| `--allowed-transports` | `SAP_ALLOWED_TRANSPORTS` | `[]` | Advanced: specific CTS transport ID whitelist. Empty (default) = no per-transport filter. |
+| `--deny-actions` | `SAP_DENY_ACTIONS` | `[]` | Fine-grained per-action denylist. Grammar: `Tool`, `Tool.action`, `Tool.glob*`. Example: `SAPWrite.delete,SAPManage.flp_*`. Accepts a CSV string or a `path/to/file.json` containing an array. Denylisted actions are both hidden from tool listings and blocked at call time. See [authorization.md → Advanced deny actions](authorization.md#advanced-deny-actions). |
+| `--check-before-write` | `SAP_CHECK_BEFORE_WRITE` | `false` | When `true`, ARC-1 runs an ADT server-side `checkruns` syntax check before save. Warnings are appended to the response (non-blocking); errors still fail. Adds one round-trip per write. Activation remains the definitive check — this is an early-feedback option. |
 
-ARC-1 also sets standard browser security headers (HSTS, CSP, X-Frame-Options, COOP, etc.) on every HTTP response via [helmet](https://helmetjs.github.io/). These are always-on; there's no flag to disable them. Full header list and rationale is in the [Security Guide §11](security-guide.md#11-network-security).
+### Recipes
+
+| Goal | Set these flags |
+|---|---|
+| Read/search only (default) | nothing |
+| Read + table preview | `SAP_ALLOW_DATA_PREVIEW=true` |
+| Read + table preview + freestyle SQL | `SAP_ALLOW_DATA_PREVIEW=true SAP_ALLOW_FREE_SQL=true` |
+| Writes to `$TMP`/`Z*` | `SAP_ALLOW_WRITES=true SAP_ALLOWED_PACKAGES='$TMP,Z*'` |
+| Writes + CTS transports | `SAP_ALLOW_WRITES=true SAP_ALLOW_TRANSPORT_WRITES=true` |
+| Writes + Git mutations | `SAP_ALLOW_WRITES=true SAP_ALLOW_GIT_WRITES=true` |
+| Full local dev (everything) | All `SAP_ALLOW_*=true`, `SAP_ALLOWED_PACKAGES='*'` |
+| Block specific mutations even with writes on | `SAP_DENY_ACTIONS=SAPWrite.delete,SAPManage.flp_*` |
+
+Shell-quote package patterns with `*` or `$TMP`: `-e SAP_ALLOWED_PACKAGES='*'` or `-e SAP_ALLOWED_PACKAGES='Z*,$TMP'`. In `.env` files no extra quoting needed.
+
+API-key profile note: `developer`, `developer-data`, and `developer-sql` profiles are intentionally capped to `$TMP` regardless of `SAP_ALLOWED_PACKAGES`. For Z-package writes via API keys use a tightly scoped `admin` key with a narrow server-side `SAP_ALLOWED_PACKAGES`, or use OIDC/XSUAA for per-user scopes.
+
+### Internal classification (for ARC-1 developers)
+
+ARC-1 classifies each action internally using an `OperationType` enum: Read, Search, Query, FreeSQL, Create, Update, Delete, Activate, Workflow, Test, Lock, Intelligence, Transport. This drives the safety check at `checkOperation()`. The enum is **internal** — admins configure via the `SAP_ALLOW_*` flags and `SAP_DENY_ACTIONS`, not directly.
+
+The `(tool, action) → (scope, opType)` mapping lives at [src/authz/policy.ts](https://github.com/marianfoo/arc-1/blob/main/src/authz/policy.ts). `npm run validate:policy` asserts every action in `src/handlers/schemas.ts` has a matching policy entry.
+
+| Op type | Admin-facing flag | Example actions |
+|---|---|---|
+| Read | (always allowed) | `SAPRead` (except TABLE_CONTENTS), `SAPSearch`, many others |
+| Search / Intelligence / Test / Lock | (always allowed) | `SAPSearch`, `SAPNavigate`, `SAPLint`, `SAPContext`, unit tests, internal CRUD lock |
+| Query | `SAP_ALLOW_DATA_PREVIEW` | `SAPRead(type=TABLE_CONTENTS)` |
+| FreeSQL | `SAP_ALLOW_FREE_SQL` | `SAPQuery` |
+| Create / Update / Delete / Activate / Workflow | `SAP_ALLOW_WRITES` | `SAPWrite`, `SAPActivate`, FLP mutations |
+| Transport | `SAP_ALLOW_WRITES` + `SAP_ALLOW_TRANSPORT_WRITES` | `SAPTransport.create`/`release`/`delete` |
 
 ---
 
-## Cache & concurrency
+## Server runtime
 
-| Flag | Env Var | Default | Description |
+How ARC-1 itself listens for MCP traffic.
+
+| Flag | Env var | Default | Effect |
 |---|---|---|---|
-| `--cache` | `ARC1_CACHE` | `auto` | `auto` / `memory` / `sqlite` / `none` |
-| `--cache-file` | `ARC1_CACHE_FILE` | `.arc1-cache.db` | SQLite cache path |
-| `--cache-warmup` | `ARC1_CACHE_WARMUP` | `false` | Pre-warm cache via TADIR scan on startup |
-| `--cache-warmup-packages` | `ARC1_CACHE_WARMUP_PACKAGES` | — | Package filter (e.g. `Z*,Y*`) |
-| `--max-concurrent` | `ARC1_MAX_CONCURRENT` | `10` | Max concurrent SAP HTTP requests |
+| `--transport` | `SAP_TRANSPORT` | `stdio` | `stdio` (subprocess over stdin/stdout) or `http-streamable` (long-lived HTTP server). The Docker image overrides this to `http-streamable` by default. |
+| `--http-addr` | `ARC1_HTTP_ADDR` / `SAP_HTTP_ADDR` | `0.0.0.0:8080` | Bind address for HTTP streamable. Use `127.0.0.1:3000` to restrict to localhost. `SAP_HTTP_ADDR` is the legacy fallback name. |
+| `--port` | `ARC1_PORT` | `8080` | Simpler alternative when only the port needs to change. Wins over `ARC1_HTTP_ADDR`'s port if both are set. Valid range `1–65535`. |
+| `--allowed-origins` | `ARC1_ALLOWED_ORIGINS` | (empty) | Comma-separated CORS allowlist for **browser-based** MCP clients. Exact match only (no wildcards — the response sets `Access-Control-Allow-Credentials: true`). Empty disables CORS entirely. Native clients (Claude Desktop / Cursor / VS Code Copilot / Copilot Studio) don't need this. See [security-guide.md §11](security-guide.md#11-network-security). |
+| — | `ARC1_PUBLIC_URL` | (auto from `VCAP_APPLICATION`, else bind host:port) | Public URL ARC-1 advertises in OAuth metadata (issuer, `authorize`/`token`/`register`/`revoke` URLs, protected-resource metadata, `WWW-Authenticate` headers). Set this when ARC-1 is reached through a reverse proxy on a different hostname or under a base-path prefix — without it, MCP clients receive metadata pointing at the underlying host and bypass the proxy. Path prefix supported (e.g. `https://gateway.example.com/arc1`); the well-known endpoints are also served at that prefix. Trailing slash stripped. |
+| `--max-concurrent` | `ARC1_MAX_CONCURRENT` | `10` | Maximum concurrent in-flight SAP HTTP requests. Caps work-process consumption on the SAP side. Increase only if your SAP system has spare work processes. |
 
-Full reference: [caching.md](caching.md).
+ARC-1 also sets standard browser security headers (HSTS, CSP, X-Frame-Options, COOP, etc.) on every HTTP response via [helmet](https://helmetjs.github.io/). These are always-on; there's no flag to disable them. Full list and rationale in [Security Guide §11](security-guide.md#11-network-security).
 
 ---
 
-## Priority and combination rules
+## Caching
 
-- **Priority:** CLI flag > env var > `.env` file > built-in default.
-- **Layer A methods chain:** any combination of API Key / OIDC / XSUAA is valid and active simultaneously.
-- **Layer B methods don't chain freely:** see the [Coexistence Matrix](enterprise-auth.md#coexistence-matrix). Unsafe combinations fail fast at startup.
-- **Startup auth summary:** ARC-1 logs one line telling you exactly what's active — `auth: MCP=[...] SAP=[...] (shared|per-user) [disable-saml=on]`. When in doubt, read that line first.
+ARC-1 caches SAP source/metadata with ETag revalidation on every hit. See [caching.md](caching.md) for the full design.
+
+| Flag | Env var | Default | Effect |
+|---|---|---|---|
+| `--cache` | `ARC1_CACHE` | `auto` | `auto` picks `sqlite` for HTTP transport and `memory` for stdio. `memory` = in-process only, lost on restart. `sqlite` = persistent across restarts, shared across processes that point at the same file. `none` = disable caching entirely (every read hits SAP). |
+| `--cache-file` | `ARC1_CACHE_FILE` | `.arc1-cache.db` | SQLite file path when `ARC1_CACHE=sqlite` (or `auto` → sqlite). Created on first use. |
+| `--cache-warmup` | `ARC1_CACHE_WARMUP` | `false` | When `true`, ARC-1 runs a TADIR scan on startup and bulk-fetches matching object sources into the cache. Speeds up first reads at the cost of a longer startup and more SAP load. |
+| `--cache-warmup-packages` | `ARC1_CACHE_WARMUP_PACKAGES` | (empty = all custom) | Comma-separated package filter for warmup (e.g. `Z*,Y*,/COMPANY/*`). Empty matches all custom packages found in TADIR. Ignored when `ARC1_CACHE_WARMUP=false`. |
+
+---
+
+## Logging and observability
+
+All ARC-1 logging goes to **stderr** to keep stdout clean for MCP JSON-RPC. Never use `console.log` from inside the codebase.
+
+| Flag | Env var | Default | Effect |
+|---|---|---|---|
+| `--log-file` | `ARC1_LOG_FILE` | — | Path to an additional file sink. Stderr output is unchanged; the file gets the same stream. |
+| `--log-level` | `ARC1_LOG_LEVEL` | `info` | One of `debug` / `info` / `warn` / `error`. Filters every log line, including the audit stream's structured entries. |
+| `--log-format` | `ARC1_LOG_FORMAT` | `text` | `text` (human-readable) or `json` (one JSON object per line — for shipping to ELK / Loki / CF log aggregator). |
+| `--verbose` | `SAP_VERBOSE` | `false` | Alias for `--log-level=debug`. Slightly older flag, kept for compatibility. |
+| — | `ARC1_LOG_HTTP_DEBUG` | `false` | When `"true"`, attaches the full HTTP request and response bodies + headers to `http_request` audit events. Sensitive headers (`Authorization`, `Cookie`, CSRF tokens) are redacted; bodies are truncated at 64 KB. **Do not enable in production** — increases log volume substantially and can leak business data in payloads. **Boolean parsing inconsistency:** unlike other booleans, this one accepts only the literal string `"true"` — `"1"` does **not** work. |
+
+---
+
+## ABAP feature toggles
+
+Each toggle gates a class of ADT tools that depend on a SAP component being installed or active. All default to `auto` — ARC-1 probes the SAP system once on startup and decides. Override to `on`/`off` when probing is wrong, slow, or you want deterministic behaviour in tests.
+
+When a feature is `off` (either set explicitly or detected as unavailable), every tool action that depends on it is hidden from tool listings *and* rejected at call time with a clear error.
+
+| Flag | Env var | Default | Effect |
+|---|---|---|---|
+| `--feature-abapgit` | `SAP_FEATURE_ABAPGIT` | `auto` | abapGit ADT bridge (`/sap/bc/adt/abapgit/*`). Required for `SAPGit` actions that talk to abapGit. |
+| `--feature-gcts` | `SAP_FEATURE_GCTS` | `auto` | gCTS Git backend (`/sap/bc/cts_abapvcs/*`). Required for `SAPGit` actions that talk to gCTS. |
+| `--feature-rap` | `SAP_FEATURE_RAP` | `auto` | RAP behavior definitions, services, drafts. Required for `SAPWrite` of BDEF/SRVD/SRVB and the RAP-specific code-intel and preflight tools. |
+| `--feature-amdp` | `SAP_FEATURE_AMDP` | `auto` | ABAP Managed Database Procedures. Required for AMDP-specific read/write paths. |
+| `--feature-ui5` | `SAP_FEATURE_UI5` | `auto` | UI5 application development tools (general). |
+| `--feature-ui5repo` | `SAP_FEATURE_UI5REPO` | `auto` | UI5 ABAP Repository OData service. Required for `SAPManage` UI5 repo upload/download actions. |
+| `--feature-flp` | `SAP_FEATURE_FLP` | `auto` | FLP `PAGE_BUILDER_CUST` OData service. Required for `SAPManage` FLP page/role mutations. |
+| `--feature-transport` | `SAP_FEATURE_TRANSPORT` | `auto` | CTS transport endpoints. Required for `SAPTransport` (even reads). |
+| `--feature-hana` | `SAP_FEATURE_HANA` | `auto` | HANA-specific developer tools. |
+
+`auto` probes one specific endpoint per feature and classifies the response: 2xx/400/405/5xx → available; 401/403/404 → unavailable. The reason is surfaced in startup logs and in the `SAPManage.system_info` response.
+
+---
+
+## Code-quality gates
+
+Optional pre-write validation layers and tool-set selection.
+
+| Flag | Env var | Default | Effect |
+|---|---|---|---|
+| `--lint-before-write` | `SAP_LINT_BEFORE_WRITE` | `true` | Runs `@abaplint/core` against the source body before every `SAPWrite`. Syntax errors block the write; warnings are appended to the response (non-blocking). When `false`, lint is skipped — the write goes straight to the activation/save round-trip. Some object types (e.g. `FUNC` source with structured signatures) are exempt from lint regardless of this flag. |
+| `--abaplint-config` | `SAP_ABAPLINT_CONFIG` | — (uses built-in preset) | Path to a custom `abaplint.jsonc`. When unset, ARC-1 builds a preset config based on the detected system type (cloud-strict for BTP, relaxed for on-prem). Custom config takes full precedence. |
+| `--check-before-write` | `SAP_CHECK_BEFORE_WRITE` | `false` | See [Authorization and safety](#authorization-and-safety) — adds a server-side ADT syntax check round-trip before save. Different layer from `lint-before-write` (this hits SAP, lint runs locally). |
+| `--tool-mode` | `ARC1_TOOL_MODE` | `standard` | `standard` exposes the 12 intent-based tools (~5K schema tokens). `hyperfocused` exposes a single universal `sap` tool (~200 tokens) that dispatches everything internally. Use `hyperfocused` for severely token-constrained LLM clients (e.g. GPT-4o-mini, Copilot Studio). |
+
+---
+
+## Removed in v0.7 (will fail at startup)
+
+ARC-1 detects these legacy identifiers and exits with a migration message. Replace before upgrading:
+
+| Removed | Replacement |
+|---|---|
+| `SAP_READ_ONLY` | `SAP_ALLOW_WRITES` (inverted — set to `true` to enable writes) |
+| `SAP_BLOCK_DATA` | `SAP_ALLOW_DATA_PREVIEW` (inverted) |
+| `SAP_BLOCK_FREE_SQL` | `SAP_ALLOW_FREE_SQL` (inverted) |
+| `SAP_ENABLE_TRANSPORTS` | `SAP_ALLOW_TRANSPORT_WRITES` + `SAP_ALLOW_WRITES=true` |
+| `SAP_ENABLE_GIT` | `SAP_ALLOW_GIT_WRITES` + `SAP_ALLOW_WRITES=true` |
+| `SAP_ALLOWED_OPS` / `SAP_DISALLOWED_OPS` | `SAP_DENY_ACTIONS` |
+| `ARC1_PROFILE` | Individual `SAP_ALLOW_*` flags (see [recipes](#recipes)) |
+| `ARC1_API_KEY` (single) | `ARC1_API_KEYS="key:profile"` |
+
+Full migration guide: [updating.md](updating.md#v07-authorization-refactor-breaking-change).
+
+---
+
+## See also
+
+- [Configuration Precedence](configuration-precedence.md) — CLI vs env vs `.env`, and what changes across npx / local / Docker / BTP.
+- [Authorization & Roles](authorization.md) — three-layer model, scope semantics, capability requirements.
+- [Enterprise Auth](enterprise-auth.md) — Layer A / Layer B coexistence matrix.
+- [`.env.example`](https://github.com/marianfoo/arc-1/blob/main/.env.example) — grouped template with inline commentary.
+- Effective config at startup: ARC-1 logs `auth: MCP=[…] SAP=[…]` and a safety summary line on every boot. When in doubt, read that first.

--- a/docs_page/docker.md
+++ b/docs_page/docker.md
@@ -246,6 +246,9 @@ All ARC-1 env vars, CLI flags, and safety recipes live in [configuration-referen
 
 ### Env vars and env files
 
+!!! note "Where do values come from in Docker?"
+    The image does **not** read a `.env` file at startup — `dotenv` would look in the container's CWD, which is empty by design. Pass values explicitly with `-e KEY=VAL` or `--env-file path/to/file.env`. CLI flags appended after the image name (e.g. `… arc1 --allow-writes`) still override env. Full per-mode breakdown: [Configuration Precedence](configuration-precedence.md).
+
 Use `-e` for short examples and `--env-file` when the list gets long:
 
 ```bash

--- a/docs_page/local-development.md
+++ b/docs_page/local-development.md
@@ -46,17 +46,28 @@ Defaults to HTTP Streamable on `:8080`. Connect MCP clients to `http://localhost
 
 For stdio mode inside Docker (Claude Desktop wraps the `docker run` in the MCP config), add `-e SAP_TRANSPORT=stdio` and use `docker run -i --rm` instead of `-d`.
 
-### git clone (contributing to ARC-1)
+### git clone (contributing or running from source)
 
 ```bash
 git clone https://github.com/marianfoo/arc-1.git
 cd arc-1
 npm ci
-npm run build
-npm start          # or: npm run dev  (tsx, auto-reload)
+cp .env.example .env       # then edit for your SAP system
+
+# Pick one:
+npm run dev                # stdio, tsx auto-reload (development loop)
+npm run dev:http           # builds + runs HTTP streamable on 0.0.0.0:8080
+npm run build && npm start # production-style: compile to dist/, run from there
 ```
 
-Config via `.env` (see below) or env vars / flags.
+| Script | What it does | When to use it |
+|---|---|---|
+| `npm run dev` | `tsx src/index.ts` — runs from source over stdio. No build step; restarts on file change. | Iterating on stdio-mode code; pairing with `node` debugger. |
+| `npm run dev:http` | `npm run build && tsx src/index.ts --transport http-streamable` | Iterating on HTTP-mode code; testing OAuth/XSUAA flows; pointing remote MCP clients at your laptop. |
+| `npm run build` | `tsc` + copies AFF schemas to `dist/`. | Producing the `dist/index.js` you ship in Docker or invoke as `node dist/index.js`. |
+| `npm start` | `node dist/index.js` (assumes you ran `npm run build` first). | Production-equivalent local run; useful when you want to test the same artifact CI publishes. |
+
+All four read `.env` from the repo root (their CWD). CLI flags and shell env vars override `.env` — see [Where do my config values come from?](#where-do-my-config-values-come-from) below.
 
 ---
 
@@ -77,6 +88,19 @@ SAP_LANGUAGE=EN
 **The `.env` file loads automatically for `npm run dev`, `npm start`, and the `arc1` CLI.** For `npx` and Docker, pass values as env vars or flags instead.
 
 Full grouped template with every option: see [`.env.example`](https://github.com/marianfoo/arc-1/blob/main/.env.example). The file is grouped into Layer B (ARC-1 → SAP) and Layer A (MCP Client → ARC-1) blocks with fail-fast rules documented inline.
+
+### Where do my config values come from?
+
+ARC-1 resolves every config field from four sources, in order: **CLI flag > `process.env` > `.env` file (in CWD) > built-in default**. The `.env` file is loaded by dotenv from the running process's CWD and **never overrides values already in `process.env`** — it only fills in missing keys.
+
+What `process.env` contains depends on how you launched ARC-1:
+
+- **`npm run dev` / `npm start` from a shell** — your shell exports + the repo's `.env`. Shell wins over `.env`.
+- **`npx arc-1` from an MCP client (stdio)** — the `env` block in your `mcp.json` / `claude_desktop_config.json` becomes the subprocess's environment. There's no `.env` involved.
+- **Remote HTTP — MCP client connects via `"url"`** — only the server's startup environment matters. Putting `env:` in mcp.json next to a `url:` does **nothing**.
+- **Docker / BTP CF** — `-e` flags, `--env-file`, `cf set-env`, manifest properties, and `VCAP_SERVICES`. No `.env` inside containers.
+
+Full per-mode table + debugging tips: [Configuration Precedence](configuration-precedence.md).
 
 ---
 
@@ -169,6 +193,66 @@ npx arc-1@latest --url https://host:44300 --user dev --password secret \
 ### Gemini CLI / Goose / OpenCode / other stdio clients
 
 Same pattern: spawn `npx -y arc-1@latest` with the same `env` block. All stdio clients are interchangeable.
+
+### Pointing an MCP client at a locally-built instance
+
+When you're iterating on ARC-1 itself (or just want to skip the npx download), point the client at your local clone instead.
+
+**Stdio against compiled `dist/`** — closest to what the published package does. Run `npm run build` first.
+
+```json
+{
+  "mcpServers": {
+    "sap-local": {
+      "command": "node",
+      "args": ["/absolute/path/to/arc-1/dist/index.js"],
+      "env": {
+        "SAP_URL": "https://your-sap-host:44300",
+        "SAP_USER": "dev",
+        "SAP_PASSWORD": "secret",
+        "SAP_CLIENT": "100"
+      }
+    }
+  }
+}
+```
+
+`.env` is **not** read here unless you set `"cwd": "/absolute/path/to/arc-1"` in the same block — dotenv looks at the subprocess CWD. Either set `cwd`, or pass everything via `env`.
+
+**Stdio against `tsx` (no build step)** — handy while iterating on source.
+
+```json
+{
+  "mcpServers": {
+    "sap-local": {
+      "command": "npx",
+      "args": ["tsx", "/absolute/path/to/arc-1/src/index.ts"],
+      "env": { "SAP_URL": "…", "SAP_USER": "…", "SAP_PASSWORD": "…", "SAP_CLIENT": "100" }
+    }
+  }
+}
+```
+
+**HTTP against a long-running `npm run dev:http`** — useful for testing OAuth/XSUAA or sharing one instance across multiple clients. Start the server in a terminal:
+
+```bash
+cd /path/to/arc-1
+npm run dev:http -- --http-addr 127.0.0.1:3000     # reads .env from repo root
+```
+
+Then point any MCP client at the URL:
+
+```json
+{
+  "servers": {
+    "sap-local": { "url": "http://localhost:3000/mcp" }
+  }
+}
+```
+
+> For local HTTP loops, bind to `127.0.0.1` (not `0.0.0.0`) so other machines on your network can't hit the instance. If you bind `0.0.0.0`, add an API key — see [api-key-setup.md](api-key-setup.md).
+
+In HTTP mode, the `env` block in mcp.json **does nothing** — the server already has its own environment from when you launched `npm run dev:http`. Change config by editing `.env` (or shell-exporting) and restarting the server. Full mode-by-mode breakdown: [Configuration Precedence](configuration-precedence.md).
 
 ---
 
@@ -290,5 +374,6 @@ Full CLI reference → [cli-guide.md](cli-guide.md).
 
 - **Deploy for a team** → [deployment.md](deployment.md)
 - **All flags** → [configuration-reference.md](configuration-reference.md)
+- **Where config values come from** → [configuration-precedence.md](configuration-precedence.md)
 - **Auth internals and combinations** → [enterprise-auth.md](enterprise-auth.md)
 - **Update ARC-1** → [updating.md](updating.md)

--- a/docs_page/phase4-btp-deployment.md
+++ b/docs_page/phase4-btp-deployment.md
@@ -119,6 +119,9 @@ The `mta.yaml` defines four BTP services that are created automatically:
 
 ### 3. Post-Deploy Configuration
 
+!!! note "Where do values come from on BTP CF?"
+    CF builds the app's environment from three sources: `manifest.yml` / `mta.yaml` `properties:` blocks, runtime overrides via `cf set-env`, and `VCAP_SERVICES` (injected from bound services like XSUAA and the Destination Service). There is **no `.env` file in the droplet** — values not present in those three places fall back to ARC-1's built-in defaults. Use `cf env <app>` to print the final resolved environment as the container sees it. Full per-mode breakdown: [Configuration Precedence](configuration-precedence.md).
+
 When using `SAP_BTP_DESTINATION`, the URL and credentials come from the BTP Destination — no `cf set-env` for `SAP_URL` or `SAP_CLIENT` is needed. Only set them if you're not using the Destination Service:
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,38 +36,38 @@ theme:
 
 nav:
   - Home: index.md
-  - Getting Started:
-      - Quickstart: quickstart.md
-      - Local Development: local-development.md
-      - CLI Guide: cli-guide.md
-      - SAP Trial Setup: sap-trial-setup.md
+  - Quickstart: quickstart.md
   - Deployment:
       - Overview: deployment.md
       - Docker: docker.md
       - BTP Cloud Foundry: phase4-btp-deployment.md
       - BTP ABAP Environment: btp-abap-environment.md
       - Best Practices: deployment-best-practices.md
-  - Authentication:
+  - Auth & Permissions:
       - Overview: enterprise-auth.md
       - Authorization & Roles: authorization.md
       - API Key: api-key-setup.md
       - OAuth / JWT: oauth-jwt-setup.md
-      - Principal Propagation: principal-propagation-setup.md
       - XSUAA Setup: xsuaa-setup.md
+      - Principal Propagation: principal-propagation-setup.md
       - BTP Destination Setup: btp-destination-setup.md
-      - Auth Test Process: auth-test-process.md
   - Using ARC-1:
       - Tools Reference: tools.md
       - MCP Usage Guide: mcp-usage.md
       - Skills: skills.md
   - Reference:
-      - Architecture: architecture.md
       - Configuration: configuration-reference.md
       - Configuration Precedence: configuration-precedence.md
-      - Caching: caching.md
       - Security: security-guide.md
-      - Updating: updating.md
+      - Caching: caching.md
       - Log Analysis: log-analysis.md
+      - Updating: updating.md
+  - Development:
+      - Local Development: local-development.md
+      - Architecture: architecture.md
+      - CLI Guide: cli-guide.md
+      - SAP Trial Setup: sap-trial-setup.md
+      - Auth Test Process: auth-test-process.md
       - Roadmap: roadmap.md
 
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
   - Reference:
       - Architecture: architecture.md
       - Configuration: configuration-reference.md
+      - Configuration Precedence: configuration-precedence.md
       - Caching: caching.md
       - Security: security-guide.md
       - Updating: updating.md


### PR DESCRIPTION
## Summary

- Restructure `configuration-reference.md` by purpose (connection / auth / authorization / runtime / caching / logging / feature toggles / code-quality) instead of by security layer, with a real "effect" description for every env var rather than just name + default.
- Add a new `configuration-precedence.md` page that gives the canonical answer to "which value wins?" across `npx`, local clone, Docker, and BTP CF — including the gotcha that mcp.json `env` does nothing for `url:`-based remote connections.
- Document the 12 env vars the codebase reads but the reference page never covered: 9× `SAP_FEATURE_*` toggles, `SAP_ABAP_RELEASE`, `SAP_CHECK_BEFORE_WRITE`, and `ARC1_LOG_HTTP_DEBUG` (including its boolean-parsing asymmetry — `"1"` doesn't work, only `"true"`).
- Enhance `local-development.md`: expand the local-clone section into a `dev` / `dev:http` / `build` / `start` table, add a "Where do my config values come from?" callout, and add a "Pointing an MCP client at a locally-built instance" subsection with mcp.json snippets for both stdio (against `dist/` and against `tsx`) and HTTP (against `npm run dev:http`).
- Cross-link to the precedence page from `docker.md` (no `.env` inside containers) and `phase4-btp-deployment.md` (manifest + `cf set-env` + `VCAP_SERVICES`).

No code changes. The `ARC1_LOG_HTTP_DEBUG` boolean asymmetry is documented but intentionally not fixed.

## Test plan

- [ ] `mkdocs serve` renders without warnings and all internal anchor links resolve (table-of-contents links inside `configuration-reference.md`, the `#logging-and-observability` deep link from `configuration-precedence.md`, and cross-refs to `authorization.md`, `enterprise-auth.md`, `updating.md`).
- [ ] Spot-check that every env var listed in the audit (48 active vars in `src/`) appears in the new reference — the only intentional omissions are the system vars (`HOME`, `LOCALAPPDATA`, `PROGRAMFILES`) and BTP-runtime-injected ones (`VCAP_APPLICATION`, `VCAP_SERVICES`).
- [ ] Read the new precedence page top-to-bottom against `src/index.ts` + `src/server/config.ts` to confirm the resolution order claims are accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)