### PR TITLE
chore(btp): per-space deploy naming via \${space}

### DIFF
--- a/docs_page/authorization.md
+++ b/docs_page/authorization.md
@@ -180,6 +180,8 @@ Common role collections:
 | `ARC-1 Developer + SQL` | `read`, `write`, `data`, `sql`, `transports`, `git` |
 | `ARC-1 Admin` | all 7 |
 
+> Deployed collection names carry the CF space as a suffix — e.g. `ARC-1 Developer (dev)` — because `mta.yaml` derives them from the `${space}` placeholder so the same mtar can run in several spaces of one subaccount. Assign the one matching your space. See [XSUAA Setup](xsuaa-setup.md).
+
 Want a developer who can write code but cannot transport or use Git? Create a custom role template with just `read` + `write`, then update the XSUAA service. Or leave the shipped role as-is and turn off `SAP_ALLOW_TRANSPORT_WRITES` / `SAP_ALLOW_GIT_WRITES` server-wide.
 
 To grant SQL to one BTP user, assign a role collection that includes `MCPSqlUser` (for example `ARC-1 Viewer + SQL` for read-only SQL or `ARC-1 Developer + SQL` for full developer access) to that user. Do **not** change server env vars for one user. The ARC-1 instance must already have `SAP_ALLOW_FREE_SQL=true`; there is no `SAP_ALLOW_SQL` flag.

