### PR TITLE
docs(skills): CDS analytical query + star-schema skills, BDEF explain branch

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -67,6 +67,12 @@ These skills assume you have:
 | [generate-rap-logic](generate-rap-logic/SKILL.md) | Implements determination and validation methods in an existing RAP behavior pool using structured class reads, version-aware edits, and quickfix-aware validation | After creating a RAP service — fills in the empty method stubs with ABAP Cloud logic |
 | [generate-cds-unit-test](generate-cds-unit-test/SKILL.md) | Generates ABAP Unit tests for CDS entities using the CDS Test Double Framework | When a CDS view has calculations, CASE expressions, WHERE filters, JOINs, or aggregations worth testing |
 | [generate-abap-unit-test](generate-abap-unit-test/SKILL.md) | Generates ABAP Unit tests for classes with dependency analysis and test doubles | When a class has non-trivial business logic and uses dependency injection |
+| [generate-analytics-star-schema](generate-analytics-star-schema/SKILL.md) | Generates a CDS analytical model — cube + dimension + text views — on top of a RAP business object or DDIC table, written in one `batch_create` + `activateAtEnd` pass | Building embedded-analytics foundations; making a transactional model analytical (SAP Joule "CDS Analytical Model Generation" parity) |
+| [generate-cds-analytical-query](generate-cds-analytical-query/SKILL.md) | Generates an analytical query (transient `provider contract analytical_query` projection view) on top of an existing analytical cube | Exposing a cube as a consumable KPI query for SAP Analytics Cloud / Analysis for Office / embedded analytics (SAP Joule "CDS Analytical Query Generation" parity) |
+
+#### generate-analytics-star-schema → generate-cds-analytical-query
+
+These two chain. The star-schema skill builds the **model** (cube + dimensions + texts); the analytical-query skill projects the consumable **query** on top of the cube. Run star-schema first when no cube exists yet, then the query skill. Both are live-verified end-to-end on S/4HANA 2023 (SAP_BASIS 7.58) — see the skills' own notes. The model layer requires the analytics annotations (7.5x); the query layer requires `provider contract analytical_query` (SAP_BASIS 7.57+).
 
 #### generate-rap-service vs generate-rap-service-researched
 
@@ -96,7 +102,7 @@ Both skills produce the same RAP artifact stack. The difference is how they get 
 
 | Skill | What it does | When to use |
 |---|---|---|
-| [explain-abap-code](explain-abap-code/SKILL.md) | Reads an ABAP object, fetches all dependencies via SAPContext, and produces a structured explanation | Onboarding to unfamiliar code, investigating bugs, documenting undocumented objects |
+| [explain-abap-code](explain-abap-code/SKILL.md) | Reads an ABAP object, fetches all dependencies via SAPContext, and produces a structured explanation — including behavior definitions (BDEF: parses `implementation in class`, reads the behavior pool CCIMP handlers, runs SAPContext impact on the bound CDS root) | Onboarding to unfamiliar code, investigating bugs, documenting undocumented objects, understanding a RAP behavior (SAP Joule "AI Explain for Behavior Definitions" parity) |
 | [migrate-custom-code](migrate-custom-code/SKILL.md) | Runs ATC readiness checks, groups findings by priority, and generates replacement code | Preparing custom code for S/4HANA migration or ABAP Cloud readiness |
 | [sap-object-documenter](sap-object-documenter/SKILL.md) | Batch-documents many custom objects at once — purpose, style (Classic/Modern/Mixed), dependencies — as Markdown | Onboarding packages, handoffs, seeding a repo wiki (vs. explain-abap-code which is single-object interactive) |
 
@@ -157,6 +163,15 @@ Skills are designed to chain together. A typical RAP development flow:
 5. generate-cds-unit-test           →  Generate tests for the CDS views
 6. optional: attach SKTD docs / inspect revisions / inspect transport history
 7. analyze-chat-session             →  Review what worked, file improvements
