### PR TITLE
docs: Clean-Core ATC skill polish + live ATC/quickfix/autoqf surface research

### DIFF
--- a/docs/research/atc-quickfix-surface-a4h.md
+++ b/docs/research/atc-quickfix-surface-a4h.md
@@ -1,0 +1,110 @@
+# ATC + Quickfix + Autoqf surface — live findings on A4H
+
+> **What:** A live smoke-test of the ABAP Test Cockpit (ATC), the quickfix engine, and the auto-quickfix batch endpoint against the A4H test system, to ground the "Semi-Automated Fixes of Clean Core ATC Findings" roadmap feature (Joule Feature 2) in what the SAP backend actually does.
+> **System:** A4H — S/4HANA 2023, SAP_BASIS 758, on-prem ABAP-cloud developer trial.
+> **Method:** `arc1-cli` tool calls + raw ADT `curl` (CSRF-authenticated), 2026-06-03. Built on top of [PR #336](https://github.com/marianfoo/arc-1/pull/336), which fixed `runAtcCheck` so ATC returns findings at all.
+> **Status:** All rows below are live-verified; quotes are actual responses.
+
+---
+
+## TL;DR
+
+| Question | Answer (live) |
+|----------|---------------|
+| Does ATC produce findings on A4H? | **Yes**, after #336. `SAPDiagnose(atc, variant=PERFORMANCE_DB)` → 1 finding; system-default → 3. ATC content is rich (493 check variants). |
+| Do ATC findings carry quickfixes? | **No.** Every finding tested carries `<atcfinding:quickfixes manual="false" automatic="false" pseudo="false"/>` → `hasQuickfix=false`. The Clean-Core "replace SQL with released CDS" autofix content is not installed/configured on this trial. |
+| Does the quickfix engine offer anything? | **Yes — refactorings.** `getFixProposals` (`/sap/bc/adt/quickfixes/evaluation`) at an identifier position returns 8–10 proposals: Rename, Convert to attribute / importing / returning / changing / exporting parameter, Assign-to-new-variable, Extract local variable. |
+| Can those refactoring proposals be applied via `apply_quickfix`? | **No — HTTP 500.** Their URIs are under `/sap/bc/adt/quickfixes/proposals/providers/refactoring/...`; they ride the separate `/sap/bc/adt/refactorings` multi-step flow, not the generic `proposalRequest` apply. |
+| Is the native batch endpoint `/atc/autoqf/worklist` driveable? | **Not without reverse-engineering the step sequence.** GET → 405; POST without a `step` query param → 400 `Parameter step could not be found`. It's a `step=`-parameterized multi-stage protocol (same family as `/refactorings`), and with no auto-fixable findings on A4H there is nothing for it to operate on. |
+
+**Bottom line for Feature 2:** the *analyze* half (run ATC, get findings) is delivered and verifiable (#336). The *auto-fix* half is **not verifiable on this trial** — there are zero quickfix-bearing findings, the universal refactoring quickfixes don't apply through `apply_quickfix`, and the native autoqf endpoint is an opaque multi-step protocol with nothing to fix. Skills should route to LLM-generated fixes when SAP quickfixes are absent or are refactorings.
+
+---
+
+## 1. ATC produces findings (post-#336)
+
+The three-step worklist flow (`POST /atc/worklists?checkVariant=<v>` → `POST /atc/runs?worklistId=<id>` → `GET /atc/worklists/<id>`) returns real findings:
+
+```
+SAPDiagnose(action=atc, type=PROG, name=Z_CREATE_BOOKING_SAMPLES, variant=PERFORMANCE_DB)
+  → 1 finding: priority 2, line 86, "Search DB Operations: DB Operation INSERT for /DMO/BOOKING found."
+SAPDiagnose(action=atc, type=PROG, name=Z_CREATE_BOOKING_SAMPLES)   (system default variant)
+  → 3 findings (priority 3)
+```
+
+Two gotchas (documented in the `sap-clean-core-atc` / `migrate-custom-code` skills):
+- **ATC skips `$TMP`/local objects** — the object set resolves empty → 0 findings. Run against a transportable package.
+- **The check variant must exist.** A4H has `S4HANA_READINESS_2023`, `PERFORMANCE_DB`, `SECURITY_*`, `SAP_CLOUD_PLATFORM_DEFAULT`, … but **not** literally `ABAP_CLOUD_READINESS` (that's the BTP/Cloud name). Omitting `variant` uses the system default.
+
+`S4HANA_READINESS_2023` returns `Check not executable, due to missing prerequisites` — the simplification-DB content isn't set up on the trial.
+
+## 2. ATC findings carry no quickfixes on A4H
+
+`hasQuickfix` was `false` for every finding across `PERFORMANCE_DB`, `SECURITY_GENERIC_DB_ACCESS`, `VERI_CLOUDIFICATION_REPOSITORY`, `SAP_CLOUD_PLATFORM_DEFAULT`:
+
+```
+PERFORMANCE_DB                 -> total=1 withQuickfix=0
+SECURITY_GENERIC_DB_ACCESS     -> total=0 withQuickfix=0
+VERI_CLOUDIFICATION_REPOSITORY -> total=0 withQuickfix=0
+SAP_CLOUD_PLATFORM_DEFAULT     -> total=3 withQuickfix=0
+```
+
+The captured finding XML carries `<atcfinding:quickfixes atcfinding:manual="false" atcfinding:automatic="false" atcfinding:pseudo="false"/>` (see `tests/fixtures/xml/atc-worklist-findings.xml`). The Clean-Core remediation content that would set `automatic="true"` is not present on this trial.
+
+## 3. The quickfix engine returns refactorings, not finding-fixes
+
+`getFixProposals` is independent of ATC — it evaluates `/sap/bc/adt/quickfixes/evaluation?uri=<src>#start=line,col` against a source position. Against a probe class (`MOVE` / `x = x + 1` / `CONCATENATE`):
+
+- On the statement **keyword** (e.g. `MOVE` at col 4) → **0 proposals**.
+- On an **identifier** (e.g. `lv_a` at col 9, or `lv_a = lv_a + 1` at col 4) → **8–10 proposals**, all refactorings:
+
+```
+Rename 'lv_a'
+Convert 'lv_a' to attribute            (.../providers/refactoring/quickfixes/promote_local_to_member)
+Convert 'lv_a' to importing|returning|changing|exporting parameter
+Assign statement to new local variable | new attribute
+Extract local variable [ (replace all occurrences) ]
+```
+
+So `getFixProposals` *does* return proposals on A4H, but they are the universal Ctrl+1 **refactorings**, position/identifier-triggered — not finding-specific fixes.
+
+## 4. Refactoring proposals 500 on `apply_quickfix`
+
+Applying "Convert 'lv_a' to attribute" via `apply_quickfix` (POST the proposal URI with a `<quickfixes:proposalRequest>` body):
+
+```
+POST /sap/bc/adt/quickfixes/proposals/providers/refactoring/quickfixes/promote_local_to_member
+  → HTTP 500 (Application Server Error)
+```
+
+Refactoring quickfixes ride the Eclipse LTK / `/sap/bc/adt/refactorings` multi-step framework, which the generic `proposalRequest` apply path does not drive. **The tell is the URI: `/providers/refactoring/`.** Non-refactoring "fix" quickfixes (pseudo-comment, statement replacement, Clean-Core remediation) *do* apply through `apply_quickfix` — but A4H has none to test with.
+
+**Skill guidance added (`migrate-custom-code`):** match the proposal to the finding (don't apply `proposals[0]` blindly); skip `/providers/refactoring/` proposals for automated apply (they 500); fall back to LLM-generated fixes.
+
+## 5. The native autoqf batch endpoint is a `step=` multi-stage protocol
+
+`/sap/bc/adt/atc/autoqf/worklist` (discovery title "Autoquickfix") accepts four content types:
+`objectreferences.v1`, `autoqf.proposal.v1`, `autoqf.selection.v1`, `genericrefactoring.v1`.
+
+Live probes:
+```
+GET  /sap/bc/adt/atc/autoqf/worklist                          → HTTP 405 (POST-only)
+POST /sap/bc/adt/atc/autoqf/worklist  (objectreferences body) → HTTP 400
+   <exc:exception><type id="ExceptionParameterNotFound"/>
+   <message>Parameter step could not be found.</message>
+```
+
+The required `step` query parameter confirms a **multi-stage state machine** (same family as `/sap/bc/adt/refactorings`): references → proposal → selection → generic-refactoring deltas. Fully driving it would require reverse-engineering the `step` sequence *and* having auto-fixable findings to feed it — neither is available on A4H. There is no reference implementation in `abap-adt-api` (it wraps `quickfixes/evaluation` and `refactorings`, not autoqf).
+
+---
+
+## Implications for Feature 2 (Clean-Core ATC fixes)
+
+1. **`runAtcCheck` fix (#336)** delivered the analyze half — verifiable, shipped.
+2. **The auto-fix half cannot be built to the live-verified bar on A4H.** No quickfix-bearing findings, refactoring quickfixes don't apply via the generic path, and the native autoqf endpoint is opaque + has nothing to operate on.
+3. **A faithful Feature 2 build needs a system with the Clean-Core remediation/cloudification content** (BTP ABAP, S/4HANA Cloud, or an on-prem system with the readiness content set up) so that `hasQuickfix=true` findings + applicable fix proposals exist to drive and verify.
+4. **Skills now degrade gracefully:** `sap-clean-core-atc` + `migrate-custom-code` document the `$TMP`-skip, variant-naming, refactoring-vs-fix, and quickfix-availability realities, and fall back to LLM-generated fixes when SAP quickfixes are absent.
+
+## Reproduction
+
+All findings are reproducible with `arc1-cli` + the `.env` A4H credentials. The ATC three-step flow and the captured findings format are unit-pinned in `tests/unit/adt/devtools.test.ts` (fixture `tests/fixtures/xml/atc-worklist-findings.xml`) and integration-guarded in `tests/integration/adt.integration.test.ts` ("runAtcCheck (worklist + variant flow)").

--- a/skills/migrate-custom-code/SKILL.md
+++ b/skills/migrate-custom-code/SKILL.md
@@ -31,19 +31,23 @@ Optionally, the user may specify:
 
 ## Step 1: Run ATC Readiness Check
 
+> **ATC gotchas (verified live on S/4HANA 2023):**
+> - **ATC skips `$TMP` / local objects.** A check run against a `$TMP` object resolves to an empty object set and returns **zero findings** — this is not "clean code", it's "not checked". Run ATC against objects in a **transportable package**. If the user points you at `$TMP` code, say so and ask them to assign it to a transportable package first.
+> - **The check variant must exist on the system.** `ABAP_CLOUD_READINESS` is the standard name on SAP BTP ABAP / S/4HANA Cloud, but on-premise systems often ship `S4HANA_READINESS_<release>` (e.g. `S4HANA_READINESS_2023`) or `SAP_CLOUD_PLATFORM_DEFAULT` instead. If the named variant is absent, fall back to the system default (omit `variant`).
+
 ### 1a. Run ATC on the target object
 
 ```
 SAPDiagnose(action="atc", type="<type>", name="<object_name>", variant="<variant>")
 ```
 
-If no variant was specified, run with the system default first:
+If no variant was specified, run with the system default first (omitting `variant` uses the system's configured default check variant):
 
 ```
 SAPDiagnose(action="atc", type="<type>", name="<object_name>")
 ```
 
-Then suggest a readiness variant if available (e.g., `S4HANA_READINESS`, `ABAP_CLOUD_READINESS`).
+Then suggest a readiness variant if available (e.g., `S4HANA_READINESS_2023`, `ABAP_CLOUD_READINESS`). If a run returns zero findings on code you expect to be flagged, first confirm the object is **not** in `$TMP` (see the gotcha above).
 
 ### 1b. For package-level checks — find all objects first
 
@@ -149,7 +153,9 @@ If proposals are returned:
 SAPDiagnose(action="apply_quickfix", type="<type>", name="<object_name>", source="<current_source>", line=<finding_line>, column=0, proposalUri="<proposal_uri>", proposalUserContent="<proposal_user_content>")
 ```
 
-- Apply the returned deltas and persist via `SAPWrite`
+- `apply_quickfix` returns ranged **text deltas — it does not persist**. Apply the returned deltas to the source yourself, then write the result via `SAPWrite(action="update")`. When applying multiple fixes to the same object, re-resolve each finding's line after each write (earlier edits shift later line numbers), or fix top-to-bottom.
+
+> **Quickfix availability is system-dependent.** SAP only offers quickfix proposals where the system has the corresponding check/cloudification content installed. On a bare ABAP trial or a system without the Clean-Core remediation content, `getFixProposals` returns `[]` and ATC findings carry `hasQuickfix=false` — that's expected, not a bug. In that case skip straight to LLM-generated fixes (the options below). Prefer SAP quickfixes only when they actually come back.
 
 ### Fix Options
 

--- a/skills/migrate-custom-code/SKILL.md
+++ b/skills/migrate-custom-code/SKILL.md
@@ -157,6 +157,10 @@ SAPDiagnose(action="apply_quickfix", type="<type>", name="<object_name>", source
 
 > **Quickfix availability is system-dependent.** SAP only offers quickfix proposals where the system has the corresponding check/cloudification content installed. On a bare ABAP trial or a system without the Clean-Core remediation content, `getFixProposals` returns `[]` and ATC findings carry `hasQuickfix=false` — that's expected, not a bug. In that case skip straight to LLM-generated fixes (the options below). Prefer SAP quickfixes only when they actually come back.
 
+> **Match the proposal to the finding — don't blindly apply `proposals[0]`.** `quickfix` returns *every* proposal applicable at that source position, which often includes generic **refactorings** unrelated to the finding (verified live on S/4HANA 2023: a position returned "Rename", "Convert to attribute", "Convert to importing parameter", "Extract local variable", …). Pick the proposal whose `name`/`description` actually addresses the finding; ignore the rest.
+
+> **Refactoring-style proposals can't be auto-applied here.** Proposals whose `uri` contains `/providers/refactoring/` (rename / convert-to-X / extract / introduce) are interactive refactorings that ride the separate `/sap/bc/adt/refactorings` multi-step flow — `apply_quickfix` returns **HTTP 500** for them (verified live). They are not finding fixes; skip them for automated apply and fall back to an LLM-generated fix. Only proposals from non-refactoring providers apply cleanly through `apply_quickfix`.
+
 ### Fix Options
 
 Present 4 options per finding:

--- a/skills/sap-clean-core-atc/SKILL.md
+++ b/skills/sap-clean-core-atc/SKILL.md
@@ -79,7 +79,9 @@ SAPContext returns a dependency list. Keep only dependencies whose names do NOT 
 SAPDiagnose(action="atc", type="<type>", name="<object_name>", variant="ABAP_CLOUD_READINESS")
 ```
 
-If `ABAP_CLOUD_READINESS` doesn't exist on the system, use the system default and note this in the report. ATC findings complement the API classification — a released API can still be used incorrectly.
+If `ABAP_CLOUD_READINESS` doesn't exist on the system, use the system default (omit `variant` — that runs the system's configured default check variant) and note this in the report. On-premise systems often ship `S4HANA_READINESS_<release>` (e.g. `S4HANA_READINESS_2023`) or `SAP_CLOUD_PLATFORM_DEFAULT` instead of `ABAP_CLOUD_READINESS`. ATC findings complement the API classification — a released API can still be used incorrectly.
+
+> **ATC skips `$TMP` / local objects (verified live on S/4HANA 2023).** A check run against a `$TMP` object resolves to an empty object set and returns **zero findings** — that's "not checked", not "clean". Package-wide classification only works on **transportable** packages. If a package is local/`$TMP`, note in the report that ATC results are unavailable and fall back to the mcp-sap-docs API classification alone. A finding count of 0 on code you expect to be flagged is almost always the `$TMP` trap, not clean code.
 
 ## Step 3: Classify Each SAP Reference via mcp-sap-docs
 


### PR DESCRIPTION
Follow-up to #336 (which fixed `runAtcCheck` so `SAPDiagnose(action="atc")` actually returns findings). This PR makes the Clean-Core skills behave correctly now that ATC works, and captures a full live smoke-test of the ATC + quickfix + auto-quickfix surface so future "Clean-Core fixes" work is grounded in what the SAP backend actually does.

All findings verified live on A4H — S/4HANA 2023, SAP_BASIS 758 — via `arc1-cli` + raw ADT `curl`. **Docs/skills only; no code or tool-surface changes.**

## 1. Skill polish — `sap-clean-core-atc` + `migrate-custom-code`

Both skills already drove ATC, but their calls silently returned zero before #336. Updated with the gotchas learned while verifying it:

- **ATC skips `$TMP`/local objects** → empty object set → 0 findings ("not checked", not "clean"). Run against a transportable package; treat a surprising 0-count as this trap first.
- **The check variant must exist** — `ABAP_CLOUD_READINESS` is the BTP/Cloud name; on-prem ships `S4HANA_READINESS_<release>` / `SAP_CLOUD_PLATFORM_DEFAULT`. Omitting `variant` uses the system default.
- **`apply_quickfix` returns deltas, not a persisted change** → apply + `SAPWrite(update)`; re-resolve line numbers across multiple fixes.
- **Match the proposal to the finding** — `quickfix` returns *every* proposal at a position, often generic refactorings unrelated to the finding. Don't apply `proposals[0]` blindly.
- **Refactoring-style proposals can't be auto-applied** — proposals whose URI is under `/providers/refactoring/` (rename/convert/extract) return HTTP 500 from `apply_quickfix` (they ride `/sap/bc/adt/refactorings`). Skip them; fall back to an LLM fix.
- **Quickfix availability is system-dependent** — on systems without the Clean-Core remediation content, `getFixProposals` returns `[]` and findings carry `hasQuickfix=false`. Expected, not a bug.

## 2. Research — `docs/research/atc-quickfix-surface-a4h.md`

Live smoke-test of the whole surface:

| Question | Live answer on A4H |
|----------|--------------------|
| ATC produces findings? | **Yes** (post-#336): `variant=PERFORMANCE_DB` → 1 finding; system default → 3. 493 check variants present. |
| Findings carry quickfixes? | **No** — `hasQuickfix=false` across all variants tested. No Clean-Core remediation content on the trial. |
| Quickfix engine returns anything? | **Yes — refactorings** (Rename / Convert-to-attribute/parameter / Extract) at identifier positions. |
| Apply those via `apply_quickfix`? | **No — HTTP 500** (they need `/sap/bc/adt/refactorings`; tell is the `/providers/refactoring/` URI). |
| Native `/atc/autoqf/worklist` driveable? | **No** — `step=`-parameterized multi-stage protocol (GET → 405; POST without `step` → 400 `Parameter step could not be found`). Same family as `/refactorings`; nothing to fix on A4H anyway. |

## Bottom line for the "Clean-Core ATC fixes" roadmap feature

- The **analyze** half is delivered + verifiable (#336).
- The **auto-fix** half is **not verifiable on this trial** — zero quickfix-bearing findings, refactoring quickfixes don't apply via the generic path, and the native autoqf endpoint is an opaque multi-step protocol with nothing to operate on. A faithful build needs a system with the Clean-Core remediation/cloudification content (BTP ABAP / S/4HANA Cloud / readiness-configured on-prem). The skills now degrade gracefully to LLM-generated fixes.

## Out of scope
The broader 2026-roadmap research docs + ralphex plans (8 files) from earlier sessions are intentionally **not** in this PR — different theme, candidate for a separate docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