--- a/docs_page/btp-destination-setup.md
+++ b/docs_page/btp-destination-setup.md
@@ -389,7 +389,7 @@ Add to your Claude Desktop `claude_desktop_config.json` or Claude Code settings:
 {
   "mcpServers": {
     "arc1-sap": {
-      "url": "https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/mcp",
+      "url": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp",
       "transport": "streamable-http"
     }
   }
@@ -406,7 +406,7 @@ In Cursor settings, add MCP server:
 {
   "mcpServers": {
     "arc1-sap": {
-      "url": "https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/mcp"
+      "url": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp"
     }
   }
 }
@@ -422,7 +422,7 @@ If using an MCP extension that supports HTTP Streamable transport:
 {
   "mcp.servers": {
     "arc1-sap": {
-      "url": "https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/mcp"
+      "url": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp"
     }
   }
 }
@@ -443,7 +443,7 @@ Copilot Studio uses a custom connector with Entra ID OAuth (not XSUAA). For PP w
 
 ```bash
 # Start MCP Inspector pointing to your server
-npx @modelcontextprotocol/inspector https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/mcp
+npx @modelcontextprotocol/inspector https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp
 ```
 
 Inspector supports OAuth discovery. It will open a browser for XSUAA login.

--- a/docs_page/phase4-btp-deployment.md
+++ b/docs_page/phase4-btp-deployment.md
@@ -247,8 +247,8 @@ docker push ghcr.io/your-org/arc1:latest
 # Push the app (first time)
 cf push
 
-# The app URL will be:
-# https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com
+# The app URL will be (route host = arc1-mcp-<space>, unique per CF space):
+# https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com
 ```
 
 ### 7. Set Credentials via Environment (not in manifest)
@@ -273,15 +273,15 @@ cf restart arc1-mcp-server
 
 ```bash
 # Health check
-curl https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/health
+curl https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/health
 # → {"status":"ok"}
 
 # Check Protected Resource Metadata (OAuth discovery)
-curl https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/.well-known/oauth-protected-resource/mcp
-# → {"resource":"https://arc1-mcp-server.cfapps.../mcp","scopes_supported":["read","write","data","sql","admin"],...}
+curl https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/.well-known/oauth-protected-resource/mcp
+# → {"resource":"https://arc1-mcp-<space>.cfapps.../mcp","scopes_supported":["read","write","data","sql","admin"],...}
 
 # Check Authorization Server Metadata
-curl https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/.well-known/oauth-authorization-server
+curl https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/.well-known/oauth-authorization-server
 # → {"authorization_endpoint":"...","token_endpoint":"...","registration_endpoint":"...",...}
 
 # Test with Bearer token
@@ -289,7 +289,7 @@ TOKEN=$(az account get-access-token --scope "api://{client-id}/access_as_user" -
 curl -X POST -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
-  https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/mcp
+  https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp
 ```
 
 ## Security headers and CORS on BTP

--- a/docs_page/updating.md
+++ b/docs_page/updating.md
@@ -169,7 +169,7 @@ Starts a new instance with the new image, waits for health checks, then stops th
 ```bash
 cf app arc1-mcp-server
 cf logs arc1-mcp-server --recent | grep "auth:"
-curl -s https://arc1-mcp-server.cfapps.us10.hana.ondemand.com/mcp
+curl -s https://arc1-mcp-<space>.cfapps.us10.hana.ondemand.com/mcp
 ```
 
 ### Rollback

--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -42,7 +42,7 @@ The included `xs-security.json` defines 7 scopes:
 | `git`          | Push / pull / commit via abapGit / gCTS                        | `SAPGit.clone`/`pull`/`push`/`commit`                                                        |
 | `admin`        | Implies ALL other scopes at runtime                            | Everything                                                                                   |
 
-And 7 pre-defined role collections (assignable to users in BTP Cockpit):
+And 7 pre-defined role collections (defined in `mta.yaml`, assignable to users in BTP Cockpit):
 
 | Role Collection           | Scopes                                                   | Use Case                                  |
 |---------------------------|----------------------------------------------------------|-------------------------------------------|
@@ -53,6 +53,18 @@ And 7 pre-defined role collections (assignable to users in BTP Cockpit):
 | ARC-1 Developer + Data    | `read`, `write`, `data`, `transports`, `git`             | Developer + data preview                  |
 | ARC-1 Developer + SQL     | `read`, `write`, `data`, `sql`, `transports`, `git`      | Developer + data + freestyle SQL          |
 | ARC-1 Admin               | all 7                                                    | Administrative access                     |
+
+> **Multi-space deployments.** `mta.yaml` derives the route host, the XSUAA
+> `xsappname`, and these role-collection names from the deploy-time `${space}`
+> placeholder, so the same mtar can be deployed into several spaces of one
+> subaccount side by side. The collections therefore appear in the cockpit with
+> the space appended — e.g. `ARC-1 Viewer (dev)` in space `dev`. Assign users to
+> the collection for *your* space (Step 3).
+>
+> **Migrating an existing instance** onto per-space naming changes its route host
+> and `xsappname`: update the MCP client URL, re-assign users to the new
+> `ARC-1 … (<space>)` collections, and set `ARC1_DCR_SIGNING_SECRET` before the
+> redeploy so cached OAuth `client_id`s survive the `xsappname` change.
 
 **Want a restricted developer** (can write code but cannot transport or push to Git)? Define your own role template in `xs-security.json` with just `[read, write]` scopes, redeploy, and assign it — or use `SAP_DENY_ACTIONS` on the server.
 
@@ -78,15 +90,15 @@ Verify XSUAA is active in the logs:
 ```bash
 cf logs arc1-mcp-server --recent | grep XSUAA
 # Should show:
-# INFO: XSUAA credentials loaded {"xsappname":"arc1-mcp!t..."}
-# INFO: XSUAA OAuth proxy enabled {"xsappname":"arc1-mcp!t..."}
+# INFO: XSUAA credentials loaded {"xsappname":"arc1-mcp-<space>!t..."}
+# INFO: XSUAA OAuth proxy enabled {"xsappname":"arc1-mcp-<space>!t..."}
 # INFO: ARC-1 HTTP server started {"auth":"XSUAA OAuth proxy"}
 ```
 
 ## Step 3: Assign Role Collections
 
 1. Open **BTP Cockpit** → **Security** → **Role Collections**
-2. Find one of the shipped collections: "ARC-1 Viewer", "ARC-1 Developer", "ARC-1 Developer + Data", "ARC-1 Developer + SQL", "ARC-1 Data Viewer", "ARC-1 Viewer + SQL", or "ARC-1 Admin"
+2. Find the shipped collection for your space — the names carry the space suffix, e.g. "ARC-1 Viewer (<space>)", "ARC-1 Developer (<space>)", … "ARC-1 Admin (<space>)" (see the multi-space note above)
 3. Click the role collection → **Edit** → **Users** tab
 4. Add your BTP user (email address)
 5. Save
@@ -94,15 +106,15 @@ cf logs arc1-mcp-server --recent | grep XSUAA
 ## Step 4: Verify OAuth Discovery
 
 ```bash
-curl -s https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/.well-known/oauth-authorization-server | jq .
+curl -s https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/.well-known/oauth-authorization-server | jq .
 ```
 
 Expected response:
 ```json
 {
-  "issuer": "https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/",
-  "authorization_endpoint": "https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/authorize",
-  "token_endpoint": "https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/token",
+  "issuer": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/",
+  "authorization_endpoint": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/authorize",
+  "token_endpoint": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/token",
   "scopes_supported": ["read", "write", "data", "sql", "transports", "git", "admin"],
   "response_types_supported": ["code"],
   "code_challenge_methods_supported": ["S256"],
@@ -120,7 +132,7 @@ Add to `claude_desktop_config.json`:
 {
   "mcpServers": {
     "arc1-sap": {
-      "url": "https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/mcp"
+      "url": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp"
     }
   }
 }
@@ -135,7 +147,7 @@ In Cursor settings → MCP Servers, add:
 ```json
 {
   "arc1-sap": {
-    "url": "https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/mcp"
+    "url": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp"
   }
 }
 ```
@@ -144,7 +156,7 @@ In Cursor settings → MCP Servers, add:
 
 Connect to:
 ```
-https://arc1-mcp-server.cfapps.us10-001.hana.ondemand.com/mcp
+https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp
 ```
 
 The inspector will perform OAuth discovery and redirect to XSUAA login.
@@ -158,7 +170,7 @@ Copilot Studio does not re-register via DCR after server restarts, so use **Manu
 1. In Copilot Studio, add an MCP server connection
 2. Select **Manual** OAuth type
 3. Fill in:
-   - **Client ID:** XSUAA `clientid` from `cf env <app-name>` (e.g. `sb-arc1-mcp!t627062`)
+   - **Client ID:** XSUAA `clientid` from `cf env <app-name>` (e.g. `sb-arc1-mcp-<space>!t627062`)
    - **Client secret:** XSUAA `clientsecret` from `cf env <app-name>`
    - **Authorization URL:** `https://<app-route>/authorize`
    - **Token URL template:** `https://<app-route>/token`

--- a/mta-overrides.mtaext.example
+++ b/mta-overrides.mtaext.example
@@ -138,3 +138,19 @@ modules:
       # on-premise self-signed-cert landscapes). Override to "false" on
       # landscapes with proper CA-signed certificates.
       # SAP_INSECURE: "false"
+
+    # ── Per-space naming override (host / xsappname) ─────────────────
+    # Base mta.yaml derives the route host and the XSUAA `xsappname` from the
+    # CF space via `${space}`, which must resolve to a valid host AND xsappname
+    # (lowercase letters, digits, hyphens — no spaces or underscores). If your
+    # space name violates that, or you want explicit names, pin them:
+    #   • add a `parameters:` block to the arc1-mcp-server module above (a
+    #     sibling of `properties:`):
+    #       parameters:
+    #         host: arc1-mcp-prod
+    #   • and append this resource block (a sibling of `modules:`):
+    #       resources:
+    #         - name: arc1-xsuaa
+    #           parameters:
+    #             config:
+    #               xsappname: arc1-mcp-prod

--- a/mta.yaml
+++ b/mta.yaml
@@ -52,6 +52,12 @@ modules:
       memory: 512M
       disk-quota: 1024M
       instances: 1
+      # Per-space route host. `${space}` is resolved by the deploy service at
+      # deploy time, so the SAME mtar deployed into different spaces of one
+      # subaccount gets a unique route each time (arc1-mcp-<space>.cfapps...).
+      # NOTE: the resolved value must be a DNS-valid host (lowercase, no
+      # underscores). Override explicitly if a space name violates that.
+      host: arc1-mcp-${space}
       health-check-type: http
       health-check-http-endpoint: /health
       # Node heap target sized to 87.5% of dyno memory (512M -> 448M) so V8 GCs
@@ -126,7 +132,51 @@ resources:
     type: com.sap.xs.uaa
     parameters:
       service-plan: application
+      # `path` supplies scopes + role-templates + oauth2-configuration; the
+      # inline `config` below overrides/augments it (config wins on merge).
       path: xs-security.json
+      config:
+        # xsappname must be unique per SUBACCOUNT — derive it from the space so
+        # the same mtar can be deployed into multiple spaces side by side.
+        xsappname: arc1-mcp-${space}
+        # Role-collection names are also subaccount-scoped. They live here (not
+        # in xs-security.json) because `${space}` is only resolved in descriptor
+        # values, not inside the path-referenced JSON. Defining the array here
+        # replaces the file's role-collections wholesale; scopes + role-templates
+        # stay in xs-security.json ($XSAPPNAME already namespaces the templates).
+        role-collections:
+          - name: "ARC-1 Viewer (${space})"
+            description: "Read-only SAP access via ARC-1 MCP"
+            role-template-references:
+              - "$XSAPPNAME.MCPViewer"
+          - name: "ARC-1 Developer (${space})"
+            description: "Read, write, transport, and git access via ARC-1 MCP"
+            role-template-references:
+              - "$XSAPPNAME.MCPDeveloper"
+          - name: "ARC-1 Data Viewer (${space})"
+            description: "Read-only SAP access with table data preview"
+            role-template-references:
+              - "$XSAPPNAME.MCPViewer"
+              - "$XSAPPNAME.MCPDataViewer"
+          - name: "ARC-1 Viewer + SQL (${space})"
+            description: "Read-only SAP access with table data preview and freestyle SQL"
+            role-template-references:
+              - "$XSAPPNAME.MCPViewer"
+              - "$XSAPPNAME.MCPSqlUser"
+          - name: "ARC-1 Developer + Data (${space})"
+            description: "Developer access with table data preview"
+            role-template-references:
+              - "$XSAPPNAME.MCPDeveloper"
+              - "$XSAPPNAME.MCPDataViewer"
+          - name: "ARC-1 Developer + SQL (${space})"
+            description: "Developer access with freestyle SQL queries"
+            role-template-references:
+              - "$XSAPPNAME.MCPDeveloper"
+              - "$XSAPPNAME.MCPSqlUser"
+          - name: "ARC-1 Admin (${space})"
+            description: "Full ARC-1 administrative access (admin implies all scopes)"
+            role-template-references:
+              - "$XSAPPNAME.MCPAdmin"
 
   - name: arc1-destination
     type: org.cloudfoundry.managed-service

--- a/package.json
+++ b/package.json
@@ -73,15 +73,7 @@
     "btp:deploy": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar',{stdio:'inherit'})\"",
     "btp:deploy-ext": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides.mtaext',{stdio:'inherit'})\"",
     "btp:build-deploy": "npm run btp:build && npm run btp:deploy",
-    "btp:build-deploy-ext": "npm run btp:build && npm run btp:deploy-ext",
-    "btp:deploy-ext-sia": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides-sia.mtaext',{stdio:'inherit'})\"",
-    "btp:deploy-ext-sip": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides-sip.mtaext',{stdio:'inherit'})\"",
-    "btp:build-deploy-ext-sia": "npm run btp:build && npm run btp:deploy-ext-sia",
-    "btp:build-deploy-ext-sip": "npm run btp:build && npm run btp:deploy-ext-sip",
-    "btp:deploy-ext-ex1": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides-ex1.mtaext',{stdio:'inherit'})\"",
-    "btp:build-deploy-ext-ex1": "npm run btp:build && npm run btp:deploy-ext-ex1",
-    "btp:deploy-ext-c2x": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides-c2x.mtaext',{stdio:'inherit'})\"",
-    "btp:build-deploy-ext-c2x": "npm run btp:build && npm run btp:deploy-ext-c2x"
+    "btp:build-deploy-ext": "npm run btp:build && npm run btp:deploy-ext"
   },
   "dependencies": {
     "@abaplint/core": "^2.119.24",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,15 @@
     "btp:deploy": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar',{stdio:'inherit'})\"",
     "btp:deploy-ext": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides.mtaext',{stdio:'inherit'})\"",
     "btp:build-deploy": "npm run btp:build && npm run btp:deploy",
-    "btp:build-deploy-ext": "npm run btp:build && npm run btp:deploy-ext"
+    "btp:build-deploy-ext": "npm run btp:build && npm run btp:deploy-ext",
+    "btp:deploy-ext-sia": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides-sia.mtaext',{stdio:'inherit'})\"",
+    "btp:deploy-ext-sip": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides-sip.mtaext',{stdio:'inherit'})\"",
+    "btp:build-deploy-ext-sia": "npm run btp:build && npm run btp:deploy-ext-sia",
+    "btp:build-deploy-ext-sip": "npm run btp:build && npm run btp:deploy-ext-sip",
+    "btp:deploy-ext-ex1": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides-ex1.mtaext',{stdio:'inherit'})\"",
+    "btp:build-deploy-ext-ex1": "npm run btp:build && npm run btp:deploy-ext-ex1",
+    "btp:deploy-ext-c2x": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides-c2x.mtaext',{stdio:'inherit'})\"",
+    "btp:build-deploy-ext-c2x": "npm run btp:build && npm run btp:deploy-ext-c2x"
   },
   "dependencies": {
     "@abaplint/core": "^2.119.24",

--- a/xs-security.json
+++ b/xs-security.json
@@ -71,55 +71,6 @@
       ]
     }
   ],