+```
+
+For embedded-analytics modeling (cube → query):
+
+```
+1. bootstrap-system-context        →  Confirm SAP_BASIS 7.57+ (analytical_query support)
+2. generate-analytics-star-schema  →  Build the cube + dimensions + texts (batch_create + activateAtEnd)
+3. generate-cds-analytical-query   →  Project the consumable KPI query on the cube
+4. explain-abap-code               →  (optional) Document the model for handoff
 ```
 
 For codebase onboarding or pre-migration work:

--- a/skills/README.md
+++ b/skills/README.md
@@ -72,7 +72,7 @@ These skills assume you have:
 
 #### generate-analytics-star-schema → generate-cds-analytical-query
 
-These two chain. The star-schema skill builds the **model** (cube + dimensions + texts); the analytical-query skill projects the consumable **query** on top of the cube. Run star-schema first when no cube exists yet, then the query skill. Both are live-verified end-to-end on S/4HANA 2023 (SAP_BASIS 7.58) — see the skills' own notes. The model layer requires the analytics annotations (7.5x); the query layer requires `provider contract analytical_query` (SAP_BASIS 7.57+).
+These two chain. The star-schema skill builds the **model** (cube + dimensions + texts); the analytical-query skill projects the consumable **query** on top of the cube. Run star-schema first when no cube exists yet, then the query skill. The model layer requires the analytics annotations (7.5x); the query layer requires `provider contract analytical_query` (SAP_BASIS 7.57+).
 
 #### generate-rap-service vs generate-rap-service-researched
 

--- a/skills/explain-abap-code/SKILL.md
+++ b/skills/explain-abap-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: explain-abap-code
-description: Explain ABAP objects with full dependency context (via SAPContext) and optional ATC code quality analysis — replicates SAP Joule's "Explain Code" capability. Use when asked to "explain this ABAP", "what does ZCL_X do", "walk me through this class/CDS view", or "review this object's quality".
+description: Explain ABAP objects with full dependency context (via SAPContext) and optional ATC code quality analysis — replicates SAP Joule's "Explain Code" capability, including behavior definitions (BDEF — CRUD graph, determinations/validations, bound handler class). Use when asked to "explain this ABAP", "what does ZCL_X do", "walk me through this class/CDS view/behavior definition", or "review this object's quality".
 ---
 
 # Explain ABAP Code
@@ -17,6 +17,7 @@ This skill replicates SAP Joule's "Explain Code" capability by combining ARC-1 (
 | Depth | Overview | Start high-level, user can ask for detail |
 | ATC | No | Only run if user asks about code quality |
 | Dependencies | Fetch via SAPContext | Always get the dependency graph |
+| BDEF handler class | Discover from `implementation in class` clause | The behavior logic lives in the bound pool class |
 
 ## Input
 
@@ -72,6 +73,41 @@ Depending on type, also read associated objects:
 
 These may fail if the related artifact doesn't exist — that's fine, skip them.
 
+### 1f. For behavior definitions (BDEF) — walk the RAP graph
+
+A behavior definition is only meaningful together with its bound CDS root entity and its behavior pool (handler) class. When the object is a BDEF, do this instead of (or in addition to) the steps above:
+
+**Read the BDEF source:**
+
+```
+SAPRead(type="BDEF", name="<bdef_name>")
+```
+
+**Identify the implementation type + bound pool class** by reading the BDEF source:
+- First non-comment token: `managed` / `unmanaged` / `projection` / `abstract` / `interface` — this is the implementation kind
+- `strict ( 2 )` → latest RAP syntax checks; `with draft` / `with collaborative draft` → draft-enabled
+- The clause `... implementation in class <ZBP_NAME> unique;` names the **behavior pool class**. Extract `<ZBP_NAME>` with a regex like `implementation\s+in\s+class\s+(\S+)`. (A `projection;` BDEF may have no pool class — it reuses the base behavior via `use ...`.)
+
+**Read the behavior pool class** (the handler logic lives in its local includes — usually CCIMP):
+
+```
+SAPRead(type="CLAS", name="<ZBP_NAME>", include="implementations")
+```
+
+If that returns empty, also try `include="definitions"` (CCDEF) and the main include. The local handler classes are named `lhc_<alias>` and each `FOR DETERMINE` / `FOR VALIDATE` / `FOR MODIFY` method implements the corresponding BDEF declaration.
+
+**Read the bound CDS root entity** to understand the data model the behavior governs:
+
+```
+SAPRead(type="DDLS", name="<root_cds>", include="elements")
+```
+
+The root CDS name appears in `define behavior for <root_cds> alias <alias>`.
+
+**For a projection BDEF**, also read the underlying base BDEF (the one it projects) to see which operations are reused (`use create; use update; use action ...`).
+
+These reads may fail if an artifact doesn't exist (e.g. a pure abstract BDEF) — skip gracefully.
+
 ## Step 2: Get Dependency Context
 
 ```
