### PR TITLE
fix(features): fall back to syntax-configurations endpoint for abapRelease

### DIFF
--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -23,7 +23,7 @@ import { fetchDiscoveryDocument } from './discovery.js';
 import { AdtApiError } from './errors.js';
 import type { AdtHttpClient } from './http.js';
 import type { AuthProbeResult, FeatureStatus, ResolvedFeatures, SystemType } from './types.js';
-import { parseInstalledComponents } from './xml-parser.js';
+import { parseInstalledComponents, parseSyntaxConfigurations } from './xml-parser.js';
 
 /** Probe definition: which URL to check for each feature */
 interface FeatureProbe {
@@ -160,8 +160,14 @@ export async function probeFeatures(
   }
 
   const resolved = result as unknown as ResolvedFeatures;
-  if (systemDetection.abapRelease) {
-    resolved.abapRelease = systemDetection.abapRelease;
+  // Primary: SAP_BASIS release from the installed components feed.
+  // Fallback: when that feed is empty (no SAP_BASIS entry — observed on systems
+  // whose technical user lacks visibility into installed components), read the
+  // release from the ADT syntax-configurations endpoint instead. See
+  // detectReleaseFromSyntaxConfigurations for details.
+  const abapRelease = systemDetection.abapRelease ?? (await detectReleaseFromSyntaxConfigurations(client));
+  if (abapRelease) {
+    resolved.abapRelease = abapRelease;
   }
   // Apply system type: manual override takes precedence over auto-detection
   if (systemTypeOverride && systemTypeOverride !== 'auto') {
@@ -239,6 +245,33 @@ async function detectSystemFromComponents(client: AdtHttpClient): Promise<System
     };
   } catch {
     return {};
+  }
+}
+
+/**
+ * Fallback release detection via the ADT syntax-configurations endpoint.
+ *
+ * Used only when `/sap/bc/adt/system/components` yields no SAP_BASIS entry —
+ * observed on systems where that feed returns parseable-but-empty XML (a thin
+ * or restricted technical-user view of installed components). Without this
+ * fallback, `abapRelease` stays undefined and the lint config silently
+ * defaults to v702, flagging every modern construct as parser_error/downport.
+ *
+ * The Standard ABAP entry (`version="X"`) of `/sap/bc/adt/abapsource/syntax/
+ * configurations` carries the SAP_BASIS release verbatim in its `etag`
+ * attribute (e.g. `etag="757"` on ABAP 7.57). The endpoint is advertised by
+ * ADT discovery and needs no auth beyond basic ADT read access.
+ */
+async function detectReleaseFromSyntaxConfigurations(client: AdtHttpClient): Promise<string | undefined> {
+  try {
+    const resp = await client.get('/sap/bc/adt/abapsource/syntax/configurations', {
+      Accept: 'application/vnd.sap.adt.syntaxconfigurations+xml',
+    });
+    if (resp.statusCode >= 400) return undefined;
+    const configs = parseSyntaxConfigurations(resp.body);
+    return configs.find((c) => c.version === 'X')?.etag || undefined;
+  } catch {
+    return undefined;
   }
 }
 

--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -160,11 +160,8 @@ export async function probeFeatures(
   }
 
   const resolved = result as unknown as ResolvedFeatures;
