### PR TITLE
test: clean up transport test requests

### DIFF
--- a/docs/research/test-suite-audit-2026-05-11.md
+++ b/docs/research/test-suite-audit-2026-05-11.md
@@ -450,6 +450,14 @@ Recommended fix:
 - Add a post-run transport residue check that fails when new draft `ARC-1 E2E` / `ARC-1 IT` requests remain.
 - For transportable-package write tests, cleanup must delete the generated object while it is still addressable and with the correct transport. If cleanup fails, the test should fail instead of logging only.
 
+Implementation status (2026-05-28 follow-up PR):
+
+- `tests/e2e/saptransport.e2e.test.ts` now deletes the transport created by the create/get suite and deletes the transportable-package write request after deleting the generated program.
+- `tests/integration/transport.integration.test.ts` now tracks created transport IDs across the suite and deletes remaining modifiable requests in `afterAll`.
+- E2E and integration transport suites now snapshot existing ARC-1 draft transports at startup and fail when the current run leaves new draft transport residue.
+- Integration transport object cleanup now fails the suite when generated objects cannot be deleted, instead of logging only.
+- Permanent release tests are gated by `TEST_TRANSPORT_RELEASE_TESTS=true` in E2E and integration because released requests cannot be deleted from the shared SAP test system.
+
 ### P1 - Real Pseudo-Skips Still Exist
 
 These branches can make tests pass without executing assertions:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -63,6 +63,7 @@ Only one E2E run can happen at a time (single SAP system). A server-side `flock`
 | `E2E_LOCK_TIMEOUT` | Seconds to wait for lock | `300` |
 | `E2E_LOG_DIR` | Local directory for collected logs | `/tmp/arc1-e2e-logs` |
 | `TEST_TRANSPORT_PACKAGE` | Transportable package for corrNr propagation tests (e.g., `Z_LLM_TEST_PACKAGE`) | *(skip if unset)* |
+| `TEST_TRANSPORT_RELEASE_TESTS` | Run permanent transport release tests (`true` only when released test requests are acceptable) | *(skip if unset)* |
 
 ## Test Object Inventory
 
@@ -75,7 +76,7 @@ Persistent objects on SAP (created once, expected to stay):
 | CLAS | `ZCL_ARC1_TEST_UT` | `$TMP` | Unit tests (ABAP Unit) |
 | INTF | `ZIF_ARC1_TEST` | `$TMP` | Read, context dependency |
 
-Transport tests (`saptransport.e2e.test.ts`) create transient transport requests and programs during test execution. The transportable-package write test requires `TEST_TRANSPORT_PACKAGE` and is skipped when unset.
+Transport tests (`saptransport.e2e.test.ts`) create transient transport requests and programs during test execution and delete modifiable requests before the suite exits. Release tests are skipped unless `TEST_TRANSPORT_RELEASE_TESTS=true` because released transport requests are permanent on the shared SAP test system. The transportable-package write test requires `TEST_TRANSPORT_PACKAGE` and is skipped when unset.
 
 `npm run test:e2e` now runs `npm run test:e2e:fixtures` first. This sync step ensures managed test objects exist in `$TMP`, and if fixture source drift is detected, it deletes and recreates those objects before the suite runs.
 

--- a/tests/e2e/saptransport.e2e.test.ts
+++ b/tests/e2e/saptransport.e2e.test.ts
@@ -16,18 +16,53 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { requireOrSkip, SkipReason } from '../helpers/skip-policy.js';
 import { callTool, connectClient, expectToolError, expectToolSuccess, expectToolSuccessOrSkip } from './helpers.js';
 