@@ -90,6 +126,14 @@ SAPContext(type="<type>", name="<object_name>", depth=2)
 ```
 
 If SAPContext fails (e.g., unsupported type), fall back to manual reads of key dependencies identified in the source code.
+
+**Supported types:** `SAPContext` accepts `CLAS`, `INTF`, `PROG`, `FUNC`, `DDLS` (on-prem) / `CLAS`, `INTF`, `DDLS` (BTP). It does **not** accept `BDEF`. So when explaining a BDEF, run dependency/impact analysis on the **bound CDS root entity** instead:
+
+```
+SAPContext(action="impact", name="<root_cds>")
+```
+
+`action="impact"` (DDLS only) returns the downstream blast radius — projection views, consumption views, and services that build on the behavior. This is the "dependencies / who consumes this" answer for a behavior definition. For the handler class internals, run `SAPContext(type="CLAS", name="<ZBP_NAME>")`.
 
 ## Step 3: (Optional) Run ATC Check
 
@@ -160,6 +204,19 @@ For CDS views:
 - Data transformations and calculations
 - Error handling approach
 
+### Behavior Definition (if the object is a BDEF)
+Structure the explanation around the RAP behavior graph you read in Step 1f:
+- **Implementation kind**: managed / unmanaged / projection / abstract — and what that implies (framework-provided CRUD vs custom handlers vs reuse layer). Note `strict(2)` and `with draft` if present.
+- **Business purpose**: derived from the bound CDS root entity + the BDEF header comments.
+- **Per-entity model**: for each `define behavior for <CDS> alias <alias>` — persistent table, `lock master`/`lock dependent`, `authorization master`/`authorization dependent`, `etag`.
+- **Operations (the CRUD graph)**: `create` / `update` / `delete`, create-by-association (`association _X { create; }`), and whether draft actions (`Edit`, `Activate`, `Discard`, `Resume`, `Prepare`) are present.
+- **Determinations**: `determination <name> on save|on modify` — what each derives, read from the matching `FOR DETERMINE` method in the pool class.
+- **Validations**: `validation <name> on save` — what each enforces, from the `FOR VALIDATE` method.
+- **Actions / functions**: `action <name>` (+ `static`/`factory`/`parameter`/`result`), from the `FOR MODIFY` / `FOR READ` methods.
+- **Side effects**: `side effects { ... }` declarations (what UI refresh / recompute they trigger).
+- **Field controls**: `field ( readonly | mandatory | numbering : managed )`, `mapping for <table>`.
+- For a **projection** BDEF: which base operations/actions are reused via `use ...`.
+
 ### Dependencies
 From SAPContext results:
 - Direct dependencies with their roles (data source, helper, framework)
@@ -187,6 +244,7 @@ Offer the user next steps:
 - "Want me to analyze the ATC findings and suggest fixes?" (→ migrate-custom-code skill)
 - "Want me to generate unit tests for this class?" (→ generate-abap-unit-test skill)
 - "Want me to show the full dependency graph?" (→ SAPContext with depth=2)
+- For a BDEF: "Want me to implement a missing determination/validation/action body?" (→ generate-rap-logic skill) or "Want me to scaffold the behavior pool handlers?" (→ `SAPWrite(action="scaffold_rap_handlers")`)
 
 ## Error Handling
 
@@ -200,6 +258,8 @@ Offer the user next steps:
 | ATC variant not found | Specified variant doesn't exist on system | Run default ATC, list available variants |
 | Method listing empty | Object is not a class or has no methods | Skip method listing, explain from source only |
 | Source is empty | Object exists but has no source (e.g., generated proxy) | Inform user, try reading related objects instead |
+| `SAPContext` rejects BDEF type | BDEF isn't a supported SAPContext type | Run `SAPContext(action="impact", name="<root_cds>")` on the bound CDS root instead |
+| BDEF pool class not found | `projection;` BDEF (no own pool) or class name parsed wrong | Skip the class read; explain from the projection's `use` clauses + base BDEF |
 
 ## Notes
 

--- a/skills/explain-abap-code/SKILL.md
+++ b/skills/explain-abap-code/SKILL.md
@@ -206,7 +206,7 @@ For CDS views:
 
 ### Behavior Definition (if the object is a BDEF)
 Structure the explanation around the RAP behavior graph you read in Step 1f:
-- **Implementation kind**: managed / unmanaged / projection / abstract — and what that implies (framework-provided CRUD vs custom handlers vs reuse layer). Note `strict(2)` and `with draft` if present.
+- **Implementation kind**: managed / unmanaged / projection / abstract / interface — and what that implies (framework-provided CRUD vs custom handlers vs reuse/typing layer). Note `strict(2)` and `with draft` if present.
 - **Business purpose**: derived from the bound CDS root entity + the BDEF header comments.
 - **Per-entity model**: for each `define behavior for <CDS> alias <alias>` — persistent table, `lock master`/`lock dependent`, `authorization master`/`authorization dependent`, `etag`.
 - **Operations (the CRUD graph)**: `create` / `update` / `delete`, create-by-association (`association _X { create; }`), and whether draft actions (`Edit`, `Activate`, `Discard`, `Resume`, `Prepare`) are present.

--- a/skills/generate-analytics-star-schema/SKILL.md
+++ b/skills/generate-analytics-star-schema/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: generate-analytics-star-schema
+description: Generate a CDS analytical model (star schema — cube + dimension + text views) on top of a RAP business object or a DDIC table. Use when asked to "create a star schema", "generate an analytical cube and dimensions", "make a RAP BO analytical", "build a CDS cube from a table", or "create an analytical model".
+---
+
+# Generate CDS Analytics Star Schema
+
+Generate a CDS **analytical model** — a star schema consisting of a cube view (`@Analytics.dataCategory: #CUBE`), one or more dimension views (`#DIMENSION`), and text views (`#TEXT`) — on top of a RAP business object or a plain DDIC table.
+
+This skill replicates SAP Joule's "CDS Analytical Model Generation" capability (basic + extended scope) by combining ARC-1 (SAP system access) with mcp-sap-docs (documentation & best practices). Basic scope = cube + reuse existing dimensions. Extended scope = also generate new dimensions, and start from a DDIC table (not just a RAP BO).
+
+## Prerequisites — read this first
+
+- **Requires SAP_BASIS 7.5x with the analytics annotations.** Verify with `SAPManage(action="probe")` (`rap.available`). If RAP/CDS isn't available, stop.
+- The output is a set of **interdependent** CDS views (cube → dimensions → texts). They must be created as inactive drafts and activated together so SAP's activator resolves the cross-references in one pass. This skill uses `SAPWrite(action="batch_create", activateAtEnd: true)` for exactly that.
+
+## Smart Defaults (apply silently, do NOT ask)
+
+| Setting | Default | Rationale |
+|---|---|---|
+| Object type | `DDLS` | Cube/dimension/text are all CDS data definitions |
+| Package | `$TMP` | Fast prototyping; ask before a transportable package |
+| Activation | `batch_create` + `activateAtEnd: true` | Cross-references resolve in one terminal pass |
+| Authorization | `#NOT_REQUIRED` (cube/dimension) | Standard for analytical interface views |
+| Naming | `ZI_<X>_CUBE`, `ZI_<X>_DIM`, `ZI_<X>_TXT` | Clear star-schema roles |
+
+## Input
+
+The user provides either:
+- A **RAP business object** root entity / behavior pool (e.g. `ZBP_R_TRAVEL` or `ZI_Travel`), or
+- A **DDIC table** (e.g. `ZTRAVEL`), or
+- An **interface CDS view** to use as the fact source.
+
+Optionally: which numeric fields are measures, which fields are dimensions, target package, and whether to generate new dimension views or reuse existing ones.
+
+## Step 1: Resolve and read the source
+
+### 1a. RAP BO input — find the bound CDS root entity
+
+If the user names a behavior pool class (`ZBP_*`), read the class metadata to find the root entity it's bound to:
+
+```
+SAPRead(type="CLAS", name="<ZBP_class>", format="structured")
+```
+
+Look for the bound root entity reference. Then read that CDS root entity (next step). If the user already named the CDS root entity / interface view, skip to 1c.
+
+### 1b. DDIC table input — read the table structure
+
+```
+SAPRead(type="TABL", name="<table>")
+```
+
+Capture the field list with types. Identify candidate keys, dimension fields (foreign keys, characteristics), and numeric measure fields (amounts, quantities, counts).
+
+### 1c. CDS view input — read source + elements
+
+```
+SAPRead(type="DDLS", name="<view>")
+SAPRead(type="DDLS", name="<view>", include="elements")
+```
+
+The element list classifies fields. Decide for each:
+- **Measure**: numeric, additive (amount / quantity / count) → goes in the cube with `@Aggregation.default: #SUM`
+- **Dimension**: a characteristic you slice by (region, customer, date) → either reuse an existing dimension view or generate a new one
+- **Currency/Unit**: paired with each amount/quantity measure
+
+## Step 2: Discover reusable dimensions
+
+For each dimension field, check whether a reusable dimension view already exists before generating a new one:
+
+```
+SAPSearch(query="*<dimension_keyword>*", searchType="object", objectType="DDLS")
+```
+
+If a released `#DIMENSION` view exists (e.g. `I_Country`, `I_CalendarDate`), reuse it via association. Otherwise generate a new `ZI_<X>_DIM` (extended scope).
+
+## Step 3: Look up current analytics annotations
+
+Ground the generation in current docs:
+
+```
+search("CDS analytical model cube Analytics.dataCategory CUBE dimension representativeKey")
+search("ObjectModel.foreignKey.association text association Semantics.text")
+```
+
+Cite the doc IDs in your summary. Key facts (7.58):
+- Cube: `@Analytics: { dataCategory: #CUBE, internalName: #LOCAL }` + `@ObjectModel: { supportedCapabilities: [ #ANALYTICAL_PROVIDER ], modelingPattern: #ANALYTICAL_CUBE }`
+- A cube needs **≥1 measure**; measures carry `@Aggregation.default: #SUM` (or `#MIN`/`#MAX`/`#AVG`); a numeric field WITHOUT `@Aggregation.default` is treated as a dimension
+- Cube→dimension associations must be **`[1..1]`**; `@ObjectModel.foreignKey.association: '_Dim'` goes on the **dimension key field in the cube**
+- Dimension: `@Analytics.dataCategory: #DIMENSION` + `@ObjectModel: { representativeKey: '<key>', supportedCapabilities: [ #ANALYTICAL_DIMENSION ], modelingPattern: #ANALYTICAL_DIMENSION }`
+- Text view uses `@ObjectModel.dataCategory: #TEXT` (the `ObjectModel.` namespace — NOT `@Analytics.dataCategory`) + `@Semantics.text: true` + `@Semantics.language: true`
+
+## Step 4: Compose the model
+
+### Cube template
+
+```abap
+@AccessControl.authorizationCheck: #NOT_REQUIRED
+@EndUserText.label: 'Sales Cube'
+@Analytics: {
+  dataCategory: #CUBE,
+  internalName: #LOCAL
+}
+@ObjectModel: {
+  supportedCapabilities: [ #ANALYTICAL_PROVIDER ],
+  modelingPattern: #ANALYTICAL_CUBE
+}
+define view entity ZI_Sales_Cube
+  as select from zsales_data
+  association [1..1] to ZI_Region_Dim as _Region
+    on _Region.RegionId = $projection.RegionId
+{
+      @ObjectModel.foreignKey.association: '_Region'
+  key region_id   as RegionId,
+  key calyear     as CalendarYear,
+
+      @Semantics.amount.currencyCode: 'CurrencyCode'
+      @Aggregation.default: #SUM
+      amount       as SalesAmount,
+
+      currency     as CurrencyCode,
+
+      @Aggregation.default: #SUM
+      @EndUserText.label: 'Number of Records'
+      1            as RecordCount,
+
+      _Region
+}
+```
+
+### Dimension template
+
+```abap
+@AccessControl.authorizationCheck: #NOT_REQUIRED
+@EndUserText.label: 'Region Dimension'
+@Analytics.dataCategory: #DIMENSION
+@ObjectModel: {
+  representativeKey: 'RegionId',
+  supportedCapabilities: [ #ANALYTICAL_DIMENSION ],
+  modelingPattern: #ANALYTICAL_DIMENSION
+}
+define view entity ZI_Region_Dim
+  as select from zregion
+  association [0..1] to ZI_Region_Txt as _Text
+    on _Text.RegionId = $projection.RegionId
+{
+      @ObjectModel.text.association: '_Text'
+  key region_id as RegionId,
+      _Text
+}
+```
+
+### Text view template
+
+```abap
+@EndUserText.label: 'Region - Text'
+@ObjectModel.dataCategory: #TEXT
+@ObjectModel.representativeKey: 'RegionId'
+define view entity ZI_Region_Txt
+  as select from zregion_t
+{
+      @ObjectModel.foreignKey.association: '_Region'
+  key region_id as RegionId,
+
+      @Semantics.language: true
+  key spras     as Language,
+
+      @Semantics.text: true
+      regiontext  as RegionName
+}
+```
+
+**Composition rules** (enforce before writing):
+- Cube has ≥1 measure (`@Aggregation.default`).
+- Each amount measure has `@Semantics.amount.currencyCode` + the currency field is projected; each quantity measure has `@Semantics.quantity.unitOfMeasure` + the unit field is projected.
+- Every cube→dimension association is `[1..1]` and the dimension key field carries `@ObjectModel.foreignKey.association`.
+- Every dimension has a `representativeKey`.
+- Text views use `@ObjectModel.dataCategory: #TEXT` + `@Semantics.text/language`.
+
+## Step 5: Show the plan as a tree, then batch-create
+
+Show the user the model tree before writing:
+
+```
+Cube: ZI_Sales_Cube  (from zsales_data)
+  Measures: SalesAmount (SUM, currency CurrencyCode), RecordCount (SUM)
+  Dimensions:
+    ZI_Region_Dim (new) → ZI_Region_Txt (new)
+```
+
+On confirmation, create all views in one batch with deferred activation so cross-references resolve together:
+
+```
+SAPWrite(action="batch_create", activateAtEnd=true, objects=[
+  { type: "DDLS", name: "ZI_Region_Txt",  source: "<text_ddl>",      package: "$TMP" },
+  { type: "DDLS", name: "ZI_Region_Dim",  source: "<dimension_ddl>", package: "$TMP" },
+  { type: "DDLS", name: "ZI_Sales_Cube",  source: "<cube_ddl>",      package: "$TMP" }
+])
+```
+
+Order the array dependencies-first (text → dimension → cube) so that even if `activateAtEnd` falls back to per-object activation on an older release, the chain still resolves. With `activateAtEnd: true`, ARC-1 writes all three as inactive drafts and fires one terminal activation over the whole graph.
+
+If `batch_create` with `activateAtEnd` is not honored (older release), fall back to: create each object with `SAPWrite(action="create", ...)` then a single `SAPActivate(objects=[...])` over all created objects.
+
+## Step 6: Verify
+
+```
+SAPRead(type="DDLS", name="ZI_Sales_Cube", include="elements")
+```
+
+Confirm the cube is live and its dimension association + measures resolved.
+
+## Step 7: Offer the query layer
+
+The cube is the foundation; the query is what end users consume. Offer:
+
+> "Want me to generate an analytical query (the consumable KPI view) on top of this cube? → `generate-cds-analytical-query`"
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| Cube has no measure | All numeric fields treated as dimensions | Add `@Aggregation.default: #SUM` to at least one numeric field |
+| Association cardinality error | Cube→dimension not `[1..1]` | Change cardinality to `[1..1]` |
+| `foreignKey.association` placement | Annotation on the association instead of the key field | Move it to the dimension key field in the cube |
+| Text view rejected | Used `@Analytics.dataCategory` instead of `@ObjectModel.dataCategory` for `#TEXT` | Text views use the `ObjectModel` namespace |
+| Cross-reference unresolved | Created objects activated individually before siblings existed | Use `batch_create` with `activateAtEnd: true` |
+| Representative key missing | Dimension has no `representativeKey` | Add `@ObjectModel.representativeKey` |
+
+## Notes
+
+- **Basic vs extended scope:** Basic = reuse existing dimensions (Step 2 finds released `#DIMENSION` views). Extended = also generate new `ZI_*_DIM` + `ZI_*_TXT` and accept a DDIC table as the fact source (Step 1b).
+- This skill builds the **model**; the consumable **query** is a separate step (`generate-cds-analytical-query`).
+- For a transactional RAP service (not analytics), use `generate-rap-service`.
+- Reuse SAP standard dimensions where they exist (`I_CalendarDate`, `I_Country`, `I_Currency`) instead of regenerating them — `SAPSearch` in Step 2.

