### PR TITLE
feat(skills): SAP CAP Enterprise Audit skill chain — Wave 1 (clean-core + customizing)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -100,6 +100,17 @@ Both skills produce the same RAP artifact stack. The difference is how they get 
 | [migrate-custom-code](migrate-custom-code/SKILL.md) | Runs ATC readiness checks, groups findings by priority, and generates replacement code | Preparing custom code for S/4HANA migration or ABAP Cloud readiness |
 | [sap-object-documenter](sap-object-documenter/SKILL.md) | Batch-documents many custom objects at once — purpose, style (Classic/Modern/Mixed), dependencies — as Markdown | Onboarding packages, handoffs, seeding a repo wiki (vs. explain-abap-code which is single-object interactive) |
 
+### SAP CAP Enterprise Audit (Preview)
+
+End-to-end audit and compliance verification for SAP CAP applications deployed on BTP (Cloud Foundry or Kyma) consuming S/4HANA Tier-2 services. Read-only skills that produce committable markdown reports.
+
+| Skill | What it does | When to use |
+|---|---|---|
+| [sap-cap-clean-core-enforce](sap-cap-clean-core-enforce/SKILL.md) | Discovery-driven Clean Core Level A audit. Scans `cds.connect.to()` runtime + `@cds.external` services, probes SAP API release-state repository via mcp-sap-docs, builds availability matrix (Public × Private × On-Premise), detects catalog drift, suggests SAP-released replacements | Pre-deployment audit / quarterly compliance check for CAP+S/4 stacks |
+| [sap-cap-customizing-honor](sap-cap-customizing-honor/SKILL.md) | Bidirectional CSV↔code customizing audit: forward orphans (seeded but unused) + inverse orphans (code-read but unseeded) + hardcoded business-decision sweep + master-data FK ValueList enforcement | Verifying that admin Setup UI parameters are wired to code consumers; pre-release coverage check |
+
+> **Status**: Preview / Work-in-progress. Wave 1 (Clean Core + Customizing) available now. Additional skills (Security RBAC matrix, Lifecycle matrix audit, Fiori app audit, Text polish, Stack audit orchestrator, CI gates pattern) tracked in follow-up PRs.
+
 ### Clean Core & Custom Code Retirement
 
 | Skill | What it does | When to use |

