### PR TITLE
fix: callback proxy for XSUAA OAuth state — fixes "State does not match" from VS Code (#214)

### DIFF
--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -117,6 +117,7 @@ SORT RULES for this table — DO NOT BREAK when adding rows:
 
 | ID | Feature | Completed | Category |
 |----|---------|-----------|----------|
+| [SEC-12](#sec-12) | XSUAA OAuth `state` Callback Proxy — fixes VS Code "State does not match" (XSUAA echoes literal `+`; signed base64url state token + `/oauth/callback` re-encodes). Removable only when XSUAA emits `%2B` (not vscode#314715). (PR #325) | 2026-06-01 | Security |
 | — | SAPSearch `tadir_lookup` `source` modes (`adt`/`db`/`both`) for TADIR ghost detection + SAPWrite `batch_create` `activateAtEnd` for interdependent / composition-linked objects. Both are opt-in fixes from the SEGW→RAP migration skill Run 6. Default behaviors unchanged: `source='adt'` keeps the existing ADT info-system path on read scope; `activateAtEnd=false` keeps per-object inline activation. The `db` and `both` sources issue `SELECT pgmid, object, obj_name, devclass FROM tadir WHERE obj_name IN (...)` via the existing freestyle-SQL path, surfacing orphan TADIR rows hidden by the ADT info-system; `both` adds a `splitBrain[]` array + per-name warnings explaining divergence (e.g. ghost from aborted create/delete cycle). `activateAtEnd=true` defers activation until the entire batch has been written, then issues one `activateBatch` — SAP's activator resolves cross-references between siblings in one pass (verified live: composition-linked DDLS pair activates cleanly via `activateAtEnd=true` vs the per-object path failing with `"data source ZR_CHILD does not exist or is not active"`). Plan: `docs/plans/completed/add-batch-defer-activate-and-tadir-db-source.md`. | 2026-05-11 | Features |
 | — | RAP handler skeleton CCIMP-only fix — `ensureRapHandlerSkeletons` was writing the `CLASS lhc_<alias> DEFINITION INHERITING FROM cl_abap_behavior_handler` block to CCDEF (`/source/definitions`), which the SAP activator rejects with `Local classes of "CL_ABAP_BEHAVIOR_HANDLER" can only be derived in the "Local Definitions/Implementations" of a global BEHAVIOR class`. Fix routes both DEFINITION + IMPLEMENTATION blocks into CCIMP per ABAP keyword doc `ABENABP_HANDLER_CLASS_GLOSRY` and SAP demo class `BP_DEMO_RAP_STRICT` (live-captured fixtures + integration regression test against the demo class). End-to-end verified on a4h S/4HANA 2023 (ABAP 7.58). **Breaking change** — pre-1.0; classes previously scaffolded by arc-1 carry the wrong CCDEF/CCIMP split and must be deleted + recreated to pick up the canonical layout. Plan: `docs/plans/completed/fix-rap-handler-skeleton-include.md`. | 2026-05-11 | Fixes |
 | — | PR-C `SAPWrite action=generate_behavior_implementation` — one-shot RAP behavior pool orchestrator. Auto-discovers the bound BDEF via class metadata's `<class:rootEntityRef>`, cross-validates `FOR BEHAVIOR OF` ↔ `managed implementation in class` agreement, scaffolds every required handler (creating missing `lhc_<alias>` skeletons), writes CCDEF + CCIMP under one stateful lock, and (by default) activates. Reliable equivalent of Eclipse ADT's "Generate Behavior Implementation" Cmd+1 quickfix without depending on the broken `/sap/bc/adt/quickfixes/proposals/.../create_class_implementation` server endpoint (HTTP 500 on a4h regardless of payload, verified live). Activation rejections matching the well-known stale-active CCDEF/CCIMP coupling return a guided recovery hint instead of throwing. Plan: `docs/plans/completed/add-generate-behavior-implementation.md`. | 2026-05-10 | Features |
@@ -2299,6 +2300,38 @@ The four shipped MCP clients — Claude Desktop, Cursor, VS Code Copilot, Copilo
 - Tier 2: CycloneDX SBOM (npm + image), Cosign keyless image signing, OpenSSF Scorecard. Plan in [docs/plans/dependency-security-tier2-attestation.md](../docs/plans/dependency-security-tier2-attestation.md).
 - Tier 3: Socket.dev PR review, internal vulnerability triage runbook, formal non-adoption decisions for Renovate / Snyk / SLSA L3. Plan in [docs/plans/dependency-security-tier3-defense.md](../docs/plans/dependency-security-tier3-defense.md).
 - 7 remaining HIGH CodeQL alerts (clear-text logging FPs in `src/cli.ts`, double-escaping in `src/adt/diagnostics.ts` + `src/adt/xml-parser.ts`, incomplete sanitization in `src/adt/diagnostics.ts`, missing rate-limiting on `/authorize` — the last maps to roadmap [SEC-05](#sec-05)). Triage in separate PRs.
+
+---
+
+<a id="sec-12"></a>
+### SEC-12: XSUAA OAuth `state` Callback Proxy (fixes VS Code "State does not match")
+| Field | Value |
+|-------|-------|
+| **Priority** | P1 |
+| **Status** | Complete (2026-06-01, PR #325) |
+
+**Problem:** OAuth login intermittently failed with **"State does not match"** when connecting from VS Code (issue [#214](https://github.com/marianfoo/arc-1/issues/214)). XSUAA echoes a **literal `+`** (not `%2B`) in the `state` it appends to the authorization redirect. Standard base64 `state` values — e.g. VS Code's `randomBytes(16).toString('base64')` — contain `+` ~50% of the time. The receiving client parses the callback query with `application/x-www-form-urlencoded` semantics (`+`→space), so the round-tripped `state` no longer matched and login failed about half the time.
+
+Verified empirically against live XSUAA with an [8-scenario spectrum reproducer](https://github.com/marianfoo/arc-1/issues/214#issuecomment-4387683481): `+` is the ONLY character XSUAA mangles (`/`, `=`, alphanumerics survive), and it mangles even when ARC-1 forwards a correctly `%2B`-encoded state — so an ingress-only fix is impossible. ARC-1 was not in the return path (XSUAA redirected directly to the client).
+
+**Implemented:**
+
+- `OAuthStateCodec` (NEW `src/server/oauth-state.ts`) — stateless, HMAC-signed, **base64url** state token (no `+`/`/`, immune to the bug) carrying the client's original `redirect_uri` + `state` + 10-min expiry. Mirrors the stateless DCR design ([SEC-09](#sec-09)): same resolved signing secret, distinct KDF label, survives `cf restart` / scale-out with no in-memory map.
+- `XsuaaProxyOAuthProvider.authorize()` sends XSUAA ARC-1's own `/oauth/callback` + the signed token instead of the client's `redirect_uri` + raw `state`.
+- New `/oauth/callback` route decodes the token and 302-redirects to the client, re-emitting the original `state` via `URL.searchParams` (encodes `+` as `%2B`). Invalid / expired / forged tokens → `400` (no open redirect — the redirect target lives inside the verified token). Rate-limited like the other OAuth endpoints.
+- `exchangeAuthorizationCode()` sends the same `/oauth/callback` so the token-exchange `redirect_uri` matches authorize.
+
+Transparent to every client shape (native loopback, browser redirect, browser popup); each now gets its exact original `state` back. No `xs-security.json` change needed — the callback matches the existing `https://*.hana.ondemand.com/**` / `http://localhost:*/**` wildcards.
+
+**Removal condition (when this workaround can be deleted):** ONLY when **XSUAA stops emitting a literal `+`** (emits `%2B`) for `state`. That is the actual root-cause defect; no public SAP Note tracks it as of 2026-06. Re-run the issue #214 spectrum reproducer against the target tenant to check.
+
+The VS Code client-side issue — [microsoft/vscode#314715](https://github.com/microsoft/vscode/issues/314715), asking VS Code to use base64url `state` — would fix the **VS Code symptom only**. Other MCP clients (Cursor, claude.ai, Copilot Studio, …) still send base64 `state` containing `+`, so the callback proxy must stay until the XSUAA-side fix lands. **Do not remove this module just because vscode#314715 closes.**
+
+**Files:**
+- `src/server/oauth-state.ts` — NEW signed state codec (removal condition documented at the top)
+- `src/server/xsuaa.ts` — `authorize()` + `exchangeAuthorizationCode()` route through `/oauth/callback`
+- `src/server/http.ts` — NEW `/oauth/callback` route (exported `createOAuthCallbackHandler`)
+- `tests/unit/server/oauth-state.test.ts`, `tests/unit/server/oauth-callback.test.ts` — codec + round-trip proof
 
 ---
 

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -34,9 +34,78 @@ import helmet from 'helmet';
 import { expandScopes } from '../authz/policy.js';
 import { API_KEY_PROFILES } from './config.js';
 import { logger } from './logger.js';
+import type { OAuthStateCodec } from './oauth-state.js';
 import { VERSION } from './server.js';
 import type { ServerConfig } from './types.js';
 import type { XsuaaCredentials } from './xsuaa.js';
+
+// ─── OAuth Callback Proxy Handler (issue #214) ───────────────────────
+
+/**
+ * Express handler for ARC-1's `/oauth/callback`, the second half of the
+ * XSUAA callback proxy that fixes the `+`-in-state bug (issue #214).
+ *
+ * XSUAA redirects here (not to the client) with an opaque base64url `state`
+ * token that ARC-1's `authorize()` minted. We verify + decode it to recover
+ * the client's ORIGINAL `redirect_uri` and `state`, then 302 to the client
+ * re-emitting the state via `URL.searchParams` — whose serializer encodes a
+ * literal `+` as `%2B`, exactly the encoding the client's parser expects.
+ *
+ * Exported for unit tests; mounted in `startHttpServer`.
+ */
+export function createOAuthCallbackHandler(stateCodec: OAuthStateCodec) {
+  return (req: Request, res: Response): void => {
+    const stateToken = typeof req.query.state === 'string' ? req.query.state : '';
+    const decoded = stateCodec.decode(stateToken);
+    if (decoded.kind !== 'ok') {
+      logger.warn('OAuth callback: invalid state token', { reason: decoded.reason });
+      // We cannot safely redirect anywhere — the client redirect_uri lives
+      // inside the (unverified) token. Return a terminal error page.
+      res
+        .status(400)
+        .type('html')
+        .send(
+          '<!doctype html><html><body style="font-family:sans-serif;padding:2rem">' +
+            '<h1>Authentication failed</h1>' +
+            '<p>The OAuth state token was invalid or expired. Please retry the sign-in from your MCP client.</p>' +
+            '</body></html>',
+        );
+      return;
+    }
+
+    let target: URL;
+    try {
+      target = new URL(decoded.clientRedirectUri);
+    } catch {
+      logger.warn('OAuth callback: stored redirect_uri is not a valid URL');
+      res.status(400).type('html').send('<!doctype html><html><body>Invalid redirect target.</body></html>');
+      return;
+    }
+
+    // Forward either the error or the authorization code to the client,
+    // re-attaching the client's ORIGINAL state. URLSearchParams serialization
+    // encodes `+` as `%2B`, which is exactly what fixes the round-trip.
+    const error = typeof req.query.error === 'string' ? req.query.error : undefined;
+    if (error) {
+      target.searchParams.set('error', error);
+      const errDesc = req.query.error_description;
+      if (typeof errDesc === 'string') target.searchParams.set('error_description', errDesc);
+    } else {
+      const code = typeof req.query.code === 'string' ? req.query.code : '';
+      target.searchParams.set('code', code);
+    }
+    if (decoded.clientState !== undefined) {
+      target.searchParams.set('state', decoded.clientState);
+    }
+
+    logger.debug('OAuth callback: redirecting to client', {
+      clientRedirectUriHost: target.host,
+      hasError: !!error,
+      hasState: decoded.clientState !== undefined,
+    });
+    res.redirect(302, target.toString());
+  };
+}
 
 // ─── API Key Matching Helper ─────────────────────────────────────────
 
@@ -273,10 +342,24 @@ export async function startHttpServer(
     // Determine app URL for OAuth metadata
     const appUrl = getAppUrl() ?? `http://${bindHost}:${port}`;
 
+    // Compute the prefix-aware public base once, up front — it's needed both
+    // for the callback URL (below) and the metadata override (further down).
+    // When ARC-1 is fronted by SAP API Management with a base path (e.g.
+    // /arc1), endpoints must be advertised at that prefix even though the
+    // Express routes live at the root (the proxy strips the prefix).
+    const oauthParsedAppUrl = new URL(appUrl);
+    const oauthBasePath = oauthParsedAppUrl.pathname.replace(/\/$/, ''); // '' for root, '/arc1' otherwise
+    const oauthFullBase = `${oauthParsedAppUrl.origin}${oauthBasePath}`;
+    // ARC-1's own OAuth callback (issue #214 callback proxy). Public, prefix-aware
+    // URL sent to XSUAA as redirect_uri; the Express route is mounted at the root
+    // `/oauth/callback` below since the proxy strips the prefix before forwarding.
+    const oauthCallbackUrl = `${oauthFullBase}/oauth/callback`;
+
     // Create XSUAA provider + chained verifier
-    const { provider, clientStore } = createXsuaaOAuthProvider(xsuaaCredentials, appUrl, {
+    const { provider, clientStore, stateCodec } = createXsuaaOAuthProvider(xsuaaCredentials, appUrl, {
       dcrTtlSeconds: config.oauthDcrTtlSeconds,
       dcrSigningSecret: config.dcrSigningSecret,
+      callbackUrl: oauthCallbackUrl,
     });
     const xsuaaVerifier = createXsuaaTokenVerifier(xsuaaCredentials);
     const oidcVerifier = config.oidcIssuer ? await createOidcVerifier(config) : undefined;
@@ -325,6 +408,9 @@ export async function startHttpServer(
       app.use('/authorize', createAuthRateLimiter('/mcp', mcpRatePerMinute, { skip: (req) => !isCopilotJsonRpc(req) }));
       app.use('/token', createAuthRateLimiter('/token', config.authRateLimit));
       app.use('/revoke', createAuthRateLimiter('/revoke', config.authRateLimit));
+      // /oauth/callback is unauthenticated and does an HMAC verify per hit —
+      // rate-limit it like the other OAuth endpoints to gate token-probing.
+      app.use('/oauth/callback', createAuthRateLimiter('/oauth/callback', config.authRateLimit));
     }
 
     // ─── OAuth authorize normalization + Copilot Studio MCP workaround ──
@@ -387,6 +473,27 @@ export async function startHttpServer(
       next();
     });
 
+    // ─── OAuth callback proxy (issue #214) ─────────────────────────
+    // XSUAA echoes a literal `+` (not `%2B`) in the `state` it appends to the
+    // redirect URL. base64 `state` values (e.g. VS Code's
+    // `randomBytes(16).toString('base64')`) contain `+` ~50% of the time; the
+    // receiving client parses the callback query with form-urlencoded
+    // semantics (`+`→space), so the round-tripped `state` no longer matches
+    // and login fails with "State does not match".
+    //
+    // ARC-1 cannot change what XSUAA emits, so the provider's authorize()
+    // sends XSUAA ARC-1's own /oauth/callback + an opaque base64url state
+    // token (immune to the `+` bug). XSUAA redirects HERE; we decode the token
+    // to recover the client's ORIGINAL redirect_uri + state, then redirect to
+    // the client re-emitting the state via URLSearchParams, which encodes `+`
+    // as `%2B` so the client parses it back correctly.
+    //
+    // Mounted at the root path; the public (prefix-aware) form was sent to
+    // XSUAA as oauthCallbackUrl. A strip-prefix proxy maps the public path
+    // back to this root route. Handler is extracted (exported) so the
+    // state-round-trip contract is unit-testable without a live XSUAA.
+    app.get('/oauth/callback', createOAuthCallbackHandler(stateCodec));
+
     // ─── Path-prefix-aware OAuth metadata override ────────────────
     // The MCP SDK's `mcpAuthRouter` builds endpoint URLs with
     // `new URL("/authorize", baseUrl).href`, which strips any path component
@@ -401,9 +508,9 @@ export async function startHttpServer(
     // endpoints (/authorize, /token, /register, /revoke) stay at the root of
     // arc-1's Express app — the proxy strips its base path before forwarding,
     // so they resolve correctly without further changes.
-    const parsedAppUrl = new URL(appUrl);
-    const basePath = parsedAppUrl.pathname.replace(/\/$/, ''); // '' for root, '/arc1' otherwise
-    const fullBase = `${parsedAppUrl.origin}${basePath}`; // 'https://api/arc1' or 'https://api'
+    // Reuse the prefix-aware base computed once near the top of this block.
+    const basePath = oauthBasePath;
+    const fullBase = oauthFullBase;
     const scopesSupported = ['read', 'write', 'data', 'sql', 'transports', 'git', 'admin'];
 
     if (basePath) {

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -51,6 +51,9 @@ import type { XsuaaCredentials } from './xsuaa.js';
  * re-emitting the state via `URL.searchParams` — whose serializer encodes a
  * literal `+` as `%2B`, exactly the encoding the client's parser expects.
  *
+ * Removal condition + upstream tracking (XSUAA root cause, arc-1#214,
+ * vscode#314715) are documented at the top of `oauth-state.ts`.
+ *
  * Exported for unit tests; mounted in `startHttpServer`.
  */
 export function createOAuthCallbackHandler(stateCodec: OAuthStateCodec) {

--- a/src/server/oauth-state.ts
+++ b/src/server/oauth-state.ts
@@ -1,0 +1,170 @@
+/**
+ * Stateless, signed OAuth `state` codec for the XSUAA callback proxy.
+ *
+ * ── Why this exists (issue #214) ──────────────────────────────────────
+ * XSUAA echoes a literal `+` (not `%2B`) for any `state` value that
+ * contains `+` when it redirects back to the OAuth client. Standard base64
+ * `state` values (e.g. VS Code generates `randomBytes(16).toString('base64')`)
+ * contain `+` ~50% of the time. The receiving client parses the callback
+ * query string with `application/x-www-form-urlencoded` semantics, where
+ * `+` decodes to a space, so the round-tripped `state` no longer matches the
+ * value the client generated → "State does not match" → login fails.
+ *
+ * ARC-1 cannot influence what XSUAA emits, and XSUAA redirects DIRECTLY to
+ * the client today (ARC-1 is not in the return path). The only fix is to
+ * insert ARC-1 into the return path: send XSUAA a `state` that ARC-1
+ * controls and that is immune to the `+` bug, then re-emit the client's
+ * ORIGINAL `state` correctly when redirecting back to the client.
+ *
+ * ── How this codec is immune to the `+` bug ───────────────────────────
+ * The token is `base64url(payload) + "." + base64url(sig)`. base64url uses
+ * the alphabet `A-Za-z0-9-_` — no `+`, no `/`. The `.` separator is an
+ * RFC 3986 unreserved character. So the entire token is URL-safe: XSUAA has
+ * no `+` to mangle, and Express's `+`→space query decoding is a no-op on it.
+ * The client's real `state` (which may contain `+`) rides INSIDE the opaque
+ * base64url payload, so it survives the XSUAA round-trip untouched.
+ *
+ * ── Why stateless (vs an in-memory map) ───────────────────────────────
+ * Mirrors the StatelessDcrClientStore design (PR #212): the token carries
+ * its own payload + HMAC signature, so any instance with the same signing
+ * key can validate it. No in-memory map → survives `cf restart`, cell
+ * moves, and horizontal scale-out. The signing key is derived (HKDF-style)
+ * from the same secret the DCR store uses, with a distinct domain-separation
+ * label so the two key spaces never overlap.
+ */
+
+import crypto from 'node:crypto';
+
+/** Domain-separation label for the HKDF-style key derivation. Bump the
+ *  version suffix to invalidate every outstanding state token at once. */
+const KDF_LABEL = 'arc1-oauth-state/v1';
+
+/** Truncated HMAC length in bytes. 16 bytes (128 bits) is ample for a
+ *  short-lived, single-use CSRF state token — matches StatelessDcrClientStore. */
+const SIG_BYTES = 16;
+
+/** Default lifetime of a state token. The OAuth authorize→callback hop is
+ *  interactive (user logs in), so a few minutes covers it; XSUAA auth codes
+ *  themselves expire on a similar horizon. */
+const DEFAULT_TTL_SECONDS = 600; // 10 minutes
+
+/** Compact JSON shape embedded in the signed token. Keys are terse to keep
+ *  the resulting URL short. */
+interface StatePayload {
+  /** Schema version. */
+  v: 1;
+  /** The OAuth client's ORIGINAL `state` (may contain `+`; may be absent —
+   *  `state` is optional per RFC 6749). */
+  s?: string;
+  /** The OAuth client's ORIGINAL `redirect_uri` — where ARC-1 sends the
+   *  user after XSUAA returns to ARC-1's callback. */
+  r: string;
+  /** Expiry, epoch seconds. */
+  exp: number;
+}
+
+export type DecodeResult =
+  | { kind: 'ok'; clientState?: string; clientRedirectUri: string }
+  | { kind: 'error'; reason: 'malformed' | 'bad_signature' | 'invalid_payload' | 'expired' };
+
+/**
+ * Signs and verifies OAuth `state` tokens for the XSUAA callback proxy.
+ */
+export class OAuthStateCodec {
+  private readonly hmacKey: Buffer;
+  private readonly ttlSeconds: number;
+
+  constructor(signingSecret: string, opts: { ttlSeconds?: number } = {}) {
+    if (!signingSecret) {
+      throw new Error('OAuthStateCodec requires a non-empty signingSecret');
+    }
+    // HKDF-style: derive a dedicated key from the shared secret + label.
+    // The label domain-separates this key from the DCR client-id signing key.
+    this.hmacKey = crypto.createHmac('sha256', signingSecret).update(KDF_LABEL).digest();
+    this.ttlSeconds = opts.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  }
+
+  /**
+   * Encode a URL-safe, signed state token. The returned value is safe to put
+   * in a query string and round-trip through XSUAA (no `+`, no `/`).
+   *
+   * @param input.now Injectable clock (epoch ms) for deterministic tests.
+   */
+  encode(input: { clientState?: string; clientRedirectUri: string; now?: number }): string {
+    const nowSec = Math.floor((input.now ?? Date.now()) / 1000);
+    const payload: StatePayload = {
+      v: 1,
+      r: input.clientRedirectUri,
+      exp: nowSec + this.ttlSeconds,
+    };
+    if (input.clientState !== undefined) {
+      payload.s = input.clientState;
+    }
+    const payloadB64 = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+    return `${payloadB64}.${this.sign(payloadB64)}`;
+  }
+
+  /**
+   * Decode and verify a state token. Never throws — returns a typed result.
+   *
+   * @param now Injectable clock (epoch ms) for deterministic tests.
+   */
+  decode(token: string, now: number = Date.now()): DecodeResult {
+    if (typeof token !== 'string' || token.length === 0) {
+      return { kind: 'error', reason: 'malformed' };
+    }
+    const dot = token.lastIndexOf('.');
+    if (dot <= 0 || dot === token.length - 1) {
+      return { kind: 'error', reason: 'malformed' };
+    }
+    const payloadB64 = token.slice(0, dot);
+    const sigB64 = token.slice(dot + 1);
+
+    if (!this.verifySignature(payloadB64, sigB64)) {
+      return { kind: 'error', reason: 'bad_signature' };
+    }
+
+    const payload = parsePayload(payloadB64);
+    if (!payload) {
+      return { kind: 'error', reason: 'invalid_payload' };
+    }
+
+    if (payload.exp * 1000 <= now) {
+      return { kind: 'error', reason: 'expired' };
+    }
+
+    return { kind: 'ok', clientState: payload.s, clientRedirectUri: payload.r };
+  }
+
+  private sign(payloadB64: string): string {
+    const fullDigest = crypto.createHmac('sha256', this.hmacKey).update(payloadB64).digest();
+    return fullDigest.subarray(0, SIG_BYTES).toString('base64url');
+  }
+
+  private verifySignature(payloadB64: string, sigB64: string): boolean {
+    const expected = Buffer.from(this.sign(payloadB64), 'base64url');
+    const actual = Buffer.from(sigB64, 'base64url');
+    if (actual.length !== expected.length || actual.length !== SIG_BYTES) {
+      return false;
+    }
+    return crypto.timingSafeEqual(actual, expected);
+  }
+}
+
+/**
+ * Parse a base64url payload back into a typed `StatePayload`. Returns
+ * `undefined` on any failure (decode error, JSON parse error, schema mismatch).
+ */
+function parsePayload(payloadB64: string): StatePayload | undefined {
+  try {
+    const json = Buffer.from(payloadB64, 'base64url').toString('utf8');
+    const obj = JSON.parse(json) as Record<string, unknown>;
+    if (obj.v !== 1) return undefined;
+    if (typeof obj.r !== 'string' || obj.r.length === 0) return undefined;
+    if (typeof obj.exp !== 'number' || !Number.isFinite(obj.exp)) return undefined;
+    if (obj.s !== undefined && typeof obj.s !== 'string') return undefined;
+    return { v: 1, s: obj.s as string | undefined, r: obj.r, exp: obj.exp };
+  } catch {
+    return undefined;
+  }
+}

--- a/src/server/oauth-state.ts
+++ b/src/server/oauth-state.ts
@@ -31,6 +31,24 @@
  * moves, and horizontal scale-out. The signing key is derived (HKDF-style)
  * from the same secret the DCR store uses, with a distinct domain-separation
  * label so the two key spaces never overlap.
+ *
+ * ── Upstream tracking / when this whole module can be deleted ──────────
+ * This is a WORKAROUND for an XSUAA bug. It can be removed ONLY when XSUAA
+ * stops emitting a literal `+` (emits `%2B`) for `state` on the authorize
+ * redirect. Tracking:
+ *   - arc-1 issue:      https://github.com/marianfoo/arc-1/issues/214
+ *   - XSUAA root cause: no public SAP Note as of 2026-06; the `+`→literal
+ *                       echo is the actual defect and the only thing whose
+ *                       fix makes this module removable.
+ *   - VS Code (client): https://github.com/microsoft/vscode/issues/314715
+ *                       asks VS Code to use base64url `state`. If accepted it
+ *                       fixes the VS Code SYMPTOM only — other MCP clients
+ *                       (Cursor, claude.ai, Copilot Studio, …) still send
+ *                       base64 `state` containing `+`, so the callback proxy
+ *                       stays until the XSUAA-side fix lands. Do NOT delete
+ *                       this module just because vscode#314715 closes.
+ * To verify whether the XSUAA bug is gone, re-run the issue #214 spectrum
+ * reproducer (see the issue thread) against the target XSUAA tenant.
  */
 
 import crypto from 'node:crypto';

--- a/src/server/xsuaa.ts
+++ b/src/server/xsuaa.ts
@@ -34,6 +34,7 @@ import { XsuaaService } from '@sap/xssec';
 import { expandScopes } from '../authz/policy.js';
 import { API_KEY_PROFILES } from './config.js';
 import { logger } from './logger.js';
+import { OAuthStateCodec } from './oauth-state.js';
 import { StatelessDcrClientStore } from './stateless-client-store.js';
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -235,11 +236,19 @@ class XsuaaProxyOAuthProvider extends ProxyOAuthServerProvider {
   private xsuaaAuthUrl: string;
   private xsuaaXsappname: string;
   private _localClientStore: StatelessDcrClientStore;
+  /** ARC-1's own callback URL, sent to XSUAA as the redirect_uri so ARC-1
+   *  sits in the return path and can re-encode the client's `state`
+   *  correctly (issue #214 — XSUAA emits literal `+`). */
+  private callbackUrl: string;
+  /** Signs/verifies the opaque, URL-safe state token sent to XSUAA. */
+  private stateCodec: OAuthStateCodec;
 
   constructor(
     credentials: XsuaaCredentials,
     verifier: (token: string) => Promise<AuthInfo>,
     localClientStore: StatelessDcrClientStore,
+    callbackUrl: string,
+    stateCodec: OAuthStateCodec,
   ) {
     const authUrl = `${credentials.url}/oauth/authorize`;
     const tokenUrl = `${credentials.url}/oauth/token`;
@@ -260,6 +269,8 @@ class XsuaaProxyOAuthProvider extends ProxyOAuthServerProvider {
     this.xsuaaAuthUrl = authUrl;
     this.xsuaaXsappname = credentials.xsappname;
     this._localClientStore = localClientStore;
+    this.callbackUrl = callbackUrl;
+    this.stateCodec = stateCodec;
     this.skipLocalPkceValidation = true;
   }
 
@@ -287,21 +298,33 @@ class XsuaaProxyOAuthProvider extends ProxyOAuthServerProvider {
     },
     res: { redirect(url: string): void },
   ): Promise<void> {
-    // XSUAA only allows http://localhost for redirect URIs, never http://127.0.0.1.
-    // Some MCP clients (e.g., MCP Inspector) use 127.0.0.1, so rewrite to localhost
-    // before forwarding to XSUAA. The token exchange must use the same rewritten URI.
-    const xsuaaRedirectUri = params.redirectUri.replace('://127.0.0.1:', '://localhost:');
+    // ── Callback proxy (issue #214) ──────────────────────────────────
+    // Instead of sending XSUAA the client's redirect_uri and the client's
+    // raw `state`, we send XSUAA ARC-1's OWN /oauth/callback and an opaque,
+    // URL-safe state token that carries the client's real redirect_uri +
+    // state. XSUAA then redirects back to ARC-1 (not the client), and the
+    // /oauth/callback route re-emits the client's ORIGINAL state with proper
+    // `%2B` encoding. This sidesteps XSUAA's bug of echoing a literal `+`
+    // for any state containing `+` (standard base64 states hit this ~50% of
+    // the time; VS Code surfaces it as "State does not match").
+    //
+    // The token is base64url (no `+`/`/`), so XSUAA has nothing to mangle on
+    // the round trip and Express's `+`→space decode is a no-op on it.
+    const arc1State = this.stateCodec.encode({
+      clientState: params.state,
+      clientRedirectUri: params.redirectUri,
+    });
 
     const targetUrl = new URL(this.xsuaaAuthUrl);
     const searchParams = new URLSearchParams({
       client_id: this.xsuaaClientId, // Use XSUAA client, not local DCR client
       response_type: 'code',
-      redirect_uri: xsuaaRedirectUri,
-      code_challenge: params.codeChallenge,
+      redirect_uri: this.callbackUrl, // ARC-1's callback, not the client's
+      code_challenge: params.codeChallenge, // client's PKCE challenge, forwarded as-is
       code_challenge_method: 'S256',
+      state: arc1State,
     });
 
-    if (params.state) searchParams.set('state', params.state);
     if (params.scopes?.length) {
       // Qualify short scope names (read, write, admin) with XSUAA xsappname prefix.
       // XSUAA rejects unqualified scopes like "admin" — it needs "arc1-mcp!t498139.admin".
@@ -317,9 +340,10 @@ class XsuaaProxyOAuthProvider extends ProxyOAuthServerProvider {
 
     targetUrl.search = searchParams.toString();
 
-    logger.debug('XSUAA authorize redirect', {
+    logger.debug('XSUAA authorize redirect (callback proxy)', {
       xsuaaClient: this.xsuaaClientId,
-      redirectUri: params.redirectUri,
+      clientRedirectUri: params.redirectUri,
+      callbackUrl: this.callbackUrl,
     });
 
     res.redirect(targetUrl.toString());
@@ -333,11 +357,10 @@ class XsuaaProxyOAuthProvider extends ProxyOAuthServerProvider {
     _client: OAuthClientInformationFull,
     authorizationCode: string,
     codeVerifier?: string,
-    redirectUri?: string,
+    _redirectUri?: string,
   ) {
     logger.debug('XSUAA token exchange: authorization_code', {
       hasCodeVerifier: !!codeVerifier,
-      redirectUri,
     });
     const params = new URLSearchParams({
       grant_type: 'authorization_code',
@@ -346,8 +369,12 @@ class XsuaaProxyOAuthProvider extends ProxyOAuthServerProvider {
       client_secret: this.xsuaaClientSecret,
     });
     if (codeVerifier) params.set('code_verifier', codeVerifier);
-    // Must match the rewritten redirect_uri sent during authorize
-    if (redirectUri) params.set('redirect_uri', redirectUri.replace('://127.0.0.1:', '://localhost:'));
+    // OAuth requires the token-exchange redirect_uri to match the one sent at
+    // authorize time. Since the callback proxy sent XSUAA ARC-1's own
+    // /oauth/callback (not the client's redirect_uri), the exchange must use
+    // the same value. The client's redirect_uri (_redirectUri) is irrelevant
+    // to XSUAA here — XSUAA only ever saw ARC-1's callback.
+    params.set('redirect_uri', this.callbackUrl);
 
     const response = await fetch(this.xsuaaTokenUrl, {
       method: 'POST',
@@ -462,13 +489,21 @@ export interface CreateXsuaaOAuthProviderOptions {
    * behavior).
    */
   dcrSigningSecret?: string;
+  /**
+   * ARC-1's own OAuth callback URL (e.g. `https://app.../oauth/callback`),
+   * sent to XSUAA as the redirect_uri so ARC-1 sits in the return path and
+   * can fix XSUAA's `+`-in-state encoding bug (issue #214). Must be
+   * absolute and match an xs-security.json `redirect-uris` pattern. When
+   * omitted, falls back to `${appUrl}/oauth/callback`.
+   */
+  callbackUrl?: string;
 }
 
 export function createXsuaaOAuthProvider(
   credentials: XsuaaCredentials,
   appUrl: string,
   options: CreateXsuaaOAuthProviderOptions = {},
-): { provider: ProxyOAuthServerProvider; clientStore: StatelessDcrClientStore } {
+): { provider: ProxyOAuthServerProvider; clientStore: StatelessDcrClientStore; stateCodec: OAuthStateCodec } {
   // The signing secret defaults to the XSUAA `clientsecret`, which is the
   // trust anchor for "this server can mint client_ids". The downside: MTA
   // `cf deploy` recreates the service binding and rotates the clientsecret
@@ -504,12 +539,22 @@ export function createXsuaaOAuthProvider(
   });
   const verifier = createXsuaaTokenVerifier(credentials);
 
-  const provider = new XsuaaProxyOAuthProvider(credentials, verifier, clientStore);
+  // The state codec reuses the same resolved signing secret as DCR (distinct
+  // KDF label inside OAuthStateCodec keeps the two key spaces separate), so it
+  // inherits the same "survives cf deploy" property when ARC1_DCR_SIGNING_SECRET
+  // is set. State tokens are short-lived (single OAuth flow), so the codec uses
+  // its own built-in TTL rather than the DCR TTL.
+  const stateCodec = new OAuthStateCodec(dcrSigningSecret);
 
-  logger.info('XSUAA OAuth provider created (stateless DCR)', {
+  const callbackUrl = options.callbackUrl ?? `${appUrl.replace(/\/$/, '')}/oauth/callback`;
+
+  const provider = new XsuaaProxyOAuthProvider(credentials, verifier, clientStore, callbackUrl, stateCodec);
+
+  logger.info('XSUAA OAuth provider created (stateless DCR + callback proxy)', {
     xsappname: credentials.xsappname,
     authorizationUrl: `${credentials.url}/oauth/authorize`,
     appUrl,
+    callbackUrl,
     dcrTtlSeconds: options.dcrTtlSeconds,
     dcrSigningSource,
   });
@@ -524,5 +569,5 @@ export function createXsuaaOAuthProvider(
     );
   }
 
-  return { provider, clientStore };
+  return { provider, clientStore, stateCodec };
 }

--- a/src/server/xsuaa.ts
+++ b/src/server/xsuaa.ts
@@ -310,6 +310,9 @@ class XsuaaProxyOAuthProvider extends ProxyOAuthServerProvider {
     //
     // The token is base64url (no `+`/`/`), so XSUAA has nothing to mangle on
     // the round trip and Express's `+`→space decode is a no-op on it.
+    //
+    // WORKAROUND removal condition + upstream tracking (XSUAA root cause,
+    // arc-1#214, vscode#314715) are documented at the top of oauth-state.ts.
     const arc1State = this.stateCodec.encode({
       clientState: params.state,
       clientRedirectUri: params.redirectUri,

--- a/tests/unit/server/oauth-callback.test.ts
+++ b/tests/unit/server/oauth-callback.test.ts
@@ -1,0 +1,109 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { createOAuthCallbackHandler } from '../../../src/server/http.js';
+import { OAuthStateCodec } from '../../../src/server/oauth-state.js';
+
+const SECRET = 'callback-test-signing-secret-1234567890';
+
+function buildApp(codec: OAuthStateCodec): express.Express {
+  const app = express();
+  app.get('/oauth/callback', createOAuthCallbackHandler(codec));
+  return app;
+}
+
+/** Parse a Location header's `state` the way an OAuth client (VS Code) does:
+ *  WHATWG URL search params, where `+` decodes to space and `%2B` to `+`. */
+function clientParsedState(location: string): string | null {
+  return new URL(location).searchParams.get('state');
+}
+
+describe('createOAuthCallbackHandler — issue #214 round-trip', () => {
+  it('redirects to the client with the ORIGINAL "+" state recoverable (the fix)', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const clientState = '6QadZ5GFXGvZ649+OuQi+Q==';
+    const token = codec.encode({ clientState, clientRedirectUri: 'http://127.0.0.1:33418/' });
+
+    const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'AUTHCODE123', state: token });
+
+    expect(res.status).toBe(302);
+    const loc = res.headers.location as string;
+    // The redirect target is the client's own loopback.
+    expect(loc.startsWith('http://127.0.0.1:33418/')).toBe(true);
+    // The code is forwarded.
+    expect(new URL(loc).searchParams.get('code')).toBe('AUTHCODE123');
+    // KEY ASSERTION: the state is encoded such that a standard URL parser
+    // recovers the EXACT original (the `+` survived as `%2B` on the wire).
+    expect(loc).toContain('state=6QadZ5GFXGvZ649%2BOuQi%2BQ%3D%3D');
+    expect(clientParsedState(loc)).toBe(clientState);
+  });
+
+  it('emits %2B (not literal +) in the Location header', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const token = codec.encode({ clientState: 'a+b+c==', clientRedirectUri: 'http://localhost:1/cb' });
+    const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'x', state: token });
+    const loc = res.headers.location as string;
+    // The state segment must not contain a raw '+'.
+    const stateSegment = loc.split('state=')[1] ?? '';
+    expect(stateSegment).not.toContain('+');
+    expect(stateSegment).toContain('%2B');
+  });
+
+  it('forwards OAuth errors to the client with the original state', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const token = codec.encode({ clientState: 'st+ate==', clientRedirectUri: 'http://127.0.0.1:5/cb' });
+    const res = await request(buildApp(codec))
+      .get('/oauth/callback')
+      .query({ error: 'access_denied', error_description: 'user cancelled', state: token });
+    expect(res.status).toBe(302);
+    const loc = res.headers.location as string;
+    const u = new URL(loc);
+    expect(u.searchParams.get('error')).toBe('access_denied');
+    expect(u.searchParams.get('error_description')).toBe('user cancelled');
+    expect(u.searchParams.get('state')).toBe('st+ate==');
+    expect(u.searchParams.get('code')).toBeNull();
+  });
+
+  it('round-trips a state with no "+" unchanged', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const token = codec.encode({ clientState: 'mElKiL3xesnEy0LnXDyKvA==', clientRedirectUri: 'http://localhost:1/cb' });
+    const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'c', state: token });
+    expect(clientParsedState(res.headers.location as string)).toBe('mElKiL3xesnEy0LnXDyKvA==');
+  });
+
+  it('omits state when the client did not send one', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const token = codec.encode({ clientRedirectUri: 'http://localhost:1/cb' });
+    const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'c', state: token });
+    expect(new URL(res.headers.location as string).searchParams.has('state')).toBe(false);
+  });
+
+  it('returns 400 (no open redirect) for an invalid/forged state token', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const res = await request(buildApp(codec))
+      .get('/oauth/callback')
+      .query({ code: 'c', state: 'forged.AAAAAAAAAAAAAAAAAAAAAA' });
+    expect(res.status).toBe(400);
+    expect(res.headers.location).toBeUndefined();
+    expect(res.text).toContain('Authentication failed');
+  });
+
+  it('returns 400 for an expired state token', async () => {
+    const codec = new OAuthStateCodec(SECRET, { ttlSeconds: 1 });
+    // Encode with a clock far in the past so it is already expired at decode (now).
+    const token = codec.encode({
+      clientState: 'x',
+      clientRedirectUri: 'http://localhost:1/cb',
+      now: 1_000_000_000_000,
+    });
+    const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'c', state: token });
+    expect(res.status).toBe(400);
+    expect(res.headers.location).toBeUndefined();
+  });
+
+  it('returns 400 when no state is provided at all', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'c' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/unit/server/oauth-state.test.ts
+++ b/tests/unit/server/oauth-state.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { OAuthStateCodec } from '../../../src/server/oauth-state.js';
+
+const SECRET = 'test-signing-secret-at-least-16-bytes-long';
+const T0 = 1_700_000_000_000; // fixed epoch ms for deterministic expiry tests
+
+describe('OAuthStateCodec', () => {
+  it('rejects an empty signing secret', () => {
+    expect(() => new OAuthStateCodec('')).toThrow(/non-empty/);
+  });
+
+  it('round-trips a state containing literal "+" (the issue #214 trigger)', () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const clientState = '6QadZ5GFXGvZ649+OuQi+Q==';
+    const token = codec.encode({ clientState, clientRedirectUri: 'http://127.0.0.1:33418/', now: T0 });
+    const decoded = codec.decode(token, T0 + 1000);
+    expect(decoded).toEqual({
+      kind: 'ok',
+      clientState,
+      clientRedirectUri: 'http://127.0.0.1:33418/',
+    });
+  });
+
+  it('produces a URL-safe token (no +, /, or = that XSUAA / Express would mangle)', () => {
+    const codec = new OAuthStateCodec(SECRET);
+    // Use a client state full of the dangerous characters; the token itself
+    // must still be URL-safe because the payload is base64url-encoded.
+    const token = codec.encode({ clientState: 'a+b/c+d==', clientRedirectUri: 'http://localhost:9999/cb', now: T0 });
+    expect(token).toMatch(/^[A-Za-z0-9_.-]+$/);
+    expect(token).not.toContain('+');
+    expect(token).not.toContain('/');
+    expect(token).not.toContain('=');
+  });
+
+  it('round-trips when clientState is absent (state is optional in OAuth)', () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const token = codec.encode({ clientRedirectUri: 'https://claude.ai/api/mcp/auth_callback', now: T0 });
+    const decoded = codec.decode(token, T0 + 1000);
+    expect(decoded).toEqual({
+      kind: 'ok',
+      clientState: undefined,
+      clientRedirectUri: 'https://claude.ai/api/mcp/auth_callback',
+    });
+  });
+
+  it('preserves additional base64 specials (/, multiple +, padding)', () => {
+    const codec = new OAuthStateCodec(SECRET);
+    for (const clientState of ['a+b+c+d==', 'aaa/bbb==', '+leading==', 'trailing+==', 'mix+/+/==']) {
+      const token = codec.encode({ clientState, clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+      const decoded = codec.decode(token, T0 + 1000);
+      expect(decoded.kind).toBe('ok');
+      if (decoded.kind === 'ok') expect(decoded.clientState).toBe(clientState);
+    }
+  });
+
+  it('rejects a tampered payload (bad_signature)', () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const token = codec.encode({ clientState: 'abc', clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+    const [payloadB64, sig] = token.split('.');
+    // Flip a char in the payload — signature no longer matches.
+    const tamperedChar = payloadB64[0] === 'A' ? 'B' : 'A';
+    const tampered = `${tamperedChar}${payloadB64.slice(1)}.${sig}`;
+    expect(codec.decode(tampered, T0 + 1000)).toEqual({ kind: 'error', reason: 'bad_signature' });
+  });
+
+  it('rejects a tampered signature (bad_signature)', () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const token = codec.encode({ clientState: 'abc', clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+    const [payloadB64] = token.split('.');
+    expect(codec.decode(`${payloadB64}.AAAAAAAAAAAAAAAAAAAAAA`, T0 + 1000)).toEqual({
+      kind: 'error',
+      reason: 'bad_signature',
+    });
+  });
+
+  it('rejects a token signed with a different key (bad_signature)', () => {
+    const a = new OAuthStateCodec(SECRET);
+    const b = new OAuthStateCodec('a-completely-different-signing-secret');
+    const token = a.encode({ clientState: 'abc', clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+    expect(b.decode(token, T0 + 1000)).toEqual({ kind: 'error', reason: 'bad_signature' });
+  });
+
+  it('rejects an expired token (expired)', () => {
+    const codec = new OAuthStateCodec(SECRET, { ttlSeconds: 60 });
+    const token = codec.encode({ clientState: 'abc', clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+    // 61s later → past the 60s TTL.
+    expect(codec.decode(token, T0 + 61_000)).toEqual({ kind: 'error', reason: 'expired' });
+    // Still valid at 59s.
+    expect(codec.decode(token, T0 + 59_000).kind).toBe('ok');
+  });
+
+  it('rejects malformed tokens (malformed)', () => {
+    const codec = new OAuthStateCodec(SECRET);
+    expect(codec.decode('', T0).reason).toBe('malformed');
+    expect(codec.decode('no-dot-here', T0).reason).toBe('malformed');
+    expect(codec.decode('.sigonly', T0).reason).toBe('malformed');
+    expect(codec.decode('payloadonly.', T0).reason).toBe('malformed');
+  });
+
+  it("a fresh codec with the same secret can verify another instance's token (stateless / multi-instance)", () => {
+    const writer = new OAuthStateCodec(SECRET);
+    const reader = new OAuthStateCodec(SECRET); // simulates a different CF instance
+    const token = writer.encode({ clientState: 'x+y==', clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+    const decoded = reader.decode(token, T0 + 1000);
+    expect(decoded.kind).toBe('ok');
+    if (decoded.kind === 'ok') expect(decoded.clientState).toBe('x+y==');
+  });
+});

--- a/tests/unit/server/xsuaa.test.ts
+++ b/tests/unit/server/xsuaa.test.ts
@@ -243,7 +243,7 @@ describe('createXsuaaOAuthProvider', () => {
       const result = createXsuaaOAuthProvider(STUB_XSUAA_CREDS, 'https://arc1.example.com');
       expect(result.clientStore).toBeDefined();
       expect(infoSpy).toHaveBeenCalledWith(
-        'XSUAA OAuth provider created (stateless DCR)',
+        'XSUAA OAuth provider created (stateless DCR + callback proxy)',
         expect.objectContaining({ dcrSigningSource: 'xsuaa' }),
       );
     } finally {
@@ -260,7 +260,7 @@ describe('createXsuaaOAuthProvider', () => {
         dcrSigningSecret: 'a-real-32-byte-secret-string-OK!',
       });
       expect(infoSpy).toHaveBeenCalledWith(
-        'XSUAA OAuth provider created (stateless DCR)',
+        'XSUAA OAuth provider created (stateless DCR + callback proxy)',
         expect.objectContaining({ dcrSigningSource: 'env' }),
       );
       expect(infoSpy).toHaveBeenCalledWith(
@@ -283,7 +283,7 @@ describe('createXsuaaOAuthProvider', () => {
       expect(result.clientStore).toBeDefined();
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('ARC1_DCR_SIGNING_SECRET was set but is empty'));
       expect(infoSpy).toHaveBeenCalledWith(
-        'XSUAA OAuth provider created (stateless DCR)',
+        'XSUAA OAuth provider created (stateless DCR + callback proxy)',
         expect.objectContaining({ dcrSigningSource: 'xsuaa' }),
       );
     } finally {
@@ -304,7 +304,7 @@ describe('createXsuaaOAuthProvider', () => {
       expect(result.clientStore).toBeDefined();
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('ARC1_DCR_SIGNING_SECRET was set but is empty'));
       expect(infoSpy).toHaveBeenCalledWith(
-        'XSUAA OAuth provider created (stateless DCR)',
+        'XSUAA OAuth provider created (stateless DCR + callback proxy)',
         expect.objectContaining({ dcrSigningSource: 'xsuaa' }),
       );
     } finally {


### PR DESCRIPTION
## Summary

Fixes #214 — OAuth login intermittently fails with **"State does not match"** when connecting from VS Code (and any client whose `state` contains `+`).

**Root cause:** XSUAA echoes a **literal `+`** (not `%2B`) in the `state` it appends to the OAuth redirect URL. Standard base64 `state` values — e.g. VS Code's `randomBytes(16).toString('base64')` — contain `+` roughly half the time. The receiving client parses the callback query with `application/x-www-form-urlencoded` semantics (`+` → space), so the round-tripped `state` no longer matches the value it generated → login fails. Because the failure depends on a random `+`, it reproduces ~50% of the time, which is what users report as flaky sign-in.

## Why ARC-1 has to fix it (and an ingress-only patch can't)

Verified empirically against live XSUAA with an [8-scenario spectrum reproducer](https://github.com/marianfoo/arc-1/issues/214#issuecomment-4387683481):

| State sent (URL-encoded) | Echoed back by XSUAA | OK? |
|---|---|---|
| `aaa+bbb==` | `aaa bbb==` | ✗ |
| `aaa/bbb==` | `aaa/bbb==` | ✓ |
| `6QadZ5GFXGvZ649+OuQi+Q==` | `6QadZ5GFXGvZ649 OuQi Q==` | ✗ |
| `aaaabbbb` | `aaaabbbb` | ✓ |

- `+` is the **only** character XSUAA mangles (`/`, `=`, alphanumerics survive).
- It mangles even when ARC-1 forwards a correctly `%2B`-encoded state — so fixing ARC-1's ingress is insufficient.
- XSUAA is a managed service: no config knob, no SAP Note. The client-side fix (filed at [microsoft/vscode#314715](https://github.com/microsoft/vscode/issues/314715), still open) would be base64url state, but we can't wait on it.

Previously XSUAA redirected **directly to the client** (ARC-1 only touched `/authorize` and `/token`), so ARC-1 had no opportunity to repair the encoding. The fix puts ARC-1 in the return path.

## The fix — callback proxy with a stateless signed token

1. **`XsuaaProxyOAuthProvider.authorize()`** now sends XSUAA ARC-1's own `/oauth/callback` as `redirect_uri` and an opaque, signed, **base64url** state token (no `+`/`/`, immune to the bug) that carries the client's **original** `redirect_uri` + `state`.
2. **New `/oauth/callback` route** decodes the token and 302-redirects to the client, re-emitting the original state via `URL.searchParams` — whose serializer encodes `+` as `%2B`, exactly the encoding the client's parser expects. Invalid/expired/forged tokens → `400` (no open redirect: the client redirect_uri lives **inside** the verified token).
3. **`exchangeAuthorizationCode()`** sends the same `/oauth/callback` so the token-exchange `redirect_uri` matches authorize (OAuth requirement). XSUAA only ever sees ARC-1's callback.

The state token (`OAuthStateCodec`, new `src/server/oauth-state.ts`) is **stateless and HMAC-signed**, mirroring the `StatelessDcrClientStore` design from #212: it reuses the same resolved signing secret with a distinct KDF label (`arc1-oauth-state/v1`), so it survives `cf restart`, cell moves, and horizontal scale-out with no in-memory map. 10-minute TTL.

## Why not copy the reference implementation

The widely-cited [lemaiwo callback proxy](https://github.com/lemaiwo/btp-sap-odata-to-mcp-server/blob/main/src/index.ts#L783) keys its in-memory map by the **already-corrupted** `state` and re-emits via `URLSearchParams` over corrupted data — it only works for `+`-free states (MCP Inspector UUIDs), not VS Code. This PR recovers the **original** state from a signed token instead, so it works for every client.

## Compatibility

Transparent to every client shape verified during the #215 testing round — native loopback (VS Code, Cursor, Eclipse Copilot, MCP Inspector), browser redirect (claude.ai), and browser popup (Copilot Studio). Each now gets its exact original `state` back. ARC-1's callback (`https://*.hana.ondemand.com/**`, `http://localhost:*/**`) already matches the `xs-security.json` redirect-uri wildcards — no XSUAA config change needed.

## Tests

- `OAuthStateCodec` unit tests (11): round-trip incl. `+`/`/`/multi-`+`, URL-safety of the token, absent-state, tamper/wrong-key/expiry/malformed, multi-instance verify.
- `/oauth/callback` handler supertest (8): **proves a `+` state is recovered byte-for-byte by a standard URL parser after the round-trip** (the core fix), `%2B` (not raw `+`) on the wire, error pass-through, no-open-redirect on forged/expired tokens.
- Full suite green: **3301 unit tests**, typecheck, lint, build all clean.

## Test plan

- [x] Unit + supertest coverage (above)
- [ ] **Live BTP verification**: deploy this branch, run the [issue #214 reproducer](https://github.com/marianfoo/arc-1/issues/214#issuecomment-4387683481) — expect it to flip from "bug reproduces" to "✓ match". Confirms real XSUAA accepts `/oauth/callback` and round-trips the base64url token intact.
- [ ] Re-verify VS Code Copilot sign-in across repeated attempts (the `+`-containing states that previously failed).

## Follow-ups (not in this PR)

- Docs: a callback-proxy subsection in `xsuaa-setup.md` + a roadmap entry — happy to add once the approach is confirmed on BTP.

Closes #214.

Co-authored-by: MagPasulke <philipp.doelker@porsche.de>