### PR TITLE
fix(write): reject mixed-case object names on update/edit_method/delete

### DIFF
--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -3491,6 +3491,13 @@ function stripIncludeHeader(source: string): string {
 
 // ─── SAPWrite Handler ────────────────────────────────────────────────
 
+/**
+ * Single-object actions whose top-level `name` is an SAP object name and must be
+ * uppercase (TADIR convention). `batch_create` is excluded — its names live in
+ * the `objects[]` items and are validated per item in the batch_create branch.
+ */
+const NAME_CASE_GUARD_ACTIONS = new Set(['create', 'update', 'edit_method', 'delete']);
+
 async function handleSAPWrite(
   client: AdtClient,
   args: Record<string, unknown>,
@@ -3514,12 +3521,16 @@ async function handleSAPWrite(
   }
 
   // SAP TADIR stores object names uppercase. Mixed-case names cause silent corruption
-  // (e.g. DDLS created as "Zc_MyView" registers as "ZC_MYVIEW" in TADIR but the source body
-  // still contains "Zc_MyView", confusing every downstream tool). Reject pre-flight on create —
-  // applies on every SAP release; this is universal SAP convention, not a 7.50 quirk.
+  // on create (e.g. DDLS "Zc_MyView" registers as "ZC_MYVIEW" in TADIR but the source body
+  // still contains "Zc_MyView", confusing every downstream tool) and broken URL lookups on
+  // mutate/delete — the lock is held against the canonical uppercase name while the request
+  // URL carries the mixed-case one, which surfaces on ECC as 423 "... is not locked" (issue
+  // #293, original report used name "Z_HELLO_world"). Reject pre-flight for every name-bearing
+  // single-object action — universal SAP convention, not a 7.50 quirk. (batch_create validates
+  // each item separately below.)
   // Note: source code INSIDE the object can use mixed case (e.g. for DDLS: name="ZC_MYVIEW"
   // but `define view entity Zc_MyView` is fine inside the source body).
-  if (action === 'create' && name && name !== name.toUpperCase()) {
+  if (NAME_CASE_GUARD_ACTIONS.has(action) && name && name !== name.toUpperCase()) {
     return errorResult(
       `Object name "${name}" contains lowercase characters. SAP object names must be uppercase (e.g. "${name.toUpperCase()}").\n\n` +
         `Note: the object NAME in TADIR must be uppercase, but the source code inside the object can use mixed case ` +

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -12975,6 +12975,55 @@ ENDCLASS.`;
       // Second object should NOT have been attempted (batch breaks on first failure).
       expect(text).not.toContain('ZCL_LATER: success');
     });
+
+    // Issue #293: mixed-case names must be rejected on mutate/delete too, not just
+    // create — the lock is held against the canonical uppercase name while the
+    // request URL carries the mixed-case one (surfaces on ECC as 423 "not locked").
+    it('rejects update with lowercase characters in object name', async () => {
+      mockFetch.mockReset();
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'update',
+        type: 'PROG',
+        name: 'Z_Hello_World',
+        source: 'REPORT z_hello_world.',
+      });
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('uppercase');
+      expect(text).toContain('Z_HELLO_WORLD');
+      // Guard fires before any lock/HTTP traffic.
+      expect(mockFetch).toHaveBeenCalledTimes(0);
+    });
+
+    it('rejects edit_method with lowercase characters in object (class) name', async () => {
+      mockFetch.mockReset();
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'edit_method',
+        type: 'CLAS',
+        name: 'Zcl_Mixed',
+        method: 'do_something',
+        source: 'METHOD do_something.\nENDMETHOD.',
+      });
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('uppercase');
+      expect(text).toContain('ZCL_MIXED');
+      expect(mockFetch).toHaveBeenCalledTimes(0);
+    });
+
+    it('rejects delete with lowercase characters in object name', async () => {
+      mockFetch.mockReset();
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'delete',
+        type: 'PROG',
+        name: 'Z_Hello_World',
+      });
+      expect(result.isError).toBe(true);
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('uppercase');
+      expect(text).toContain('Z_HELLO_WORLD');
+      expect(mockFetch).toHaveBeenCalledTimes(0);
+    });
   });
 
   // ─── MSAG transport-vs-task guard (PR-γ) ──────────────────────────


### PR DESCRIPTION
## Summary

Part 2 of #293. The pre-flight uppercase-name guard in `handleSAPWrite` only covered `create`. On `update`/`edit_method`/`delete`, a mixed-case `name` passed straight through to the URL builder (`encodeURIComponent(name)`), so the `LOCK` was held against SAP's canonical uppercase object name while the request URL carried the mixed-case one. On ECC this surfaces as `423 "Resource ... is not locked (invalid lock handle)"` — matching the **original** reporter's example (`/programs/programs/Z_HELLO_world/...`).

This is distinct from the cookie-auth root cause fixed in #310; it's the second variable called out in that PR's "not in this PR" note.

## Changes

- Hoist the guarded actions into `NAME_CASE_GUARD_ACTIONS = {create, update, edit_method, delete}` and apply the existing reject to all of them (was `action === 'create'` only).
- `batch_create` is intentionally excluded — it already validates each `objects[]` item separately.
- The guard still fires pre-flight (before any lock/HTTP), so callers get a clear "must be uppercase" error and retry with the canonical name. Method specifiers for `edit_method` (e.g. `lhc_handler~method`) are unaffected — only the object `name` is checked.
- Adds `update`/`edit_method`/`delete` rejection tests (each asserts zero HTTP traffic).

## Test plan

- [x] `npm test` — 3084 passed
- [x] `npm run typecheck` — clean
- [x] biome on changed files — clean
- [x] New tests: 6/6 in the mixed-case describe block pass (3 existing + 3 new)

Refs #293.

https://claude.ai/code/session_01EpfMUiNsDesSPrwYxEGg1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpfMUiNsDesSPrwYxEGg1w)_