### PR TITLE
chore: bump engines.node to >=22.22.1 (match lint-staged 17 + CI/Docker)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,8 @@ updates:
           - "biome"
     ignore:
       # @types/node major must match `engines.node` minimum (currently
-      # `>=22.0.0`), not Node's latest release line. Bumping to a newer
+      # `>=22.22.1` — a minor bump kept lint-staged 17.x happy; the major
+      # is still 22), not Node's latest release line. Bumping to a newer
       # major surfaces APIs that don't exist on the minimum supported
       # runtime, allowing accidental use of APIs that crash at runtime.
       # Bump @types/node major in the same PR that bumps engines.node.

--- a/mcpb-manifest.json
+++ b/mcpb-manifest.json
@@ -99,7 +99,7 @@
       "linux"
     ],
     "runtimes": {
-      "node": ">=22.0.0"
+      "node": ">=22.22.1"
     }
   },
   "user_config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "vitest": "^4.1.1"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.22.1"
       }
     },
     "node_modules/@abaplint/core": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.22.1"
   },
   "bin": {
     "arc-1": "./bin/arc1.js",


### PR DESCRIPTION
## Why

`npm install` emits an `EBADENGINE` warning because **lint-staged 17.x requires Node `>=22.22.1`** while `package.json` declared `engines.node >=22.0.0`.

Investigation finding (corrects the original assumption): this floor was **not** introduced by the #320 dev-deps bump (17.0.5→17.0.7). **Every** lint-staged 17.x — including 17.0.0 — requires `>=22.22.1`, so the repo has needed it since adopting lint-staged 17; `engines.node` was just never updated to match. (The last lint-staged supporting `>=22.0.0` is 16.4.0.)

CI (`node 22`) and Docker (`node:22-alpine`) already run the **latest** 22.x (≥22.22.1), which is why this only surfaces for local dev on a stale Node 22 patch.

## Decision

Chosen: **raise `engines.node` to `>=22.22.1`** to match the toolchain and the de-facto tested/shipped environment, rather than downgrading a working pre-commit lint runner to 16.x and pinning it against Dependabot.

- Within-major bump → `@types/node` stays `^22` (no reconciliation), and the CI `[22, 24]` matrix is unaffected (major selectors resolve to latest).
- **No `engine-strict`** is configured anywhere, so the floor is advisory: it **warns, never blocks** `npm install` / `npm ci` / publish. Verified locally — `npm install` exits 0 and the Husky pre-commit hook (lint-staged 17) runs fine on Node 22.21.1 despite the warning.

## Changes

- `package.json` — `engines.node` `>=22.0.0` → `>=22.22.1`
- `package-lock.json` — root `engines` mirror auto-synced by npm to match (1 line)
- `mcpb-manifest.json` — `compatibility.runtimes.node` `>=22.0.0` → `>=22.22.1` (kept in sync with package.json)
- `.github/dependabot.yml` — updated the `@types/node` ignore-rule comment to reference the new floor

"Node 22+" prose elsewhere (CLAUDE.md / docs) stays accurate and is left untouched.

## Verification

- `npm install` → exit 0 (non-blocking warnings only); `npm run lint` → clean; `npm test` → **3310/3310 pass**.
- Honest note: on a box running Node < 22.22.1 (e.g. this dev box at 22.21.1) the `EBADENGINE` warning **still shows** (now for `arc-1` and `lint-staged`) — that's the floor being honest. It **clears on any Node ≥22.22.1**, which CI and Docker already use; contributors on an older 22.x patch should update Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)