--- a/skills/generate-analytics-star-schema/SKILL.md
+++ b/skills/generate-analytics-star-schema/SKILL.md
@@ -22,7 +22,7 @@ This skill replicates SAP Joule's "CDS Analytical Model Generation" capability (
 | Package | `$TMP` | Fast prototyping; ask before a transportable package |
 | Activation | `batch_create` + `activateAtEnd: true` | Cross-references resolve in one terminal pass |
 | Authorization | `#NOT_REQUIRED` (cube/dimension) | Standard for analytical interface views |
-| Naming | `ZI_<X>_CUBE`, `ZI_<X>_DIM`, `ZI_<X>_TXT` | Clear star-schema roles |
+| Naming | `ZI_<X>_Cube`, `ZI_<X>_Dim`, `ZI_<X>_Txt` | Clear star-schema roles (match the casing the templates use) |
 
 ## Input
 
@@ -123,7 +123,7 @@ define view entity ZI_Sales_Cube
 
       @Aggregation.default: #SUM
       @EndUserText.label: 'Number of Records'
-      1            as RecordCount,
+      abap.int8'1' as RecordCount,
 
       _Region
 }
@@ -154,13 +154,13 @@ define view entity ZI_Region_Dim
 ### Text view template
 
 ```abap
+@AccessControl.authorizationCheck: #NOT_REQUIRED
 @EndUserText.label: 'Region - Text'
 @ObjectModel.dataCategory: #TEXT
 @ObjectModel.representativeKey: 'RegionId'
 define view entity ZI_Region_Txt
   as select from zregion_t
 {
-      @ObjectModel.foreignKey.association: '_Region'
   key region_id as RegionId,
 
       @Semantics.language: true
@@ -170,6 +170,8 @@ define view entity ZI_Region_Txt
       regiontext  as RegionName
 }
 ```
