### PR TITLE
[arc1] Transport review proof A4HK905691

### DIFF
--- a/checks/syntax.md
+++ b/checks/syntax.md
@@ -1,3 +1,6 @@
 # Syntax Check
 
-Not run for baseline snapshot.
+| Object | Result | Messages |
+| --- | --- | --- |
+| ZARC1_RV_TFVA5L_A | pass | 0 |
+| ZARC1_RV_TFVA5L_B | pass | 0 |

--- a/objects/PROG/ZARC1_RV_TFVA5L_A/zarc1_rv_tfva5l_a.prog.abap
+++ b/objects/PROG/ZARC1_RV_TFVA5L_A/zarc1_rv_tfva5l_a.prog.abap
@@ -1,6 +1,8 @@
 REPORT zarc1_rv_tfva5l_a.
 
-DATA gv_counter TYPE i VALUE 1.
+DATA gv_counter TYPE i VALUE 10.
+DATA gv_review_note TYPE string VALUE 'review proof A4HK905691'.
 
-WRITE: / 'ARC-1 transport review baseline'.
+WRITE: / 'ARC-1 transport review changed version'.
 WRITE: / gv_counter.
+WRITE: / gv_review_note.

--- a/objects/PROG/ZARC1_RV_TFVA5L_B/zarc1_rv_tfva5l_b.prog.abap
+++ b/objects/PROG/ZARC1_RV_TFVA5L_B/zarc1_rv_tfva5l_b.prog.abap
@@ -1,6 +1,8 @@
 REPORT zarc1_rv_tfva5l_b.
 
-DATA gv_counter TYPE i VALUE 2.
+DATA gv_counter TYPE i VALUE 11.
+DATA gv_review_note TYPE string VALUE 'review proof A4HK905691'.
 
-WRITE: / 'ARC-1 transport review baseline'.
+WRITE: / 'ARC-1 transport review changed version'.
 WRITE: / gv_counter.
+WRITE: / gv_review_note.


### PR DESCRIPTION
## What this proves

This is a generated transport-review PR from a live S/4HANA system using ARC-1 ADT operations.

- Created SAP transport `A4HK905691` in package `Z_LLM_TEST_PACKAGE`.
- Created and changed two ABAP reports: `ZARC1_RV_TFVA5L_A` and `ZARC1_RV_TFVA5L_B`.
- SAP transport details show both objects locked in task `A4HK905692`.
- Base branch `arc1/base/A4HK905691` contains the first active snapshot.
- Review branch `arc1/review/A4HK905691` contains the later active S/4 DEV state.
- Syntax check for the review snapshot passed with 0 messages.

## Feasibility signal

GitHub's compare API reports the review branch is one commit ahead of the base branch and the PR diff is limited to three modified files: the syntax report and two generated `.prog.abap` files. This confirms the proposed pull-request-style review flow is technically feasible for code-like transport objects when ARC-1 can produce stable before/after snapshots.

## Caveats

This proof uses iterative-review mode (`ARC-1 stored first snapshot`) rather than PRD/QAS or last-transported baseline. It does not yet prove baseline extraction from SAP revision history or cross-system comparison, and it only covers `PROG` objects.