### PR TITLE
fix(deps): bump express-rate-limit to 8.5.2 and key IPv6 by /56 subnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "cors": "2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
-        "express-rate-limit": "^7.5.1",
+        "express-rate-limit": "^8.5.2",
         "fast-xml-parser": "^5.8.0",
         "helmet": "^8.2.0",
         "jose": "^6.2.2",
@@ -866,24 +866,6 @@
         "zod": {
           "optional": false
         }
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2568,10 +2550,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "cors": "2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
-    "express-rate-limit": "^7.5.1",
+    "express-rate-limit": "^8.5.2",
     "fast-xml-parser": "^5.8.0",
     "helmet": "^8.2.0",
     "jose": "^6.2.2",

--- a/src/server/auth-rate-limit.ts
+++ b/src/server/auth-rate-limit.ts
@@ -9,6 +9,8 @@
  * Design choices:
  * - Per-IP, in-memory only — multi-instance attackers cost `limit × instances`. We
  *   accept that trade-off to preserve the stateless-deployment property from PR #212.
+ *   IPv6 clients are keyed by /56 subnet (via express-rate-limit v8's `ipKeyGenerator`)
+ *   so they can't bypass the cap by rotating addresses within their prefix.
  * - The operator-facing knob is a single per-minute baseline (`ARC1_AUTH_RATE_LIMIT`,
  *   default 20). Per-endpoint differentiation is done at the mount site in http.ts:
  *   OAuth endpoints all use the baseline; `/mcp` gets a higher cap to absorb
@@ -20,7 +22,7 @@
  */
 
 import type { Request, RequestHandler, Response } from 'express';
-import { rateLimit } from 'express-rate-limit';
+import { ipKeyGenerator, rateLimit } from 'express-rate-limit';
 import { logger } from './logger.js';
 
 /**
@@ -67,7 +69,12 @@ export function createAuthRateLimiter(
     legacyHeaders: false,
     // Explicit keyGenerator: rely on Express's req.ip after `trust proxy 1` (set in http.ts).
     // Operators running behind multiple proxy hops must increase the trust-proxy count there.
-    keyGenerator: (req) => req.ip ?? 'unknown',
+    // `ipKeyGenerator` (express-rate-limit v8) masks IPv6 addresses to a /56 subnet so a client
+    // cannot bypass the per-IP cap by rotating addresses within its prefix; IPv4 is returned
+    // unchanged, so IPv4 keying is identical to before. Using the helper (vs raw `req.ip`) is
+    // also required by v8's `keyGeneratorIpFallback` validation: a raw-`req.ip` keyGenerator
+    // logs ERR_ERL_KEY_GEN_IPV6 and re-opens the IPv6 bypass that v8.0.0 explicitly fixed.
+    keyGenerator: (req) => (req.ip ? ipKeyGenerator(req.ip) : 'unknown'),
     skip: opts.skip,
     handler: (req, res, _next, options) => {
       const ip = req.ip ?? 'unknown';

--- a/tests/unit/server/auth-rate-limit.test.ts
+++ b/tests/unit/server/auth-rate-limit.test.ts
@@ -134,6 +134,27 @@ describe('createAuthRateLimiter (Layer 1)', () => {
     const ipB = await fireRequests(app, 2, '10.0.0.2');
     expect(ipB.codes).toEqual([200, 200]);
   });
+
+  it('groups IPv6 addresses by /56 subnet — prevents per-/128 bypass (v8 ipKeyGenerator)', async () => {
+    // express-rate-limit v8 masks IPv6 to a /56 subnet so a client cannot dodge the cap by
+    // rotating addresses within its prefix. Both addresses below sit in the same /56
+    // (2001:db8:abcd:1200::/56) but differ in the lower bits, so they MUST share one bucket.
+    // Under the previous raw-`req.ip` keyGenerator these were independent buckets (the bug
+    // that re-opened the IPv6 rate-limit bypass express-rate-limit v8.0.0 had fixed).
+    const app = appWithLimiter(createAuthRateLimiter('/test', 2));
+    const first = await fireRequests(app, 2, '2001:db8:abcd:1200::1');
+    expect(first.codes).toEqual([200, 200]); // fills the shared /56 bucket
+    const sameSubnet = await fireRequests(app, 1, '2001:db8:abcd:12ff::9');
+    expect(sameSubnet.codes).toEqual([429]); // same /56 → over cap
+  });
+
+  it('keeps IPv6 addresses in different /56 blocks on independent buckets', async () => {
+    const app = appWithLimiter(createAuthRateLimiter('/test', 2));
+    const blockA = await fireRequests(app, 2, '2001:db8:abcd:1200::1'); // /56 == ...:1200
+    expect(blockA.codes).toEqual([200, 200]);
+    const blockB = await fireRequests(app, 1, '2001:db8:abcd:1300::1'); // /56 == ...:1300 (different)
+    expect(blockB.codes).toEqual([200]); // independent bucket
+  });
 });
 
 // Note: when ARC1_AUTH_RATE_LIMIT=0 the limiter is NOT mounted at all (see http.ts).


### PR DESCRIPTION
## Why

This is the reviewed-and-fixed replacement for the plain Dependabot bump in #324.

`express-rate-limit` **v8.0.0** fixed a vulnerability where *"IPv6 users could bypass rate limiting by iterating through multiple IP addresses"* — v8 now masks IPv6 to a **/56 subnet** in its default `keyGenerator`.

ARC-1's Layer-1 limiter (`src/server/auth-rate-limit.ts`) uses a **custom** `keyGenerator` that returned the raw `req.ip` (a full **/128** for IPv6). Merging v8 as-is would:

1. **Re-open that exact bypass** — an IPv6 client rotating addresses within its prefix gets a fresh bucket per request, defeating the per-IP cap. This is the very module written to close CodeQL `js/missing-rate-limiting`.
2. **Trip v8's `keyGeneratorIpFallback` validation** — it inspects `keyGenerator.toString()`, sees `req.ip` without `ipKeyGenerator`, and logs `ERR_ERL_KEY_GEN_IPV6` on every limiter build (caught + logged, not fatal — which is why #324's CI was green while still being wrong).

