### PR TITLE
fix(intent): replace 3 raw NUL bytes in source with \x00 escapes

### DIFF
--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -2003,7 +2003,7 @@ async function handleSAPSearch(client: AdtClient, args: Record<string, unknown>)
         // Preserve the more-specific slash form when both originate from ADT+DB.
         const seen = new Map<string, AdtSearchResult>();
         const baseKey = (m: AdtSearchResult): string =>
-          `${(m.objectType.split('/')[0] || m.objectType).toUpperCase()} ${m.objectName.toUpperCase()}`;
+          `${(m.objectType.split('/')[0] || m.objectType).toUpperCase()}\x00${m.objectName.toUpperCase()}`;
         for (const m of adtMatches) seen.set(baseKey(m), m);
         for (const m of dbMatches) {
           const k = baseKey(m);
@@ -5264,10 +5264,10 @@ async function handleSAPWrite(
           const batchStatuses = buildBatchActivationStatuses(writtenObjects, activationOutcome);
           const statusDetails = formatBatchActivationStatuses(batchStatuses);
           terminalActivationFailure = statusDetails;
-          const statusByName = new Map(batchStatuses.map((s) => [`${s.type} ${s.name}`, s]));
+          const statusByName = new Map(batchStatuses.map((s) => [`${s.type}\x00${s.name}`, s]));
           for (const result of results) {
             if (result.status !== 'success') continue;
-            const key = `${result.type} ${result.name}`;
+            const key = `${result.type}\x00${result.name}`;
             const matched = statusByName.get(key);
             if (!matched) continue;
             // Some entries may still report status 'active' if the activator returned


### PR DESCRIPTION
## Summary

`src/handlers/intent.ts` contained **3 literal NUL bytes (0x00)** embedded directly in the source. They were intentional separators in composite `Map`-key template literals (`` `${type}<NUL>${name}` ``) but written as raw bytes instead of the `\x00` escape sequence.

The runtime key is identical, but a raw NUL in a `.ts` file makes the whole file register as **binary** — `grep` and other line-oriented tooling silently skip it unless forced with `-a` — and it's a latent hazard for editors, diffs, and CI.

## Change

Replaced each raw `0x00` with the explicit `\x00` escape inside the template literals (3 spots: a TADIR composite key ~line 2006, and the batch-activation status map key + lookup ~lines 5267/5270). Byte-identical NUL-separated keys at runtime, clean UTF-8 source.

```
- `${s.type}<0x00>${s.name}`
+ `${s.type}\x00${s.name}`
```

## Verification

- `python3 -c "print(open('src/handlers/intent.ts','rb').read().count(b'\x00'))"` → `0`
- `grep handleSAPRead src/handlers/intent.ts` now matches without `-a` (file no longer detected as binary)
- `npm run typecheck`, `npm run lint`, `npm test` (3202 tests) all green — no behavior change

Found while reviewing #316 (the raw NULs were why `grep` treated `intent.ts` as binary throughout that work). Pre-existing on `main`; unrelated to the grep feature, so split into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
