### PR TITLE
test(e2e): fix ZI_ARC1_I33_PROJ fixture activation on S/4HANA 2023

### DIFF
--- a/tests/fixtures/abap/zi_arc1_i33_proj.ddls.abap
+++ b/tests/fixtures/abap/zi_arc1_i33_proj.ddls.abap
@@ -1,6 +1,6 @@
 @EndUserText.label: 'ARC-1 FEAT-33 projection'
 @AccessControl.authorizationCheck: #NOT_REQUIRED
-define view entity ZI_ARC1_I33_PROJ as projection on ZI_ARC1_I33_ROOT {
-  id,
+define view entity ZI_ARC1_I33_PROJ as select from ZI_ARC1_I33_ROOT {
+  key id,
   description
 }


### PR DESCRIPTION
## Summary

The e2e suite (`npm run test:e2e`) is blocked on S/4HANA 2023 (SAP_BASIS 758, e.g. a4h) during the **fixture-sync prerequisite**. Because the script is `test:e2e:fixtures && vitest …`, a failed sync short-circuits and **no e2e test runs at all**.

The failing object is the DDLS fixture `ZI_ARC1_I33_PROJ` (unchanged since #143). On S/4 2023 a bare `as projection on` fails to activate with two CDS errors:

- **SD_CDS_PC_TQ 013** — base key field `ID` is not re-declared as `key` in the projection.
- **SD_CDS_PC_TQ 009** — a projection view is treated as a *transactional* projection and must belong to a business object (no BDEF exists for this fixture).

## Fix

Convert the fixture to a read-only `as select from` consumer view with `key id`:

```diff
-define view entity ZI_ARC1_I33_PROJ as projection on ZI_ARC1_I33_ROOT {
-  id,
+define view entity ZI_ARC1_I33_PROJ as select from ZI_ARC1_I33_ROOT {
+  key id,
   description
 }
```

This activates standalone (no business object / BDEF needed) and **preserves the `cds-impact` e2e test's intent**:
- Upstream: the `ZI_` prefix still classifies `ZI_ARC1_I33_ROOT` as a view (`buildCdsUpstream` → `isLikelyCdsViewName`), so `impact.upstream.views` still contains the root.
- Downstream: any DDLS consumer is still bucketed as a `projectionView` (classifier keys on object type, not the `projection` keyword).

`provider contract transactional_query` was considered but rejected — it would still require the root to be a business object.

## Validation

Live against a4h (S/4HANA 2023): fixture activates, and the **full e2e suite passes**:

```
Test Files  18 passed (18)
     Tests  142 passed | 3 skipped (145)   # 3 skips unrelated (saptransport, navigate)
```

All 4 `cds-impact.e2e` tests pass, including *"returns upstream root reference for a projection view"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)