The existing tests didn't catch it because they exercise only IPv4 addresses.

## What

- Bump `express-rate-limit` `^7.5.1` → `^8.5.2` (latest 8.x; engines `>=16`, peer `express >=4.11` — both satisfied. The MCP SDK already pulled v8 transitively, so this dedupes to one copy).
- Route the custom `keyGenerator` through v8's `ipKeyGenerator(req.ip)` helper:
  - masks IPv6 to **/56**, returns **IPv4 unchanged** (IPv4 keying identical to before),
  - contains the literal `ipKeyGenerator`, so the v8 validation passes,
  - preserves the `'unknown'` fallback for undefined `req.ip`.
- Add two regression tests:
  - same-/56 IPv6 addresses **share** one bucket — **this test fails under the old raw-`req.ip` keyGenerator** (`expected [200] to equal [429]`), so it genuinely guards the fix,
  - different-/56 blocks stay **independent**.

`handler`'s `req.ip` (audit-log only) is unchanged — forensics keep the full source IP while the bucket keys by /56.

## Verification

- `npm run typecheck` ✓ · `npm run build` ✓ · `biome check` ✓
- `npm test` → **3310 passed / 0 failed**; `ERR_ERL_KEY_GEN_IPV6` no longer appears in test output.
- Confirmed empirically against the installed 8.5.2: `ipKeyGenerator('2001:db8:abcd:1200::1')` and `…:12ff::9` both → `2001:db8:abcd:1200::/56`; `…:1300::1` → a different /56. IPv4 returned unchanged.
- `npm audit --audit-level=high` → 0 vulnerabilities.
- CodeQL `js/missing-rate-limiting` dataflow (`rateLimit({…}) → app.use`) is untouched — only the keyGenerator value changed.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)