### PR TITLE
fix: release-aware 423 lock-handle guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ src/
 │   ├── http.ts                 # HTTP transport (undici/fetch, CSRF, cookies, sessions)
 │   ├── discovery.ts            # ADT discovery (endpoint MIME map fetch + resolve)
 │   ├── errors.ts               # Typed errors (AdtApiError, AdtSafetyError, AdtNetworkError)
+│   ├── release.ts              # SAP_BASIS release parsing (release-aware hints/warnings, #293)
 │   ├── safety.ts               # Safety system (positive opt-ins, package gates, deny actions)
 │   ├── features.ts             # Feature detection (auto/on/off)
 │   ├── config.ts, types.ts     # ADT client config + response types
@@ -217,6 +218,7 @@ tests/
 | Modify ADT service discovery / MIME types | `src/adt/discovery.ts`, `src/adt/http.ts` |
 | Improve DDIC save diagnostics + SAP-domain error hints (T100/line + lock/auth/dependency hints) | `src/adt/errors.ts` (`extractDdicDiagnostics`, `formatDdicDiagnostics`, `classifySapDomainError`), `src/handlers/intent.ts` (`enrichWithSapDetails`, `formatErrorForLLM`) |
 | Add SAP error classification (new `category` + hint) | `src/adt/errors.ts` (`extractExceptionType`/`extractLockOwner`/`classifySapDomainError`/`SapErrorClassification`), `src/handlers/intent.ts` (`formatErrorForLLM`/`classifyError`), `tests/unit/adt/errors.test.ts`. Existing categories live in the union type. Ground hints in verified SAP Notes/KBAs (use `mcp__sap-notes__search`) — no speculative tcode pointers. |
