### PR TITLE
test: harden e2e fixture activation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,7 +204,7 @@ jobs:
        (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository))
     needs: [test, gate, integration]
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v6

--- a/docs/research/test-suite-audit-2026-05-11.md
+++ b/docs/research/test-suite-audit-2026-05-11.md
@@ -410,6 +410,15 @@ Recommended fix:
 - Make `activateObject()` throw unless the error is classified as a known backend gap.
 - Add a post-sync assertion that all non-skipped persistent fixtures are active/readable.
 
+Implementation status (2026-05-28 follow-up PR):
+
+- `tests/fixtures/abap/zi_arc1_i33_root.ddls.abap` now uses only view-entity-compatible annotations.
+- `tests/e2e/setup.ts` now treats `SAPActivate` errors as hard fixture-sync failures unless the existing fixture-error classifier recognizes the error.
+- Fixture sync now checks `SAPRead(type="INACTIVE_OBJECTS")` after reconciliation and fails if any managed non-skipped fixture remains inactive.
+- Fixture sync now verifies created/recreated fixtures are actively readable. Exact post-recreate source equality is intentionally not required because SAP canonicalizes some DDIC source text such as TABL definitions.
+- `.github/workflows/test.yml` now gives the E2E job 20 minutes. CI run `26543612479` completed all E2E tests in 852.71s but hit the previous 15-minute job timeout during artifact upload and teardown, so the old limit was too tight for the current serial SAP-backed suite.
+- `tests/unit/e2e/setup.test.ts` covers activation-error failure, inactive-fixture detection, and the unchanged-fixture success path without requiring SAP credentials.
+
 ### P0 - Transport Tests Leave Live SAP Transports
 
 The current run created real transport requests that remain in draft state:
@@ -1232,10 +1241,11 @@ Known remaining blind spots are intentional external-scope items, not unresearch
 
 No matching open GitHub tracking issues were found during PR review. File or link issues for these items before treating the audit as closed:
 
-Implemented quick wins in PR `#274`:
+Implemented follow-ups:
 
 | Priority | Implemented item | Source finding |
 |---|---|---|
+| P0 | Hardened E2E fixture activation and fixed the invalid CDS fixture annotation set. | Fixture Sync Activation Contract |
 | P1 | Renamed reliability summary wording from `Top Skip Reasons` to `Top Skipped Tests`. | Skip Telemetry Semantics |
 | P1 | Reworked local E2E start/stop portability and made stop-script error detection handle the default text logger. | E2E Script Portability And Log Signal |
 | P1 | Converted SKTD and activation-failure pseudo-skips to real `ctx.skip()`/`requireOrSkip()` paths and added a static guard against `[SKIP]` pseudo-skip markers. | Pseudo-Skip Discipline |
@@ -1246,7 +1256,6 @@ Remaining follow-ups:
 
 | Priority | Follow-up | Source finding |
 |---|---|---|
-| P0 | Harden E2E fixture activation and fix the invalid CDS fixture. | Fixture Sync Activation Contract |
 | P0 | Stop CTS transport leakage and add a cleanup audit. | CTS Transport And Transportable Package Cleanup |
 | P1 | Add structured skip artifacts and reason extraction now that the misleading heading has been corrected. | Skip Telemetry Semantics |
 | P1 | Further reduce PR-path live SAP runtime for remaining cache warmup scans, broad `BAPIRET2` where-used calls, recursive release coverage, and RAP write coverage. | GitHub Actions Runtime Deep Dive |

--- a/tests/e2e/setup.ts
+++ b/tests/e2e/setup.ts
@@ -16,6 +16,14 @@ import { callTool, type ToolResult } from './helpers.js';
 
 type PersistentObject = (typeof PERSISTENT_OBJECTS)[number];
 
+interface InactiveFixture {
+  type: string;
+  name: string;
+  uri?: string;
+  transport?: string;
+  deleted?: boolean;
+}
+
 export interface FixtureSyncSummary {
   created: string[];
   recreated: string[];
@@ -75,6 +83,7 @@ export async function syncPersistentFixtures(client: Client): Promise<FixtureSyn
     deleted: [],
     skipped: [],
   };
+  const verifiedActiveSources = new Set<string>();
 
   for (const obj of PERSISTENT_OBJECTS) {
     const label = `${obj.type} ${obj.name}`;
@@ -116,6 +125,7 @@ export async function syncPersistentFixtures(client: Client): Promise<FixtureSyn
       }
       console.log(`    [setup] ${label}: up-to-date`);
       summary.unchanged.push(label);