+const transportReleaseTestsEnabled = process.env.TEST_TRANSPORT_RELEASE_TESTS === 'true';
+
+interface TransportListEntry {
+  id?: string;
+  description?: string;
+  status?: string;
+}
+
+function isArc1TestTransport(transport: TransportListEntry): boolean {
+  return /^ARC-1 (E2E|IT|integration test)\b/.test(transport.description ?? '');
+}
+
 describe('E2E SAPTransport Tests', () => {
   let client: Client;
+  let initialArc1DraftTransportIds = new Set<string>();
+
+  async function listArc1DraftTransportIds(): Promise<Set<string>> {
+    const result = await callTool(client, 'SAPTransport', { action: 'list', status: 'D' });
+    const transports = JSON.parse(expectToolSuccess(result)) as TransportListEntry[];
+    return new Set(
+      transports
+        .filter(isArc1TestTransport)
+        .map((transport) => transport.id)
+        .filter(Boolean) as string[],
+    );
+  }
+
+  async function expectNoNewArc1DraftTransportResidue(): Promise<void> {
+    const current = await listArc1DraftTransportIds();
+    const leaked = [...current].filter((id) => !initialArc1DraftTransportIds.has(id));
+    expect(leaked, 'New ARC-1 draft transports left by E2E run').toEqual([]);
+  }
 
   beforeAll(async () => {
     client = await connectClient();
+    initialArc1DraftTransportIds = await listArc1DraftTransportIds();
   });
 
   afterAll(async () => {
     try {
-      await client?.close();
-    } catch {
-      // Ignore close errors
+      if (client) await expectNoNewArc1DraftTransportResidue();
+    } finally {
+      try {
+        await client?.close();
+      } catch {
+        // Ignore close errors
+      }
     }
   });
 
@@ -36,6 +71,17 @@ describe('E2E SAPTransport Tests', () => {
   describe('SAPTransport create + get', () => {
     let createdTransportId: string | undefined;
     let transportsEnabled = true;
+
+    afterAll(async () => {
+      if (!createdTransportId) return;
+      const result = await callTool(client, 'SAPTransport', {
+        action: 'delete',
+        id: createdTransportId,
+        recursive: true,
+      });
+      expectToolSuccess(result);
+      createdTransportId = undefined;
+    });
 
     it('creates a transport and returns a valid transport ID', async (ctx) => {
       const desc = `ARC-1 E2E test ${Date.now()}`;
@@ -135,26 +181,35 @@ describe('E2E SAPTransport Tests', () => {
     let transportsEnabled = true;
 
     it('delete action removes a transport', async (ctx) => {
-      // Create transport first
-      const createResult = await callTool(client, 'SAPTransport', {
-        action: 'create',
-        description: `ARC-1 E2E delete test ${Date.now()}`,
-      });
-      if (createResult.isError && createResult.content?.[0]?.text?.includes('allowTransportWrites=false')) {
-        transportsEnabled = false;
-        return ctx.skip('Transport writes not enabled on MCP server');
-      }
-      const createText = expectToolSuccess(createResult);
-      const match = createText.match(/([A-Z0-9]+K\d+)/);
-      expect(match).toBeTruthy();
-      const id = match![1];
+      let id = '';
+      try {
+        // Create transport first
+        const createResult = await callTool(client, 'SAPTransport', {
+          action: 'create',
+          description: `ARC-1 E2E delete test ${Date.now()}`,
+        });
+        if (createResult.isError && createResult.content?.[0]?.text?.includes('allowTransportWrites=false')) {
+          transportsEnabled = false;
+          return ctx.skip('Transport writes not enabled on MCP server');
+        }
+        const createText = expectToolSuccess(createResult);
+        const match = createText.match(/([A-Z0-9]+K\d+)/);
+        expect(match).toBeTruthy();
+        id = match![1];
 
-      const deleteResult = await callTool(client, 'SAPTransport', {
-        action: 'delete',
-        id,
-      });
-      const text = expectToolSuccess(deleteResult);
-      expect(text).toContain(`Deleted transport request: ${id}`);
+        const deleteResult = await callTool(client, 'SAPTransport', {
+          action: 'delete',
+          id,
+        });
+        const text = expectToolSuccess(deleteResult);
+        expect(text).toContain(`Deleted transport request: ${id}`);
+        id = '';
+      } finally {
+        if (id) {
+          const deleteResult = await callTool(client, 'SAPTransport', { action: 'delete', id, recursive: true });
+          expectToolSuccess(deleteResult);
+        }
+      }
     });
 
     it('create with type W creates Customizing transport', async (ctx) => {
@@ -173,11 +228,8 @@ describe('E2E SAPTransport Tests', () => {
         id = match![1];
       } finally {
         if (id) {
-          try {
-            await callTool(client, 'SAPTransport', { action: 'delete', id });
-          } catch {
-            // best-effort-cleanup
-          }
+          const deleteResult = await callTool(client, 'SAPTransport', { action: 'delete', id, recursive: true });
+          expectToolSuccess(deleteResult);
         }
       }
     });
@@ -211,36 +263,44 @@ describe('E2E SAPTransport Tests', () => {
         expect(reassignText).toContain('Reassigned transport');
       } finally {
         if (id) {
-          try {
-            await callTool(client, 'SAPTransport', { action: 'delete', id });
-          } catch {
-            // best-effort-cleanup
-          }
+          const deleteResult = await callTool(client, 'SAPTransport', { action: 'delete', id, recursive: true });
+          expectToolSuccess(deleteResult);
         }
       }
     });
 
     it('release_recursive releases transport', async (ctx) => {
       if (!transportsEnabled) return ctx.skip('Transport writes not enabled on MCP server');
+      requireOrSkip(ctx, transportReleaseTestsEnabled ? true : undefined, SkipReason.TRANSPORT_RELEASE_DISABLED);
 
-      const createResult = await callTool(client, 'SAPTransport', {
-        action: 'create',
-        description: `ARC-1 E2E recursive-release ${Date.now()}`,
-      });
-      const createText = expectToolSuccessOrSkip(ctx, createResult);
-      const match = createText.match(/([A-Z0-9]+K\d+)/);
-      expect(match).toBeTruthy();
-      const id = match![1];
+      let id = '';
+      let released = false;
+      try {
+        const createResult = await callTool(client, 'SAPTransport', {
+          action: 'create',
+          description: `ARC-1 E2E recursive-release ${Date.now()}`,
+        });
+        const createText = expectToolSuccessOrSkip(ctx, createResult);
+        const match = createText.match(/([A-Z0-9]+K\d+)/);
+        expect(match).toBeTruthy();
+        id = match![1];
 
-      const result = await callTool(client, 'SAPTransport', {
-        action: 'release_recursive',
-        id,
-      });
-      const text = expectToolSuccess(result);
-      expect(text).toContain(id);
+        const result = await callTool(client, 'SAPTransport', {
+          action: 'release_recursive',
+          id,
+        });
+        const text = expectToolSuccess(result);
+        expect(text).toContain(id);
+        released = true;
+      } finally {
+        if (id && !released) {
+          const deleteResult = await callTool(client, 'SAPTransport', { action: 'delete', id, recursive: true });
+          expectToolSuccess(deleteResult);
+        }
+      }
     });
 
-    it('unknown action error lists all 7 actions', async () => {
+    it('returns a schema error for unknown action', async () => {
       const result = await callTool(client, 'SAPTransport', {
         action: 'nonexistent',
       });
@@ -256,29 +316,33 @@ describe('E2E SAPTransport Tests', () => {
       requireOrSkip(ctx, pkg, SkipReason.NO_TRANSPORT_PACKAGE);
 
       const testName = `ZARC1_E2E_TR_${Date.now().toString(36).toUpperCase().slice(-6)}`;
-
-      // Step 1: Create a transport for the create operation
-      const createTransportResult = await callTool(client, 'SAPTransport', {
-        action: 'create',
-        description: `ARC-1 E2E transportable write ${Date.now()}`,
-      });
-      const transportText = expectToolSuccess(createTransportResult);
-      const transportMatch = transportText.match(/([A-Z0-9]+K\d+)/);
-      expect(transportMatch, 'Should get a transport ID').toBeTruthy();
-      const transportId = transportMatch![1];
-
-      // Step 2: Create a program in the transportable package
-      const createResult = await callTool(client, 'SAPWrite', {
-        action: 'create',
-        type: 'PROG',
-        name: testName,
-        source: `REPORT ${testName.toLowerCase()}.\nWRITE: / 'original'.`,
-        package: pkg,
-        transport: transportId,
-      });
-      expectToolSuccess(createResult);
+      let transportId = '';
+      let programCreated = false;
+      const cleanupErrors: string[] = [];
 
       try {
+        // Step 1: Create a transport for the create operation
+        const createTransportResult = await callTool(client, 'SAPTransport', {
+          action: 'create',
+          description: `ARC-1 E2E transportable write ${Date.now()}`,
+        });
+        const transportText = expectToolSuccess(createTransportResult);
+        const transportMatch = transportText.match(/([A-Z0-9]+K\d+)/);
+        transportId = transportMatch?.[1] ?? '';
+        expect(transportMatch, 'Should get a transport ID').toBeTruthy();
+
+        // Step 2: Create a program in the transportable package
+        const createResult = await callTool(client, 'SAPWrite', {
+          action: 'create',
+          type: 'PROG',
+          name: testName,
+          source: `REPORT ${testName.toLowerCase()}.\nWRITE: / 'original'.`,
+          package: pkg,
+          transport: transportId,
+        });
+        expectToolSuccess(createResult);
+        programCreated = true;
+
         // Step 3: Update WITHOUT explicit transport — should auto-use lock corrNr
         const updateResult = await callTool(client, 'SAPWrite', {
           action: 'update',
@@ -296,18 +360,32 @@ describe('E2E SAPTransport Tests', () => {
         const readText = expectToolSuccess(readResult);
         expect(readText).toContain('auto-corrNr propagated');
       } finally {
-        // Best-effort cleanup — delete the test program
-        try {
-          await callTool(client, 'SAPWrite', {
+        if (programCreated) {
+          const deleteProgramResult = await callTool(client, 'SAPWrite', {
             action: 'delete',
             type: 'PROG',
             name: testName,
             transport: transportId,
           });
-        } catch {
-          // best-effort-cleanup
-          console.error(`Failed to clean up test program ${testName}`);
+          if (deleteProgramResult.isError) {
+            cleanupErrors.push(deleteProgramResult.content?.[0]?.text ?? `Failed to delete ${testName}`);
+          }
         }
+
+        if (transportId) {
+          const deleteTransportResult = await callTool(client, 'SAPTransport', {
+            action: 'delete',
+            id: transportId,
+            recursive: true,
+          });
+          if (deleteTransportResult.isError) {
+            cleanupErrors.push(deleteTransportResult.content?.[0]?.text ?? `Failed to delete transport ${transportId}`);
+          }
+        }
+      }
+
+      if (cleanupErrors.length > 0) {
+        expect(cleanupErrors, 'Transportable E2E cleanup failed').toEqual([]);
       }
     });
   });

--- a/tests/helpers/skip-policy.ts
+++ b/tests/helpers/skip-policy.ts
@@ -13,6 +13,8 @@ export const SkipReason = {
   NO_DDLS: 'No DDLS object found on system',
   NO_DUMPS: 'No short dumps found on system',
   NO_TRANSPORT_PACKAGE: 'TEST_TRANSPORT_PACKAGE not configured (transportable package required)',
+  TRANSPORT_RELEASE_DISABLED:
+    'TEST_TRANSPORT_RELEASE_TESTS not enabled (transport release is permanent on the shared SAP test system)',
   BACKEND_UNSUPPORTED: 'Backend feature not supported on this SAP system',
 } as const;
 

--- a/tests/integration/transport.integration.test.ts
+++ b/tests/integration/transport.integration.test.ts
@@ -35,6 +35,12 @@ import { requireOrSkip, SkipReason } from '../helpers/skip-policy.js';
 import { buildCreateXml, CrudRegistry, cleanupAll, generateUniqueName } from './crud-harness.js';
 import { requireSapCredentials } from './helpers.js';
 
+const transportReleaseTestsEnabled = process.env.TEST_TRANSPORT_RELEASE_TESTS === 'true';
+
+function isArc1TestTransport(description: string): boolean {
+  return /^ARC-1 (IT|integration test)\b/.test(description);
+}
+
 /** Create an ADT client with transport writes enabled */
 function getTransportEnabledClient(): AdtClient {
   requireSapCredentials();
@@ -71,10 +77,68 @@ function isUnsupportedBackend(err: unknown): boolean {
 
 describe('Transport Integration Tests', () => {
   let client: AdtClient;
+  const createdTransportIds = new Set<string>();
+  let initialArc1DraftTransportIds = new Set<string>();
 
-  beforeAll(() => {
+  function trackTransport(id: string): string {
+    createdTransportIds.add(id);
+    return id;
+  }
+
+  async function listArc1DraftTransportIds(): Promise<Set<string>> {
+    const transports = await listTransports(client.http, client.safety, undefined, 'D');
+    return new Set(
+      transports
+        .filter((transport) => isArc1TestTransport(transport.description) && transport.status === 'D')
+        .map((transport) => transport.id),
+    );
+  }
+
+  async function deleteTrackedTransport(id: string): Promise<void> {
+    try {
+      await deleteTransport(client.http, client.safety, id, true);
+      createdTransportIds.delete(id);
+    } catch (err) {
+      try {
+        const transport = await getTransport(client.http, client.safety, id);
+        if (!transport) {
+          createdTransportIds.delete(id);
+          return;
+        }
+      } catch {
+        // Keep the original cleanup error below.
+      }
+      throw err;
+    }
+  }
+
+  beforeAll(async () => {
     requireSapCredentials();
     client = getTransportEnabledClient();
+    initialArc1DraftTransportIds = await listArc1DraftTransportIds();
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+
+    const failures: Array<{ id: string; error: string }> = [];
+    for (const id of [...createdTransportIds].reverse()) {
+      try {
+        await deleteTrackedTransport(id);
+      } catch (err) {
+        failures.push({ id, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    const currentArc1DraftTransportIds = await listArc1DraftTransportIds();
+    const leaked = [...currentArc1DraftTransportIds].filter((id) => !initialArc1DraftTransportIds.has(id));
+    for (const id of leaked) {
+      failures.push({ id, error: 'new ARC-1 draft transport still exists after integration cleanup' });
+    }
+
+    if (failures.length > 0) {
+      throw new Error(`Transport cleanup failed: ${JSON.stringify(failures)}`);
+    }
   });
 
   // ─── getTransport ──────────────────────────────────────────────
@@ -85,7 +149,9 @@ describe('Transport Integration Tests', () => {
       const transports = await listTransports(client.http, client.safety);
       if (transports.length === 0) {
         // No transports available — create one to test with
-        const id = await createTransport(client.http, client.safety, 'ARC-1 integration test: getTransport');
+        const id = trackTransport(
+          await createTransport(client.http, client.safety, 'ARC-1 integration test: getTransport'),
+        );
         expect(id).toBeTruthy();
         expect(id).toMatch(/^[A-Z0-9]+K\d+$/);
 
@@ -120,26 +186,13 @@ describe('Transport Integration Tests', () => {
   // ─── createTransport ───────────────────────────────────────────
 
   describe('createTransport', () => {
-    const createdTransportIds: string[] = [];
-
-    afterAll(() => {
-      // Log created transports for manual cleanup if needed
-      // We intentionally do NOT auto-release test transports
-      if (createdTransportIds.length > 0) {
-        console.error(
-          `Transport integration test created transports: ${createdTransportIds.join(', ')} (not auto-released)`,
-        );
-      }
-    });
-
     it('creates a transport without explicit package (defaults to $TMP)', async () => {
       const desc = `ARC-1 IT default-tmp ${Date.now()}`;
-      const id = await createTransport(client.http, client.safety, desc);
+      const id = trackTransport(await createTransport(client.http, client.safety, desc));
 
       expect(id).toBeTruthy();
       // SAP transport IDs follow pattern: <SID>K<number>
       expect(id).toMatch(/^[A-Z0-9]+K\d+$/);
-      createdTransportIds.push(id);
 
       // Verify the created transport can be retrieved and has the right description + owner
       const transport = await getTransport(client.http, client.safety, id);
@@ -154,10 +207,9 @@ describe('Transport Integration Tests', () => {
       requireOrSkip(ctx, pkg, SkipReason.NO_TRANSPORT_PACKAGE);
 
       const desc = `ARC-1 IT pkg ${Date.now()}`;
-      const id = await createTransport(client.http, client.safety, desc, pkg);
+      const id = trackTransport(await createTransport(client.http, client.safety, desc, pkg));
       expect(id).toBeTruthy();
       expect(id).toMatch(/^[A-Z0-9]+K\d+$/);
-      createdTransportIds.push(id);
     });
   });
 
@@ -222,10 +274,11 @@ describe('Transport Integration Tests', () => {
 
   describe('deleteTransport', () => {
     it('creates and deletes a transport', async () => {
-      const id = await createTransport(client.http, client.safety, `ARC-1 IT delete ${Date.now()}`);
+      const id = trackTransport(await createTransport(client.http, client.safety, `ARC-1 IT delete ${Date.now()}`));
       expect(id).toBeTruthy();
 
       await deleteTransport(client.http, client.safety, id);
+      createdTransportIds.delete(id);
 
       // Verify transport is gone or returns null
       try {
@@ -249,7 +302,7 @@ describe('Transport Integration Tests', () => {
     it('reassigns a transport to same user', async (ctx) => {
       let id = '';
       try {
-        id = await createTransport(client.http, client.safety, `ARC-1 IT reassign ${Date.now()}`);
+        id = trackTransport(await createTransport(client.http, client.safety, `ARC-1 IT reassign ${Date.now()}`));
         expect(id).toBeTruthy();
 
         const transport = await getTransport(client.http, client.safety, id);
@@ -274,11 +327,7 @@ describe('Transport Integration Tests', () => {
         throw err;
       } finally {
         if (id) {
-          try {
-            await deleteTransport(client.http, client.safety, id, true);
-          } catch {
-            // best-effort-cleanup
-          }
+          await deleteTrackedTransport(id);
         }
       }
     }, 30_000);
@@ -288,13 +337,20 @@ describe('Transport Integration Tests', () => {
 
   describe('releaseTransportRecursive', () => {
     it('recursively releases a transport', async (ctx) => {
+      requireOrSkip(ctx, transportReleaseTestsEnabled ? true : undefined, SkipReason.TRANSPORT_RELEASE_DISABLED);
+
       let id = '';
+      let released = false;
       try {
-        id = await createTransport(client.http, client.safety, `ARC-1 IT recursive-release ${Date.now()}`);
+        id = trackTransport(
+          await createTransport(client.http, client.safety, `ARC-1 IT recursive-release ${Date.now()}`),
+        );
         expect(id).toBeTruthy();
 
         const result = await releaseTransportRecursive(client.http, client.safety, id);
         expect(result.released).toContain(id);
+        released = true;
+        createdTransportIds.delete(id);
 
         const transport = await getTransport(client.http, client.safety, id);
         if (transport) {
@@ -312,6 +368,10 @@ describe('Transport Integration Tests', () => {
             'NW 7.5x ADT_TM gap: release endpoint rejects /newreleasejobs path segment; no client-side workaround',
           );
         throw err;
+      } finally {
+        if (id && !released) {
+          await deleteTrackedTransport(id);
+        }
       }
     }, 60_000);
   });
@@ -325,8 +385,8 @@ describe('Transport Integration Tests', () => {
       if (!client) return;
       const report = await cleanupAll(client.http, client.safety, registry);
       if (report.failed.length > 0) {
-        // best-effort-cleanup
         console.error('Transport test cleanup failures:', report.failed);
+        throw new Error(`Transport object cleanup failed: ${JSON.stringify(report.failed)}`);
       }
     });
 
@@ -340,7 +400,9 @@ describe('Transport Integration Tests', () => {
 
       // Create object in transportable package (needs a transport)
       // First create a transport for the create operation
-      const transportId = await createTransport(client.http, client.safety, `ARC-1 IT corrNr ${Date.now()}`, pkg);
+      const transportId = trackTransport(
+        await createTransport(client.http, client.safety, `ARC-1 IT corrNr ${Date.now()}`, pkg),
+      );
       expect(transportId).toBeTruthy();
 
       const xml = buildCreateXml('PROG', testName, pkg, 'ARC-1 corrNr propagation test');
@@ -372,7 +434,9 @@ describe('Transport Integration Tests', () => {
       const sourceUrl = `${objectUrl}/source/main`;
 
       // Create transport and object
-      const transportId = await createTransport(client.http, client.safety, `ARC-1 IT explicit ${Date.now()}`, pkg);
+      const transportId = trackTransport(
+        await createTransport(client.http, client.safety, `ARC-1 IT explicit ${Date.now()}`, pkg),
+      );
       expect(transportId).toBeTruthy();
 
       const xml = buildCreateXml('PROG', testName, pkg, 'ARC-1 explicit transport test');


### PR DESCRIPTION
## Goal

Stop transport integration and E2E tests from leaving new modifiable ARC-1 transport requests behind on the shared SAP test system.

## Content

- Track created transport IDs in integration tests and delete remaining modifiable requests in `afterAll`.
- Add E2E transport cleanup for create/get and transportable-package write paths.
- Add startup/end residue checks for new ARC-1 draft transports.
- Gate permanent release tests behind `TEST_TRANSPORT_RELEASE_TESTS=true`.
- Document the behavior in the E2E README and update the audit report implementation status.

## Local validation

- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run test:npx-smoke`
- `git diff --check`

## GitHub Actions validation

Run: https://github.com/marianfoo/arc-1/actions/runs/26561947577

- `test (22)`: passed in 1m17s
- `test (24)`: passed in 1m16s
- `integration`: passed in 5m35s
- `e2e`: passed in 13m33s
- `reliability-summary`: passed in 14s
- CodeQL, dependency review, MTA validation, and gate passed

## Notes

Local SAP credentials were not configured in this worktree, so live SAP validation was done by GitHub Actions with repository secrets.