### PR TITLE
test: convert pseudo skips to real skips

### DIFF
--- a/docs/research/test-suite-audit-2026-05-11.md
+++ b/docs/research/test-suite-audit-2026-05-11.md
@@ -455,6 +455,10 @@ Recommended fix:
 - Delete `skipIf()` or rewrite it to require a Vitest context.
 - Add a static test that rejects `[SKIP]` logs paired with bare `return` in test files.
 
+Implementation status:
+
+- A follow-up PR after `#274` converts the SKTD and activation-failure pseudo-skips to real Vitest skips, removes the obsolete `skipIf()` helper, and adds a static unit guard that rejects future `[SKIP]` pseudo-skip markers in integration/E2E/helper test code.
+
 ### P1 - Skip Reason Telemetry Is Misleading
 
 `scripts/ci/collect-test-reliability.mjs:44-47` uses `test.title` as the skip reason. Vitest JSON does not include the actual `ctx.skip()` message, and the JUnit report also emitted blank skip messages in this run.
@@ -1234,6 +1238,7 @@ Implemented quick wins in PR `#274`:
 |---|---|---|
 | P1 | Renamed reliability summary wording from `Top Skip Reasons` to `Top Skipped Tests`. | Skip Telemetry Semantics |
 | P1 | Reworked local E2E start/stop portability and made stop-script error detection handle the default text logger. | E2E Script Portability And Log Signal |
+| P1 | Converted SKTD and activation-failure pseudo-skips to real `ctx.skip()`/`requireOrSkip()` paths and added a static guard against `[SKIP]` pseudo-skip markers. | Pseudo-Skip Discipline |
 | P1 | Stabilized the cache warmup delta integration test by moving the strict second-run assertion from shared `$TMP` to stable `$DEMO_SOI_DRAFT`. | GitHub Actions Runtime Deep Dive |
 | P2 | Split cheap CI checks from the SAP title gate and moved SAP serialization to repository-wide integration/E2E job concurrency. | CI Gating And SAP Serialization |
 
@@ -1243,7 +1248,6 @@ Remaining follow-ups:
 |---|---|---|
 | P0 | Harden E2E fixture activation and fix the invalid CDS fixture. | Fixture Sync Activation Contract |
 | P0 | Stop CTS transport leakage and add a cleanup audit. | CTS Transport And Transportable Package Cleanup |
-| P1 | Convert pseudo-skips to real `ctx.skip()` calls and add a guard against bare skip returns. | Pseudo-Skip Discipline |
 | P1 | Add structured skip artifacts and reason extraction now that the misleading heading has been corrected. | Skip Telemetry Semantics |
 | P1 | Further reduce PR-path live SAP runtime for remaining cache warmup scans, broad `BAPIRET2` where-used calls, recursive release coverage, and RAP write coverage. | GitHub Actions Runtime Deep Dive |
 

--- a/tests/e2e/activation-failure.e2e.test.ts
+++ b/tests/e2e/activation-failure.e2e.test.ts
@@ -41,7 +41,7 @@ describe('E2E SAPActivate failure path (PR #179 regression)', () => {
     }
   });
 