+      verifiedActiveSources.add(label);
       continue;
     }
 
@@ -137,6 +147,8 @@ export async function syncPersistentFixtures(client: Client): Promise<FixtureSyn
       summary.skipped.push({ label, reason });
     }
   }
+
+  await assertSyncedFixturesActive(client, summary, verifiedActiveSources);
 
   console.log(
     `    [setup] Fixture sync summary: created=${summary.created.length}, recreated=${summary.recreated.length}, unchanged=${summary.unchanged.length}, deleted=${summary.deleted.length}, skipped=${summary.skipped.length}`,
@@ -185,10 +197,7 @@ async function createObjectFromFixture(client: Client, obj: PersistentObject): P
 
 async function activateObject(client: Client, type: string, name: string): Promise<void> {
   const activateResult = await callTool(client, 'SAPActivate', { type, name });
-  if (activateResult.isError) {
-    // SAPActivate may surface warnings as error text in some backends.
-    console.warn(`    [setup] ${name} activation warning: ${toolText(activateResult).slice(0, 300)}`);
-  }
+  assertToolSuccess(activateResult, `activate ${type} ${name}`);
 }
 
 // Types SAPWrite(action="delete") accepts. SAP-generated siblings like STOB (structure
@@ -283,6 +292,86 @@ async function readObjectSource(client: Client, type: string, name: string): Pro
   return toolText(result);
 }
 
