### PR TITLE
docs: add AI ABAP Development blog series page

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Full documentation is available at **[marianfoo.github.io/arc-1](https://marianf
 | [Tool Reference](https://marianfoo.github.io/arc-1/tools/) | Complete reference for all 12 tools |
 | [Architecture](https://marianfoo.github.io/arc-1/architecture/) | System architecture with diagrams |
 | [AI Usage Patterns](https://marianfoo.github.io/arc-1/mcp-usage/) | Agent workflow patterns and best practices |
+| [Blog Series](https://marianfoo.github.io/arc-1/blog-series/) | Long-form posts on AI for ABAP development, ARC-1 internals, and real-world walkthroughs |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ ARC-1 connects AI assistants (Claude, GitHub Copilot, Copilot Studio, and any MC
 [![CodeQL](https://github.com/marianfoo/arc-1/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/marianfoo/arc-1/security/code-scanning)
 [![Dependency Review](https://github.com/marianfoo/arc-1/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/marianfoo/arc-1/actions/workflows/dependency-review.yml)
 
-**[Full Documentation](https://marianfoo.github.io/arc-1/)** | **[Quickstart](https://marianfoo.github.io/arc-1/quickstart/)** | **[Tool Reference](https://marianfoo.github.io/arc-1/tools/)**
+**[Full Documentation](https://marianfoo.github.io/arc-1/)** | **[Quickstart](https://marianfoo.github.io/arc-1/quickstart/)** | **[Tool Reference](https://marianfoo.github.io/arc-1/tools/)** | **[Blog Series](https://blog.zeis.de/tags/ai-abap-development-series/)**
+
+> 📖 **New: AI ABAP Development blog series** — long-form posts on AI for ABAP, ARC-1 design, and real-world BTP / Copilot Studio / Joule walkthroughs. **[Read the series →](https://blog.zeis.de/tags/ai-abap-development-series/)**
 
 ## Why ARC-1?
 
@@ -140,6 +142,20 @@ npx arc-1@latest --url https://your-sap-host:44300 --user YOUR_USER
 - **Trying it out on your laptop?** → [Quickstart](https://marianfoo.github.io/arc-1/quickstart/)
 - **Full local dev setup (Docker, cookie extractor, client configs)?** → [Local Development](https://marianfoo.github.io/arc-1/local-development/)
 - **Deploying for a team / BTP?** → [Deployment](https://marianfoo.github.io/arc-1/deployment/)
+
+## Blog Series — AI ABAP Development
+
+A long-form series on [blog.zeis.de](https://blog.zeis.de/tags/ai-abap-development-series/) covering AI for ABAP development, ARC-1's design, and real-world walkthroughs:
+
+1. [How I Use AI for Development and Why Context Matters](https://blog.zeis.de/posts/2026-04-20-how-i-use-ai/)
+2. [ABAP and Agentic AI: The Hidden Problem in Real Projects](https://blog.zeis.de/posts/2026-04-22-ai-abap-development/)
+3. [Introducing ARC-1: A Secure ADT MCP Server for Enterprise SAP Development](https://blog.zeis.de/posts/2026-04-27-arc-1/)
+4. [ARC-1 on SAP BTP: Secure ABAP Agentic Development Beyond the Laptop](https://blog.zeis.de/posts/2026-04-29-arc-1-btp/)
+5. [ARC-1 with Copilot Studio: SAP System Context Beyond Developers](https://blog.zeis.de/posts/2026-05-05-arc-1-copilot-studio/)
+6. [ARC-1 with Joule Studio: Bringing Real ABAP System Context into Joule](https://blog.zeis.de/posts/2026-05-08-arc-1-joule-studio-clean-core/)
+7. [From SEGW and Legacy UI5 to RAP with ARC-1](https://blog.zeis.de/posts/2026-05-11-segw-to-rap/)
+
+Full list and new posts → **[blog.zeis.de/tags/ai-abap-development-series](https://blog.zeis.de/tags/ai-abap-development-series/)**.
 
 ## Documentation
 

--- a/docs_page/blog-series.md
+++ b/docs_page/blog-series.md
@@ -1,0 +1,15 @@
+# Blog Series: AI ABAP Development
+
+A series of long-form posts on [blog.zeis.de](https://blog.zeis.de/tags/ai-abap-development-series/) that progresses from AI development in general, to ABAP-specific problems, and then to ARC-1.
+
+| # | Post | Date |
+|---|------|------|
+| 1 | [How I Use AI for Development and Why Context Matters](https://blog.zeis.de/posts/2026-04-20-how-i-use-ai/) | 2026-04-20 |
+| 2 | [ABAP and Agentic AI: The Hidden Problem in Real Projects](https://blog.zeis.de/posts/2026-04-22-ai-abap-development/) | 2026-04-22 |
+| 3 | [Introducing ARC-1: A Secure ADT MCP Server for Enterprise SAP Development](https://blog.zeis.de/posts/2026-04-27-arc-1/) | 2026-04-27 |
+| 4 | [ARC-1 on SAP BTP: Secure ABAP Agentic Development Beyond the Laptop](https://blog.zeis.de/posts/2026-04-29-arc-1-btp/) | 2026-04-29 |
+| 5 | [ARC-1 with Copilot Studio: SAP System Context Beyond Developers](https://blog.zeis.de/posts/2026-05-05-arc-1-copilot-studio/) | 2026-05-04 |
+| 6 | [ARC-1 with Joule Studio: Bringing Real ABAP System Context into Joule](https://blog.zeis.de/posts/2026-05-08-arc-1-joule-studio-clean-core/) | 2026-05-06 |
+| 7 | [From SEGW and Legacy UI5 to RAP with ARC-1](https://blog.zeis.de/posts/2026-05-11-segw-to-rap/) | 2026-05-11 |
+
+New posts are tagged [`ai-abap-development-series`](https://blog.zeis.de/tags/ai-abap-development-series/) on the blog.

--- a/docs_page/index.md
+++ b/docs_page/index.md
@@ -225,6 +225,7 @@ With both flags at their defaults, ARC-1 stays inside the FAQ envelope for endor
 | [phase4-btp-deployment.md](phase4-btp-deployment.md) | BTP Cloud Foundry deployment details |
 | [sap-trial-setup.md](sap-trial-setup.md) | SAP BTP trial setup |
 | [roadmap.md](roadmap.md) | Planned features |
+| [blog-series.md](blog-series.md) | Long-form blog series — AI for ABAP development, ARC-1 design, BTP / Copilot Studio / Joule walkthroughs |
 
 ## License
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Tools Reference: tools.md
       - MCP Usage Guide: mcp-usage.md
       - Skills: skills.md
+      - Blog Series: blog-series.md
   - Reference:
       - Configuration: configuration-reference.md
       - Configuration Precedence: configuration-precedence.md


### PR DESCRIPTION
## Summary
- New [docs_page/blog-series.md](docs_page/blog-series.md) lists all 7 posts in the [blog.zeis.de ai-abap-development-series tag](https://blog.zeis.de/tags/ai-abap-development-series/) with title + date.
- Linked from `README.md` Documentation table, `docs_page/index.md` Documentation table, and the mkdocs **Using ARC-1** nav group.
- Tag-page link kept prominent so new posts surface without needing to re-edit the docs every time.

## Test plan
- [ ] `mkdocs serve` renders **Using ARC-1 → Blog Series** in the nav and the page itself.
- [ ] All 7 post links resolve (manual click).
- [ ] README + docs landing page Documentation tables include the new row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)