+
+(The text view stands alone — it declares no association, so it carries no `@ObjectModel.foreignKey.association`. The link is one-directional: the **dimension** associates to this text view via `_Text` + `@ObjectModel.text.association`, not the other way round.)
 
 **Composition rules** (enforce before writing):
 - Cube has ≥1 measure (`@Aggregation.default`).

--- a/skills/generate-cds-analytical-query/SKILL.md
+++ b/skills/generate-cds-analytical-query/SKILL.md
@@ -11,7 +11,7 @@ This skill replicates SAP Joule's "CDS Analytical Query Generation" capability b
 
 ## Prerequisites — read this first
 
-- **Requires SAP_BASIS 7.57+ (S/4HANA 2022+).** The `provider contract analytical_query` form is unavailable on 7.56 and earlier. Verify with `SAPManage(action="probe")` (checks `rap.available`) — if RAP/CDS isn't available, stop and tell the user.
+- **Requires SAP_BASIS 7.57+ (S/4HANA 2022+).** The `provider contract analytical_query` form is unavailable on 7.56 and earlier. Note that `SAPManage(action="probe")` `rap.available` is **necessary but not sufficient** — RAP shipped in 7.54, so a `true` does not confirm the 7.57 floor. To gate reliably, check the release directly, e.g. `SAPQuery(sql="SELECT release FROM cvers WHERE component = 'SAP_BASIS'")` and require `>= 757`; otherwise be ready for the provider-contract syntax error to surface at activation (Step 5) and stop there.
 - **You need an existing cube.** This skill projects ON a cube. If no cube exists yet, run the `generate-analytics-star-schema` skill first to build the cube + dimensions, then come back here.
 
 ## Smart Defaults (apply silently, do NOT ask)