-  "role-collections": [
-    {
-      "name": "ARC-1 Viewer",
-      "description": "Read-only SAP access via ARC-1 MCP",
-      "role-template-references": ["$XSAPPNAME.MCPViewer"]
-    },
-    {
-      "name": "ARC-1 Developer",
-      "description": "Read, write, transport, and git access via ARC-1 MCP",
-      "role-template-references": ["$XSAPPNAME.MCPDeveloper"]
-    },
-    {
-      "name": "ARC-1 Data Viewer",
-      "description": "Read-only SAP access with table data preview",
-      "role-template-references": [
-        "$XSAPPNAME.MCPViewer",
-        "$XSAPPNAME.MCPDataViewer"
-      ]
-    },
-    {
-      "name": "ARC-1 Viewer + SQL",
-      "description": "Read-only SAP access with table data preview and freestyle SQL",
-      "role-template-references": [
-        "$XSAPPNAME.MCPViewer",
-        "$XSAPPNAME.MCPSqlUser"
-      ]
-    },
-    {
-      "name": "ARC-1 Developer + Data",
-      "description": "Developer access with table data preview",
-      "role-template-references": [
-        "$XSAPPNAME.MCPDeveloper",
-        "$XSAPPNAME.MCPDataViewer"
-      ]
-    },
-    {
-      "name": "ARC-1 Developer + SQL",
-      "description": "Developer access with freestyle SQL queries",
-      "role-template-references": [
-        "$XSAPPNAME.MCPDeveloper",
-        "$XSAPPNAME.MCPSqlUser"
-      ]
-    },
-    {
-      "name": "ARC-1 Admin",
-      "description": "Full ARC-1 administrative access (admin implies all scopes)",
-      "role-template-references": ["$XSAPPNAME.MCPAdmin"]
-    }
-  ],
   "oauth2-configuration": {
     "redirect-uris": [
       "http://localhost:*/**",


### PR DESCRIPTION
## What

Lets the same ARC-1 mtar be deployed into **multiple Cloud Foundry spaces of one subaccount** side by side, by deriving each instance's identifiers from the deploy-time `${space}` placeholder (resolved by the CF deploy service to the target space name).

`mta.yaml` derives three things from `${space}`:
- **route host** → `arc1-mcp-${space}` (unique per space on the shared domain)
- **XSUAA `xsappname`** → `arc1-mcp-${space}` (must be unique per subaccount)
- **role-collection names** → `ARC-1 … (${space})` (also subaccount-scoped)

## Changes

- **`mta.yaml`** — `host` + an inline XSUAA `config` block that overrides `xsappname` and defines the `${space}`-suffixed role collections. `config` merges over `xs-security.json` (config wins per property; scopes / role-templates / oauth2-configuration stay in the file).
- **`xs-security.json`** — role-collections removed; they live in `mta.yaml` because `${space}` only resolves in descriptor values, not in path-referenced JSON.
- **docs** — route-host example URLs (`arc1-mcp-<space>`), space-suffixed role-collection names, `xsappname` examples, and an existing-instance migration note (`xsuaa-setup`, `authorization`, `phase4-btp-deployment`, `btp-destination-setup`, `updating`).
- **`mta-overrides.mtaext.example`** — how to pin an explicit `host`/`xsappname` when a space name isn't a valid host/xsappname (uppercase / underscores).

## Migrating an existing instance

Per-space naming changes the route host and `xsappname` on the next deploy: update the MCP client URL, re-assign users to the new `ARC-1 … (<space>)` collections, and set `ARC1_DCR_SIGNING_SECRET` beforehand so cached OAuth `client_id`s survive the `xsappname` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