+| Make an error hint release-aware (e.g. 423 lock-handle on NW <7.51 → abapfs_extensions, #293) | `src/adt/release.ts` (`parseReleaseNumber`/`shouldWarnPreStatefulRelease`), `src/adt/errors.ts` (`classifySapDomainError` `abapRelease` param), `src/handlers/intent.ts` (`buildBaseErrorMessage` passes `cachedFeatures?.abapRelease ?? config.abapRelease`), `src/server/server.ts` (`runStartupProbe` startup warn), `tests/unit/adt/{release,errors}.test.ts`, `tests/unit/handlers/intent.test.ts`. Root cause: <7.51 ignores `X-sap-adt-sessiontype: stateful`; fix is the abapfs_extensions backend enhancement. |
 | Add release-gated content-type fallback (e.g. DTEL v2→v1 on 415) | `src/adt/crud.ts` (`CONTENT_TYPE_FALLBACKS` map — narrow static allowlist, 415-only retry in both `createObject` and `updateObject`), `tests/unit/adt/crud.test.ts`. Don't turn it into a generic retry loop — each entry must be a specific, tested compatibility gap. |
 | Add / update test skip reason | `tests/helpers/skip-policy.ts`, `tests/e2e/helpers.ts` (`classifyToolErrorSkip`), `docs/integration-test-skips.md`, `scripts/ci/summarize-skips.mjs`. Skip messages are the taxonomy's public API — keep all four in sync. |
 | Run ADT type-availability probe against a live system | `scripts/probe-adt-types.ts` (`npm run probe`), `src/probe/{catalog,runner,fixtures}.ts`, `tests/unit/probe/replay.test.ts`. New fixture set: `npm run probe -- --save-fixtures tests/fixtures/probe/<name>`. See [docs/probe-adt-types.md](docs/probe-adt-types.md). |

--- a/docs/integration-test-skips.md
+++ b/docs/integration-test-skips.md
@@ -80,7 +80,7 @@ Not fixable from ARC-1 client code. The error classifier (`classifySapDomainErro
 
 ARC-1 originally posted DTEL create/update with `Content-Type: application/vnd.sap.adt.dataelements.v2+xml; charset=utf-8`. Older SAP_BASIS releases (pre-7.52) only accept the v1 MIME type `…dataelements.v1+xml` — same XML body, different MIME version suffix.
 
-**Fixed** in `src/adt/crud.ts` via a static `CONTENT_TYPE_FALLBACKS` map: on HTTP 415 for the v2 MIME type, `createObject` and `updateObject` transparently retry once with the v1 MIME type. DTEL create now works across releases. Follow-up DTEL updates (lock → PUT) may still hit the lock-handle 423 issue on systems missing SAP Note 2727890 — see below.
+**Fixed** in `src/adt/crud.ts` via a static `CONTENT_TYPE_FALLBACKS` map: on HTTP 415 for the v2 MIME type, `createObject` and `updateObject` transparently retry once with the v1 MIME type. DTEL create now works across releases. Follow-up DTEL updates (lock → PUT) may still hit the lock-handle 423 issue on NW < 7.51 systems without the `abapfs_extensions` enhancement — see below.
 
 ## Category 3 — Backend quirk (trial systems, unstable services)
 
@@ -88,13 +88,15 @@ ARC-1 originally posted DTEL create/update with `Content-Type: application/vnd.s
 
 | Skip message fragment | Affected tests | Typical on | Should NOT skip on |
 |---|---|---|---|
-| `BACKEND_UNSUPPORTED: lock-handle session correlation differs on this release` | `crud.lifecycle.integration.test.ts` full PROG lifecycle, DTEL CRUD update step, RAP write + SKTD + MSAG on E2E | Systems missing SAP Note 2727890 (ADT lock-handle bug) | Systems with the note / a later SP applied |
+| `BACKEND_UNSUPPORTED: lock-handle session correlation differs on this release` | `crud.lifecycle.integration.test.ts` full PROG lifecycle, DTEL CRUD update step, RAP write + SKTD + MSAG on E2E | NW < 7.51 without the `abapfs_extensions` enhancement | NW ≥ 7.51, or any release with `abapfs_extensions` installed |
 
 ### Root cause: persistent lock-handle 423 after successful LOCK
 
-Known ABAP Development Tools bug — [SAP Note 2727890 "ADT: fix unstable adt lock handle"](https://me.sap.com/notes/2727890/E), component `BC-DWB-AIE`, released 2018-12-11. Apply the note (or a support package that includes it) on the target system.
+On **SAP_BASIS < 7.51** the ADT REST handler `CL_REST_HTTP_HANDLER` does not honor the `X-sap-adt-sessiontype: stateful` header over HTTP (the 7.51+ mechanism `CONFIGURE_SESSION_STATE` in `CL_ADT_WB_RES_APP` does not exist). The session reverts to stateless, the ENQUEUE lock is released, and the PUT after a successful LOCK fails with `423 invalid lock handle`. Validated live on NPL 7.50 (423 before, 200 after the fix); a4h (kernel 7.58) works natively.
 
-Not fixable from ARC-1 client code; the error hint (`category: enqueue-error`) now cites the note directly so operators can jump to the SAP Knowledge Base entry.
+**Fix:** install the [`abapfs_extensions`](https://github.com/marcellourbani/abapfs_extensions) enhancement on the SAP system (abapGit import, or a manual implicit enhancement on `CL_REST_HTTP_HANDLER`). Once installed, these skips no longer fire — the NPL test instance now passes these writes. See [docs_page/sap-trial-setup.md](../docs_page/sap-trial-setup.md) (423 troubleshooting) for both install paths.
+
+> **SAP Note 2727890** ("ADT: fix unstable adt lock handle", `BC-DWB-AIE`) is a *separate, narrow* bug for lock handles containing `+` characters — it is **not** this issue and does not fix it (confirmed: reporters with the note applied on 7.40 still fail). The error hint (`category: enqueue-error`) is release-aware: on a detected < 7.51 system it points at `abapfs_extensions`.
 | `BACKEND_UNSUPPORTED: PageChipInstances service unstable on this release` | `adt.integration.test.ts` FLP lists tiles | NW 7.50, some older S/4 | Recent S/4 |
 | `BACKEND_UNSUPPORTED: scope denied` (transport test) | `transport.integration.test.ts` type-W/R (customizing, repair) | Systems where user lacks `S_TRANSPRT` for non-K types | Full-privilege users |
 

--- a/docs/plans/issue-293-release-aware-lock-handle-guidance.md
+++ b/docs/plans/issue-293-release-aware-lock-handle-guidance.md
@@ -1,0 +1,182 @@
+# Issue #293 — Release-Aware 423 Lock-Handle Guidance (abapfs_extensions)
+
+## Overview
+
+ARC-1 issue #293 reports that **every ADT write fails with `423 ExceptionResourceInvalidLockHandle`** on NetWeaver < 7.51 / ECC, while S/4HANA works. ARC-1's current error hint blames **SAP Note 2727890**, but that note is a *red herring*: it fixes a narrow bug for lock handles containing `+` characters. The reporter (`@acmebcn`) has that note applied on SAP_BASIS 7.40 SP33 and still fails.
+
+The real root cause (researched and **validated live**): on SAP_BASIS < 7.51 the ADT REST handler `CL_REST_HTTP_HANDLER` does **not** honor the `X-sap-adt-sessiontype: stateful` HTTP header (the 7.51+ mechanism `CONFIGURE_SESSION_STATE` in `CL_ADT_WB_RES_APP` does not exist on older releases). So the LOCK succeeds but the session silently reverts to stateless, and the subsequent PUT can't see the enqueue lock → 423. The fix is a **server-side ABAP enhancement** — `marcellourbani/abapfs_extensions` (an implicit enhancement `ZABAPFILESYSTEM_SESSION` on `CL_REST_HTTP_HANDLER->HANDLE_REQUEST` that back-ports the header read). This was reproduced on NPL 7.50 (423), the enhancement installed, and the identical ARC-1 write then returned 200. a4h (kernel 7.58) works natively.
+
+This plan makes the failure **easy for users to fix themselves** by: (1) replacing the misleading 423 hint with **release-aware** guidance that points to `abapfs_extensions` when the detected SAP_BASIS is < 7.51; (2) emitting a proactive startup warning when writes are enabled on a < 7.51 system; (3) adding a user-facing troubleshooting section (abapGit + manual SE19/SE24 install recipes); (4) cleaning up stale "apply Note 2727890" framing across docs; (5) adding a regression test pinning the stateful header on include-write paths; (6) updating the issue research doc with the validated conclusion. No new tool parameters; no MCP-protocol changes.
+
+## Context
+
+### Current State
+- `classifySapDomainError()` in `src/adt/errors.ts` (lines ~384-394) returns the 423 `enqueue-error` hint that cites **only** SAP Note 2727890. It takes `(statusCode, responseBody?, path?)` — no awareness of the detected SAP_BASIS release.
+- The hint is surfaced via `buildBaseErrorMessage()` in `src/handlers/intent.ts` (line ~429), which already has `config: ServerConfig` in scope and lives in the same module as the module-level `cachedFeatures` variable (defined line ~7069; `getCachedFeatures()`/`setCachedFeatures()` exported ~7484-7490).
+- ARC-1 **already detects** the SAP_BASIS release at startup: `runStartupProbe()` in `src/server/server.ts` calls `probeFeatures()` and `setCachedFeatures(features)` (line ~356). `features.abapRelease` is a string like `"750"`/`"758"`. `src/adt/features.ts` already maps releases (`releaseToVersion`, `if (num >= 751) ...` at line ~204) and exposes `abapRelease` on the resolved features (line ~216, ~239).
+- ARC-1 is **architecturally immune** to the two client-side causes of the same 423: (b) it sets `X-sap-adt-sessiontype: stateful` at the *session-client* level in `src/adt/http.ts` (line ~326) so every in-session request carries it — there is no per-call flag to forget; (c) `checkPackage()` and `runPreWriteLint()` run *before* the lock cycle in `handleSAPWrite` (intent.ts ~3633/~3805), never interleaved between LOCK and PUT. All source writes go through `safeUpdateSource`/`safeUpdateObject` → `withStatefulSession` (`src/adt/crud.ts` ~219/~243).
+- Docs that frame Note 2727890 as the primary fix: `docs/integration-test-skips.md` (lines ~83, ~91, ~95, ~97) and `docs_page/tools.md` (line ~511).
+- Existing tests asserting the note text: `tests/unit/adt/errors.test.ts` (line ~425, `toContain('2727890')`) and `tests/unit/handlers/intent.test.ts` (line ~6373, `toContain('2727890')`).
+- `INFRASTRUCTURE.md` (gitignored) is already updated with the validated root cause + the manual SE24 install recipe. The prior research doc `research/issues/293-ecc-423-invalid-lock-handle.md` exists only on branch `claude/review-issue-293-rm0tK` and predates the validation (it still ranks Note 2727890 / a duplicate-cookie theory).
+
+### Target State
+- The 423 hint is **release-aware**:
+  - **release < 751** → leads with `abapfs_extensions` as the fix, explains the stateful-session root cause, mentions Note 2727890 only as a separate narrow possibility.
+  - **release ≥ 751** → transient/real-lock guidance (retry, check SM12); abapfs_extensions not mentioned.
+  - **release unknown** → retry first; if persistent on a < 7.51 system install abapfs_extensions; Note 2727890 noted as a separate narrow bug.
+- A one-line startup `logger.warn` fires when `allowWrites && abapRelease < 751`, pointing operators to abapfs_extensions before they hit the first cryptic 423.
+- A user-facing troubleshooting section documents the symptom and both install paths (abapGit import + manual SE19/SE24 enhancement).
+- Stale "apply Note 2727890" framing is corrected to "install abapfs_extensions (Note 2727890 is a separate narrow bug)".
+- A regression test asserts the stateful header on a class-include write path (mirrors vibing-steampunk #98 guard).
+- `research/issues/293-ecc-423-invalid-lock-handle.md` exists on the PR branch with the validated conclusion, and a drafted issue comment is ready for the maintainer to post.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/release.ts` | NEW — tiny pure helper `parseReleaseNumber(release?: string): number \| undefined` (no imports, no cycles). Used by the hint and the startup warning to compare against 751. |
+| `src/adt/errors.ts` | `classifySapDomainError()` — add optional `abapRelease` param; rewrite the 423 branch to be release-aware. |
+| `src/handlers/intent.ts` | `buildBaseErrorMessage()` — pass `cachedFeatures?.abapRelease ?? config.abapRelease` into `classifySapDomainError()`. |
+| `src/server/server.ts` | `runStartupProbe()` — after `setCachedFeatures(features)`, emit a warn when `allowWrites && release < 751`. |
+| `tests/unit/adt/release.test.ts` | NEW — unit tests for `parseReleaseNumber`. |
+| `tests/unit/adt/errors.test.ts` | Update the existing 423 test (~line 418-425); add release-branch tests. |
+| `tests/unit/handlers/intent.test.ts` | Update the existing 423 handler test (~line 6357-6373) to be release-aware. |
+| `tests/unit/adt/http.test.ts` | Add a regression test: in-session class-include PUT sends `X-sap-adt-sessiontype: stateful` (real client + mocked undici). |
+| `docs_page/sap-trial-setup.md` | Add the "423 invalid lock handle on NW < 7.51" troubleshooting section. |
+| `docs_page/tools.md` | Demote Note 2727890 (line ~511); add a short pointer to the troubleshooting section. |
+| `docs/integration-test-skips.md` | Demote Note 2727890 to secondary; abapfs_extensions is the fix (lines ~83/~91/~95/~97). |
+| `research/issues/293-ecc-423-invalid-lock-handle.md` | NEW on PR branch — validated conclusion + drafted issue comment. |
+| `CLAUDE.md` | Add `src/adt/release.ts` to the codebase structure tree and a Key Files row for the release-aware hint. |
+
+### Design Principles
+1. **Release-aware, fail-soft.** When the release is unknown (detection failed), the hint must still be useful — mention both retry and the < 7.51 abapfs_extensions path. Never hide guidance behind a detection that may not have run.
+2. **abapfs_extensions is the primary fix for < 7.51; Note 2727890 is a separate narrow bug.** Keep a brief mention of the note (some users will have the `+`-handle variant) but never present it as THE fix.
+3. **No new tool parameters / no MCP-protocol change.** This is an error-message + docs + startup-log change. The three-file tool-schema sync rule does not apply.
+4. **Pure, testable release parsing.** Put release-number parsing in one tiny dependency-free module (`src/adt/release.ts`) and unit-test it, rather than duplicating `parseInt` logic or risking an import cycle by importing `features.ts` into `errors.ts`.
+5. **Preserve the existing classification contract.** `classifySapDomainError` keeps returning `SapErrorClassification | undefined` with `category: 'enqueue-error'` for 423 so downstream behavior (audit `errorClass`, transaction hints) is unchanged.
+6. **Don't rewrite history.** Historical/competitor-analysis references to Note 2727890 in `compare/00-feature-matrix.md` and `docs_page/roadmap.md` are records of past decisions — leave them; only fix forward-looking guidance docs.
+
+## Development Approach
+
+- Foundation first (`release.ts` helper + tests), then the hint (`errors.ts`), then wiring (`intent.ts`), then the startup warning (`server.ts`), then the regression test, then docs, then the research/issue artifact, then final verification.
+- Every code task ends by running `npm test`. Two existing tests assert `'2727890'` and MUST be updated in the same task that changes the hint text, or the suite breaks.
+- Code-only changes here → unit tests are sufficient (no new ADT endpoint, no new tool op). Live validation against NPL/a4h is a manual verification step in the final task, not a CI gate.
+- Biome auto-fixes formatting on commit; still run `npm run lint` and `npm run typecheck` before finishing.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add pure release-number helper
+
+**Files:**
+- Create: `src/adt/release.ts`
+- Create: `tests/unit/adt/release.test.ts`
+
+A single dependency-free helper for comparing SAP_BASIS release strings against the 7.51 threshold, used by both the release-aware hint (Task 2) and the startup warning (Task 4). Kept separate to avoid importing `features.ts` into `errors.ts` (which would risk a circular dependency).
+
+- [ ] Create `src/adt/release.ts` exporting `parseReleaseNumber(release?: string): number | undefined`. Behavior: trim the input; take the leading digit run (e.g. `"750"`, `"758"`, `"7.50"`→handle the dot by stripping non-digits OR documenting that SAP_BASIS feeds are dotless like `"750"`); return the integer, or `undefined` if no digits / empty / undefined. Keep it pure — no imports.
+- [ ] Add a JSDoc note that SAP_BASIS release strings from `/sap/bc/adt/system/components` are dotless 3-digit codes (`"700"`, `"740"`, `"750"`, `"758"`), and that values < 751 lack native stateful-session support over HTTP.
+- [ ] Add unit tests (~8 tests): `"750"`→750, `"758"`→758, `"700"`→700, `"751"`→751, `undefined`→undefined, `""`→undefined, `"abc"`→undefined, and one dotted/whitespace edge case (e.g. `" 750 "`→750). Assert the < 751 / ≥ 751 boundary with `parseReleaseNumber("750")! < 751` and `parseReleaseNumber("751")! >= 751`.
+- [ ] Run `npm test` — all tests must pass.
+
+### Task 2: Make the 423 hint release-aware in errors.ts
+
+**Files:**
+- Modify: `src/adt/errors.ts`
+- Modify: `tests/unit/adt/errors.test.ts`
+
+`classifySapDomainError()` (lines ~344-395) currently returns a 423 `enqueue-error` hint that cites only SAP Note 2727890. Make it release-aware so < 7.51 systems get pointed at `abapfs_extensions` (the real fix), while keeping the function's return contract.
+
+- [ ] Add an optional 4th parameter `abapRelease?: string` to `classifySapDomainError(statusCode, responseBody?, path?, abapRelease?)`.
+- [ ] Import `parseReleaseNumber` from `./release.js` and compute `const releaseNum = parseReleaseNumber(abapRelease);` inside the function.
+- [ ] Rewrite the `423 / ExceptionResourceInvalidLockHandle` branch (lines ~384-394) to choose the hint by release. Keep `category: 'enqueue-error'` and the `details: { exceptionType }` shape unchanged. Three variants:
+  - **`releaseNum !== undefined && releaseNum < 751`**: lead with the real fix — e.g. *"Your SAP_BASIS (<release>) does not honor stateful ADT HTTP sessions, so the lock is released before the write. Install the abapfs_extensions enhancement (https://github.com/marcellourbani/abapfs_extensions) via abapGit — it back-ports the 7.51 stateful-session handling to CL_REST_HTTP_HANDLER. (SAP Note 2727890 is a separate, narrow bug for lock handles containing '+' and is NOT this issue.)"*
+  - **`releaseNum !== undefined && releaseNum >= 751`**: transient/real-lock guidance — *"Lock handle is invalid or expired. Retry first (transient expiry is common). If it persists, check SM12 for stale locks; ensure no other editor holds the object."* (no abapfs mention). Set `transaction: 'SM12'`.
+  - **`releaseNum === undefined`** (unknown): combined — *"Lock handle is invalid or expired. Retry first. If 423 persists on the first PUT after LOCK and your SAP_BASIS is < 7.51, install abapfs_extensions (https://github.com/marcellourbani/abapfs_extensions) — older releases ignore the stateful-session header over HTTP. (SAP Note 2727890 is a separate narrow '+'-handle bug.)"*
+- [ ] Keep the link text exactly `https://github.com/marcellourbani/abapfs_extensions` so docs and hint agree.
+- [ ] Update the existing test at `tests/unit/adt/errors.test.ts` ~line 418-425 ("classifies enqueue errors for 423"): it calls `classifySapDomainError(423, 'Lock handle invalid')` (no release → unknown branch). Change the assertion from `toContain('2727890')` to assert the unknown-branch hint mentions `abapfs_extensions` AND still mentions `2727890` as secondary.
+- [ ] Add new tests (~4 tests): (a) `classifySapDomainError(423, 'x', undefined, '750')` → hint contains `abapfs_extensions`, category `enqueue-error`; (b) `(423, 'x', undefined, '700')` → contains `abapfs_extensions`; (c) `(423, 'x', undefined, '758')` → does NOT contain `abapfs_extensions`, mentions retry/SM12; (d) `(423, 'x', undefined, '751')` → does NOT contain `abapfs_extensions` (boundary).
+- [ ] Run `npm test` — all tests must pass.
+
+### Task 3: Wire the detected release into the hint from intent.ts
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+`buildBaseErrorMessage()` (line ~418-434) calls `classifySapDomainError(err.statusCode, err.responseBody, err.path)`. Pass the detected release so the hint can specialize. The release is available as the module-level `cachedFeatures?.abapRelease` (set by the startup probe) with `config.abapRelease` (manual `SAP_ABAP_RELEASE` override) as fallback.
+
+- [ ] In `buildBaseErrorMessage()` compute `const abapRelease = cachedFeatures?.abapRelease ?? config.abapRelease;` and pass it as the 4th argument: `classifySapDomainError(err.statusCode, err.responseBody, err.path, abapRelease)` (line ~429).
+- [ ] Confirm no import is needed (`cachedFeatures` is module-level in this file; `config` is a function parameter).
+- [ ] Update the existing handler test at `tests/unit/handlers/intent.test.ts` ~line 6357-6373 ("423 lock handle error returns enqueue hint"): currently asserts `toContain('2727890')` with no release set. Because no `cachedFeatures` release is set in that test, it exercises the unknown branch — update the assertion to expect `abapfs_extensions` (and keep a `2727890` mention if the unknown-branch hint retains it).
+- [ ] Add a release-specific handler test (~2 tests): build a valid `ResolvedFeatures` via `resolveWithoutProbing(defaultFeatureConfig())` (from `src/adt/features.js`), override `.abapRelease = '750'`, and call `setCachedFeatures(...)` (both `setCachedFeatures` and `getCachedFeatures` are exported from the handler module, intent.ts ~7483/~7488). Trigger a 423 and assert the tool error text contains `abapfs_extensions`; then repeat with `.abapRelease = '758'` asserting it does NOT. Reset with `setCachedFeatures(undefined)` in `afterEach` to avoid cross-test leakage. (Do NOT hand-build a partial features object — `resolveWithoutProbing` yields the correct shape.)
+- [ ] Run `npm test` — all tests must pass.
+
+### Task 4: Startup warning when writes are enabled on a < 7.51 system
+
+**Files:**
+- Modify: `src/server/server.ts`
+- Modify: `tests/unit/server/` (add or extend the relevant server test file; create `tests/unit/server/startup-warning.test.ts` if no suitable file exists)
+
+Proactively warn operators at startup — before they hit the first cryptic 423 — when the system can't honor stateful writes and writes are enabled. Keep the network-dependent `runStartupProbe` thin by extracting a pure decision helper that can be unit-tested.
+
+- [ ] Add a pure exported helper (e.g. in `src/adt/release.ts` from Task 1) `function shouldWarnPreStatefulRelease(allowWrites: boolean, abapRelease?: string): boolean` → returns `true` iff `allowWrites === true` and `parseReleaseNumber(abapRelease)` is defined and `< 751`.
+- [ ] In `src/server/server.ts` `runStartupProbe()`, immediately after `setCachedFeatures(features)` (line ~356), call the helper with `config.allowWrites` and `features.abapRelease`; when `true`, emit a single `logger.warn(...)` such as: *"SAP_BASIS <release> is below 7.51 and does not honor stateful ADT HTTP sessions — object writes will fail with 423 'invalid lock handle'. Install abapfs_extensions (https://github.com/marcellourbani/abapfs_extensions) on the SAP system. See docs/sap-trial-setup troubleshooting."* Include the detected release in the message.
+- [ ] Add unit tests (~5 tests) for `shouldWarnPreStatefulRelease`: `(true,'750')`→true, `(true,'700')`→true, `(true,'758')`→false, `(false,'750')`→false (writes disabled), `(true,undefined)`→false (unknown release: don't cry wolf). Place them in the same test file as the `release.test.ts` helper tests OR the new server test file — but the pure-helper tests belong with the helper in `tests/unit/adt/release.test.ts`.
+- [ ] Run `npm test` — all tests must pass.
+
+### Task 5: Regression test — stateful header on include-write path
+
+**Files:**
+- Modify: `tests/unit/adt/http.test.ts`
+
+ARC-1 is currently immune to the vibing-steampunk #98 class of 423 (a write leaf that forgets the stateful flag) because the header is set at the *session-client* level in `AdtHttpClient.request()` (`src/adt/http.ts` ~line 326), not per call. Lock that guarantee in with a URL-specific regression test so a future refactor can't silently regress it for class-include writes.
+
+- [ ] IMPORTANT — put this in `tests/unit/adt/http.test.ts`, NOT `crud.test.ts`. `crud.test.ts` mocks `withStatefulSession` with a fake `{post, put}` session, so it bypasses the real header-setting code and would assert nothing. `http.test.ts` uses the **real** `AdtHttpClient` with `undici.fetch` mocked, which exercises the actual `request()` header logic (see existing tests at ~line 517-560 and ~line 866-871 that assert `X-sap-adt-sessiontype: stateful`).
+- [ ] Add a test that, inside `client.withStatefulSession(async (session) => { ... })`, issues a `session.put('/sap/bc/adt/oo/classes/ZCL_X/includes/implementations?lockHandle=...', 'source', 'text/plain')` against the mocked `undici.fetch`, and asserts the captured PUT request carries header `X-sap-adt-sessiontype: stateful`. Mirror the header-reading helper used by the existing stateful-session tests in the same file.
+- [ ] Add a short comment citing vibing-steampunk #98 as the regression this guards (every in-session write — including class-include PUTs — must carry the stateful header).
+- [ ] Run `npm test` — all tests must pass.
+
+### Task 6: User-facing troubleshooting doc
+
+**Files:**
+- Modify: `docs_page/sap-trial-setup.md`
+- Modify: `docs_page/tools.md`
+
+Give users a self-serve fix. The NW 7.50 trial audience documented in `sap-trial-setup.md` is exactly the affected population.
+
+- [ ] In `docs_page/sap-trial-setup.md`, add a new `###` subsection (under "SAP System Configuration", e.g. after "Session Timeout Tuning" ~line 264, or in a Troubleshooting area near "Known Test Failures") titled e.g. **"Writes fail with 423 'invalid lock handle' (NW < 7.51)"**. Cover: symptom (every SAPWrite/edit/delete returns 423 `ExceptionResourceInvalidLockHandle`; reads work); root cause (CL_REST_HTTP_HANDLER doesn't honor `X-sap-adt-sessiontype: stateful` before 7.51; the 7.51 mechanism `CONFIGURE_SESSION_STATE` in `CL_ADT_WB_RES_APP` is missing); that **SAP Note 2727890 is NOT the fix** (it's a narrow `+`-handle bug); the fix = install **abapfs_extensions**.
+- [ ] Document **both** install paths: (1) **abapGit** — import https://github.com/marcellourbani/abapfs_extensions into the dev system; (2) **Manual SE19/SE24** (for systems without abapGit, like the NPL trial): create an implicit enhancement implementation `ZABAPFILESYSTEM_SESSION` at the *begin* of `CL_REST_HTTP_HANDLER->IF_HTTP_EXTENSION~HANDLE_REQUEST`, package `$TMP`, activate. Include the exact ABAP snippet (reproduce it from `INFRASTRUCTURE.md` — the `__abapfs_stateful = server->request->get_header_field( 'X-sap-adt-sessiontype' )` block setting `gv_stateful`). Note no ICM restart is needed and that it's safe/no-op on ≥ 7.51.
+- [ ] In `docs_page/tools.md`, under the SAPWrite section, add a short note: writes on NW < 7.51 require the abapfs_extensions enhancement, linking to the new troubleshooting section.
+- [ ] No code/tests in this task. Run `npm run lint` (markdown is not linted by biome, but run it to confirm nothing else broke) — optional; primary check is the next task's `npm test`.
+
+### Task 7: Demote Note 2727890 in guidance docs + update research doc/issue
+
+**Files:**
+- Modify: `docs/integration-test-skips.md`
+- Modify: `docs_page/tools.md`
+- Create: `research/issues/293-ecc-423-invalid-lock-handle.md`
+- Modify: `CLAUDE.md`
+
+Correct forward-looking guidance and capture the validated conclusion. Do NOT touch historical references in `compare/00-feature-matrix.md` or `docs_page/roadmap.md` (records of past decisions).
+
+- [ ] `docs/integration-test-skips.md` (lines ~83, ~91, ~95, ~97): change the framing so **abapfs_extensions is the primary fix** for the lock-handle 423 on < 7.51; keep Note 2727890 only as a secondary "separate narrow bug" mention. Update the line "now cites the note directly" (~97) to reflect that the hint is now release-aware and points at abapfs_extensions for < 7.51. Note that NPL (with the enhancement installed) now passes these writes, so the relevant skips no longer fire on that specific instance.
+- [ ] `docs_page/tools.md` (~line 511, class-section cross-release note): change "Writes ... can trip SAP Note 2727890 ... ARC-1 detects the 423 and emits a hint" to reference the real cause (stateful-session header not honored < 7.51) and that the hint points at abapfs_extensions. (This may already be partly edited in Task 6 — ensure the two edits are consistent.)
+- [ ] Create `research/issues/293-ecc-423-invalid-lock-handle.md` on this branch with the **validated** conclusion: three root-cause classes (server stateless < 7.51 [the #293 cause, validated on NPL]; client missing stateful flag [ARC-1 immune]; stateless hop between LOCK/PUT [ARC-1 immune]); Note 2727890 is a red herring; abapfs_extensions is the fix (with the manual SE24 recipe); the live before/after evidence (NPL 423 → 200 after install; a4h native). Include a ready-to-post **drafted GitHub issue comment** (a fenced block) the maintainer can paste into #293.
+- [ ] `CLAUDE.md`: add `release.ts # SAP_BASIS release parsing (release-aware hints/warnings)` to the `src/adt/` section of the codebase structure tree, and add a Key Files row: "Add release-aware SAP error hint | `src/adt/errors.ts` (`classifySapDomainError` abapRelease param), `src/adt/release.ts`, `src/handlers/intent.ts` (`buildBaseErrorMessage`), `tests/unit/adt/{errors,release}.test.ts`".
+- [ ] No automated tests in this task (docs only). Run `npm test` afterward to confirm nothing referencing changed strings broke.
+
+### Task 8: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass.
+- [ ] Run typecheck: `npm run typecheck` — no errors.
+- [ ] Run lint: `npm run lint` — no errors.
+- [ ] Grep for stray primary-fix references to the note: `grep -rn "2727890" src/ docs/ docs_page/` — confirm remaining mentions are either secondary "separate narrow bug" framing or historical (feature-matrix/roadmap), not "apply this to fix writes".
+- [ ] Confirm hint wiring end-to-end with a focused run: `npx vitest run tests/unit/adt/errors.test.ts tests/unit/adt/release.test.ts tests/unit/handlers/intent.test.ts tests/unit/adt/crud.test.ts`.
+- [ ] (Live, optional — requires SAP creds) Validate against a4h (≥7.51): a 423 is unlikely, but confirm the build runs and `SAPRead` works. Validate against NPL (now has abapfs_extensions): confirm a `SAPWrite update` **succeeds** (regression-proves the fix is in place) — e.g. `SAP_URL=https://npl.marianzeis.de SAP_USER=DEVELOPER SAP_PASSWORD=Appl1ance SAP_CLIENT=001 SAP_INSECURE=true SAP_ALLOW_WRITES=true SAP_ALLOWED_PACKAGES='*' node dist/cli.js call SAPWrite --arg action=update --arg type=PROG --arg name=ZARC1_E2E_WRITE --arg 'source=REPORT zarc1_e2e_write.'`.
+- [ ] (Optional, maintainer decision) Post the drafted comment from the research doc to GitHub issue #293 via `gh issue comment 293 --repo marianfoo/arc-1 --body-file <draft>`. Leave as a manual step — do not auto-post from an autonomous session.
+- [ ] File follow-up issues for the out-of-scope findings (do NOT implement here): (1) abap-adt-api#42 — verify `SAPQuery`/`/datapreview/freestyle` sends `Content-Type: text/plain` for `LIKE '%'` queries; (2) vscode_abap_remote_fs#293 — guard `fast-xml-parser` paths against non-XML 4xx/5xx bodies (BASIS 731 `mainprograms` 500); (3) vibing-steampunk#114 — `/system/components` 406 on kernel 758 release detection (has a syntax-config fallback today; verify it still detects release).
+- [ ] Move this plan to `docs/plans/completed/`.

--- a/docs_page/sap-trial-setup.md
+++ b/docs_page/sap-trial-setup.md
@@ -302,6 +302,67 @@ docker exec a4h /usr/sap/hostctrl/exe/sapcontrol -nr 00 -function Start
 > **Note:** `RestartInstance` did not work reliably; use explicit `Stop` then
 > `Start`.
 
+### Writes fail with 423 "invalid lock handle" (NW < 7.51)
+
+**Symptom:** reads work, but every `SAPWrite` / `edit_method` / delete / activate-after-edit
+fails with:
+
+```
+status 423 ... Resource ... is not locked (invalid lock handle: ...)
+type id="ExceptionResourceInvalidLockHandle"
+```
+
+The LOCK appears to succeed (it returns a handle), but the very next PUT is rejected.
+SM12 shows no lock, because the lock was released the instant the PUT failed.
+
+**Root cause:** ADT writes require a *stateful* HTTP session so the ENQUEUE lock from
+LOCK survives until the PUT. ARC-1 sends the `X-sap-adt-sessiontype: stateful` header
+correctly — but on **SAP_BASIS < 7.51** the ADT REST handler `CL_REST_HTTP_HANDLER`
+silently ignores it (the mechanism that honors it, `CONFIGURE_SESSION_STATE` in
+`CL_ADT_WB_RES_APP`, only exists from 7.51). So the session reverts to stateless and the
+lock handle is invalid on the PUT. Eclipse is unaffected because it talks ADT over RFC,
+which is stateful by default. S/4HANA (≥ 7.51) works natively.
+
+> **SAP Note 2727890 is NOT the fix.** It addresses a separate, narrow bug (lock handles
+> containing `+` characters). Systems with the note applied on 7.40/7.50 still fail here.
+
+**Fix — install the `abapfs_extensions` enhancement** on the SAP system. It back-ports the
+7.51 stateful-session handling to `CL_REST_HTTP_HANDLER`. It's a single implicit
+enhancement, needs no ICM restart, and is a safe no-op on ≥ 7.51.
+
+**Option A — abapGit (preferred, if abapGit is installed):**
+Import [`marcellourbani/abapfs_extensions`](https://github.com/marcellourbani/abapfs_extensions)
+into the dev system (online clone, or offline ZIP upload via `ZABAPGIT_STANDALONE`), then
+activate the imported objects.
+
+**Option B — manual (no abapGit, e.g. the NPL trial), via SE24:**
+1. `SE24` → class `CL_REST_HTTP_HANDLER` → Display.
+2. Double-click method `IF_HTTP_EXTENSION~HANDLE_REQUEST`.
+3. Click **Enhance** (the spanner), then **Edit → Enhancement Operations → Show Implicit
+   Enhancement Options** so the method-begin marker appears.
+4. Position the cursor on the marker at the **start of the method body** (right after
+   `METHOD ...`), then **Create** an enhancement implementation named
+   `ZABAPFILESYSTEM_SESSION`.
+5. Paste this into the `ENHANCEMENT ... ENDENHANCEMENT` block:
+
+   ```abap
+   "Stateful mode support (compatible with implementation in 7.51)
+   "required for write support over HTTP (ADT clients)
+   DATA: __abapfs_stateful TYPE string.
+   __abapfs_stateful = server->request->get_header_field( 'X-sap-adt-sessiontype' ).
+   IF __abapfs_stateful = 'stateful'.
+     gv_stateful = abap_true.
+   ELSEIF __abapfs_stateful = 'stateless'.
+     gv_stateful = abap_false.
+   ENDIF.
+   ```
+6. Assign to package `$TMP` (or a transportable package) and **activate** (Ctrl+F3).
+
+After activation, retry the write — the next ADT request picks up the enhanced handler.
+
+> ARC-1 also detects this at startup: when writes are enabled on a < 7.51 system it logs a
+> warning pointing here, and the `423` error hint names `abapfs_extensions` directly.
+
 ### User Access
 
 The trial system ships with these pre-configured users:

--- a/docs_page/tools.md
+++ b/docs_page/tools.md
@@ -206,6 +206,11 @@ Every match in the result set is stamped with an `_origin: 'adt' | 'db'` field s
 
 Create or update ABAP source code. Handles lock/modify/unlock automatically.
 
+> **NetWeaver < 7.51:** ADT writes over HTTP require a stateful session that older releases
+> don't honor, so writes fail with `423 invalid lock handle` until the `abapfs_extensions`
+> enhancement is installed on the SAP system. This is *not* SAP Note 2727890 (a separate
+> narrow bug). See [SAP trial setup → Writes fail with 423](sap-trial-setup.md) (423 troubleshooting section). S/4HANA (≥ 7.51) is unaffected.
+
 **Parameters:**
 
 | Parameter | Type | Required | Description |

--- a/research/issues/293-ecc-423-invalid-lock-handle.md
+++ b/research/issues/293-ecc-423-invalid-lock-handle.md
@@ -1,0 +1,96 @@
+# Issue #293 — 423 "invalid lock handle" on ECC / NW < 7.51 (VALIDATED)
+
+**Status:** Root cause confirmed and fix validated live (2026-05-29).
+**Symptom:** Every ADT write (PROG/CLAS/INTF/DDIC/…) fails with
+`status 423 … Resource … is not locked (invalid lock handle: …)` /
+`type id="ExceptionResourceInvalidLockHandle"`. Reads work. S/4HANA works; ECC / NW 7.4x–7.50 fails.
+
+## TL;DR
+
+- The fix is **NOT SAP Note 2727890**. That note is a narrow bug for lock handles containing `+`
+  characters. Reporter `@acmebcn` has it applied on SAP_BASIS 7.40 SP33 and still fails; the NPL
+  handles we reproduced with had no `+`.
+- **Real root cause:** on **SAP_BASIS < 7.51** the ADT REST handler `CL_REST_HTTP_HANDLER` does not
+  honor the `X-sap-adt-sessiontype: stateful` HTTP header. The LOCK succeeds, but the session
+  reverts to stateless, the ENQUEUE lock is released, and the next PUT is rejected as 423. The 7.51+
+  mechanism that honors the header (`CONFIGURE_SESSION_STATE` in `CL_ADT_WB_RES_APP`) does not exist
+  on older releases. Eclipse is unaffected because it uses RFC, which is stateful by default.
+- **Fix:** install the [`abapfs_extensions`](https://github.com/marcellourbani/abapfs_extensions)
+  enhancement on the SAP system (one implicit enhancement on `CL_REST_HTTP_HANDLER` that back-ports
+  the header read). ARC-1 is doing the right thing on the wire; the gap is server-side.
+
+## Live validation (2026-05-29)
+
+| Test on NPL (NW 7.50 SP02) | Before | After installing `ZABAPFILESYSTEM_SESSION` |
+|---|---|---|
+| Raw lock→PUT (PROG/CLAS, correct handle, correct CSRF, no rotation) | 423 | **200** |
+| ARC-1 `SAPWrite update` (product path) | 423 | **"Successfully updated"** (bytes verified on server) |
+
+- Reproduced deterministically (6/6) before the fix; not transient.
+- Direct-to-ICM (via SSH tunnel, bypassing nginx) failed identically to via-nginx → nginx is not the cause.
+- a4h (S/4HANA 2023, kernel 7.58) works on both HTTP and RFC — it has the native 7.51 mechanism.
+
+## The three independent causes of this 423 (don't conflate)
+
+Researched across sibling ADT clients (abap-adt-api, vscode_abap_remote_fs, erpl-adt,
+vibing-steampunk, fr0ster):
+
+1. **(a) Server ignores the stateful header on < 7.51** — *this issue*. Fix: server-side
+   `abapfs_extensions` (or, where allowed, a lockless "optimistic" write — but that does **not** work
+   on NPL, which rejects a no-handle PUT with `400 Parameter lockHandle could not be found`).
+2. **(b) Client omits the stateful flag on a write leaf** (vibing-steampunk #98; hit even on 758 in
+   #110). **ARC-1 is immune** — it sets `X-sap-adt-sessiontype: stateful` at the *session-client*
+   level (`src/adt/http.ts`), so every in-session request carries it. Pinned by a regression test in
+   `tests/unit/adt/http.test.ts`.
+3. **(c) A stateless hop between LOCK and PUT** retires the session (vibing-steampunk #125).
+   **ARC-1 is immune** — `checkPackage` and pre-write lint run *before* the lock cycle; lock→PUT→unlock
+   is a single `withStatefulSession` with nothing interleaved.
+
+## What ARC-1 changed for this (PR for #293)
+
+- **Release-aware 423 hint** (`src/adt/errors.ts` `classifySapDomainError`): on a detected < 7.51
+  system the hint leads with `abapfs_extensions`; on ≥ 7.51 it gives transient/SM12 guidance; when the
+  release is unknown it offers both. Note 2727890 is demoted to a "separate narrow bug" mention.
+- **Startup warning** (`src/server/server.ts`): when `allowWrites` is on and the detected release is
+  < 7.51, log a one-line warning pointing at `abapfs_extensions`.
+- **Troubleshooting docs** (`docs_page/sap-trial-setup.md`, `docs_page/tools.md`): symptom, root cause,
+  and both install paths (abapGit import + manual SE24 enhancement recipe).
+- **Doc cleanup** (`docs/integration-test-skips.md`): `abapfs_extensions` is the primary fix; Note
+  2727890 kept only as a secondary mention.
+
+## Out of scope (separate follow-ups)
+
+- abap-adt-api#42 — verify `SAPQuery` (`/datapreview/freestyle`) sends `Content-Type: text/plain` for `LIKE '%'`.
+- vscode_abap_remote_fs#293 — guard `fast-xml-parser` against non-XML 4xx/5xx bodies (BASIS 731 `mainprograms` 500).
+- vibing-steampunk#114 — `/system/components` 406 on kernel 758 release detection (has a fallback today).
+
+---
+
+## Drafted comment for GitHub issue #293
+
+```markdown
+Update — we reproduced this on a NW 7.50 system and **validated the actual fix**. Correcting my earlier reply: **SAP Note 2727890 is not the fix.**
+
+**Root cause.** On SAP_BASIS < 7.51, the ADT REST handler `CL_REST_HTTP_HANDLER` does not honor the `X-sap-adt-sessiontype: stateful` header over HTTP. ARC-1 sends it correctly, but the server ignores it on older releases, so the LOCK is released before the PUT and you get `423 invalid lock handle`. The mechanism that honors the header (`CONFIGURE_SESSION_STATE` in `CL_ADT_WB_RES_APP`) only exists from 7.51 — which is why S/4HANA works and ECC/7.4x–7.50 doesn't, and why Eclipse (RFC, stateful by default) works while HTTP clients don't. Note 2727890 is a *separate, narrow* bug (lock handles containing `+`); @acmebcn confirmed it's applied on 7.40 SP33 and still fails — consistent with this.
+
+**Fix (server-side, ~2 minutes).** Install the `abapfs_extensions` enhancement — it back-ports the 7.51 stateful-session handling to `CL_REST_HTTP_HANDLER`. No ICM restart; safe no-op on ≥ 7.51.
+
+- **abapGit:** import https://github.com/marcellourbani/abapfs_extensions into your dev system and activate.
+- **No abapGit (manual, SE24):** on `CL_REST_HTTP_HANDLER` → method `IF_HTTP_EXTENSION~HANDLE_REQUEST`, click *Enhance*, show implicit enhancement options, and at the **start of the method** create an implicit enhancement implementation `ZABAPFILESYSTEM_SESSION` containing:
+
+  ```abap
+  DATA: __abapfs_stateful TYPE string.
+  __abapfs_stateful = server->request->get_header_field( 'X-sap-adt-sessiontype' ).
+  IF __abapfs_stateful = 'stateful'.
+    gv_stateful = abap_true.
+  ELSEIF __abapfs_stateful = 'stateless'.
+    gv_stateful = abap_false.
+  ENDIF.
+  ```
+
+  Assign to `$TMP` (or a transport) and activate. Retry your write — it should succeed.
+
+We validated this end-to-end on NW 7.50: the identical write that returned 423 returns 200 once the enhancement is active.
+
+The next ARC-1 release makes this self-explanatory: the 423 hint now points at `abapfs_extensions` when it detects SAP_BASIS < 7.51, and ARC-1 logs a startup warning if writes are enabled on such a system. Thanks @abappdpatel and @acmebcn for the reports and the SP detail that pinned it down.
+```

--- a/src/adt/errors.ts
+++ b/src/adt/errors.ts
@@ -15,6 +15,8 @@
  * in AdtApiError.fromResponse().
  */
 
+import { parseReleaseNumber, STATEFUL_SESSION_MIN_RELEASE } from './release.js';
+
 /** Base error for all ADT-related errors */
 export class AdtError extends Error {
   constructor(message: string) {
@@ -345,6 +347,7 @@ export function classifySapDomainError(
   statusCode: number,
   responseBody?: string,
   path?: string,
+  abapRelease?: string,
 ): SapErrorClassification | undefined {
   const bodyRaw = responseBody ?? '';
   const bodyLower = bodyRaw.toLowerCase();
@@ -382,14 +385,43 @@ export function classifySapDomainError(
   }
 
   if (typeId === 'ExceptionResourceInvalidLockHandle' || statusCode === 423) {
+    // The 423 "invalid lock handle" on ADT writes has a release-specific root cause:
+    // on SAP_BASIS < 7.51 the ADT REST handler (CL_REST_HTTP_HANDLER) does not honor
+    // the `X-sap-adt-sessiontype: stateful` header, so the LOCK is released before the
+    // PUT and the handle is rejected. The fix is the abapfs_extensions enhancement
+    // (back-ports the 7.51 CONFIGURE_SESSION_STATE behavior). SAP Note 2727890 is a
+    // SEPARATE, narrow bug (lock handles containing '+') — not this issue. See #293.
+    const releaseNum = parseReleaseNumber(abapRelease);
+    const abapfsFix =
+      'install the abapfs_extensions enhancement on the SAP system ' +
+      '(https://github.com/marcellourbani/abapfs_extensions) via abapGit — it back-ports the ' +
+      '7.51 stateful-session handling to CL_REST_HTTP_HANDLER. SAP Note 2727890 is a separate, ' +
+      "narrow bug (lock handles containing '+') and is NOT this issue.";
+
+    let hint: string;
+    if (releaseNum !== undefined && releaseNum < STATEFUL_SESSION_MIN_RELEASE) {
+      hint =
+        `Your SAP_BASIS (${abapRelease}) does not honor stateful ADT HTTP sessions, so the lock ` +
+        `is released before the write completes. To fix: ${abapfsFix}`;
+    } else if (releaseNum !== undefined) {
+      // 7.51+ honors stateful sessions natively — a 423 here is more likely a transient
+      // expiry or a genuine concurrent lock, not the pre-7.51 backend gap.
+      hint =
+        'Lock handle is invalid or expired. Retry first — transient expiry is the common case. ' +
+        'If it persists, check SM12 for stale lock entries and ensure no other editor (Eclipse, ' +
+        'SE80) holds the object.';
+    } else {
+      // Release unknown (detection unavailable): give the actionable < 7.51 guidance too,
+      // so the hint is useful even when we could not detect the backend release.
+      hint =
+        'Lock handle is invalid or expired. Retry first — transient expiry is the common case. ' +
+        `If 423 persists on the first PUT after a successful LOCK and your SAP_BASIS is below 7.51, ${abapfsFix}`;
+    }
+
     return {
       category: 'enqueue-error',
-      hint:
-        'Lock handle is invalid or expired. First, retry — transient expiry is the common case. ' +
-        'If 423 persists on the first PUT after a successful LOCK, see SAP Note 2727890 ' +
-        '"ADT: fix unstable adt lock handle" (component BC-DWB-AIE) — a known ABAP Development ' +
-        'Tools bug where the lock handle is not stable under certain conditions. Apply the note ' +
-        'or a support package that includes it.',
+      hint,
+      transaction: releaseNum !== undefined && releaseNum >= STATEFUL_SESSION_MIN_RELEASE ? 'SM12' : undefined,
       details: typeId ? { exceptionType: typeId } : undefined,
     };
   }

--- a/src/adt/release.ts
+++ b/src/adt/release.ts
@@ -1,0 +1,49 @@
+/**
+ * SAP_BASIS release parsing helpers.
+ *
+ * Kept dependency-free (no imports) so it can be used from low-level modules
+ * such as `errors.ts` without risking an import cycle through `features.ts`.
+ *
+ * SAP_BASIS release strings reported by `/sap/bc/adt/system/components` are
+ * dotless three-digit codes: "700", "740", "750", "757", "758". Releases below
+ * 751 lack native honoring of the `X-sap-adt-sessiontype: stateful` header over
+ * HTTP (the 7.51+ `CONFIGURE_SESSION_STATE` of `CL_ADT_WB_RES_APP` does not
+ * exist), so ADT writes fail with `423 invalid lock handle` unless the
+ * `abapfs_extensions` enhancement is installed. See issue #293.
+ */
+
+/** The release at and above which ADT honors stateful HTTP sessions natively. */
+export const STATEFUL_SESSION_MIN_RELEASE = 751;
+
+/**
+ * Parse a SAP_BASIS release string into a comparable integer.
+ *
+ * Strips any non-digit characters first, so both dotless ("750") and dotted
+ * ("7.50") forms map to the same number (750). Returns `undefined` when the
+ * input is empty/undefined or contains no digits.
+ */
+export function parseReleaseNumber(release?: string): number | undefined {
+  if (!release) return undefined;
+  const digits = release.replace(/\D/g, '');
+  if (digits.length === 0) return undefined;
+  const num = Number.parseInt(digits, 10);
+  return Number.isNaN(num) ? undefined : num;
+}
+
+/**
+ * True when the detected release is known to be below the stateful-session
+ * threshold (i.e. ADT HTTP writes need the abapfs_extensions enhancement).
+ * Returns false when the release is unknown — never cry wolf on missing data.
+ */
+export function isPreStatefulRelease(abapRelease?: string): boolean {
+  const num = parseReleaseNumber(abapRelease);
+  return num !== undefined && num < STATEFUL_SESSION_MIN_RELEASE;
+}
+
+/**
+ * Decide whether to emit the startup warning about pre-7.51 write support:
+ * only when writes are enabled AND the detected release is known to be < 7.51.
+ */
+export function shouldWarnPreStatefulRelease(allowWrites: boolean, abapRelease?: string): boolean {
+  return allowWrites === true && isPreStatefulRelease(abapRelease);
+}

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -416,7 +416,11 @@ function buildBaseErrorMessage(
     // Append additional SAP messages (line numbers, secondary errors) if available
     const enriched = enrichWithSapDetails(err, message);
     const argType = canonicalTablType(String(args.type ?? '').toUpperCase());
-    const classification = classifySapDomainError(err.statusCode, err.responseBody, err.path);
+    // Pass the detected SAP_BASIS release so the 423 lock-handle hint can specialize
+    // (< 7.51 → point at abapfs_extensions; see issue #293). cachedFeatures is set by the
+    // startup probe; config.abapRelease is the manual SAP_ABAP_RELEASE override fallback.
+    const abapRelease = cachedFeatures?.abapRelease ?? config.abapRelease;
+    const classification = classifySapDomainError(err.statusCode, err.responseBody, err.path, abapRelease);
 
     if (classification) {
       const transactionLine = classification.transaction ? `\nSAP Transaction: ${classification.transaction}` : '';

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -15,6 +15,7 @@ import { AdtClient } from '../adt/client.js';
 import type { AdtClientConfig } from '../adt/config.js';
 import { resolveCookies } from '../adt/cookies.js';
 import { AdtApiError } from '../adt/errors.js';
+import { shouldWarnPreStatefulRelease } from '../adt/release.js';
 import { deriveUserSafety, deriveUserSafetyFromProfile } from '../adt/safety.js';
 import { Semaphore } from '../adt/semaphore.js';
 import { getActionPolicy, hasRequiredScope } from '../authz/policy.js';
@@ -354,6 +355,19 @@ export function runStartupProbe(
         }
       }
       setCachedFeatures(features);
+      // Proactive warning: on SAP_BASIS < 7.51 the ADT REST handler does not honor the
+      // stateful-session header over HTTP, so object writes fail with 423 "invalid lock
+      // handle" until the abapfs_extensions enhancement is installed. Warn at startup —
+      // before the first cryptic 423 — but only when writes are enabled (issue #293).
+      if (shouldWarnPreStatefulRelease(config.allowWrites, features.abapRelease)) {
+        logger.warn(
+          `SAP_BASIS ${features.abapRelease} is below 7.51 and does not natively honor stateful ADT ` +
+            'HTTP sessions — object writes will fail with 423 "invalid lock handle" UNLESS the ' +
+            'abapfs_extensions enhancement is installed on the SAP system ' +
+            '(https://github.com/marcellourbani/abapfs_extensions). If writes already work, this is ' +
+            'installed and you can ignore this. See docs/sap-trial-setup.md (423 troubleshooting).',
+        );
+      }
       setCachedDiscovery(features.discoveryMap ?? new Map());
     } catch {
       setCachedDiscovery(new Map());

--- a/tests/unit/adt/errors.test.ts
+++ b/tests/unit/adt/errors.test.ts
@@ -415,15 +415,35 @@ describe('AdtApiError', () => {
       expect(classification?.category).toBe('authorization');
     });
 
-    it('classifies enqueue errors for 423', () => {
+    it('classifies enqueue errors for 423 (release unknown → combined guidance)', () => {
       const classification = classifySapDomainError(423, 'Lock handle invalid');
       expect(classification?.category).toBe('enqueue-error');
       // First-line advice: retry (transient expiry is the common case).
-      expect(classification?.hint).toContain('retry');
-      // Cites the specific SAP Note verified via the SAP Knowledge Base
-      // search — the concrete grounded reference for persistent 423s.
+      expect(classification?.hint).toContain('Retry first');
+      // Release unknown → still point at the real fix for < 7.51 systems
+      // (abapfs_extensions) so the hint is actionable even without detection.
+      expect(classification?.hint).toContain('abapfs_extensions');
+      // SAP Note 2727890 is kept only as a "separate, narrow bug" mention — NOT the fix.
       expect(classification?.hint).toContain('2727890');
-      expect(classification?.hint).toContain('BC-DWB-AIE');
+    });
+
+    it('423 on SAP_BASIS < 7.51 leads with the abapfs_extensions fix', () => {
+      for (const release of ['700', '740', '750']) {
+        const classification = classifySapDomainError(423, 'x', undefined, release);
+        expect(classification?.category).toBe('enqueue-error');
+        expect(classification?.hint).toContain('abapfs_extensions');
+        expect(classification?.hint).toContain(release);
+      }
+    });
+
+    it('423 on SAP_BASIS >= 7.51 does NOT mention abapfs_extensions (transient/real-lock)', () => {
+      for (const release of ['751', '758']) {
+        const classification = classifySapDomainError(423, 'x', undefined, release);
+        expect(classification?.category).toBe('enqueue-error');
+        expect(classification?.hint).not.toContain('abapfs_extensions');
+        expect(classification?.hint).toContain('Retry first');
+        expect(classification?.transaction).toBe('SM12');
+      }
     });
 
     it('classifies 404 "No suitable resource found" as ICF handler not bound', () => {

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -924,6 +924,28 @@ describe('AdtHttpClient', () => {
       expect(fetchHeaders(0)['X-sap-adt-sessiontype']).toBe('stateful');
     });
 
+    // Regression guard for the vibing-steampunk #98 bug class: a class-include write
+    // (CCDEF/CCIMP/testclasses) must carry the stateful-session header so SAP's ICM
+    // routes the PUT to the same session that holds the ENQUEUE lock. ARC-1 sets the
+    // header at the session-client level (request()), so EVERY in-session request —
+    // including include PUTs — gets it; this test pins that for the include URL shape.
+    it('class-include PUT inside a stateful session carries X-sap-adt-sessiontype', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, ''));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      (client as unknown as { csrfToken: string }).csrfToken = 'T'; // skip CSRF fetch round-trip
+
+      await client.withStatefulSession(async (session) => {
+        await session.put(
+          '/sap/bc/adt/oo/classes/ZCL_X/includes/implementations?lockHandle=ABC',
+          'CLASS lcl IMPLEMENTATION. ENDCLASS.',
+          'text/plain',
+        );
+      });
+
+      expect(fetchHeaders(0)['X-sap-adt-sessiontype']).toBe('stateful');
+    });
+
     it('explicit extra headers win over discovery for Accept and Content-Type', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(200, '', { 'x-csrf-token': 'T' }));
       mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));

--- a/tests/unit/adt/release.test.ts
+++ b/tests/unit/adt/release.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isPreStatefulRelease,
+  parseReleaseNumber,
+  STATEFUL_SESSION_MIN_RELEASE,
+  shouldWarnPreStatefulRelease,
+} from '../../../src/adt/release.js';
+
+describe('parseReleaseNumber', () => {
+  it('parses dotless 3-digit SAP_BASIS codes', () => {
+    expect(parseReleaseNumber('700')).toBe(700);
+    expect(parseReleaseNumber('740')).toBe(740);
+    expect(parseReleaseNumber('750')).toBe(750);
+    expect(parseReleaseNumber('751')).toBe(751);
+    expect(parseReleaseNumber('758')).toBe(758);
+  });
+
+  it('strips non-digits (dotted / whitespace forms)', () => {
+    expect(parseReleaseNumber('7.50')).toBe(750);
+    expect(parseReleaseNumber(' 750 ')).toBe(750);
+  });
+
+  it('returns undefined for empty/undefined/non-numeric input', () => {
+    expect(parseReleaseNumber(undefined)).toBeUndefined();
+    expect(parseReleaseNumber('')).toBeUndefined();
+    expect(parseReleaseNumber('abc')).toBeUndefined();
+  });
+
+  it('places the 7.51 boundary correctly', () => {
+    expect(parseReleaseNumber('750')!).toBeLessThan(STATEFUL_SESSION_MIN_RELEASE);
+    expect(parseReleaseNumber('751')!).toBeGreaterThanOrEqual(STATEFUL_SESSION_MIN_RELEASE);
+  });
+});
+
+describe('isPreStatefulRelease', () => {
+  it('is true below 7.51', () => {
+    expect(isPreStatefulRelease('700')).toBe(true);
+    expect(isPreStatefulRelease('750')).toBe(true);
+  });
+
+  it('is false at/above 7.51', () => {
+    expect(isPreStatefulRelease('751')).toBe(false);
+    expect(isPreStatefulRelease('758')).toBe(false);
+  });
+
+  it('is false when the release is unknown', () => {
+    expect(isPreStatefulRelease(undefined)).toBe(false);
+    expect(isPreStatefulRelease('')).toBe(false);
+  });
+});
+
+describe('shouldWarnPreStatefulRelease', () => {
+  it('warns only when writes are enabled AND release < 7.51', () => {
+    expect(shouldWarnPreStatefulRelease(true, '750')).toBe(true);
+    expect(shouldWarnPreStatefulRelease(true, '700')).toBe(true);
+  });
+
+  it('does not warn at/above 7.51', () => {
+    expect(shouldWarnPreStatefulRelease(true, '758')).toBe(false);
+    expect(shouldWarnPreStatefulRelease(true, '751')).toBe(false);
+  });
+
+  it('does not warn when writes are disabled', () => {
+    expect(shouldWarnPreStatefulRelease(false, '750')).toBe(false);
+  });
+
+  it('does not warn when the release is unknown (no false alarms)', () => {
+    expect(shouldWarnPreStatefulRelease(true, undefined)).toBe(false);
+  });
+});

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -6354,7 +6354,8 @@ ENDCLASS.`;
       expect(result.content[0]?.text).toContain('E19K900001');
     });
 
-    it('423 lock handle error returns enqueue hint', async () => {
+    it('423 lock handle error returns enqueue hint (release unknown → combined guidance)', async () => {
+      resetCachedFeatures(); // no detected release → unknown-release branch
       mockFetch.mockReset();
       mockFetch.mockRejectedValueOnce(
         new AdtApiError(
@@ -6367,11 +6368,52 @@ ENDCLASS.`;
       const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', { type: 'PROG', name: 'ZPROG' });
       expect(result.isError).toBe(true);
       expect(result.content[0]?.text).toContain('Lock handle is invalid or expired');
-      // Hint cites SAP Note 2727890 (component BC-DWB-AIE) — verified via the
-      // SAP Knowledge Base as the concrete known-fix for ADT lock-handle
-      // instability. Replaces the previous generic SM12 transaction pointer.
+      // Release unknown → still point at the real fix for < 7.51 (abapfs_extensions);
+      // SAP Note 2727890 is kept only as a "separate, narrow bug" mention (issue #293).
+      expect(result.content[0]?.text).toContain('abapfs_extensions');
       expect(result.content[0]?.text).toContain('2727890');
-      expect(result.content[0]?.text).toContain('BC-DWB-AIE');
+    });
+
+    it('423 on detected SAP_BASIS < 7.51 leads with the abapfs_extensions fix', async () => {
+      setCachedFeatures({ abapRelease: '750', systemType: 'onprem' } as ResolvedFeatures);
+      try {
+        mockFetch.mockReset();
+        mockFetch.mockRejectedValueOnce(
+          new AdtApiError(
+            'Locked',
+            423,
+            '/sap/bc/adt/programs/programs/ZPROG/source/main',
+            '<exc:exception><type id="ExceptionResourceInvalidLockHandle"/></exc:exception>',
+          ),
+        );
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', { type: 'PROG', name: 'ZPROG' });
+        expect(result.isError).toBe(true);
+        expect(result.content[0]?.text).toContain('abapfs_extensions');
+        expect(result.content[0]?.text).toContain('750');
+      } finally {
+        resetCachedFeatures();
+      }
+    });
+
+    it('423 on detected SAP_BASIS >= 7.51 does NOT mention abapfs_extensions', async () => {
+      setCachedFeatures({ abapRelease: '758', systemType: 'onprem' } as ResolvedFeatures);
+      try {
+        mockFetch.mockReset();
+        mockFetch.mockRejectedValueOnce(
+          new AdtApiError(
+            'Locked',
+            423,
+            '/sap/bc/adt/programs/programs/ZPROG/source/main',
+            '<exc:exception><type id="ExceptionResourceInvalidLockHandle"/></exc:exception>',
+          ),
+        );
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', { type: 'PROG', name: 'ZPROG' });
+        expect(result.isError).toBe(true);
+        expect(result.content[0]?.text).not.toContain('abapfs_extensions');
+        expect(result.content[0]?.text).toContain('Retry first');
+      } finally {
+        resetCachedFeatures();
+      }
     });
 
     it('403 authorization XML returns SU53/PFCG hint', async () => {


### PR DESCRIPTION
## Summary

Issue #293: every ADT write fails with `423 invalid lock handle` on ECC / NetWeaver < 7.51, while S/4HANA works. ARC-1's hint currently blames **SAP Note 2727890** — but that note is a *red herring* (a narrow bug for lock handles containing `+`). Reporter `@acmebcn` has it applied on 7.40 SP33 and still fails.

**Real root cause (researched + validated live):** on SAP_BASIS < 7.51 the ADT REST handler `CL_REST_HTTP_HANDLER` does not honor the `X-sap-adt-sessiontype: stateful` header over HTTP (the 7.51+ mechanism `CONFIGURE_SESSION_STATE` in `CL_ADT_WB_RES_APP` doesn't exist). The LOCK succeeds, the session reverts to stateless, and the next PUT is rejected. Eclipse is unaffected (RFC = stateful by default). The fix is the server-side [`abapfs_extensions`](https://github.com/marcellourbani/abapfs_extensions) enhancement.

**Validated live on NW 7.50 (NPL):** identical write returned 423 before installing the enhancement, **200 after**. a4h (kernel 7.58) works natively.

ARC-1 was already correct on the wire (stateful header set at the session-client level; no stateless hop between LOCK and PUT — immune to the vibing-steampunk #98 and #125 client-side 423 classes). The gap was **user guidance**.

## Changes

- **Release-aware 423 hint** (`src/adt/errors.ts`): `< 7.51` → leads with `abapfs_extensions`; `>= 7.51` → transient/SM12 guidance; unknown release → both. Wired via `cachedFeatures?.abapRelease ?? config.abapRelease` (`src/handlers/intent.ts`).
- **`src/adt/release.ts`** (new): pure release-number helpers (no import cycle).
- **Startup warning** (`src/server/server.ts`): when `allowWrites` + detected release `< 7.51`.
- **Troubleshooting docs** (`docs_page/sap-trial-setup.md`, `docs_page/tools.md`): abapGit + manual SE24 install recipes.
- **Doc cleanup** (`docs/integration-test-skips.md`): `abapfs_extensions` is the primary fix; Note 2727890 demoted to a secondary mention.
- **Regression test** (`tests/unit/adt/http.test.ts`): class-include PUT carries the stateful header (guards the #98 class).
- **`research/issues/293-…md`**: validated root cause + a drafted comment for issue #293.

## Test plan

- `npm test` (3100 unit tests), `npm run typecheck`, `npm run lint` — all green.
- New/updated tests: `release.test.ts` (11), release-branch cases in `errors.test.ts` + `intent.test.ts`, stateful-header regression in `http.test.ts`.
- **Live:** NPL 7.50 `SAPWrite update` succeeds (post-enhancement); built artifact emits the correct hint per release (750→abapfs, 758→SM12, unknown→both); a4h read no-regression.

## Follow-ups (out of scope; noted in the plan)

- abap-adt-api#42 — verify `SAPQuery` sends `Content-Type: text/plain` for `LIKE '%'`.
- vscode_abap_remote_fs#293 — guard XML parser against non-XML 4xx/5xx bodies (BASIS 731).
- vibing-steampunk#114 — `/system/components` 406 on kernel 758 release detection.

Closes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)