@@ -26,7 +26,7 @@ This skill replicates SAP Joule's "CDS Analytical Query Generation" capability b
 
 ## Input
 
-The user provides a cube name (e.g., `ZI_SALES_CUBE`) or a business description ("revenue by region and month"). Only the **cube** is strictly required; if the user gives a description, find the cube via Step 1.
+The user provides a cube name (e.g., `ZI_Sales_Cube`) or a business description ("revenue by region and month"). Only the **cube** is strictly required; if the user gives a description, find the cube via Step 1.
 
 Optionally:
 - **Query name** (default: derive from the cube, e.g. `ZC_SalesQuery`; **must be ≤ 28 characters** — the analytical engine prepends `2C` to the runtime name)
@@ -150,7 +150,7 @@ where CalendarYear = $parameters.p_year
 ```
 
 **Composition rules** (enforce before writing):
-- Element names must match the cube's element names exactly (you read them in Step 1c).
+- Every element you **project directly** from the cube must use the cube's exact element name (you read them in Step 1c). Calculated and restricted measures (Template B) are the exception — they introduce new aliases (`... as SalesAmount2025`) that need not exist in the cube.
 - Every amount measure needs a `@Semantics.amount.currencyCode: '<field>'` and that currency field must also be projected.
 - Every quantity measure needs `@Semantics.quantity.unitOfMeasure: '<field>'` and that unit field must be projected.
 - Query name ≤ 28 chars.

--- a/skills/generate-cds-analytical-query/SKILL.md
+++ b/skills/generate-cds-analytical-query/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: generate-cds-analytical-query
+description: Generate an analytical CDS query (transient projection view with PROVIDER CONTRACT ANALYTICAL_QUERY) on top of an existing analytical cube. Use when asked to "create an analytical query", "build a KPI query on a cube", "generate an ANALYTICAL_QUERY view", or "expose a cube for analytics/embedded analytics".
+---
+
+# Generate CDS Analytical Query
+
+Generate an analytical CDS query — a **transient projection view** with `provider contract analytical_query` — on top of an existing analytical cube (`@Analytics.dataCategory: #CUBE`).
+
+This skill replicates SAP Joule's "CDS Analytical Query Generation" capability by combining ARC-1 (SAP system access) with mcp-sap-docs (documentation & best practices). The query view is what end users consume in analytical clients (SAP Analytics Cloud, Analysis for Office, embedded analytics) — it selects measures and dimensions from a cube and arranges them on rows/columns/free axes.
+
+## Prerequisites — read this first
+
+- **Requires SAP_BASIS 7.57+ (S/4HANA 2022+).** The `provider contract analytical_query` form is unavailable on 7.56 and earlier. Verify with `SAPManage(action="probe")` (checks `rap.available`) — if RAP/CDS isn't available, stop and tell the user.
+- **You need an existing cube.** This skill projects ON a cube. If no cube exists yet, run the `generate-analytics-star-schema` skill first to build the cube + dimensions, then come back here.
+
+## Smart Defaults (apply silently, do NOT ask)
+
+| Setting | Default | Rationale |
+|---|---|---|
+| Object type | `DDLS` | Analytical queries are CDS data definitions |
+| Package | `$TMP` | Fast prototyping; ask before a transportable package |
+| Authorization | `#NOT_ALLOWED` | **Mandatory** on analytical queries — any other value fails activation |
+| Axis layout | Dimensions → `#ROWS`, measures → `#COLUMNS` | Sensible default grid; user can rearrange |
+| ATC | No | Only run if user asks about code quality |
+
+## Input
+
+The user provides a cube name (e.g., `ZI_SALES_CUBE`) or a business description ("revenue by region and month"). Only the **cube** is strictly required; if the user gives a description, find the cube via Step 1.
+
+Optionally:
+- **Query name** (default: derive from the cube, e.g. `ZC_SalesQuery`; **must be ≤ 28 characters** — the analytical engine prepends `2C` to the runtime name)
+- **Package** (default `$TMP`)
+- **Measures / dimensions to expose** (default: all measures + key dimensions from the cube)
+
+## Step 1: Resolve and read the cube
+
+### 1a. Find the cube (if the user gave a description, not a name)
+
+```
+SAPSearch(query="<keyword>*", searchType="object", objectType="DDLS")
+```
+
+Pick the candidate whose name/description matches an analytical cube. If multiple match, list them and ask.
+
+### 1b. Read the cube source and confirm it IS a cube
+
+```
+SAPRead(type="DDLS", name="<cube>")
+```
+
+**Verify** the source contains `@Analytics.dataCategory: #CUBE` (or `@Analytics: { dataCategory: #CUBE ... }`). If it does NOT, stop: an analytical query can only project on a cube or a dimension. Suggest `generate-analytics-star-schema` to build a cube first.
+
+### 1c. Get the structured element list
+
+```
+SAPRead(type="DDLS", name="<cube>", include="elements")
+```
+
+This returns every field with key markers and types. Use it to classify each element:
+- **Measures** — numeric fields carrying `@Aggregation.default` (e.g. `#SUM`) in the cube source
+- **Dimensions** — key fields and foreign-key-association fields
+- **Units/currencies** — fields referenced by `@Semantics.amount.currencyCode` / `@Semantics.quantity.unitOfMeasure`
+
+## Step 2: Look up current analytical-query syntax
+
+Ground the generation in current docs — do NOT rely on memory for annotation names:
+
+```
+search("CDS analytical query provider contract analytical_query transient view")
+search("AnalyticsDetails.query.axis ROWS COLUMNS FREE")
+```
+
+Cite the doc IDs you used in your final summary. Key facts the docs confirm (7.58):
+- Header form: `define transient view entity <name> provider contract analytical_query as projection on <cube>`
+- `@AccessControl.authorizationCheck: #NOT_ALLOWED` is **mandatory** (queries can't be read via ABAP SQL → no DCL allowed; the cube's access control applies)
+- The `transient` keyword is mandatory (no HANA SQL view is generated)
+- You cannot define new associations or use `KEY` in a query view
+- A calculated measure (arithmetic / CASE-on-a-measure) needs `@Aggregation.default: #FORMULA`
+
+## Step 3: Compose the analytical query
+
+Pick the template that matches the request.
+
+### Template A — simple projection (1+ dimensions on rows, 1+ measures on columns)
+
+```abap
+@EndUserText.label: 'Sales Analytical Query'
+@AccessControl.authorizationCheck: #NOT_ALLOWED
+define transient view entity ZC_SalesQuery
+  provider contract analytical_query
+  as projection on ZI_Sales_Cube
+{
+      @AnalyticsDetails.query.axis: #ROWS
+  RegionId,
+
+      @AnalyticsDetails.query.axis: #FREE
+  CalendarYear,
+
+      @AnalyticsDetails.query.axis: #COLUMNS
+      @Semantics.amount.currencyCode: 'CurrencyCode'
+  SalesAmount,
+
+  CurrencyCode
+}
+```
+
+### Template B — restricted + calculated measures
+
+```abap
+@EndUserText.label: 'Sales KPI Query'
+@AccessControl.authorizationCheck: #NOT_ALLOWED
+define transient view entity ZC_SalesKpiQuery
+  provider contract analytical_query
+  as projection on ZI_Sales_Cube
+{
+      @AnalyticsDetails.query.axis: #ROWS
+  RegionId,
+
+      // restricted measure: selection-related CASE — WHEN must reference a DIMENSION
+      @Semantics.amount.currencyCode: 'CurrencyCode'
+  case when CalendarYear = '2025' then SalesAmount else null end as SalesAmount2025,
+
+      // calculated measure: formula CASE — needs @Aggregation.default: #FORMULA
+      @Aggregation.default: #FORMULA
+  case when SalesAmount is initial then abap.int8'0' else abap.int8'1' end as HasSales,
+
+  CurrencyCode
+}
+```
+
+### Template C — query with input parameters (filter prompt)
+
+```abap
+@EndUserText.label: 'Sales Query (parameterized)'
+@AccessControl.authorizationCheck: #NOT_ALLOWED
+define transient view entity ZC_SalesParamQuery
+  provider contract analytical_query
+  with parameters
+    p_year : abap.numc(4)
+  as projection on ZI_Sales_Cube
+{
+      @AnalyticsDetails.query.axis: #ROWS
+  RegionId,
+      @Semantics.amount.currencyCode: 'CurrencyCode'
+  SalesAmount,
+  CurrencyCode
+}
+where CalendarYear = $parameters.p_year
+```
+
+**Composition rules** (enforce before writing):
+- Element names must match the cube's element names exactly (you read them in Step 1c).
+- Every amount measure needs a `@Semantics.amount.currencyCode: '<field>'` and that currency field must also be projected.
+- Every quantity measure needs `@Semantics.quantity.unitOfMeasure: '<field>'` and that unit field must be projected.
+- Query name ≤ 28 chars.
+
+## Step 4: Show the plan, then write
+
+Show the user the composed DDL and the axis layout (which fields are rows / columns / free) before writing. On confirmation:
+
+```
+SAPWrite(action="create", type="DDLS", name="<query>", source="<ddl>", package="$TMP")
+```
+
+For a transportable package, pass `package="<pkg>"` and `transport="<TR>"` (the user must supply the TR; create one with `SAPTransport` if needed).
+
+## Step 5: Activate
+
+```
+SAPActivate(name="<query>", type="DDLS")
+```
+
+If activation fails, surface the diagnostics **verbatim** and let the user re-prompt. Do NOT silently retry. Common failures:
+- `@AccessControl.authorizationCheck` not `#NOT_ALLOWED` → fix the annotation
+- Element not found in cube → you used a name not in the cube (re-check Step 1c)
+- Measure missing currency/unit reference → add the `@Semantics.*` annotation + project the currency/unit field
+- Name > 28 chars → shorten the query name
+
+## Step 6: Verify
+
+```
+SAPRead(type="DDLS", name="<query>", include="elements")
+```
+
+Confirm the query is live and the projected elements appear. Report success with the runtime name (`2C<query>`).
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| Projection target is not a cube | Tried to project on a plain view | Build a cube first via `generate-analytics-star-schema` |
+| `provider contract` syntax error | SAP_BASIS < 7.57 | Stop — analytical_query unsupported on this release |
+| Authorization check error on activate | Used a value other than `#NOT_ALLOWED` | Set `@AccessControl.authorizationCheck: #NOT_ALLOWED` |
+| Element does not exist | Element name typo vs cube | Re-read the cube elements (Step 1c) |
+| Name too long | Query name > 28 chars | Shorten it |
+
+## Notes
+
+- This skill **only creates the query layer**. To build the underlying cube + dimensions + texts, use `generate-analytics-star-schema` first — the two skills chain: star-schema produces the cube, this skill projects on it.
+- For a transactional (RAP) service rather than analytics, use `generate-rap-service` instead.
+- BTP ABAP and on-prem 7.58 both support this; on 7.57 verify the exact provider-contract form via `search()` first.