-  // Primary: SAP_BASIS release from the installed components feed.
-  // Fallback: when that feed is empty (no SAP_BASIS entry — observed on systems
-  // whose technical user lacks visibility into installed components), read the
-  // release from the ADT syntax-configurations endpoint instead. See
-  // detectReleaseFromSyntaxConfigurations for details.
+  // Prefer SAP_BASIS from installed components. If that feed does not expose a
+  // release, fall back to the ADT syntax configuration metadata.
   const abapRelease = systemDetection.abapRelease ?? (await detectReleaseFromSyntaxConfigurations(client));
   if (abapRelease) {
     resolved.abapRelease = abapRelease;
@@ -249,18 +246,11 @@ async function detectSystemFromComponents(client: AdtHttpClient): Promise<System
 }
 
 /**
- * Fallback release detection via the ADT syntax-configurations endpoint.
+ * Fallback release detection via ADT syntax configurations.
  *
- * Used only when `/sap/bc/adt/system/components` yields no SAP_BASIS entry —
- * observed on systems where that feed returns parseable-but-empty XML (a thin
- * or restricted technical-user view of installed components). Without this
- * fallback, `abapRelease` stays undefined and the lint config silently
- * defaults to v702, flagging every modern construct as parser_error/downport.
- *
- * The Standard ABAP entry (`version="X"`) of `/sap/bc/adt/abapsource/syntax/
- * configurations` carries the SAP_BASIS release verbatim in its `etag`
- * attribute (e.g. `etag="757"` on ABAP 7.57). The endpoint is advertised by
- * ADT discovery and needs no auth beyond basic ADT read access.
+ * Used when `/sap/bc/adt/system/components` does not expose a SAP_BASIS
+ * release. The Standard ABAP language entry (`version="X"`) carries the parser
+ * release in its link `etag` attribute, e.g. `etag="757"`.
  */
 async function detectReleaseFromSyntaxConfigurations(client: AdtHttpClient): Promise<string | undefined> {
   try {

--- a/src/adt/xml-parser.ts
+++ b/src/adt/xml-parser.ts
@@ -259,6 +259,41 @@ export function parseInstalledComponents(
 }
 
 /**
+ * Parse ABAP syntax-configurations response (/sap/bc/adt/abapsource/syntax/configurations).
+ *
+ *   <abapsource:syntaxConfigurations>
+ *     <abapsource:syntaxConfiguration>
+ *       <abapsource:language>
+ *         <abapsource:version>X</abapsource:version>
+ *         <abapsource:description>Standard ABAP</abapsource:description>
+ *         <atom:link etag="757" .../>
+ *       </abapsource:language>
+ *     </abapsource:syntaxConfiguration>
+ *     ...
+ *   </abapsource:syntaxConfigurations>
+ *
+ * The Standard ABAP entry (version="X") carries the SAP_BASIS release verbatim
+ * in its link `etag` attribute (e.g. "757" on ABAP 7.57). Used by feature
+ * detection as a fallback when /sap/bc/adt/system/components returns an empty
+ * feed.
+ */
+export function parseSyntaxConfigurations(xml: string): Array<{ version: string; description: string; etag: string }> {
+  const parsed = parseXml(xml);
+  const configs = getNestedArray(parsed, 'syntaxConfigurations', 'syntaxConfiguration');
+  return configs.map((cfg: Record<string, unknown>) => {
+    const language = (cfg.language ?? {}) as Record<string, unknown>;
+    const linkRaw = language.link;
+    // `link` is forced to array by the parser config; take the first element.
+    const link = (Array.isArray(linkRaw) ? linkRaw[0] : (linkRaw ?? {})) as Record<string, unknown>;
+    return {
+      version: String(language.version ?? ''),
+      description: String(language.description ?? ''),
+      etag: String(link['@_etag'] ?? ''),
+    };
+  });
+}
+
+/**
  * Parse function group structure.
  *
  * <group name="ZGROUP" type="FUGR/F">

--- a/src/adt/xml-parser.ts
+++ b/src/adt/xml-parser.ts
@@ -272,10 +272,8 @@ export function parseInstalledComponents(
  *     ...
  *   </abapsource:syntaxConfigurations>
  *
- * The Standard ABAP entry (version="X") carries the SAP_BASIS release verbatim
- * in its link `etag` attribute (e.g. "757" on ABAP 7.57). Used by feature
- * detection as a fallback when /sap/bc/adt/system/components returns an empty
- * feed.
+ * Feature detection uses the Standard ABAP entry (version="X") as a fallback
+ * release signal when installed components do not expose SAP_BASIS.
  */
 export function parseSyntaxConfigurations(xml: string): Array<{ version: string; description: string; etag: string }> {
   const parsed = parseXml(xml);

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -461,6 +461,78 @@ describe('Feature Detection', () => {
       expect(result.discoveryMap?.size).toBe(0);
     });
 
+    // ─── abapRelease fallback via /sap/bc/adt/abapsource/syntax/configurations ──
+
+    const syntaxConfigurationsXml = `<?xml version="1.0" encoding="utf-8"?>
+<abapsource:syntaxConfigurations xmlns:abapsource="http://www.sap.com/adt/abapsource">
+  <abapsource:syntaxConfiguration>
+    <abapsource:language>
+      <abapsource:version>X</abapsource:version>
+      <abapsource:description>Standard ABAP</abapsource:description>
+      <atom:link href="/sap/bc/adt/abapsource/parsers/rnd/grammar" rel="http://www.sap.com/adt/relations/abapsource/parser" type="text/plain" title="Standard ABAP" etag="757" xmlns:atom="http://www.w3.org/2005/Atom"/>
+    </abapsource:language>
+  </abapsource:syntaxConfiguration>
+</abapsource:syntaxConfigurations>`;
+
+    const emptyComponentsFeed = `<?xml version="1.0" encoding="utf-8"?>
+<atom:feed xmlns:atom="http://www.w3.org/2005/Atom">
+  <atom:title>Installed Components</atom:title>
+</atom:feed>`;
+
+    function mockProbeClientWithSyntaxConfigs(options: {
+      componentsBody: string;
+      syntaxConfigsBody?: string;
+    }): AdtHttpClient {
+      return {
+        get: vi.fn().mockImplementation((url: string) => {
+          if (url === '/sap/bc/adt/discovery') {
+            return Promise.resolve({ statusCode: 200, body: discoveryXml });
+          }
+          if (url === '/sap/bc/adt/system/components') {
+            return Promise.resolve({ statusCode: 200, body: options.componentsBody });
+          }
+          if (url === '/sap/bc/adt/abapsource/syntax/configurations') {
+            return Promise.resolve({
+              statusCode: 200,
+              body: options.syntaxConfigsBody ?? syntaxConfigurationsXml,
+            });
+          }
+          return Promise.resolve({ statusCode: 200, body: '' });
+        }),
+      } as unknown as AdtHttpClient;
+    }
+
+    it('falls back to syntax-configurations endpoint when components feed has no SAP_BASIS', async () => {
+      const client = mockProbeClientWithSyntaxConfigs({ componentsBody: emptyComponentsFeed });
+      const result = await probeFeatures(client, defaultConfig);
+
+      expect(result.abapRelease).toBe('757');
+      expect((client as any).get).toHaveBeenCalledWith('/sap/bc/adt/abapsource/syntax/configurations', {
+        Accept: 'application/vnd.sap.adt.syntaxconfigurations+xml',
+      });
+    });
+
+    it('skips syntax-configurations probe when components feed already yields a release', async () => {
+      const client = mockProbeClientWithSyntaxConfigs({ componentsBody: componentsXml });
+      const result = await probeFeatures(client, defaultConfig);
+
+      expect(result.abapRelease).toBe('758'); // From componentsXml (SAP_BASIS 758)
+      const calls = (client as any).get.mock.calls.map((args: unknown[]) => args[0]);
+      expect(calls).not.toContain('/sap/bc/adt/abapsource/syntax/configurations');
+    });
+
+    it('leaves abapRelease undefined when both components and syntax-configurations are empty', async () => {
+      const emptySyntaxConfigs = `<?xml version="1.0" encoding="utf-8"?>
+<abapsource:syntaxConfigurations xmlns:abapsource="http://www.sap.com/adt/abapsource"/>`;
+      const client = mockProbeClientWithSyntaxConfigs({
+        componentsBody: emptyComponentsFeed,
+        syntaxConfigsBody: emptySyntaxConfigs,
+      });
+      const result = await probeFeatures(client, defaultConfig);
+
+      expect(result.abapRelease).toBeUndefined();
+    });
+
     function makeComponentsXml(entries: Array<{ id: string; title: string }>): string {
       const items = entries
         .map(

--- a/tests/unit/adt/xml-parser.test.ts
+++ b/tests/unit/adt/xml-parser.test.ts
@@ -332,7 +332,7 @@ describe('XML Parser', () => {
   // ─── parseSyntaxConfigurations ─────────────────────────────────────
 
   describe('parseSyntaxConfigurations', () => {
-    // Verbatim response captured live from a 7.57 system (see PR description).
+    // Mirrors a live 7.57 syntax-configurations response.
     const liveResponse = `<?xml version="1.0" encoding="utf-8"?>
 <abapsource:syntaxConfigurations xmlns:abapsource="http://www.sap.com/adt/abapsource">
   <abapsource:syntaxConfiguration>

--- a/tests/unit/adt/xml-parser.test.ts
+++ b/tests/unit/adt/xml-parser.test.ts
@@ -23,6 +23,7 @@ import {
   parseSearchResults,
   parseServiceBinding,
   parseSourceSearchResults,
+  parseSyntaxConfigurations,
   parseSystemInfo,
   parseTableContents,
   parseTransactionMetadata,
@@ -325,6 +326,77 @@ describe('XML Parser', () => {
       const components = parseInstalledComponents(xml);
       expect(components[0]?.name).toBe('CUSTOM');
       expect(components[0]?.release).toBe('100');
+    });
+  });
+
+  // ─── parseSyntaxConfigurations ─────────────────────────────────────
+
+  describe('parseSyntaxConfigurations', () => {
+    // Verbatim response captured live from a 7.57 system (see PR description).
+    const liveResponse = `<?xml version="1.0" encoding="utf-8"?>
+<abapsource:syntaxConfigurations xmlns:abapsource="http://www.sap.com/adt/abapsource">
+  <abapsource:syntaxConfiguration>
+    <abapsource:language>
+      <abapsource:version>2</abapsource:version>
+      <abapsource:description>ABAP for Key Users</abapsource:description>
+      <atom:link href="/sap/bc/adt/abapsource/parsers/rnd/grammar/2" rel="http://www.sap.com/adt/relations/abapsource/parser" type="text/plain" title="ABAP for Key Users" etag="7572" xmlns:atom="http://www.w3.org/2005/Atom"/>
+    </abapsource:language>
+    <abapsource:objectUsage abapsource:restricted="true"/>
+  </abapsource:syntaxConfiguration>
+  <abapsource:syntaxConfiguration>
+    <abapsource:language>
+      <abapsource:version>5</abapsource:version>
+      <abapsource:description>ABAP for Cloud Development</abapsource:description>
+      <atom:link href="/sap/bc/adt/abapsource/parsers/rnd/grammar/5" rel="http://www.sap.com/adt/relations/abapsource/parser" type="text/plain" title="ABAP for Cloud Development" etag="7575" xmlns:atom="http://www.w3.org/2005/Atom"/>
+    </abapsource:language>
+  </abapsource:syntaxConfiguration>
+  <abapsource:syntaxConfiguration>
+    <abapsource:language>
+      <abapsource:version>X</abapsource:version>
+      <abapsource:description>Standard ABAP</abapsource:description>
+      <atom:link href="/sap/bc/adt/abapsource/parsers/rnd/grammar" rel="http://www.sap.com/adt/relations/abapsource/parser" type="text/plain" title="Standard ABAP" etag="757" xmlns:atom="http://www.w3.org/2005/Atom"/>
+    </abapsource:language>
+  </abapsource:syntaxConfiguration>
+</abapsource:syntaxConfigurations>`;
+
+    it('parses each syntax configuration entry with version, description, etag', () => {
+      const configs = parseSyntaxConfigurations(liveResponse);
+      expect(configs).toHaveLength(3);
+
+      const standard = configs.find((c) => c.version === 'X');
+      expect(standard).toEqual({
+        version: 'X',
+        description: 'Standard ABAP',
+        etag: '757',
+      });
+
+      const keyUsers = configs.find((c) => c.version === '2');
+      expect(keyUsers?.description).toBe('ABAP for Key Users');
+      expect(keyUsers?.etag).toBe('7572');
+
+      const cloud = configs.find((c) => c.version === '5');
+      expect(cloud?.description).toBe('ABAP for Cloud Development');
+      expect(cloud?.etag).toBe('7575');
+    });
+
+    it('returns empty array when the feed has no syntaxConfiguration entries', () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+<abapsource:syntaxConfigurations xmlns:abapsource="http://www.sap.com/adt/abapsource"/>`;
+      expect(parseSyntaxConfigurations(xml)).toEqual([]);
+    });
+
+    it('tolerates entries with missing description', () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+<abapsource:syntaxConfigurations xmlns:abapsource="http://www.sap.com/adt/abapsource">
+  <abapsource:syntaxConfiguration>
+    <abapsource:language>
+      <abapsource:version>4</abapsource:version>
+      <atom:link etag="7574" xmlns:atom="http://www.w3.org/2005/Atom"/>
+    </abapsource:language>
+  </abapsource:syntaxConfiguration>
+</abapsource:syntaxConfigurations>`;
+      const configs = parseSyntaxConfigurations(xml);
+      expect(configs).toEqual([{ version: '4', description: '', etag: '7574' }]);
     });
   });
 


### PR DESCRIPTION
## Summary

On systems where `/sap/bc/adt/system/components` returns a valid but empty Atom feed (observed on a real ABAP 7.57 system), `detectSystemFromComponents` yields no `abapRelease`. Downstream, `buildLintConfig` falls through to `Version.v702`, so `SAPLint(action="list_rules")` reports `abapVersion: "unknown"` / `syntaxVersion: "v702"` and modern ABAP constructs (`DATA(...)`, `VALUE`, `NEW`, `FOR`, `LOOP … INTO DATA(...)`) get flagged as `parser_error` / `downport` / `inline_data_old_versions`.

This adds a single fallback probe: when the components feed yields no release, `probeFeatures` reads `/sap/bc/adt/abapsource/syntax/configurations` and takes the `etag` of the Standard ABAP entry (`version="X"`) as the SAP_BASIS release verbatim (e.g. `etag="757"` on ABAP 7.57).

## Why this endpoint

- Already advertised in the ADT discovery doc on the affected system.
- Needs no auth beyond basic ADT read access (verified live via Postman — returns 200 with full XML on a system where the components feed returned an empty feed).
- Carries the release in a documented, stable shape.

## Cost

Zero extra HTTP requests on the happy path — the fallback fires only when the existing detection yielded nothing.

## Verified

- Unit tests: parser + wiring (190 tests pass in the two affected files).
- Typecheck: clean.
- Live: With the supplied patch, a Claude instance launched against the same SAP system after `npm run build` correctly reports `SAP_BASIS release 757` and proposes `v757` for abaplint.