-  it('reports activation failure with a clear error message for a deliberately broken PROG', async () => {
+  it('reports activation failure with a clear error message for a deliberately broken PROG', async (ctx) => {
     const brokenSource = readFileSync(join(FIXTURES_DIR, 'zarc1_e2e_act_broken.abap'), 'utf-8');
     // Unique name per run to avoid collisions on parallel CI executions.
     const suffix = Date.now().toString(36).slice(-6);
@@ -67,7 +67,7 @@ describe('E2E SAPActivate failure path (PR #179 regression)', () => {
         //     "is not locked (invalid lock handle)"). Distinct from the bug under test.
         //   - Server safety gates (read-only, package allowlist) blocking writes.
         if (/read-only|not allowed|package|forbidden/i.test(text) || /invalid lock handle|is not locked/i.test(text)) {
-          console.log(`    [SKIP] create blocked by precondition: ${text.slice(0, 200)}`);
+          ctx.skip(`Create blocked by activation-failure precondition: ${text.slice(0, 200)}`);
           return;
         }
         throw new Error(`Unexpected create failure: ${text.slice(0, 300)}`);
@@ -86,7 +86,7 @@ describe('E2E SAPActivate failure path (PR #179 regression)', () => {
       if (updateResult.isError) {
         const text = updateResult.content?.[0]?.text ?? '';
         if (/invalid lock handle|is not locked/i.test(text)) {
-          console.log(`    [SKIP] update blocked by NW 7.50 lock-handle quirk: ${text.slice(0, 200)}`);
+          ctx.skip(`Update blocked by NW 7.50 lock-handle quirk: ${text.slice(0, 200)}`);
           return;
         }
         console.log(`    update warning (continuing): ${text.slice(0, 200)}`);

--- a/tests/e2e/cds-context.e2e.test.ts
+++ b/tests/e2e/cds-context.e2e.test.ts
@@ -36,7 +36,7 @@ describe('E2E CDS Context Tests', () => {
     client = await connectClient();
     cdsName = await findAvailableDdls(client);
     if (!cdsName) {
-      console.log('    [SKIP] No DDLS found on system — CDS tests will be skipped');
+      console.log('    [setup] No DDLS found on system; CDS tests will skip through requireOrSkip');
     }
   }, 60000);
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -200,17 +200,6 @@ export function expectToolError(result: ToolResult, ...expectedSubstrings: strin
 }
 
 /**
- * Skip test with a clear message if a feature is not available.
- */
-export function skipIf(condition: boolean, reason: string): void {
-  if (condition) {
-    console.log(`    [SKIP] ${reason}`);
-    // vitest doesn't have skip inside a test, but we can return early
-    // The caller should check this return value
-  }
-}
-
-/**
  * Classify a `ToolResult` error message as a known SAP release gap / backend
  * limitation that should skip the test cleanly rather than fail.
  *

--- a/tests/e2e/sktd-write.e2e.test.ts
+++ b/tests/e2e/sktd-write.e2e.test.ts
@@ -13,6 +13,7 @@
 
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { requireOrSkip, SkipReason } from '../helpers/skip-policy.js';
 import { callTool, connectClient, expectToolError, expectToolSuccess, expectToolSuccessOrSkip } from './helpers.js';
 
 function uniqueName(prefix: string): string {
@@ -41,9 +42,6 @@ describe('E2E SKTD (Knowledge Transfer Document) tests', () => {
       probeText.includes('Invalid arguments') ||
       probeText.includes('expected one of');
     sktdSupported = !isTypeRejected;
-    if (!sktdSupported) {
-      console.log('    [SKIP] Server does not support SKTD type — skipping SKTD E2E tests');
-    }
   });
 
   afterAll(async () => {
@@ -54,8 +52,8 @@ describe('E2E SKTD (Knowledge Transfer Document) tests', () => {
     }
   });
 
-  it('SAPRead SKTD returns decoded Markdown for existing KTD (ZC_FBCLUBTP)', async () => {
-    if (!sktdSupported) return;
+  it('SAPRead SKTD returns decoded Markdown for existing KTD (ZC_FBCLUBTP)', async (ctx) => {
+    requireOrSkip(ctx, sktdSupported ? true : undefined, SkipReason.BACKEND_UNSUPPORTED);
     const result = await callTool(client, 'SAPRead', {
       type: 'SKTD',
       name: 'ZC_FBCLUBTP',
@@ -72,8 +70,8 @@ describe('E2E SKTD (Knowledge Transfer Document) tests', () => {
     expect(/[a-zA-Z]/.test(text)).toBe(true);
   });
 
-  it('SAPRead SKTD returns soft message for non-existent KTD', async () => {
-    if (!sktdSupported) return;
+  it('SAPRead SKTD returns soft message for non-existent KTD', async (ctx) => {
+    requireOrSkip(ctx, sktdSupported ? true : undefined, SkipReason.BACKEND_UNSUPPORTED);
     const result = await callTool(client, 'SAPRead', {
       type: 'SKTD',
       name: 'ZARC1_NONEXISTENT_KTD_XXXX',
@@ -83,8 +81,8 @@ describe('E2E SKTD (Knowledge Transfer Document) tests', () => {
     expect(text).toContain('No Knowledge Transfer Document');
   });
 
-  it('SAPWrite create SKTD rejects missing refObjectType', async () => {
-    if (!sktdSupported) return;
+  it('SAPWrite create SKTD rejects missing refObjectType', async (ctx) => {
+    requireOrSkip(ctx, sktdSupported ? true : undefined, SkipReason.BACKEND_UNSUPPORTED);
     const result = await callTool(client, 'SAPWrite', {
       action: 'create',
       type: 'SKTD',
@@ -95,7 +93,7 @@ describe('E2E SKTD (Knowledge Transfer Document) tests', () => {
   });
 
   it('SKTD full CRUD lifecycle: create DDLS → create KTD → update with Markdown → read → activate → delete', async (ctx) => {
-    if (!sktdSupported) return;
+    requireOrSkip(ctx, sktdSupported ? true : undefined, SkipReason.BACKEND_UNSUPPORTED);
     // Use a unique name to avoid collisions across test runs
     const objectName = uniqueName('ZARC1SKTD');
 

--- a/tests/unit/helpers/skip-discipline.test.ts
+++ b/tests/unit/helpers/skip-discipline.test.ts
@@ -1,0 +1,41 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(import.meta.dirname, '../../..');
+const SCAN_DIRS = ['tests/e2e', 'tests/integration', 'tests/helpers'];
+
+function listTsFiles(dir: string): string[] {
+  const fullDir = join(REPO_ROOT, dir);
+  const entries = readdirSync(fullDir);
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(fullDir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...listTsFiles(relative(REPO_ROOT, fullPath)));
+    } else if (entry.endsWith('.ts')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function matchingFiles(pattern: RegExp): string[] {
+  return SCAN_DIRS.flatMap(listTsFiles)
+    .filter((file) => pattern.test(readFileSync(file, 'utf8')))
+    .map((file) => relative(REPO_ROOT, file))
+    .sort();
+}
+
+describe('integration and e2e skip discipline', () => {
+  it('does not use console [SKIP] pseudo-skip markers', () => {
+    expect(matchingFiles(/\[SKIP\]/)).toEqual([]);
+  });
+
+  it('does not reintroduce the obsolete skipIf helper', () => {
+    expect(matchingFiles(/\bskipIf\b/)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Goal

Follow up the merged test-suite audit quick wins by fixing the remaining low-risk pseudo-skip cases called out in the report.

## Changes

- Convert SKTD E2E early returns to real Vitest skips through `requireOrSkip()`.
- Convert activation-failure precondition branches from `[SKIP]` logs plus `return` to `ctx.skip()`.
- Remove the obsolete `skipIf()` helper whose comment claimed Vitest could not skip inside a test.
- Add a unit guard that rejects future `[SKIP]` pseudo-skip markers and `skipIf` usage in integration/E2E/helper test code.
- Update the audit report follow-up tracking to mark pseudo-skip cleanup as implemented.

## Validation

- `npm test -- tests/unit/helpers/skip-discipline.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npm test`