### PR DESCRIPTION
## Summary

Adds two new Claude skills and extends an existing one, covering three **SAP Joule for Developers 2026 roadmap** features with ARC-1 + skills. Skills only — no TypeScript / package changes.

| Roadmap feature | Skill | Change |
|---|---|---|
| CDS Analytical Query Generation | `generate-cds-analytical-query` | **new** |
| CDS Analytical Model Generation (basic + extended) | `generate-analytics-star-schema` | **new** |
| AI Explain for Behavior Definitions | `explain-abap-code` | **extended** (BDEF branch) |

## What each skill does

- **`generate-cds-analytical-query`** — generates a transient projection view with `provider contract analytical_query` on an existing analytical cube (`@Analytics.dataCategory: #CUBE`). Enforces the mandatory `@AccessControl.authorizationCheck: #NOT_ALLOWED`, the 28-char name cap, and `@AnalyticsDetails.query.axis` layout. Ships simple / restricted-measure / parameterized templates.
- **`generate-analytics-star-schema`** — generates a cube + dimension + text views from a RAP BO or DDIC table, written in one `SAPWrite(action="batch_create", activateAtEnd: true)` call so the cube→dimension cross-references resolve in a single activation pass. Basic scope (reuse existing dimensions) + extended scope (generate new dimensions, DDIC-table source).
- **`explain-abap-code`** (extended) — new BDEF branch: read the BDEF, parse `implementation in class` to find the behavior pool, read its CCIMP handlers, and run `SAPContext(action="impact")` on the bound CDS root.