--- a/skills/sap-cap-clean-core-enforce/SKILL.md
+++ b/skills/sap-cap-clean-core-enforce/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: sap-cap-clean-core-enforce
+description: Discovery-driven Clean Core Level A enforcement audit for SAP CAP + S/4HANA projects. Scans `cds.connect.to()` runtime calls + `@cds.external` services, identifies SAP-released probe objects, builds an availability matrix (Public Cloud × Private Cloud × On-Premise) via `mcp-sap-docs`, detects catalog drift versus the project's declared compatibility policy, and suggests SAP-released replacements for non-released references. Use when asked to "verify Clean Core Level A compliance", "audit S/4 API usage", "check which S/4 services we consume are released", "are we Clean Core compliant on BTP", or "build a Clean Core compliance matrix".
+---
+
+# SAP CAP Clean Core Level A Enforcement
+
+Discovery-driven Clean Core Level A compliance audit for SAP CAP + S/4HANA projects. This skill **scans your CAP codebase for S/4 API consumption**, **verifies each service against the SAP API release-state repository** ([`SAP/abap-atc-cr-cv-s4hc`](https://github.com/SAP/abap-atc-cr-cv-s4hc)) on all three editions (Public Cloud, Private Cloud / RISE, On-Premise), and produces a **compliance matrix** that can be checked into the repo as compliance evidence.
+
+Unlike [sap-clean-core-atc](../sap-clean-core-atc/SKILL.md) which classifies **ABAP custom code on the SAP side** into Levels A-D, this skill classifies **the BTP CAP application's outbound S/4 API consumption** — useful when the CAP app is the consumer and the question is "are all S/4 APIs we call actually released?".
+
+Read-only audit, idempotent, ~5 minute run, zero side-effects on either the source SAP system or the target CAP project (unless `--apply` mode is selected).
+
+## Smart Defaults (apply silently, do NOT ask)
+
+| Setting | Default | Rationale |
+|---|---|---|
+| Target edition | All 3: `public_cloud`, `private_cloud`, `on_premise` | Full matrix — multi-customer-deployable projects need to know per-edition availability |
+| Clean Core level | `A` (Released APIs only) | The most restrictive level — works for any cloud target |
+| Compatibility policy file | Auto-detect: `srv/integration/s4*Policy*.{ts,js,cds}` → `srv/config/s4*.{ts,js}` → `src/config/clean-core*.{ts,js}` | Project-specific files vary; auto-detect first, fall back to discovery-only |
+| Probe identification | Catalog `probeObject` field if present → CDS view naming heuristic (`I_*API01` / `I_*`) → MCP search fallback | Multi-strategy gives best coverage |
+| BTP managed services | Excluded from S/4 audit | `db`, `auth`, `messaging`, `connectivity`, `responsibility-management`, `enterprise-messaging`, `audit-log-service`, `nats`, `redis` are not S/4 |
+| Report output | `docs/audit/<yyyy-mm-dd>-clean-core-level-a.md` | Markdown + committable for traceability |
+| Mode | `report` (read-only) | Reversible by default; user opts into `apply` mode for catalog updates |
+| Drift severity | Over-declared = HIGH, Under-declared = MEDIUM, Missing-field = LOW | HIGH if catalog claims availability that MCP denies (customer would fail in prod) |
+
+## Input
+
+Optional flags (all auto-detected by default):
+
+- **scope** — `all` (default) | `discovery-only` (skip MCP) | `matrix-only` (presume discovery cached) | `<SERVICE_NAME>` (focus single service)
+- **policy file path** — explicit override for the compatibility policy file
+- **target editions** — comma list to restrict, e.g., `public_cloud,private_cloud`
+- **mode** — `report` (default) | `apply` (auto-update catalog `availability[]` field if MCP-verified differs from declared)
+
+If neither flag is provided, run with defaults and full discovery.
+
+## Step 1: Pre-flight + Compatibility Policy Discovery
+
+### 1a. Verify project type
+
+```bash
+test -f package.json && grep -q '"@sap/cds"' package.json
+```
+
+If not a CAP project, stop and inform the user this skill targets CAP+S/4HANA stacks.
+
+### 1b. Detect compatibility policy file
+
+Search for the project's S/4 compatibility policy file (commonly used pattern: a JS/TS module exporting a `SERVICE_CATALOG` constant that maps logical service names to OData version + destination aliases + entity sets + Communication Scenarios).
+
+Auto-detect order:
+
+```bash
+find srv/integration -name "s4*Policy*.{ts,js}" -maxdepth 2 2>/dev/null
+find srv/config -name "*compat*.{ts,js}" -maxdepth 2 2>/dev/null
+find src/config -name "clean-core*.{ts,js}" -maxdepth 2 2>/dev/null
+```
+
+If multiple candidates → ask user to pick one. If none → proceed with `discovery-only` scope (no catalog drift detection, only inventory + MCP verification).
+
+### 1c. Parse compatibility policy
+
+Extract from the policy file (regardless of exact location):
+
+- Service entries (keys of `SERVICE_CATALOG` or equivalent): logical names like `BUSINESS_PARTNER`, `SUPPLIER_INVOICE`, `PURCHASE_ORDER`, etc.
+- Per-entry: `odata` (versions array), `destinations` (alias names), `entitySets`, `communicationScenarios`, optionally `availability` (already-declared edition list), optionally `probeObject` (already-declared SAP probe object).
+
+If the policy file does not exist or doesn't follow this convention, proceed with code-grep discovery only.
+
+## Step 2: Dynamic Discovery (4 sources)
+
+Combine 4 input sources to build the candidate service list. **Do not** start from a hardcoded list — discover dynamically.
+
+### 2a. Runtime destinations (`cds.connect.to`)
+
+```bash
+grep -rhE "cds\.connect\.to\(['\"]([A-Z][A-Z0-9_-]+)['\"]" srv/ \
+  --include="*.ts" --include="*.js" 2>/dev/null \
+  | grep -oE "['\"][A-Z][A-Z0-9_-]+['\"]" \
+  | tr -d "'\"" \
+  | sort -u
+```
+
+### 2b. External service contracts
+
+```bash
+ls srv/external/*.cds 2>/dev/null | xargs -I {} basename {} .cds | sort -u
+```
+
+These are typically `@cds.external` services or remote OData proxies with metadata committed to the project.
+
+### 2c. SERVICE_CATALOG declared destinations (if Step 1c succeeded)
+
+Extract from the parsed policy file.
+
+### 2d. ServiceConnectors seed CSV (if present)
+
+```bash
+test -f db/data/sap.*-ServiceConnectors.csv && \
+  awk -F',' 'NR>1 {print $2}' db/data/sap.*-ServiceConnectors.csv | sort -u
+```
+
+This is a common pattern for CAP apps that declare admin-configurable S/4 service connectors as master data.
+
+### 2e. Apply exclusions
+
+Remove BTP managed services (not S/4):
+
+```
+db | auth | messaging | connectivity | responsibility-management |
+enterprise-messaging | audit-log-service | nats | redis
+```
+
+Also remove dev / mock / test destinations (matching `mock-*`, `test-*`, `dev-*`).
+
+The result is the **service candidate list** to audit.
+
+## Step 3: Probe Identification
+
+For each service candidate, identify the representative SAP object to query against the SAP API Release State repository.
+
+### Heuristic order (most preferred first)
+
+1. **Explicit `probeObject`** from policy file (if Step 1c found it) — zero cost, already documented.
+2. **Naming convention** — SAP's pattern for OData service-backing CDS views:
+   - Destination `API_*` (e.g., `API_PURCHASEORDER_PROCESS_SRV`) → probe `I_*API01` (e.g., `I_PURCHASEORDERAPI01`)
+   - Destination `I_*` directly (e.g., `I_PURCHASEORDERHISTORYAPI01`) → probe is the destination itself
+3. **Special cases** (known SAP framework patterns):
+   - Electronic Document Files / DRC services → probe `DTEL EDOC_TYPE` (component `CA-GTF-CSC-EDO`)
+   - Attachment service (`API_CV_ATTACHMENT_SRV`) → probe `CLAS CL_ATTACHMENT_SERVICE_API` (component `CA-DMS`)
+   - Workflow services (`s4-flexible-workflow`) → probe `DDLS I_WORKFLOWEXTERNALSTATUS` (component `BC-BMT-WFM`)
+4. **MCP search fallback** for ambiguous cases:
+   ```
+   mcp-sap-docs:sap_search_objects(
+     query="<keyword derived from logical name>",
+     system_type="public_cloud",
+     clean_core_level="A",
+     object_type="DDLS",
+     limit=10
+   )
+   ```
+   Take the first result matching `I_<TOPIC>API01` or `I_<TOPIC>` pattern.
+
+### Untraceable services
+
+If no probe object can be identified for a service (none of the heuristics produce a match), emit a **LOW finding** in the report:
+
+```
+[LOW] Untraceable service: <SERVICE_NAME>
+  - Destination(s): <list>
+  - Inferred attempts:
+    - Naming heuristic I_*API01: no MCP match
+    - Search fallback: no result matching pattern
+  - Recommendation: manually add `probeObject` field to the catalog entry
+```
+
+The skill continues without crashing — untraceable services are flagged but not treated as compliance gaps (they may be released, just not auto-detectable).
+
+## Step 4: Matrix MCP-Verified (3 editions × N services)
+
+For each `(service, probe_object)` identified, issue **3 parallel MCP queries** — one per edition:
+
+```
+mcp-sap-docs:sap_get_object_details(
+  object_type=<probe.type>,
+  object_name=<probe.name>,
+  system_type="public_cloud",       # then private_cloud, then on_premise
+  target_clean_core_level="A"
+)
+```
+
+### Per-cell evaluation
+
+For each `(service, edition)` cell of the matrix:
+
+| MCP response | Interpretation | Matrix value |
+|---|---|---|
+| `found: true && state: "released" && cleanCoreLevel: "A" && complianceStatus: "compliant"` | Released L-A available | ✅ |
+| `found: true && state: "released" && cleanCoreLevel: "B/C/D"` | Released but not L-A | 🟡 (level mismatch) |
+| `found: true && state: "deprecated"` | Available but deprecated | ⚠️ (deprecated, migration needed) |
+| `found: true && state: "notToBeReleased*"` | Not released, internal use | 🔴 (Clean Core violation) |
+| `found: false` | Not in repository | ⚪ (unknown — probe may be wrong) |
+
+### Cache MCP results
+
+Cache by `(object_type, object_name, system_type)` — the same probe is often queried for multiple services that share a CDS view backbone (e.g., `I_BUSINESSPARTNER` underlies multiple API_* services). 30+ queries for a 12-service catalog is normal.
+
+## Step 5: Catalog Drift Detection
+
+For each catalog entry, compare declared `availability[]` against MCP-verified result.
+
+### Drift classification
+
+| Drift type | Declared vs Verified | Severity | Impact |
+|---|---|---|---|
+| **NONE** | Declared matches verified exactly | — | Healthy |
+| **OVER_DECLARED** | Catalog says `['PUBLIC', 'PRIVATE', 'ONPREM']` but MCP confirms only 2 editions | 🔴 **HIGH** | Customer on Public Cloud configures connector → runtime fails with 404. False positive. |
+| **UNDER_DECLARED** | Catalog says `['PRIVATE']` but MCP confirms 3 editions | 🟡 **MEDIUM** | Customer Public Cloud blocked unnecessarily. False negative. |
+| **MISSING_FIELD** | Catalog has no `availability` field | 🟢 **LOW** | Undefined runtime behavior. Defaults may be too permissive. |
+| **STATE_CHANGE** | Catalog implies released but MCP reports deprecated | ⚠️ **MEDIUM** | Migration needed (probably future cutoff). |
+
+## Step 6: Compliance Matrix Rollup
+
+Aggregate the per-cell matrix into multi-dimensional reports.
+
+### Rollup A: Per-service matrix
+
+```
+| Service          | Public | Private | OnPrem | Probe                       | App Component       | Drift          |
+|------------------|--------|---------|--------|-----------------------------|---------------------|----------------|
+| BUSINESS_PARTNER | ✅      | ✅       | ✅      | DDLS I_BUSINESSPARTNER      | AP-MD-BP            | NONE           |
+| PURCHASE_ORDER   | ✅      | ✅       | ✅      | DDLS I_PURCHASEORDERAPI01   | MM-PUR-PO-2CL       | NONE           |
+| HYPOTHETICAL_X   | ❌      | ✅       | ✅      | DDLS I_HYPOTHETICALX        | (not found public)  | OVER_DECLARED  |
+```
+
+### Rollup B: Per Communication Scenario
+
+For each `SAP_COM_XXXX` in the catalog, list which services use it and their edition coverage:
+
+```
+| SAP_COM      | Description                       | Services NOVA using       | Edition coverage     |
+|--------------|-----------------------------------|---------------------------|----------------------|
+| SAP_COM_0008 | Business Partner Integration      | BUSINESS_PARTNER          | All 3 ✅              |
+| SAP_COM_0057 | Supplier Invoice + Attachments    | SUPPLIER_INVOICE, ATTACHMENT | All 3 ✅          |
+```
+
+### Rollup C: Coverage summary
+
+```
+Total services audited:           N
+Cells (services × 3 editions):    M
+Cells compliant (L-A all 3):      X (X/M %)
+Cells with drift HIGH:            n
+Cells with drift MEDIUM:          n
+Cells with drift LOW:             n
+Untraceable services:             n
+Z-namespace runtime references:   n
+
+Rating: A (≥95% compliant) / A- (90-94%) / B (75-89%) / C (<75%)
+```
+
+## Step 7: Emit Report
+
+Save markdown to `docs/audit/<yyyy-mm-dd>-clean-core-level-a.md` (create `docs/audit/` directory if needed):
+
+```markdown
+# Clean Core Level A Compliance Audit — <yyyy-mm-dd>
+
+## Pre-flight
+- Branch: <branch>
+- Commit: <sha>
+- Compatibility policy file: <path or 'not detected'>
+- Scope: <discovery sources used>
+
+## Discovery
+- Runtime destinations (cds.connect.to): N
+- External service contracts: N
+- SERVICE_CATALOG entries: N
+- ServiceConnectors CSV: N
+- Effective services (post-dedup + post-exclusion): N
+
+## Probe Identification
+| Service | Probe | Type | App Component | Source |
+
+## Matrix (MCP-verified)
+| Service | Public | Private | OnPrem | Notes |
+
+## Drift Detection
+| Service | Declared | Verified | Drift | Severity |
+
+## Compliance per Communication Scenario
+| SAP_COM | Description | Services | All editions |
+
+## Findings (≥0.8 confidence)
+### [HIGH] OVER_DECLARED: <service>
+- Catalog: <declared>
+- MCP verified: <actual>
+- Impact: <concrete failure scenario>
+- Fix: <recommendation>
+
+## Compliance Summary
+- Services: N · Cells compliant: X/M
+- Rating: A / A- / B / C
+
+## Fix Plan / Applied
+| Service | Field | Before | After | Status |
+
+## Re-verification process
+- Cadence: quarterly (Q-review) or on SAP API sunset announcement
+- Command: `sap-cap-clean-core-enforce` (this skill)
+- Output: re-save report with current date
+```
+
+## Step 8: Apply Fixes (only when `--apply` mode)
+
+When user explicitly opts in:
+
+### Safe auto-fixes
+
+1. **Sync `availability[]` field** for services where MCP-verified is a **superset** of declared (UNDER_DECLARED case) — adding editions never breaks customers; only removing does.
+2. **Add `probeObject` field** when missing but heuristic-identified — improves traceability for re-verification.
+3. **Add timestamp comment** at the top of the catalog file recording verification date.
+
+### NOT auto-applied (require manual review)
+
+- **Remove edition from `availability[]`** when OVER_DECLARED — risks breaking customers on the over-declared edition. Surface as a finding with recommendation, but never auto-remove.
+- **Add new service entry** not currently in catalog. Use `--add-service <name>` explicit flag.
+- **Z-namespace usage** at runtime — architectural decision, not auto-fixable.
+
+### Verification after fix
+
+Re-run Steps 4-6 against the updated catalog to confirm zero drift remains.
+
+## BTP vs On-Premise Differences
+
+| Aspect | BTP target (Public Cloud) | Private Cloud / RISE | On-Premise |
+|---|---|---|---|
+| Software component | `SAPSCORE` | `S4CORE` | `S4CORE` or `SAP_BASIS` |
+| App component suffix | `-2CL` ("To Cloud") | base name (no suffix) | base name (no suffix) |
+| Released API set | Most restrictive | Includes legacy classic APIs | Same as Private |
+| ABAP CDS views | `I_*` views released L-A | `I_*` views (no -2CL suffix) | Same as Private |
+| Cross-edition probes | Use Public Cloud `-2CL` as authoritative | Both base + -2CL may exist | base name preferred |
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| `mcp-sap-docs not connected` | MCP server unavailable | Run installation: `npx skills add marianfoo/arc-1` includes recommended MCP setup |
+| `mcp-sap-docs returns found: false` for known SAP object | Repository dataset lag or wrong probe object | Try alternative probe (variant CDS view name); flag service as untraceable |
+| Policy file detected but parse fails | Non-standard policy file format | Skill falls back to `discovery-only` scope and logs warning |
+| Multiple policy files candidates found | Project structure ambiguity | Ask user to pick one (interactive prompt) |
+| Probe object naming heuristic miss | Custom destination name doesn't match `API_*` / `I_*` pattern | Manual probe specification via policy file `probeObject` field |
+| No `cds.connect.to` calls found | Project uses different connection pattern (e.g., `cds.requires.<dest>`) | Extend Step 2a grep with project-specific pattern; report what was found |
+| Catalog file in TypeScript with complex syntax | Cannot statically parse with regex | Read entries via `node -e` evaluation or ask user to export JSON snapshot |
+
+## What This Skill Does NOT Do
+
+- **No SAP write operations** — read-only on SAP side via mcp-sap-docs queries
+- **No replacement code generation** — suggests replacement APIs (in drift report), but does not generate the replacement CAP service binding
+- **No ABAP-side classification** — that's [sap-clean-core-atc](../sap-clean-core-atc/SKILL.md) (which audits Z code on SAP)
+- **No SystemParameter / customizing validation** — separate concern (see [sap-cap-customizing-honor](../sap-cap-customizing-honor/SKILL.md))
+- **No deployment / runtime testing** — static audit only; doesn't make HTTP calls to the destination
+- **No CDS compile validation** — assumes the project already compiles; this skill audits the S/4 API surface, not CDS syntax
+- **No Z-namespace runtime replacement** — flags Z-namespace usage as finding but architectural redesign is out of scope
+- **No catalog file generation** — works against an existing compatibility policy or with `discovery-only` if none exists
+
+## When to Use This Skill
+
+- **Pre-deployment audit** — before committing to a BTP customer go-live, verify that all S/4 APIs consumed are released for that customer's edition
+- **Quarterly compliance check** — schedule as part of release governance; re-verifies the catalog matches latest SAP API release state
+- **After adding a new S/4 destination** — verify the new service is released before merge
+- **Pre-CI gate validation** — pair with a CI script (e.g., `scripts/ci/check-s4-compat-coverage.sh`) for runtime drift prevention
+- **Pre-acquisition audit** — when assessing a 3rd-party CAP application, verify it's Clean Core L-A before adoption
+- **Documentation evidence** — auditor-friendly report committed to `docs/audit/` for compliance trail
+
+## When NOT to Use This Skill
+
+- **Greenfield project with no SERVICE_CATALOG yet** — there's nothing to audit yet; start with [modernize-abap-to-btp-cap](../modernize-abap-to-btp-cap/SKILL.md) to scaffold the project, then audit later
+- **ABAP-only codebase** (no CAP) — use [sap-clean-core-atc](../sap-clean-core-atc/SKILL.md) instead
+- **Custom Z* CDS views on the S/4 side that are NOT meant to be released** — that's a design choice; this skill measures consumption, not source generation
+- **Single-edition deployment fixed by customer contract** — you can use this skill but most of the value (cross-edition matrix) is lost; consider `--target-editions public_cloud` flag
+
+## Follow-up
+
+After this skill produces the compliance matrix:
+
+- **HIGH drift findings**: investigate manually, decide whether to remove edition from declared availability OR switch to a different SAP service that IS released on the affected edition
+- **UNDER_DECLARED findings**: run with `--apply` to expand `availability[]` and unlock customer editions
+- **Untraceable services**: manually add `probeObject` field to policy entries
+- **Deprecated state warnings**: plan migration to successor APIs (use [sap-clean-core-atc](../sap-clean-core-atc/SKILL.md) for ABAP-side migrations)
+- **Z-namespace runtime references**: architectural review — either Clean Core B opt-in (documented exception) or replacement
+
+Related skills:
+
+- [sap-clean-core-atc](../sap-clean-core-atc/SKILL.md) — ABAP-side classification (companion, source side)
+- [migrate-custom-code](../migrate-custom-code/SKILL.md) — ABAP-side ATC fixes when replacements are needed
+- [modernize-abap-to-btp-cap](../modernize-abap-to-btp-cap/SKILL.md) — generate the CAP scaffold this skill later audits
+
+## References
+
+- [SAP API Release State repository](https://github.com/SAP/abap-atc-cr-cv-s4hc) — authoritative source for object classifications
+- [Clean Core principles](https://help.sap.com/docs/btp/sap-business-technology-platform/clean-core)
+- [SAP API Business Hub](https://api.sap.com)
+- [CAP `cds.connect.to` documentation](https://cap.cloud.sap/docs/node.js/cds-connect)
+- [SAP Communication Management (S/4HANA Cloud)](https://help.sap.com/docs/SAP_S4HANA_CLOUD/0f69f8fb28ac4bf48d2b57b9637e81fa/community-management.html)

--- a/skills/sap-cap-clean-core-enforce/SKILL.md
+++ b/skills/sap-cap-clean-core-enforce/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: sap-cap-clean-core-enforce
-description: Discovery-driven Clean Core Level A enforcement audit for SAP CAP + S/4HANA projects. Scans `cds.connect.to()` runtime calls + `@cds.external` services, identifies SAP-released probe objects, builds an availability matrix (Public Cloud × Private Cloud × On-Premise) via `mcp-sap-docs`, detects catalog drift versus the project's declared compatibility policy, and suggests SAP-released replacements for non-released references. Use when asked to "verify Clean Core Level A compliance", "audit S/4 API usage", "check which S/4 services we consume are released", "are we Clean Core compliant on BTP", or "build a Clean Core compliance matrix".
+description: Discovery-driven Clean Core Level A enforcement gate for SAP CAP + S/4HANA projects. Scans `cds.connect.to()` runtime calls + `@cds.external` services, identifies SAP-released probe objects, builds an availability matrix (Public Cloud × Private Cloud × On-Premise) by consulting two authoritative sources (the SAP API release-state repository `SAP/abap-atc-cr-cv-s4hc` + the SAP API Hub at api.sap.com), detects catalog drift versus the project's declared compatibility policy, and supports an `--enforce` mode that fails CI on HIGH findings to block deployment of non-released consumption. Use when asked to "verify Clean Core Level A compliance", "audit S/4 API usage", "check which S/4 services we consume are released", "enforce Clean Core in CI", "build a Clean Core compliance matrix", or "block deployment if non-released API is consumed".
 ---
 
 # SAP CAP Clean Core Level A Enforcement
 
-Discovery-driven Clean Core Level A compliance audit for SAP CAP + S/4HANA projects. This skill **scans your CAP codebase for S/4 API consumption**, **verifies each service against the SAP API release-state repository** ([`SAP/abap-atc-cr-cv-s4hc`](https://github.com/SAP/abap-atc-cr-cv-s4hc)) on all three editions (Public Cloud, Private Cloud / RISE, On-Premise), and produces a **compliance matrix** that can be checked into the repo as compliance evidence.
+Discovery-driven Clean Core Level A enforcement for SAP CAP + S/4HANA projects. This skill **scans your CAP codebase for S/4 API consumption**, **verifies each service against two authoritative sources** — the SAP API release-state repository ([`SAP/abap-atc-cr-cv-s4hc`](https://github.com/SAP/abap-atc-cr-cv-s4hc/blob/main/README.md)) and the [SAP API Hub](https://api.sap.com/) — on all three editions (Public Cloud, Private Cloud / RISE, On-Premise), and produces a **compliance matrix** that can be checked into the repo as compliance evidence. With `--enforce`, the matrix becomes a **CI-blocking deployment gate**.
 
-Unlike [sap-clean-core-atc](../sap-clean-core-atc/SKILL.md) which classifies **ABAP custom code on the SAP side** into Levels A-D, this skill classifies **the BTP CAP application's outbound S/4 API consumption** — useful when the CAP app is the consumer and the question is "are all S/4 APIs we call actually released?".
+Unlike [sap-clean-core-atc](../sap-clean-core-atc/SKILL.md) which classifies **ABAP custom code on the SAP side** into Levels A-D, this skill classifies **the BTP CAP application's outbound S/4 API consumption** — useful when the CAP app is the consumer and the question is "are all S/4 APIs we call actually released, on all editions we deploy to?".
 
-Read-only audit, idempotent, ~5 minute run, zero side-effects on either the source SAP system or the target CAP project (unless `--apply` mode is selected).
+Default mode is **`report`** (read-only audit, idempotent, ~5 minute run). Opt into **`--apply`** for safe additive catalog corrections, or **`--enforce`** for CI-gating semantics (non-zero exit on HIGH findings).
 
 ## Smart Defaults (apply silently, do NOT ask)
 
@@ -159,6 +159,12 @@ The skill continues without crashing — untraceable services are flagged but no
 
 ## Step 4: Matrix MCP-Verified (3 editions × N services)
 
+The matrix verification consults **three authoritative sources** in priority order. Each cell of the matrix `(service × edition)` is filled from the first source that returns a definitive answer:
+
+1. **`SAP/abap-atc-cr-cv-s4hc`** — the [ABAP API Release State repository](https://github.com/SAP/abap-atc-cr-cv-s4hc/blob/main/README.md). JSON files per object class; updated by SAP product teams. **Authoritative for**: whether an ABAP object (CDS view, BAPI, RFC FM, table) is released-for-cloud-development and at what Clean Core Level. Queried via `mcp-sap-docs:sap_get_object_details` which wraps the repo.
+2. **`api.sap.com`** — the [SAP API Hub](https://api.sap.com/). **Authoritative for**: OData service lifecycle (released / sandbox / deprecated), Communication Scenario membership, version history, deprecation timeline. Queried via `mcp-sap-docs:sap_search_objects` and `WebFetch` against the API Hub HTML pages, OR scraped offline via Apify Website Content Crawler into a refreshable cache.
+3. **Project's own compatibility catalog** (e.g. `srv/integration/s4CompatibilityPolicy.js`). **Authoritative only for**: the project's *declared* availability claim — which the audit verifies against sources 1 + 2.
+
 For each `(service, probe_object)` identified, issue **3 parallel MCP queries** — one per edition:
 
 ```
@@ -169,6 +175,8 @@ mcp-sap-docs:sap_get_object_details(
   target_clean_core_level="A"
 )
 ```
+
+Cross-check the abap-atc result against the API Hub for the matching Communication Scenario. When the two sources disagree, the API Hub wins for OData service questions; the abap-atc repo wins for raw ABAP object questions. Record the resolution rationale in the report.
 
 ### Per-cell evaluation
 
@@ -312,6 +320,62 @@ When user explicitly opts in:
 
 Re-run Steps 4-6 against the updated catalog to confirm zero drift remains.
 
+## Step 9: Enforcement mode (`--enforce` flag)
+
+The skill defaults to `report` mode. With `--enforce`, it acts as a **CI-blocking deployment gate**: it exits with a non-zero status code on any HIGH finding, and the calling workflow refuses to deploy.
+
+### Contract
+
+| Mode | Exit on HIGH | Exit on MEDIUM | Exit on LOW | Use case |
+|---|---|---|---|---|
+| `report` (default) | 0 | 0 | 0 | Audit run; review the markdown report |
+| `--apply` | 0 | 0 | 0 | Audit run + apply safe additive fixes |
+| `--enforce` | **1** | 0 (warning) | 0 (info) | CI gate — pre-deployment block |
+| `--enforce --strict` | **1** | **1** | 0 | Tightest gate — block on any finding above LOW |
+
+HIGH severity criteria (the gate-blocking class):
+- A consumed S/4 service is **NOT released** for the deployment target's edition (per source 1 + 2 of Step 4).
+- A consumed service is **deprecated** with a known sunset date inside the customer's release window.
+- The catalog declares availability that MCP-verification refutes (**OVER_DECLARED** drift).
+- Direct DB-table or RFC/BAPI consumption detected against a non-released artifact.
+
+### CI integration patterns
+
+Pair this skill with `sap-cap-ci-gates-pattern` Pattern 3 (API-availability drift) for the GitHub Actions / GitLab CI / Jenkins YAML wiring. The gate runs **per-PR** (fast feedback) AND **per-deploy** (final safety net before `cf deploy` / `kubectl apply`).
+
+GitHub Actions example:
+```yaml
+- name: Clean Core Level A enforcement
+  run: |
+    npx skills run sap-cap-clean-core-enforce -- \
+      --enforce \
+      --target ${{ inputs.deployment_target }} \
+      --abap-atc-source ./.cache/abap-atc-cr-cv-s4hc \
+      --report-path docs/audit/${{ github.run_id }}-clean-core.md
+  # CI fails here if any HIGH finding remains
+```
+
+### Sources refresh discipline
+
+The two upstream sources (`abap-atc-cr-cv-s4hc` repo + `api.sap.com`) are **mutable**. They evolve as SAP releases new objects, deprecates old ones, or revises Communication Scenarios.
+
+| Source | Refresh cadence | How |
+|---|---|---|
+| `abap-atc-cr-cv-s4hc` | weekly | Cron job: `git -C .cache/abap-atc-cr-cv-s4hc pull --ff-only` |
+| `api.sap.com` snapshots | weekly (or per-PR if cheap) | Apify Website Content Crawler against the API Hub package pages — store output as JSON cache. Re-run when "stale" (>7 days) |
+
+A weekly cron in CI surfaces drift caused by SAP-side changes, not by the project's own commits. File these as "upstream drift" findings with a 90-day window to remediate (per SAP's typical deprecation timeline).
+
+### Side-by-side extension fallback
+
+When `--enforce` blocks the build on a non-released service that the project genuinely needs:
+
+1. Surface the finding as a **side-by-side extension candidate** — the consumption should move out of the CAP service into a separate extension service on BTP (or out of ABAP into BTP entirely).
+2. Cross-link to the broader Clean Core return path documented in [`../sap-cap-fiori-battle-tested-patterns/SKILL.md#311--clean-core-level-a-as-deployment-gate-not-just-an-audit`](../sap-cap-fiori-battle-tested-patterns/SKILL.md).
+3. Optionally invoke a custom-code refactor skill (e.g. a future `sap-erp-clean-core-refactor`) to plan the migration.
+
+The gate is **not** about preventing all custom logic — it's about preventing **non-released custom logic from coupling to the deployment pipeline**. Custom logic that legitimately needs to live on BTP belongs in a side-by-side extension, not in the CAP service itself.
+
 ## BTP vs On-Premise Differences
 
 | Aspect | BTP target (Public Cloud) | Private Cloud / RISE | On-Premise |
@@ -379,8 +443,20 @@ Related skills:
 
 ## References
 
-- [SAP API Release State repository](https://github.com/SAP/abap-atc-cr-cv-s4hc) — authoritative source for object classifications
-- [Clean Core principles](https://help.sap.com/docs/btp/sap-business-technology-platform/clean-core)
-- [SAP API Business Hub](https://api.sap.com)
+**Primary authoritative sources** (Step 4 verification consults both):
+
+- [SAP API Release State repository (`SAP/abap-atc-cr-cv-s4hc`)](https://github.com/SAP/abap-atc-cr-cv-s4hc/blob/main/README.md) — JSON-encoded ABAP object classifications by edition; pin / submodule into the project and refresh weekly.
+- [SAP API Hub (`api.sap.com`)](https://api.sap.com/) — OData service lifecycle, Communication Scenario membership, deprecation timeline. Scrape via Apify Website Content Crawler or query via `mcp-sap-docs:sap_search_objects` for offline matrix construction.
+
+**Methodology references**:
+
+- [Clean Core principles (BTP docs)](https://help.sap.com/docs/btp/sap-business-technology-platform/clean-core)
 - [CAP `cds.connect.to` documentation](https://cap.cloud.sap/docs/node.js/cds-connect)
 - [SAP Communication Management (S/4HANA Cloud)](https://help.sap.com/docs/SAP_S4HANA_CLOUD/0f69f8fb28ac4bf48d2b57b9637e81fa/community-management.html)
+- [SAP Clean Core extensibility guide (developers.sap.com)](https://developers.sap.com/topics/clean-core.html)
+- [SAP Custom Code Migration Guide for S/4HANA](https://help.sap.com/docs/SAP_S4HANA_ON-PREMISE/c160bf4ba0fc415da4d34d29c1547d27/d4f8e6cb9c4d4fd99b6a96b3e64dd8e2.html)
+
+**Related skills (companion gates)**:
+
+- [`../sap-cap-ci-gates-pattern/SKILL.md`](../sap-cap-ci-gates-pattern/SKILL.md) Pattern 3 — wire the `--enforce` mode into a per-PR + per-deploy CI gate.
+- [`../sap-cap-fiori-battle-tested-patterns/SKILL.md#311--clean-core-level-a-as-deployment-gate-not-just-an-audit`](../sap-cap-fiori-battle-tested-patterns/SKILL.md) — broader context on Clean Core as a deployment gate.

--- a/skills/sap-cap-customizing-honor/SKILL.md
+++ b/skills/sap-cap-customizing-honor/SKILL.md
@@ -1,0 +1,494 @@
+---
+name: sap-cap-customizing-honor
+description: Bidirectional CSV ↔ code customizing audit for SAP CAP applications that use a SystemParameter / settings-table pattern. Detects forward orphans (CSV seeded but never consumed in code), inverse orphans (code reads parameter but no CSV seed), hardcoded business decisions that bypass the customizing mechanism (thresholds, timeouts, retry policies, severity mappings), and master-data foreign-key fields missing `@Common.ValueList` annotation. Use when asked to "audit customizing coverage", "verify SystemParameter consumption is 100%", "find hardcoded business decisions", "check that customizing is honored end-to-end", or "is admin config actually being read by the code?".
+---
+
+# SAP CAP Customizing Honor Audit
+
+Exhaustive audit that **enforces customizing is honored at 100%** in a SAP CAP application — both forward (every SystemParameter seed in CSV has a code consumer) and inverse (every `params.X` read in code has a CSV seed). Additionally, sweeps for **hardcoded business decisions** that bypass the customizing mechanism, and verifies that every **foreign-key field to master data** is bound to `@Common.ValueList` on filter bars and edit forms — no free-text where customizing exists.
+
+Read-only audit, idempotent, ~3 minute run, zero side-effects (unless `--apply` mode auto-fixes safe cases).
+
+## Smart Defaults (apply silently, do NOT ask)
+
+| Setting | Default | Rationale |
+|---|---|---|
+| Scope | `all` — entire `srv/` + `app/` codebase | Default to full sweep; user narrows if needed |
+| SystemParameter source | `db/data/*-SystemParameters.csv` (CAP convention) | CAP CSV seed pattern is conventional |
+| Code consumer pattern | `getSystemParamReader().get(...)` + `params.X` / `cfg.X` / `paramReader.X` | Common CAP customizing reader patterns |
+| Inverse orphan severity | ERROR (admin sees param in Setup UI but code ignores it) | Customer-facing problem |
+| Forward orphan severity | WARNING | Internal cleanliness, less urgent |
+| Hardcoded business decision severity | HIGH for thresholds in lifecycle handlers, MEDIUM otherwise | Production impact-aware |
+| Master-data unreferenced fields severity | P1 (filter bar) / P2 (edit form) / P3 (display only) | UX-first priority |
+| Report output | `docs/audit/<yyyy-mm-dd>-customizing-honor.md` | Committed for traceability |
+| Mode | `report` (read-only) | Safe by default |
+| Auto-fix scope | Add missing seed CSV rows for inverse orphans + add `@Common.ValueList` annotations for master-data filter bars | Reversible, contained |
+
+## Input
+
+Optional flags:
+
+- **scope** — `all` (default) | `<app-name>` (focus single Fiori app) | `srv-only` | `app-only` | `<subfolder>` (e.g., `srv/handlers`)
+- **mode** — `report` (default) | `fix` (auto-apply safe fixes on a dedicated branch)
+- **csv pattern** — override default `db/data/*-SystemParameters.csv` glob
+- **reader pattern** — override regex for code-side consumer detection
+- **skip checks** — comma list of check categories to skip (e.g., `--skip hardcoded,master-data`)
+
+## Step 1: Pre-flight + Project Detection
+
+### 1a. Verify project type
+
+```bash
+test -f package.json && grep -q '"@sap/cds"' package.json && test -d srv
+```
+
+If not a CAP project, stop and inform user this skill targets CAP apps.
+
+### 1b. Detect SystemParameter CSV files
+
+```bash
+find db/data -name "*-SystemParameter*.csv" -maxdepth 2 2>/dev/null
+```
+
+Expected pattern: `db/data/<namespace>-SystemParameters.csv` with columns `ParamKey,CompanyCode,ParamValue,Description,Category,IsSecret`.
+
+If multiple files found → process all; if none → warn user and proceed with inverse-orphan check only.
+
+### 1c. Detect code-side consumer pattern
+
+```bash
+grep -rohE "(getSystemParamReader|paramReader|params\.|cfg\.)[A-Z][A-Z0-9_]+\(" srv/ \
+  --include="*.ts" --include="*.js" 2>/dev/null | head -10
+```
+
+If matches are found, the reader pattern is confirmed. Otherwise the project may not use the customizing pattern at all; ask user to confirm.
+
+### 1d. Resolve scope
+
+| scope value | Folder paths to audit |
+|---|---|
+| `all` | `srv/` + `app/` |
+| `<app-name>` | `app/<app-name>/` only |
+| `srv-only` | `srv/` only |
+| `app-only` | `app/` only |
+| `<subfolder>` | exact path |
+
+### 1e. Branch creation (if mode=fix)
+
+```bash
+git checkout -b codex/customizing-honor-<scope>-$(date +%Y-%m-%d)
+```
+
+## Step 2: Bidirectional CSV ↔ Code Check (Forward + Inverse Orphans)
+
+### 2a. Extract CSV-seeded parameter keys
+
+```bash
+awk -F',' 'NR>1 {print $1}' db/data/*-SystemParameters.csv 2>/dev/null \
+  | sort -u > /tmp/csv-keys.txt
+```
+
+Result: deduplicated `ParamKey` list (header `ParamKey,...`).
+
+### 2b. Extract code-consumed parameter keys
+
+```bash
+grep -rohE "(p|params|cfg|wfParams|matchingParams|techParams|aiParams|monitoringParams|envCfg|dbCfg|slaParams|apprParams)(\?\.\|\[['\"]|\.)([A-Z][A-Z0-9_]+)" "$SCOPE" \
+  --include="*.ts" --include="*.js" 2>/dev/null \
+  | grep -oE "[A-Z][A-Z0-9_]+\b" \
+  | sort -u > /tmp/code-keys.txt
+```
+
+This greps common reader variable names (`params.X`, `cfg.X`, `wfParams.X`, etc.) and extracts the parameter key.
+
+### 2c. Compute orphans
+
+```bash
+# Inverse orphan: code reads but CSV doesn't seed
+comm -23 /tmp/code-keys.txt /tmp/csv-keys.txt > /tmp/inverse-orphans.txt
+
+# Forward orphan: CSV seeds but code never reads
+comm -13 /tmp/code-keys.txt /tmp/csv-keys.txt > /tmp/forward-orphans.txt
+```
+
+### 2d. Classify orphans
+
+For each inverse orphan, find the source file + line:
+
+```bash
+while IFS= read -r key; do
+  grep -rn "\.${key}\b\|\['${key}'\]\|\[\"${key}\"\]" srv/ app/ \
+    --include="*.ts" --include="*.js" 2>/dev/null | head -3
+done < /tmp/inverse-orphans.txt
+```
+
+For each forward orphan, find the CSV line:
+
+```bash
+while IFS= read -r key; do
+  grep -n "^${key}," db/data/*-SystemParameters.csv 2>/dev/null
+done < /tmp/forward-orphans.txt
+```
+
+### 2e. Compile per-category counts
+
+Group orphans by `Category` (from CSV column 5):
+
+```
+SystemParameter category    Forward    Inverse
+INTEGRATION                  3          7
+TECHNICAL                    1          12
+APPROVAL                     0          4
+...
+```
+
+## Step 3: Hardcoded Business Decisions Sweep
+
+For each file in scope (`*.ts`, `*.js`), search for patterns that represent **business decisions** but are NOT routed through `getSystemParamReader()`.
+
+### 3a. Numeric thresholds
+
+```bash
+grep -rnE ">=\s*[0-9]+|>\s*[0-9]+|<=\s*[0-9]+|<\s*[0-9]+|=\s*[0-9]{2,}\b" "$SCOPE" \
+  --include="*.ts" --include="*.js" 2>/dev/null \
+  | grep -vE "//|^.*\*|\.test\.|HTTP|status:|\.length|substring|setTimeout|process\.env|throw|>=\s*0\b|>\s*0\b|<=\s*100\b" \
+  | head -50
+```
+
+For each match, classify:
+
+- **TRUE positive (business threshold)** — e.g., `if (riskScore >= 80) markHighRisk()` — should be `params.HIGH_RISK_THRESHOLD`
+- **FALSE positive** — HTTP status codes (`200`, `400`, `500`), array index, `.length`, `setTimeout` ms — ignore
+
+### 3b. Hardcoded fragment XML thresholds (Fiori app)
+
+```bash
+grep -rnE ">=\s*[0-9]+|>\s*[0-9]+|<\s*[0-9]+" "$SCOPE" \
+  --include="*.xml" 2>/dev/null \
+  | grep -vE "//|^.*\*|ErrorCount|currentStep|>= ?\$\{|> ?\$\{|>= 0\b|> 0\b|>= 1\b" \
+  | head -30
+```
+
+### 3c. `cds.env` reads not dual-source
+
+```bash
+grep -rn "cds\.env\." "$SCOPE" --include="*.ts" 2>/dev/null \
+  | grep -vE "//|^.*\*|cds\.env\.(profile|profiles|requires|features|build|sql|hana|odata|telemetry|i18n|log|app|server|effective)" \
+  | grep -v "_resolveArchiverConfig\|fallback\|legacy" \
+  | head -20
+```
+
+The **dual-source pattern** is: SystemParameter first, fallback to `cds.env`, fallback to `process.env`, fallback to hardcoded. Direct `cds.env.X` reads without going through SystemParamReader are findings (admin can't override).
+
+### 3d. UX timing / delay hardcoded
+
+```bash
+grep -rnE "setTimeout.*[0-9]{3,}|DELAY|INTERVAL_MS|TTL\s*=\s*[0-9]" "$SCOPE" \
+  --include="*.ts" 2>/dev/null \
+  | grep -vE "//|^.*\*|\.test\." | head -10
+```
+
+### 3e. i18n hardcoded inline (user-facing strings)
+
+```bash
+grep -rnE "MessageBox\.|MessageToast\.show\(|req\.notify\(" "$SCOPE" \
+  --include="*.ts" 2>/dev/null \
+  | grep -vE "_t\(|i18n>|getText\(|bundle\.|//|^.*\*" \
+  | head -10
+```
+
+User-visible text should be i18n keys, not inline strings. Hardcoded inline strings are findings (no localization).
+
+### 3f. Per-finding triage
+
+For each match, decide:
+
+- **TRUE positive** → business decision tunable → add to findings list with file:line + suggested fix
+- **FALSE positive** → security boundary / HTTP code / internal cache TTL / `.length` → ignore
+
+## Step 4: Catalog Raise Coverage (if applicable)
+
+For CAP apps with a `ProcessStepCheck` catalog (a common pattern for workflow-driven apps):
+
+```bash
+test -f db/data/*-ProcessStepCheck.csv && \
+  bash scripts/ci/check-catalog-raise-coverage.sh 2>/dev/null
+```
+
+This verifies every CSV-seeded check code has a runtime `raiseCatalogException(...)` call in the codebase.
+
+If the CI script is not present, run an equivalent check inline:
+
+```bash
+# Extract active check codes
+awk -F',' 'NR>1 && $X=="true" {print $Y}' db/data/*-ProcessStepCheck.csv | sort -u
+
+# Find raise sites
+grep -rhE "raiseCatalogException\(.*['\"]([A-Z][A-Z0-9_]+)['\"]" srv/ \
+  --include="*.ts" | grep -oE "['\"][A-Z][A-Z0-9_]+['\"]" | tr -d "'\"" | sort -u
+
+# Diff
+comm -23 <(active_codes) <(raise_sites)
+```
+
+Active checks without a raise site = code-coverage gap.
+
+## Step 5: Adapter Factory Dual-Source Verification
+
+For CAP apps using adapter factory patterns (`srv/{notifications,messaging,monitoring,...}/`):
+
+```bash
+find srv -path "*/Factory*.ts" -o -name "*AdapterFactory*.ts" 2>/dev/null
+```
+
+For each factory, verify the canonical pattern:
+
+```typescript
+// Expected pattern (4-layer fallback):
+const adapterName =
+  params['<KEY>_ADAPTER'] ||     // 1. SystemParameter (admin-configurable)
+  env.adapter ||                  // 2. cds.env fallback
+  process.env.ADAPTER_OVERRIDE || // 3. env var fallback
+  'default-adapter';              // 4. hardcoded last resort
+```
+
+If a factory reads only from `cds.env` or `process.env` without going through SystemParameter, that's a finding — "adapter not customizing-driven".
+
+## Step 6: Master-Data Reference Audit (Filter + Edit Form)
+
+For CAP+Fiori projects, verify that every field referencing master data has `@Common.ValueList` annotation.
+
+### 6a. Master data catalog (target entities)
+
+Common SAP master-data CodeList patterns in CAP:
+
+| Pattern | Master data target |
+|---|---|
+| `*CompanyCode*` | `CompanyCodeMappings` |
+| `*BusinessPartner*` | `BusinessPartner` / `Suppliers` |
+| `*Currency*` | `Currencies` (CodeList) |
+| `*PaymentMethod*`, `*PaymentBlock*` | `PaymentMethods` / `PaymentBlockCodes` |
+| `*Status*` | Status CodeList (domain-specific) |
+| `step_ID`, `check_ID` (process workflow) | `ProcessSteps` / `ProcessStepChecks` |
+| `*Severity*` | `Severities` CodeList |
+| `*GLAccount*`, `*CostCenter*`, `*WBSElement*` | cost-object master data |
+
+### 6b. Filter bar (SelectionFields) check
+
+For each `UI.SelectionFields: [...]` in `app/annotations/*.cds`:
+
+```bash
+grep -rnE "UI\.SelectionFields:\s*\[" app/annotations/ app/*.cds 2>/dev/null
+```
+
+For each field listed, verify a `@Common.ValueList` annotation exists, either:
+
+1. **Direct annotation** on the field
+2. **Indirect via Association** — e.g., `step` (Association) has the ValueList, and `step_ID` (foreign-key column) is the actual SelectionField
+
+Pattern verification:
+
+```bash
+for FIELD in CompanyCode SupplierBP Currency PaymentMethod ...; do
+  # Pattern 1: direct annotation on field
+  DIRECT=$(grep -rnE "$FIELD\s*@Common\.ValueList" app/annotations/ srv/ 2>/dev/null | wc -l)
+  # Pattern 2: annotation on Association (FK column ends with _ID)
+  ASSOC=$(echo "$FIELD" | sed 's/_ID$//')
+  if [ "$ASSOC" != "$FIELD" ]; then
+    INDIRECT=$(grep -rnE "$ASSOC\s+@Common\.ValueList" app/annotations/ srv/ 2>/dev/null \
+               | grep -E "LocalDataProperty:\s*$FIELD\b" | wc -l)
+  else
+    INDIRECT=0
+  fi
+  TOTAL=$((DIRECT + INDIRECT))
+  if [ $TOTAL -eq 0 ]; then
+    echo "❌ $FIELD: missing ValueList in filter bar"
+  fi
+done
+```
+
+### 6c. Edit form (FieldGroup / LineItem) check
+
+For each `@odata.draft.enabled` entity, check editable fields against master-data patterns. Edit-form ValueList is **strongly recommended** but can require context-dependent filtering (e.g., `step` filter on active template) — flag for manual review when filter cardinality is non-trivial.
+
+### 6d. TextArrangement check
+
+For each FK field with `ValueList`, verify the display-name cascade is configured:
+
+```cds
+@Common.Text: <X>.Name
+@Common.TextArrangement: #TextOnly
+```
+
+Without TextArrangement, the UI displays the raw ID — bad UX.
+
+### 6e. False-positive whitelist
+
+These fields are legitimately free-text (NOT findings):
+
+- Descriptive: `Description`, `Name`, `Notes`, `Comment`, `Justification`, `RejectReason`
+- Natural external identifiers: `eDocumentGuid`, `InvoiceNumber`, `IBAN`, `TaxCode`, `VATIdNumber` (input via parsing, not catalog-pick)
+- Amounts / quantities: `Amount`, `Percentage`, `Quantity`, `Price`, `Score`, `Confidence`
+- Timestamps: `*At`, `*Date`, `*Timestamp`
+- Technical: `ID`, `UUID`, `*_ID` (internal keys handled by framework)
+- File-system: `FileName`, `FilePath`, `Url`
+
+## Step 7: Output Report
+
+Save markdown to `docs/audit/<yyyy-mm-dd>-customizing-honor.md`:
+
+```markdown
+# Customizing Honor Audit — <scope> — <yyyy-mm-dd>
+
+## Summary
+- Forward orphans: N (CSV seeded, code doesn't read)
+- Inverse orphans: N (code reads, CSV doesn't seed)
+- Hardcoded business decisions: N
+- Master-data unreferenced fields: filter=N1, edit=N2, missing TextArrangement=N3
+- Catalog coverage: ✅ PASS / ❌ N CheckCode without raise site
+- Adapter dual-source: ✅ M/N OK / ❌ N missing
+
+## Inverse Orphans
+| ParamKey | File:line | Default used | Suggested category |
+
+## Forward Orphans
+| ParamKey | CSV line | Verification grep | Action (remove seed or wire consumer) |
+
+## Hardcoded Business Decisions
+| File:line | Pattern | Type | Severity | Suggested fix |
+
+## Master Data Unreferenced
+| Entity.Field | Position (filter/edit/header) | File:line | Master data target | Severity | Suggested fix |
+
+## Fix Plan
+1. [P1] hardcoded threshold — suggested diff:
+```diff
+- const HIGH_RISK_THRESHOLD = 80;
++ async function _resolveHighRiskThreshold(cc) {
++   const params = await getSystemParamReader().get('RISK', cc);
++   const n = parseInt(params.HIGH_RISK_THRESHOLD, 10);
++   return Number.isFinite(n) && n > 0 ? n : 80;
++ }
+```
+
+2. [P1] master-data unreferenced (filter bar) — suggested diff:
+```diff
++ annotate service.MyEntity with {
++   companyCode @Common.ValueListWithFixedValues: true
++               @Common.ValueList: { ... };
++   companyCode @Common.Text: companyCode.CompanyName @Common.TextArrangement: #TextOnly;
++ };
+```
+
+## Verifications
+- bash scripts/ci/check-systemparams-bidirectional.sh: PASS / FAIL
+- bash scripts/ci/check-catalog-raise-coverage.sh: PASS / FAIL
+- npm run lint:csv: PASS / FAIL
+- npx cds compile srv app: PASS / FAIL
+
+## Residual Risk
+- <list of items requiring manual review>
+```
+
+## Step 8: Apply Fixes (only when `--apply` / `mode=fix`)
+
+### Safe auto-applicable fixes
+
+1. **Add missing CSV seed rows** for inverse orphans:
+   ```csv
+   <PARAM_KEY>,,<detected_default>,<placeholder description>,<inferred category>,false
+   ```
+   One commit per seed: `chore(seed): add <PARAM_KEY> for inverse-orphan fix`.
+
+2. **Add `@Common.ValueList` annotation** on filter bar fields for master-data references (SAFE — non-breaking, additive):
+   ```cds
+   annotate service.<Entity> with {
+     <field> @Common.ValueListWithFixedValues: true
+             @Common.ValueList: {
+               CollectionPath: '<TargetEntity>',
+               Parameters: [
+                 { $Type: 'Common.ValueListParameterInOut', LocalDataProperty: <field>, ValueListProperty: '<key>' },
+                 { $Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: '<displayName>' }
+               ]
+             };
+     <field> @Common.Text: <field>.<displayName> @Common.TextArrangement: #TextOnly;
+   };
+   ```
+   One commit per annotation: `feat(masterdata): add ValueList on <Entity>.<field>`.
+
+### NOT auto-applied (manual decision required)
+
+- **Removing forward-orphan CSV seeds** — could break customer environments that currently rely on the param (even if unused in code), and a future PR may add a consumer. Surface as finding only.
+- **Refactoring hardcoded business decisions** — code refactor involves logic changes; risk too high for auto-apply. Surface as finding with suggested diff.
+- **Adding ValueList on edit-form fields** — can require filter context (cascading dropdowns); test manually before applying.
+
+### Post-fix verification
+
+Re-run Step 2 + Step 6 and confirm orphan/unreferenced counts decrease as expected.
+
+## BTP vs On-Premise Differences
+
+This skill is target-edition-neutral — the same audit applies for CAP apps deployed to BTP Cloud Foundry, Kyma, or on-premise. The only consideration:
+
+| Aspect | BTP | On-Premise |
+|---|---|---|
+| SystemParameter storage | HANA Cloud / HDI | HANA or PostgreSQL |
+| CSV seed loading | `cds deploy` at boot | Same |
+| Per-tenant customizing | Single-tenant per service (multi-customer = multi-deployment) | Same |
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| No `db/data/*-SystemParameters.csv` found | Project doesn't use the SystemParameter pattern | Skip Steps 2 and 5; run hardcoded sweep + master-data check only |
+| `getSystemParamReader` not found in codebase | Project uses different reader pattern | Ask user for the reader function name + adjust grep pattern |
+| Grep returns thousands of "matches" in hardcoded check | Permissive regex catches FP | Tighten patterns in Step 3a/3b; user can override with `--strict-thresholds` flag |
+| Annotations folder doesn't exist | Project uses inline annotations or non-standard structure | Skip Step 6 or ask user to point to annotation locations |
+| Multiple SystemParameter CSV files | Multi-namespace project | Audit all CSVs in scope; deduplicate keys |
+| `forward orphan` is in user-known allowlist (e.g., NATS_URL only used in NATS adapter) | False positive | User can extend `FORWARD_ALLOWLIST` in the CSV's frontmatter comment or `--allowlist` flag |
+
+## What This Skill Does NOT Do
+
+- **No refactoring** — hardcoded business decisions are flagged with suggested fix, not auto-refactored
+- **No CSV seed removal** — never deletes seeded parameters (breaking risk for customer envs)
+- **No CDS schema validation** — assumes the schema compiles; audits the customizing coverage, not entity structure
+- **No semantic verification** — doesn't check if the param value chosen by admin is a sensible default
+- **No fallback chain testing** — verifies dual-source pattern is present, doesn't test runtime fallback behavior
+- **No i18n translation generation** — flags hardcoded user-facing strings; user translates manually
+- **No master-data CodeList generation** — references existing master data; doesn't create new CodeList entities
+
+## When to Use This Skill
+
+- **Pre-release audit** — verify admin Setup UI parameters are all wired to code consumers
+- **Quarterly compliance check** — customizing drift over time (params added/removed)
+- **Onboarding new developer** — understand which parameters drive runtime behavior
+- **Customer escalation** — "admin changed param X but nothing happened" → run this skill to verify code reads it
+- **Pre-acquisition audit** — when assessing a 3rd-party CAP app, verify customizing surface area is honest
+- **Before refactor / cleanup** — identify which "dead" parameters can safely be removed (forward orphans)
+
+## When NOT to Use This Skill
+
+- **Project doesn't use SystemParameter pattern** — skill loses its core value; only hardcoded sweep applies
+- **Pure greenfield project** — too early; come back after first iteration when params accumulate
+- **Single-tenant fixed-config deployment** — customizing is less relevant; UX-level master-data check is still useful
+
+## Follow-up
+
+After this skill produces the audit report:
+
+- **Inverse orphans**: with `--apply` mode, the skill auto-adds CSV rows. Manually verify the inferred default + category, then commit.
+- **Forward orphans**: manually decide for each: (a) remove from CSV (truly unused) or (b) wire consumer (currently TODO).
+- **Hardcoded business decisions**: refactor each to `getSystemParamReader()` pattern, one parameter per commit, tested individually.
+- **Master-data unreferenced fields**: with `--apply` mode, the skill auto-adds filter-bar ValueList. Manually verify edit-form bindings (context-dependent filters).
+
+Related skills:
+
+- [sap-cap-clean-core-enforce](../sap-cap-clean-core-enforce/SKILL.md) — verifies the S/4 API destinations consumed are Clean Core L-A (complementary audit)
+- [sap-clean-core-atc](../sap-clean-core-atc/SKILL.md) — ABAP-side compliance (companion, source-side)
+
+## References
+
+- [CAP `cds.env` profile-aware configuration](https://cap.cloud.sap/docs/node.js/cds-env)
+- [CAP CSV seed pattern](https://cap.cloud.sap/docs/guides/databases#providing-initial-data)
+- [CAP `@Common.ValueList` annotation](https://cap.cloud.sap/docs/advanced/odata#valuehelp-annotations)
+- [Fiori Elements V4 value-help integration](https://experience.sap.com/fiori-design-web/value-helper/)


### PR DESCRIPTION
## Summary

Adds **Wave 1 of the SAP CAP Enterprise Audit skill chain**: 2 read-only audit skills (clean-core enforcement + customizing honor) for SAP CAP applications deployed on BTP consuming S/4HANA Tier-2 services.

This is a **separate PR from #278** (modernization skill chain) — they complement each other:
- **#278** generates a CAP scaffold from ABAP source (greenfield migration)
- **This PR** audits an existing CAP scaffold for Clean Core compliance + customizing coverage

Both are skill-first contributions, zero core code change, zero new MCP tools, zero new ACTION_POLICY entries.

## Skills

| Skill | Lines | What it does |
|---|---|---|
| [sap-cap-clean-core-enforce](https://github.com/Raistlin82/arc-1-fork/blob/feat/skills-sap-cap-audit-wave1/skills/sap-cap-clean-core-enforce/SKILL.md) | 386 | Discovery-driven Clean Core L-A audit. 4-source dynamic discovery (cds.connect.to + @cds.external + catalog + CSV) → probe identification (catalog → naming heuristic → MCP search) → 3-edition matrix MCP verification → drift detection → compliance rollup |
| [sap-cap-customizing-honor](https://github.com/Raistlin82/arc-1-fork/blob/feat/skills-sap-cap-audit-wave1/skills/sap-cap-customizing-honor/SKILL.md) | 494 | Bidirectional CSV↔code audit. Forward orphans + inverse orphans + hardcoded business-decision sweep + adapter factory dual-source verification + master-data FK ValueList enforcement + catalog raise-site coverage |

### README update

New \"SAP CAP Enterprise Audit (Preview)\" section in \`skills/README.md\` with discovery descriptions for both skills and a follow-up tracker for the planned 6 additional skills.

## Why this PR

The proposed skill cluster (commented on PR #278: https://github.com/marianfoo/arc-1/pull/278#issuecomment-4439475977) starts here with the 2 most universally applicable skills:

1. **Clean Core enforcement** is the natural inverse of [sap-clean-core-atc](https://github.com/marianfoo/arc-1/blob/main/skills/sap-clean-core-atc/SKILL.md): that skill classifies **ABAP custom code on the SAP side**; this one classifies **the BTP CAP application's outbound S/4 API consumption**. Same compliance goal (Level A), different observation point.

2. **Customizing honor** is a pattern audit for the CAP \`SystemParameter\` / settings-table pattern — universally applicable to any CAP app that exposes admin-configurable runtime parameters.

Together they answer the two most common audit questions for production CAP apps:
- *"Are we Clean Core L-A compliant per edition?"*
- *"Are admin Setup UI parameters actually being read by code?"*

## Maintainer-friendly properties

- ✅ **Zero core code change** (skills are markdown only)
- ✅ **No new MCP tools** (honors 12-tool token-efficient principle from CLAUDE.md §Design Principles)
- ✅ **No new ACTION_POLICY entries** (read-only ARC-1 surface: SAPRead, SAPSearch, SAPContext)
- ✅ **No new dependencies** in package.json
- ✅ **Skill-first pattern** consistent with sap-clean-core-atc + migrate-custom-code community pattern
- ✅ **New skill format compliant** (directory + SKILL.md + YAML frontmatter — same as upstream main)
- ✅ **Cross-link convention** \`../<name>/SKILL.md\` matching new format
- ✅ **Tone consistent** with existing arc-1 skills (Smart Defaults table, Input, numbered Steps, Error Handling table, What this skill does NOT do, When to use / When NOT to use, Follow-up, References)

## Follow-up (separate PRs planned)

- [ ] \`sap-cap-security-rbac-matrix\` — Multi-area parallel security audit + RBAC coherence + OWASP/ASVS mapping (~600 lines)
- [ ] \`sap-cap-lifecycle-matrix-audit\` — Workflow phase × step × check × state × role × policy matrix audit (~500 lines)
- [ ] \`sap-fiori-app-audit\` — End-to-end Fiori Elements V4 app audit (~450 lines)
- [ ] \`sap-cap-text-polish\` — User-visible text polish (~400 lines)
- [ ] \`sap-cap-stack-audit-full\` — Multi-tool SAP stack audit orchestrator (~400 lines)
- [ ] \`sap-cap-ci-gates-pattern\` — Library of 5 CI gate patterns for CAP (~400 lines)

Each will be a separate draft PR for digestible review.

## Testing

Per arc-1 convention, skills are markdown — no automated tests apply.

Smoke-testable manually by:
1. Connecting ARC-1 to a SAP system (read-only access sufficient)
2. Connecting \`mcp-sap-docs\` MCP server (recommended for sap-cap-clean-core-enforce)
3. Running against a CAP project with \`db/data/*-SystemParameters.csv\` + \`cds.connect.to\` calls
4. Verifying the produced \`docs/audit/<date>-*.md\` reports match expectations

## Stats

- Files changed: 3 (2 new + 1 modified)
- Lines added: 891
- Lines removed: 0
- Code dependencies added: 0
- New MCP tools: 0
- New ACTION_POLICY entries: 0

---

Marked as **Draft** to invite review. Open to maintainer feedback on:

1. **Cluster section name**: \"SAP CAP Enterprise Audit\" feels right but open to alternatives
2. **Naming convention**: \`sap-cap-*\` prefix for CAP-explicit; would you prefer \`cap-audit-*\` or \`sap-cap-audit-*\`?
3. **Wave sequencing**: 6 additional skills planned; happy to bundle differently if a different cadence works better
4. **Scope alignment**: confident these stay within arc-1's mission (\"AI-assisted SAP development with guardrails\")? Or do they push into companion-repo territory?

🤖 Generated with [Claude Code](https://claude.com/claude-code)