+async function assertSyncedFixturesActive(
+  client: Client,
+  summary: FixtureSyncSummary,
+  verifiedActiveSources: ReadonlySet<string>,
+): Promise<void> {
+  const skippedLabels = new Set(summary.skipped.map((skip) => skip.label));
+  const checkedFixtures = PERSISTENT_OBJECTS.filter((obj) => !skippedLabels.has(`${obj.type} ${obj.name}`));
+  if (checkedFixtures.length === 0) return;
+
+  const inactiveFixtures = await findInactiveFixtures(client, checkedFixtures);
+  if (inactiveFixtures.length > 0) {
+    const details = inactiveFixtures
+      .map((obj) => {
+        const suffix = [obj.transport ? `transport=${obj.transport}` : null, obj.deleted ? 'deleted=true' : null]
+          .filter(Boolean)
+          .join(', ');
+        return `${obj.type} ${obj.name}${suffix ? ` (${suffix})` : ''}`;
+      })
+      .join(', ');
+    throw new Error(`Persistent fixture activation incomplete; inactive fixtures remain: ${details}`);
+  }
+
+  for (const obj of checkedFixtures) {
+    const label = `${obj.type} ${obj.name}`;
+    if (verifiedActiveSources.has(label)) continue;
+    await readObjectSource(client, obj.type, obj.name);
+  }
+}
+
+async function findInactiveFixtures(client: Client, fixtures: readonly PersistentObject[]): Promise<InactiveFixture[]> {
+  const result = await callTool(client, 'SAPRead', { type: 'INACTIVE_OBJECTS' });
+  assertToolSuccess(result, 'read INACTIVE_OBJECTS');
+  const parsed = parseInactiveObjectsPayload(toolText(result));
+  return parsed.filter((inactive) =>
+    fixtures.some(
+      (fixture) =>
+        inactive.name.toUpperCase() === fixture.name.toUpperCase() && inactiveTypeMatches(fixture.type, inactive.type),
+    ),
+  );
+}
+
+function parseInactiveObjectsPayload(text: string): InactiveFixture[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripCachedPrefix(text));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`read INACTIVE_OBJECTS failed: invalid JSON response: ${message}`);
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('read INACTIVE_OBJECTS failed: expected JSON object response');
+  }
+
+  const objects = (parsed as { objects?: unknown }).objects;
+  if (!Array.isArray(objects)) {
+    throw new Error('read INACTIVE_OBJECTS failed: expected objects array');
+  }
+
+  const inactive: InactiveFixture[] = [];
+  for (const entry of objects) {
+    if (!entry || typeof entry !== 'object') continue;
+    const name = getString(entry, 'name');
+    const type = getString(entry, 'type');
+    if (!name || !type) continue;
+    inactive.push({
+      name,
+      type,
+      uri: getString(entry, 'uri') ?? undefined,
+      transport: getString(entry, 'transport') ?? undefined,
+      deleted: getBoolean(entry, 'deleted') ?? undefined,
+    });
+  }
+  return inactive;
+}
+
+function inactiveTypeMatches(expectedType: string, inactiveType: string): boolean {
+  return (inactiveType.split('/')[0] ?? inactiveType).toUpperCase() === expectedType.toUpperCase();
+}
+
 function assertToolSuccess(result: ToolResult, action: string): void {
   if (result.isError) {
     throw new Error(`${action} failed: ${toolText(result)}`);
@@ -307,6 +396,11 @@ function normalizeSource(source: string): string {
 function getString(input: object, key: string): string | null {
   const value = (input as Record<string, unknown>)[key];
   return typeof value === 'string' ? value : null;
+}
+
+function getBoolean(input: object, key: string): boolean | null {
+  const value = (input as Record<string, unknown>)[key];
+  return typeof value === 'boolean' ? value : null;
 }
 
 /**

--- a/tests/fixtures/abap/zi_arc1_i33_root.ddls.abap
+++ b/tests/fixtures/abap/zi_arc1_i33_root.ddls.abap
@@ -1,5 +1,3 @@
-@AbapCatalog.sqlViewName: 'ZIARC1I33R'
-@AbapCatalog.compiler.compareFilter: true
 @AccessControl.authorizationCheck: #NOT_REQUIRED
 @EndUserText.label: 'ARC-1 FEAT-33 root view'
 define view entity ZI_ARC1_I33_ROOT as select from ztabl_arc1_i33 {

--- a/tests/fixtures/abap/ztabl_arc1_i33.tabl.abap
+++ b/tests/fixtures/abap/ztabl_arc1_i33.tabl.abap
@@ -3,7 +3,7 @@
 @AbapCatalog.tableCategory : #TRANSPARENT
 @AbapCatalog.deliveryClass : #A
 @AbapCatalog.dataMaintenance : #RESTRICTED
-define table ztabl_arc1_i33 {
+define table ZTABL_ARC1_I33 {
   key client      : abap.clnt not null;
   key id          : abap.numc(8) not null;
   description     : abap.char(80);

--- a/tests/unit/e2e/setup.test.ts
+++ b/tests/unit/e2e/setup.test.ts
@@ -1,0 +1,114 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { describe, expect, it, vi } from 'vitest';
+import { PERSISTENT_OBJECTS, readFixture } from '../../e2e/fixtures.js';
+import { syncPersistentFixtures } from '../../e2e/setup.js';
+
+interface FakeToolResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}
+
+function textResult(text: string): FakeToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+function errorResult(text: string): FakeToolResult {
+  return { content: [{ type: 'text', text }], isError: true };
+}
+
+function fakeClient(handler: (name: string, args: Record<string, unknown>) => FakeToolResult): Client {
+  return {
+    callTool: vi.fn(async ({ name, arguments: args }) => handler(name, (args ?? {}) as Record<string, unknown>)),
+  } as unknown as Client;
+}
+
+function fixtureFor(name: string) {
+  const fixture = PERSISTENT_OBJECTS.find((obj) => obj.name === name);
+  if (!fixture) throw new Error(`No fixture for ${name}`);
+  return fixture;
+}
+
+describe('E2E fixture setup', () => {
+  it('fails fixture sync when activation returns an error result', async () => {
+    const client = fakeClient((name) => {
+      if (name === 'SAPSearch') return textResult('[]');
+      if (name === 'SAPWrite') return textResult('created');
+      if (name === 'SAPActivate') return errorResult('Activation failed: invalid CDS annotation');
+      throw new Error(`Unexpected tool call: ${name}`);
+    });
+
+    await expect(syncPersistentFixtures(client)).rejects.toThrow(
+      /activate PROG ZARC1_TEST_REPORT failed: Activation failed/i,
+    );
+  });
+
+  it('fails fixture sync when a managed fixture remains in the inactive object list', async () => {
+    const client = fakeClient((name, args) => {
+      if (name === 'SAPSearch') {
+        const fixture = fixtureFor(String(args.query));
+        return textResult(JSON.stringify([{ objectName: fixture.name, objectType: fixture.type }]));
+      }
+      if (name === 'SAPRead' && args.type === 'INACTIVE_OBJECTS') {
+        return textResult(
+          JSON.stringify({
+            count: 1,
+            objects: [{ type: 'DDLS/DF', name: 'ZI_ARC1_I33_ROOT', uri: '/sap/bc/adt/ddic/ddl/sources/...' }],
+          }),
+        );
+      }
+      if (name === 'SAPRead') {
+        const fixture = fixtureFor(String(args.name));
+        return textResult(readFixture(fixture.fixture));
+      }
+      throw new Error(`Unexpected tool call: ${name}`);
+    });
+
+    await expect(syncPersistentFixtures(client)).rejects.toThrow(
+      /Persistent fixture activation incomplete; inactive fixtures remain: DDLS\/DF ZI_ARC1_I33_ROOT/i,
+    );
+  });
+
+  it('accepts unchanged fixtures when active source matches and no inactive drafts remain', async () => {
+    const client = fakeClient((name, args) => {
+      if (name === 'SAPSearch') {
+        const fixture = fixtureFor(String(args.query));
+        return textResult(JSON.stringify([{ objectName: fixture.name, objectType: fixture.type }]));
+      }
+      if (name === 'SAPRead' && args.type === 'INACTIVE_OBJECTS') {
+        return textResult(JSON.stringify({ count: 0, objects: [] }));
+      }
+      if (name === 'SAPRead') {
+        const fixture = fixtureFor(String(args.name));
+        return textResult(readFixture(fixture.fixture));
+      }
+      throw new Error(`Unexpected tool call: ${name}`);
+    });
+
+    const summary = await syncPersistentFixtures(client);
+
+    expect(summary.unchanged).toHaveLength(PERSISTENT_OBJECTS.length);
+    expect(summary.created).toEqual([]);
+    expect(summary.recreated).toEqual([]);
+    expect(summary.skipped).toEqual([]);
+  });
+
+  it('accepts created fixtures when SAP canonicalizes the active source text', async () => {
+    const client = fakeClient((name, args) => {
+      if (name === 'SAPSearch') return textResult('[]');
+      if (name === 'SAPWrite') return textResult('created');
+      if (name === 'SAPActivate') return textResult('activated');
+      if (name === 'SAPRead' && args.type === 'INACTIVE_OBJECTS') {
+        return textResult(JSON.stringify({ count: 0, objects: [] }));
+      }
+      if (name === 'SAPRead') return textResult(`canonicalized ${String(args.type)} ${String(args.name)}`);
+      throw new Error(`Unexpected tool call: ${name}`);
+    });
+
+    const summary = await syncPersistentFixtures(client);
+
+    expect(summary.created).toHaveLength(PERSISTENT_OBJECTS.length);
+    expect(summary.recreated).toEqual([]);
+    expect(summary.unchanged).toEqual([]);
+    expect(summary.skipped).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Goal

Implement the next P0 test-suite audit follow-up after the pseudo-skip cleanup: make persistent E2E fixture activation trustworthy.

## Changes

- Remove invalid ABAP CDS view-entity annotations from `ZI_ARC1_I33_ROOT`.
- Make E2E fixture sync fail when `SAPActivate` returns an error result instead of logging it as a warning.
- Add a post-sync inactive-object audit through `SAPRead(type="INACTIVE_OBJECTS")` for all non-skipped persistent fixtures.
- Verify created/recreated fixtures are actively readable after activation.
- Keep byte-exact source equality out of the post-recreate assertion because SAP canonicalizes some DDIC source text, as seen with TABL in CI.
- Canonicalize the TABL fixture source to uppercase `define table ZTABL_ARC1_I33` so setup does not recreate the table every run.
- Avoid fixture setup `force_refresh` reads so sync does not repeatedly invalidate the inactive-object cache on large shared systems.
- Raise the E2E job timeout from 15 to 20 minutes. CI proved the E2E tests complete but need more than the old job budget for teardown/artifact upload.
- Add unit coverage for activation failure, inactive fixture detection, successful unchanged fixture sync, and SAP-canonicalized active source text.
- Update the test-suite audit follow-up tracking to mark the fixture activation contract as implemented.

## CI-learned adjustments

- First E2E run proved the activation contract worked but failed on exact TABL source comparison after SAP canonicalization.
- Second E2E run passed fixture activation and progressed into the suite, but hit the runtime budget after setup had recreated TABL and invalidated inactive-object cache repeatedly.
- Third E2E run completed all 16 E2E files with 134 passed / 3 skipped in 852.71s, but the 15-minute job timeout cancelled the workflow during post-test upload/teardown.
- Final CI run `26544542410` is green: integration 6m15s, E2E 15m13s, reliability-summary 17s.

## Validation

- `npm test -- tests/unit/e2e/setup.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npm run build`
- GitHub Actions run `26544542410`