## Two corrections vs. the planning docs

While verifying against the live tool surface I found the BDEF plan referenced non-existent surface; the skill uses the correct one:
- **No `SAPDiagnose` `rap_preflight` action exists** — dropped.
- **`SAPContext` does not accept `BDEF`** (only `CLAS|INTF|PROG|FUNC|DDLS`) — the skill runs `action="impact"` on the bound DDLS root instead.

## Live verification (arc1-cli → A4H, S/4HANA 2023, SAP_BASIS 758)

Every skill's tool sequence was executed end-to-end against the live system:
- **Star schema:** dimension + cube `batch_create(activateAtEnd=true)` on `/dmo/carrier` + `/dmo/flight` → both activated as one batch (cross-reference resolved).
- **Analytical query:** transient `analytical_query` projection on that cube → created + activated + read back.
- **BDEF explain:** `/DMO/I_TRAVEL_M` → parsed `implementation in class /DMO/BP_TRAVEL_M` → read pool CCIMP (`lhc_travel`, `FOR VALIDATE ON SAVE` handlers) → `SAPContext(action=impact)` on `/DMO/I_Travel_M`.
- All test objects (`ZARC_FLIGHT_Q`, `ZARC_FLIGHT_CUBE`, `ZARC_CARRIER_DIM`) deleted and verified gone.

## Not included

Research docs and ralphex plans for these (and the other roadmap features) are intentionally out of this PR. Optional follow-ups remain per the plans: pre-write lint hint, analytical AFF schema variant, E2E test files, and end-user doc updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)