### PR TITLE
docs: capture 2026 Joule roadmap research + per-feature ralphex plans

### DIFF
--- a/docs/plans/joule-atc-batch-quickfix.md
+++ b/docs/plans/joule-atc-batch-quickfix.md
@@ -1,0 +1,253 @@
+# Joule Roadmap Feature 2 — Clean-Core ATC Batch Quickfix
+
+> **Status (2026-06-03): APPROACH SUPERSEDED — do not implement as written.** Live investigation on A4H revealed (1) ARC-1's `runAtcCheck` never bound a check variant, so ATC returned zero findings on every system — fixed in **PR #336** (the real, verifiable prerequisite this plan assumed already worked); (2) the native `/sap/bc/adt/atc/autoqf/worklist` endpoint is **not** the simple request/response this plan assumed — it's a `step=`-parameterized multi-stage protocol (4 content types, no template links, no reference implementation); and (3) the A4H trial produces **zero quickfix-bearing findings** and zero quickfix proposals, so the auto-apply half is **unverifiable** there. See **`docs/research/atc-quickfix-surface-a4h.md`** (PR #337) for the full live surface map. A faithful build needs a system with the Clean-Core remediation/cloudification content (BTP ABAP / S/4HANA Cloud / readiness-configured on-prem). Kept for historical context; the design below (wrap `autoqf/worklist`) is inaccurate.
+
+## Overview
+
+SAP's Joule for Developers 2026 roadmap announces "Semi-Automated Fixes of Clean Core related ATC Findings" — Joule chat reads an ATC finding (typically a Clean-Core rule), proposes a code transformation, and applies it via the ADT quickfix machinery. Planned release: S/4HANA Cloud Private 2027 *only*.
+
+ARC-1 already implements per-finding quickfix end-to-end (`SAPDiagnose action='quickfix' / 'apply_quickfix'` wrapping `/sap/bc/adt/quickfixes/evaluation`, verified live on a4h 2026-04-14, see `docs/plans/completed/fix-proposals-auto-fix-from-atc.md`). The remaining gap is the **batch auto-quickfix worklist** endpoint `/sap/bc/adt/atc/autoqf/worklist` (backed by ABAP class `CL_SATC_ADT_RES_AUTOQUICKFIX`). It enumerates findings tagged `<atcfinding:quickfixes automatic="true"/>` and applies them in one server-side pass — exactly what the Joule "fix every Clean-Core finding on this package" workflow needs.
+
+`adt-ls` cannot help here: its `atc/runCheck` returns findings (`AtcRunFinding`) but exposes **no quickfix data** — report-only. So this remains ARC-1 territory, regardless of how SAP's official MCP server evolves. This plan adds the batch-quickfix wrapper, then polishes the existing `sap-clean-core-atc` and `migrate-custom-code` skills to use it when finding counts exceed a threshold.
+
+See [`docs/research/joule-2026-roadmap-feature-assessment.md §2`](../research/joule-2026-roadmap-feature-assessment.md) for the full feature assessment.
+
+## Context
+
+### Current State
+
+- `runAtcCheck()` exists at `src/adt/devtools.ts:551` — wraps `/sap/bc/adt/atc/runs` and returns `AtcFinding[]`
+- `getFixProposals()` exists at `src/adt/devtools.ts:593` — POSTs `/sap/bc/adt/quickfixes/evaluation`, returns proposal evaluations with `<userContent>` blocks
+- `applyFixProposal()` exists at `src/adt/devtools.ts:621` — POSTs the proposal URI with `<quickfixes:proposalRequest>` body, returns ranged delta replacements
+- `SAPDiagnose action='quickfix'` and `action='apply_quickfix'` are dispatched in `handleSAPDiagnose` at `src/handlers/intent.ts:5564` and `:5586`
+- `SAPDiagnoseSchema` at `src/handlers/schemas.ts:672` is the Zod schema source of truth
+- ATC findings already carry `<atcfinding:quickfixes manual="..." automatic="..." pseudo="..."/>` markers identifying which are machine-applicable
+- No wrapper for `/sap/bc/adt/atc/autoqf/worklist` — the batch endpoint isn't reachable from ARC-1 today
+- Skills `skills/sap-clean-core-atc/SKILL.md` and `skills/migrate-custom-code/SKILL.md` use one-by-one apply
+
+### Target State
+
+- New `runAutoQuickfixWorklist(http, safety, opts)` in `src/adt/devtools.ts` wrapping `/sap/bc/adt/atc/autoqf/worklist`
+- New `SAPDiagnose action='batch_quickfix'` in `handleSAPDiagnose` — args `{ atcRunId, packageScope?, maxFindings? }`
+- Three-file schema sync: Zod (`schemas.ts`), JSON Schema (`tools.ts`), handler (`intent.ts`)
+- `ACTION_POLICY` updated in `src/authz/policy.ts` — required scope `'write'`
+- XML parser for the `<autoqf:worklistResult>` response in `src/adt/xml-parser.ts`
+- Skills updated: when `automatic="true"` finding count > 5 (threshold), call `batch_quickfix`; otherwise fall back to one-by-one `apply_quickfix`
+- Documentation updated: tools.md, CLAUDE.md "Key Files" + ACTION_POLICY references, README, feature matrix
+- Unit tests (mock-fetch) + an opt-in integration test gated on a Clean-Core ATC variant being published on the test system
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/devtools.ts` | Add `runAutoQuickfixWorklist()` near `getFixProposals()` (line 593) |
+| `src/adt/types.ts` | Add `AutoQuickfixWorklistResult` + `AutoQuickfixSkip` types |
+| `src/adt/xml-parser.ts` | Add `parseAutoQuickfixWorklist()` for the `<autoqf:worklistResult>` response |
+| `src/handlers/intent.ts` | Add `case 'batch_quickfix'` in `handleSAPDiagnose` (after the existing `apply_quickfix` case ~line 5586) |
+| `src/handlers/schemas.ts` | Add `'batch_quickfix'` to `SAPDiagnoseSchema` action union (line 672) |
+| `src/handlers/tools.ts` | Add `batch_quickfix` to SAPDiagnose JSON Schema action enum + per-action property descriptors |
+| `src/authz/policy.ts` | Add `'SAPDiagnose.batch_quickfix': 'write'` |
+| `tests/unit/adt/devtools.test.ts` | Mock-fetch tests for `runAutoQuickfixWorklist()` |
+| `tests/unit/adt/xml-parser.test.ts` | Unit tests for `parseAutoQuickfixWorklist()` |
+| `tests/unit/handlers/intent.test.ts` | Tests for the new SAPDiagnose action |
+| `tests/integration/adt.integration.test.ts` | Optional integration test (gated) |
+| `tests/fixtures/xml/autoqf-worklist-result.xml` | New XML fixture |
+| `skills/sap-clean-core-atc/SKILL.md` | Update to use batch_quickfix when count > threshold |
+| `skills/migrate-custom-code/SKILL.md` | Same update |
+| `docs/tools.md`, `CLAUDE.md`, `README.md`, `compare/00-feature-matrix.md` | Documentation updates |
+
+### Design Principles
+
+1. **Mirror the existing quickfix pair.** `runAutoQuickfixWorklist()` follows `getFixProposals()` / `applyFixProposal()` exactly: same safety guard (`checkOperation(safety, OperationType.Update, 'BatchQuickfix')`), same XML parsing pattern, same error formatting.
+2. **Three-file schema sync is mandatory.** Per CLAUDE.md invariant: every new property in `tools.ts`, `schemas.ts`, and `intent.ts`.
+3. **Authz policy must be updated atomically with the handler.** Without `ACTION_POLICY` entry, the runtime check + tool-list pruning go out of sync.
+4. **XML root element TBD against a4h.** Capture from a real call; the placeholder name in this plan is `<autoqf:worklistResult>` but verify on first integration run.
+5. **Idempotent + reportable.** The handler returns `{ applied, skipped, remaining }` so the LLM can decide whether to re-run.
+6. **No silent skipping in tests.** Use `requireOrSkip(ctx, ..., 'NO_CLEAN_CORE_VARIANT')` for integration test guards; never empty `if (!x) return;`.
+
+## Development Approach
+
+- Task 1: Core wrapper + types
+- Task 2: XML parser + fixture
+- Task 3: Handler dispatch + schema sync + authz policy
+- Task 4: Unit tests
+- Task 5: Integration test (gated)
+- Task 6: Skill updates
+- Task 7: Documentation
+- Task 8: Final verification
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:integration` (requires TEST_SAP_URL)
+
+### Task 1: Add `runAutoQuickfixWorklist()` to devtools
+
+**Files:**
+- Modify: `src/adt/devtools.ts`
+- Modify: `src/adt/types.ts`
+
+Add the core wrapper for `/sap/bc/adt/atc/autoqf/worklist` near the existing `getFixProposals()` at line 593.
+
+- [ ] In `src/adt/types.ts`, add:
+  - `interface AutoQuickfixSkip { findingId: string; reason: string }`
+  - `interface AutoQuickfixWorklistResult { applied: number; skipped: AutoQuickfixSkip[]; remaining: number; transports: string[] }`
+- [ ] In `src/adt/devtools.ts`, add `runAutoQuickfixWorklist(http, safety, opts: { atcRunId: string; packageScope?: string; maxFindings?: number }): Promise<AutoQuickfixWorklistResult>` near line 593. Pattern:
+  - Call `checkOperation(safety, OperationType.Update, 'BatchQuickfix')` first
+  - POST to `/sap/bc/adt/atc/autoqf/worklist` with body `<autoqf:worklistRequest xmlns:autoqf="http://www.sap.com/adt/atc/autoqf"><autoqf:atcRunId>{atcRunId}</autoqf:atcRunId><autoqf:scope>{packageScope or '*'}</autoqf:scope><autoqf:maxFindings>{maxFindings or 100}</autoqf:maxFindings></autoqf:worklistRequest>`
+  - Content-Type `application/vnd.sap.adt.atc.autoqf+xml; charset=UTF-8`
+  - Accept `application/vnd.sap.adt.atc.autoqf+xml; charset=UTF-8`
+  - Pass response body to `parseAutoQuickfixWorklist()` (added in Task 2)
+  - Return the parsed result
+- [ ] If a 404 comes back, throw a typed error explaining the endpoint isn't available on this SAP system (NW 7.50 / older releases). Match existing patterns in `src/adt/errors.ts`.
+- [ ] Run `npm run typecheck` — no errors
+- [ ] Run `npm test` — all tests pass (no new tests yet, but existing ones must still pass)
+
+### Task 2: XML parser + fixture
+
+**Files:**
+- Modify: `src/adt/xml-parser.ts`
+- Create: `tests/fixtures/xml/autoqf-worklist-result.xml`
+- Modify: `tests/unit/adt/xml-parser.test.ts`
+
+Parse the `<autoqf:worklistResult>` response. The exact root element name + attribute shape must be verified against a4h on the first integration run; this task ships a best-guess shape that can be adjusted.
+
+- [ ] In `src/adt/xml-parser.ts`, add `parseAutoQuickfixWorklist(xml: string): AutoQuickfixWorklistResult`. Use the `fast-xml-parser` v5 pattern existing parsers use.
+- [ ] Expected XML shape (best-guess; verify on first live call):
+  ```xml
+  <autoqf:worklistResult xmlns:autoqf="http://www.sap.com/adt/atc/autoqf">
+    <autoqf:summary applied="12" skipped="3" remaining="0"/>
+    <autoqf:skipped>
+      <autoqf:skip findingId="..." reason="manual_only"/>
+    </autoqf:skipped>
+    <autoqf:transports>
+      <autoqf:transport>NPLK900042</autoqf:transport>
+    </autoqf:transports>
+  </autoqf:worklistResult>
+  ```
+- [ ] Create `tests/fixtures/xml/autoqf-worklist-result.xml` matching the above (placeholder — real captured response replaces this on first integration run; tag with `// TODO: replace with live capture from a4h`)
+- [ ] Add unit tests (~4 tests) to `tests/unit/adt/xml-parser.test.ts`:
+  - Parses a happy-path response with applied + skipped + transports
+  - Parses an empty-skipped response (just applied count)
+  - Returns `skipped: []` and `transports: []` for minimal responses
+  - Throws a parse error on malformed XML (or returns a defaulted result — match the existing parser's error policy)
+- [ ] Run `npm test -- xml-parser` — all tests pass
+
+### Task 3: Handler dispatch + schema sync + authz policy
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/tools.ts`
+- Modify: `src/authz/policy.ts`
+
+Wire the new action through the three-file sync + the authz policy. Required by CLAUDE.md "Tool schema three-file sync" invariant.
+
+- [ ] In `src/handlers/intent.ts`, add `case 'batch_quickfix'` in `handleSAPDiagnose` after the existing `case 'apply_quickfix'` (line ~5586). Body:
+  - Validate args via the Zod schema
+  - Call `runAutoQuickfixWorklist(http, safety, { atcRunId, packageScope, maxFindings })`
+  - Format the result as `JSON.stringify(result, null, 2)` and return `textResult(...)`
+  - Wrap in the standard try/catch and error formatter `formatErrorForLLM`
+- [ ] In `src/handlers/schemas.ts`, extend `SAPDiagnoseSchema` (line 672) action union to include `'batch_quickfix'` plus its argument schema:
+  ```ts
+  z.object({
+    action: z.literal('batch_quickfix'),
+    atcRunId: z.string().min(1),
+    packageScope: z.string().optional(),
+    maxFindings: z.coerce.number().int().positive().max(1000).optional(),
+  })
+  ```
+- [ ] In `src/handlers/tools.ts`, add `'batch_quickfix'` to the SAPDiagnose action enum (find the JSON Schema for SAPDiagnose) + add the per-action property descriptors with clear descriptions:
+  - `atcRunId`: "The ATC run UUID returned by SAPDiagnose action=atc (required)"
+  - `packageScope`: "Restrict to a single package (default: all in the run scope). Supports wildcards: 'Z*'"
+  - `maxFindings`: "Cap the number of findings processed in one call (default: 100, max: 1000)"
+- [ ] In `src/authz/policy.ts`, add `'SAPDiagnose.batch_quickfix': 'write'` to `ACTION_POLICY`
+- [ ] Run `npm run typecheck` — no errors
+- [ ] Run `npm test` — all tests must pass (handler test added in Task 4)
+
+### Task 4: Unit tests for the new action
+
+**Files:**
+- Modify: `tests/unit/adt/devtools.test.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+Mock-fetch tests covering happy + error paths, plus a handler-level test verifying the dispatch + JSON response format.
+
+- [ ] In `tests/unit/adt/devtools.test.ts`, add a `describe('runAutoQuickfixWorklist')` block with:
+  - Happy path: returns `{ applied: 12, skipped: [...], remaining: 0, transports: [...] }`
+  - Empty worklist: returns `{ applied: 0, skipped: [], remaining: 0, transports: [] }`
+  - 4xx response: throws typed `AdtApiError` with the SAP message
+  - 404 (endpoint not available): throws typed error with the "not available on this release" hint
+  - Safety blocked: throws `AdtSafetyError` when `allowWrites=false`
+- [ ] In `tests/unit/handlers/intent.test.ts`, add a `describe('SAPDiagnose batch_quickfix')` block:
+  - Happy path: calls the underlying wrapper and returns a JSON-formatted result
+  - Validation: missing `atcRunId` → returns Zod validation error
+  - Scope: `allowWrites=false` → returns the safety-error message verbatim
+- [ ] Mock pattern: `vi.mock('undici', ...)` with `mockResponse(200, fixtureXml, { 'x-csrf-token': 'T' })` from `tests/helpers/mock-fetch.ts`
+- [ ] Run `npm test` — all tests pass
+
+### Task 5: Integration test (gated)
+
+**Files:**
+- Modify: `tests/integration/adt.integration.test.ts`
+
+Add a live integration test against the a4h system. Skip when a Clean-Core ATC variant is not configured.
+
+- [ ] Use `getTestClient()` from `tests/integration/helpers.ts`
+- [ ] First, run `runAtcCheck()` with `variant: 'SAP_CP_CCM_TRANSITION_S4_2025_CLOUD'` (or whichever Clean-Core variant is configured)
+- [ ] If no findings come back, skip via `requireOrSkip(ctx, hasAutomaticFindings, 'NO_CLEAN_CORE_AUTOMATIC_FINDINGS')`
+- [ ] If findings exist, call `runAutoQuickfixWorklist({ atcRunId, maxFindings: 1 })` (limit to one to keep the test light)
+- [ ] Assert: `result.applied >= 0`, `result.remaining >= 0`, response shape matches `AutoQuickfixWorklistResult`
+- [ ] Cleanup: any applied changes should be in `$TMP` only; if a transport was created, log it but don't release/delete (that's `SAPTransport` territory)
+- [ ] Capture the raw response into a new fixture: `tests/fixtures/xml/autoqf-worklist-result-a4h.xml` for future replays
+- [ ] Tag the test with `// best-effort-cleanup` where applicable
+- [ ] Run `TEST_SAP_URL=... npm run test:integration -- batch_quickfix` — test passes or skips with a valid reason
+
+### Task 6: Update Clean-Core skills to use batch_quickfix
+
+**Files:**
+- Modify: `skills/sap-clean-core-atc/SKILL.md`
+- Modify: `skills/migrate-custom-code/SKILL.md`
+
+Both existing skills currently iterate one-by-one. Update them to switch to `batch_quickfix` when the finding count exceeds a threshold (default: 5 automatic findings in scope).
+
+- [ ] In `skills/sap-clean-core-atc/SKILL.md`, add a new step after the ATC-run step:
+  - Count findings tagged `automatic="true"` in the package scope
+  - If count > 5 (configurable threshold), call `SAPDiagnose action='batch_quickfix' atcRunId=<id> packageScope=<pkg>` — one call, fast
+  - If count ≤ 5, fall back to the existing per-finding `quickfix` + `apply_quickfix` loop (better LLM visibility for small counts)
+  - After the call, re-run ATC to verify `remaining: 0`
+- [ ] Same update for `skills/migrate-custom-code/SKILL.md` — it has a slightly different audience (migration-time bulk apply), so the threshold may be 10 there
+- [ ] Add a "Failure modes" note: if `batch_quickfix` returns a non-empty `skipped[]`, the skill should iterate the skipped IDs and explain why each was skipped (typical: requires manual review)
+- [ ] Update the skill's frontmatter `description` to advertise the new capability ("...batch-applies machine-fixable findings via SAPDiagnose action='batch_quickfix'")
+- [ ] Run a manual smoke: invoke each skill via Claude Code against a test system to verify the new flow
+
+### Task 7: Documentation
+
+**Files:**
+- Modify: `docs/tools.md`
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `docs/roadmap.md` (if it exists)
+
+- [ ] In `docs/tools.md`, document the new `SAPDiagnose action='batch_quickfix'` under the SAPDiagnose section: action, args, return shape, scope requirement, error modes
+- [ ] In `CLAUDE.md`, add a row to "Key Files for Common Tasks":
+  - `| Add SAPDiagnose batch_quickfix wrapper (ATC auto-quickfix worklist) | src/adt/devtools.ts (`runAutoQuickfixWorklist`), src/adt/xml-parser.ts (`parseAutoQuickfixWorklist`), src/handlers/intent.ts (case 'batch_quickfix'), src/handlers/schemas.ts, src/handlers/tools.ts, src/authz/policy.ts, tests/unit/adt/devtools.test.ts |`
+- [ ] In `README.md`, mention the new action in the SAPDiagnose feature blurb (one line)
+- [ ] In `compare/00-feature-matrix.md`, add or update a row in the ATC section indicating ARC-1 supports batch quickfix; reference the SAP S/4HANA Cloud Private 2027 GA window
+- [ ] Update the "Last Updated" header in the feature matrix
+- [ ] If `docs/roadmap.md` exists, mark the batch quickfix item as completed and cross-link to this plan
+- [ ] Run `npm run lint` — Markdown formatting passes
+
+### Task 8: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Run integration: `npm run test:integration` — passes or skips with valid reason
+- [ ] Verify three-file sync: grep `batch_quickfix` in `src/handlers/{intent,schemas,tools}.ts` and `src/authz/policy.ts` — each must appear
+- [ ] Verify tool-list pruning works: a viewer-scope user must NOT see `batch_quickfix` in the tool list (manual test via the MCP inspector or an API-key with `viewer` profile)
+- [ ] Manually invoke `SAPDiagnose action='batch_quickfix'` against a test ATC run to confirm end-to-end flow
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/joule-bdef-explain-skill.md
+++ b/docs/plans/joule-bdef-explain-skill.md
@@ -1,0 +1,137 @@
+# Joule Roadmap Feature 8 — AI Explain for Behavior Definitions (skill)
+
+> **Status (2026-06-03): Skill IMPLEMENTED + live-verified.** `skills/explain-abap-code/SKILL.md` was extended with a BDEF branch (Step 1f + Step 2 SAPContext note + Step 5 explanation structure + follow-ups + error rows). Verified end-to-end against live A4H via `arc1-cli` on `/DMO/I_TRAVEL_M`: BDEF read → `implementation in class /DMO/BP_TRAVEL_M` parse → pool-class CCIMP read (showed `lhc_travel` with `FOR VALIDATE ON SAVE` handlers) → `SAPContext(action=impact)` on the bound root CDS `/DMO/I_Travel_M`.
+> **Two plan corrections applied to the skill (the plan referenced non-existent surface):** (1) `SAPDiagnose` has **no** `rap_preflight` action — that reference was dropped. (2) `SAPContext` does **not** accept `BDEF` (only `CLAS|INTF|PROG|FUNC|DDLS`) — the skill runs `SAPContext(action=impact, name=<root_cds>)` on the bound DDLS root instead. **Remaining (optional/deferred):** Task 2 (E2E test file), Task 3 (doc updates).
+
+## Overview
+
+SAP's Joule for Developers 2026 roadmap announces "ABAP AI Explain for Behavior Definitions" — explanations of *"the business purpose, business logic, and dependencies associated with behavior definitions."* Planned release: SAP BTP ABAP environment 2611 / S/4HANA Cloud Public 2702 / S/4HANA Cloud Private 2027 (note the later 2611/2702 dates compared to most siblings).
+
+This is the RAP-native equivalent of the function-group explain feature: instead of digesting flow logic + screen flow, the model summarises a BDEF's CRUD/action graph, determinations, validations, side effects, and authorisation scopes. Behavior definitions are an ABAP RAP construct (SAP_BASIS 7.53+).
+
+ARC-1 already has every primitive this feature needs. BDEF source read is wired (`SAPRead type='BDEF'`); the bound CLAS (behavior pool) can be discovered either via the BDEF source's `implementation in class` clause or via `<class:rootEntityRef>` on class metadata (`parseClassMetadata` in `src/adt/xml-parser.ts`, consumed in `src/adt/rap-generate.ts:200`); the handler CLAS source supports include-aware reading (CCDEF/CCIMP/testclasses); `src/adt/rap-preflight.ts` provides structured "what is wired / what is broken" signal; `SAPRead(WHERE_USED)` plus the cds-impact classifier in `src/adt/cds-impact.ts` enumerate consumers.
+
+**No ARC-1 code change needed.** This plan adds a BDEF-specific branch to the existing `explain-abap-code` skill (the same skill extended in `joule-fugr-explain.md` for FUGR). On systems where adt-ls is available (arc-1-lsp), `hover` on a BDEF returns rich markdown — the skill can mention this as a sibling capability but doesn't depend on it.
+
+See [`docs/research/joule-2026-roadmap-feature-assessment.md §8`](../research/joule-2026-roadmap-feature-assessment.md) for the full feature assessment.
+
+## Context
+
+### Current State
+
+- `SAPRead(type='BDEF')` reads behavior definition source
+- The behavior pool CLAS binding is parseable from the BDEF source (`implementation in class ZBP_*`) or via `<class:rootEntityRef>` on class metadata
+- `SAPRead(type='CLAS', include='implementations')` reads CCIMP where the handler class lives (per `src/adt/rap-handlers.ts` design notes)
+- `SAPDiagnose(action='rap_preflight')` returns deterministic findings about wired-up state
+- `SAPRead(action='WHERE_USED')` plus `src/adt/cds-impact.ts` give downstream consumers
+- `skills/explain-abap-code/SKILL.md` exists but has no BDEF-specific branch
+- arc-1-lsp's adt-ls provides `hover` on BDEF (DDLS-style inline parse) but arc-1 itself does not
+
+### Target State
+
+- The existing `explain-abap-code` skill handles BDEF natively:
+  1. Read BDEF source via `SAPRead`
+  2. Parse `implementation in class` to discover the bound behavior pool
+  3. Read the pool's CCDEF + CCIMP via `SAPRead(type='CLAS', include='implementations')` and `include='definitions'`
+  4. Optionally run `SAPDiagnose action='rap_preflight'` for structural signal
+  5. Optionally run `SAPRead WHERE_USED` to find consumers
+  6. LLM composes the explanation covering CRUD graph + determinations + validations + side effects + authz
+- E2E test exercises the skill's tool sequence on a fixture BDEF
+- Documentation updated
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `skills/explain-abap-code/SKILL.md` | Extend with a BDEF-specific Step 1 / Step 2 |
+| `tests/e2e/explain-bdef.e2e.test.ts` | New: E2E test for the BDEF read + handler discovery flow |
+| `tests/e2e/fixtures.ts` | Reference: existing BDEF fixture (or add one) |
+| `README.md`, `docs/index.md`, `compare/00-feature-matrix.md`, `CLAUDE.md`, `docs/roadmap.md` (if exists) | Documentation |
+
+### Design Principles
+
+1. **No ARC-1 code change.** All primitives ready; this is purely a skill extension.
+2. **Reuse the existing `explain-abap-code` skill.** Don't create a parallel `explain-bdef` skill; extend the canonical one. Keeps single source of truth.
+3. **BDEF parse stays in the skill's prompt.** `implementation in class ZBP_*` extraction is a short regex on the BDEF source — no need to wire a TypeScript parser. The skill prompts the LLM to extract it.
+4. **Cross-link to RAP preflight.** When the skill detects RAP-specific issues during explanation (e.g. handler class missing), it should suggest `SAPDiagnose action='rap_preflight'` to the user.
+5. **arc-1-lsp benefits automatically.** When wired against arc-1-lsp's MCP, the skill's `SAPRead type='BDEF'` resolves through adt-ls and `hover` becomes available as a complement. The skill must not assume hover is present — it's a bonus when available.
+
+## Development Approach
+
+- Task 1: Extend the existing `explain-abap-code` skill with a BDEF branch
+- Task 2: E2E test for the BDEF read + handler discovery flow
+- Task 3: Documentation
+- Task 4: Final verification
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:e2e`
+
+### Task 1: Extend `explain-abap-code` for BDEF
+
+**Files:**
+- Modify: `skills/explain-abap-code/SKILL.md`
+
+Add a BDEF-specific branch. The existing skill already covers CLAS/PROG/DDLS — add BDEF alongside, sharing Steps 2-4 (dependency context, ATC, documentation lookup) but with BDEF-specific Step 1.
+
+- [ ] Add a "BDEF (behavior definition)" branch in Step 1 of the skill:
+  - 1a. `SAPRead(type='BDEF', name='<name>')` — get the source
+  - 1b. Parse the source for `implementation in class\s+(\S+)\.` to discover the behavior pool class name. Examples:
+    - `managed implementation in class ZBP_R_TRAVEL unique` → pool = `ZBP_R_TRAVEL`
+    - `unmanaged implementation in class ZBP_X` → pool = `ZBP_X`
+  - 1c. `SAPRead(type='CLAS', name='<pool>')` — main class source
+  - 1d. `SAPRead(type='CLAS', name='<pool>', include='implementations')` — CCIMP where handlers live; if it returns empty, also try `include='definitions'`
+  - 1e. (Optional) `SAPDiagnose(action='rap_preflight', name='<bdef>')` — structural sanity (returns deterministic findings)
+  - 1f. (Optional) `SAPRead(action='WHERE_USED', name='<bdef>')` — downstream consumers (services, projection views)
+- [ ] Add a "Smart Defaults" row for BDEF: `expand_includes` not used (BDEF doesn't have it); always discover bound class via source parse; ATC = no; WHERE_USED = no unless asked
+- [ ] Update the skill `description` frontmatter to advertise BDEF: *"...including behavior definitions (BDEF — CRUD graph + determinations/validations + bound handler class)..."*
+- [ ] Add a "BDEF explanation prompt" section showing the LLM-side prompt structure: cover (1) business purpose (from BDEF header comments + bound CDS root); (2) CRUD graph (which operations are exposed, draft/non-draft); (3) determinations + validations (from CCIMP method signatures); (4) side effects + authorization scopes; (5) bound projection views (from WHERE_USED if available)
+- [ ] Cross-link: *"For pure RAP handler scaffolding, see `generate-rap-logic`. For the underlying CDS view explanation, run this skill on the bound CDS root entity."*
+- [ ] Verify: `cat skills/explain-abap-code/SKILL.md | grep -i BDEF | head -5` shows BDEF references
+
+### Task 2: E2E test for the BDEF read + handler discovery sequence
+
+**Files:**
+- Create: `tests/e2e/explain-bdef.e2e.test.ts`
+- Modify: `tests/e2e/fixtures.ts` (if no existing BDEF fixture)
+
+The skill content itself is prompt-engineering; the tool sequence it invokes is testable.
+
+- [ ] Check `tests/e2e/fixtures.ts` for an existing BDEF fixture (`PERSISTENT_OBJECTS`); if absent, add a minimal BDEF + bound CLAS + bound CDS view (a fully wired RAP triple) following the `rap-write.e2e.test.ts` fixture pattern
+- [ ] Create `tests/e2e/explain-bdef.e2e.test.ts`:
+  - Connect MCP client
+  - Use `requireOrSkip(ctx, rapAvailable, 'RAP_NOT_AVAILABLE')` for skip gating
+  - Test: `SAPRead(type='BDEF', name='<fixture>')` returns source containing `implementation in class` clause
+  - Test: extract the class name via regex on the BDEF source (in test code — verify the parse approach the skill uses works); `SAPRead(type='CLAS', name='<parsed>')` returns CCDEF (or main class)
+  - Test: `SAPRead(type='CLAS', name='<parsed>', include='implementations')` returns CCIMP source (or empty if no impl yet)
+  - Test: `SAPDiagnose(action='rap_preflight', name='<bdef>')` returns a structured result (no exception)
+- [ ] Tag cleanup catches with `// best-effort-cleanup` (no cleanup needed — all reads)
+- [ ] Run `npm run test:e2e -- explain-bdef` — passes or skips with valid reason
+
+### Task 3: Documentation
+
+**Files:**
+- Modify: `README.md`, `docs/index.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+- Modify: `docs/roadmap.md` (if exists)
+- Modify: `skills/explain-abap-code/SKILL.md` (cross-link the BDEF branch in the skill index)
+
+- [ ] In `README.md` / `docs/index.md`, update the `explain-abap-code` skill blurb to mention BDEF
+- [ ] In `compare/00-feature-matrix.md`, add or update a row "BDEF deep read + handler discovery" — ARC-1 ✅; SAP Joule "AI Explain for Behavior Definitions" GA window noted (BTP 2611 / S/4 Cloud Public 2702 / Private 2027)
+- [ ] In `CLAUDE.md`, no new "Key Files" row needed (no code change), but if there's a "Skills inventory" section, ensure `explain-abap-code` is listed as covering BDEF
+- [ ] Update the feature matrix "Last Updated" header
+- [ ] If `docs/roadmap.md` exists, mark "AI Explain for BDEF parity" completed
+- [ ] Run `npm run lint` — passes
+
+### Task 4: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Run E2E: `npm run test:e2e -- explain-bdef` — passes or skips with valid reason
+- [ ] Manually invoke `/explain-abap-code` on a real BDEF via Claude Code — verify the explanation covers the CRUD graph, the bound handler class methods, and any downstream consumers
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/joule-cds-analytical-model-skill.md
+++ b/docs/plans/joule-cds-analytical-model-skill.md
@@ -1,0 +1,170 @@
+# Joule Roadmap Features 3 & 4 — CDS Analytical Model Generation (skill)
+
+> **Status (2026-06-03): Skill IMPLEMENTED + live-verified.** `skills/generate-analytics-star-schema/SKILL.md` is written and its tool sequence was verified end-to-end against live A4H (S/4HANA 2023, SAP_BASIS 758) via `arc1-cli`: a dimension view (`@Analytics.dataCategory: #DIMENSION`) + a cube (`@Analytics.dataCategory: #CUBE`, `@Aggregation.default: #SUM`, `[1..1]` foreign-key association) were created in one `SAPWrite(action=batch_create, activateAtEnd=true)` call and activated as a single batch — the cube→dimension cross-reference resolved in one pass. Built on `/dmo/flight` + `/dmo/carrier`. Cleaned up after. **Remaining (optional/deferred):** Task 3 (analytical AFF schema variant), Task 2 (E2E test file), Task 4 (doc updates).
+
+## Overview
+
+SAP's Joule for Developers 2026 roadmap announces "CDS Analytical Model Generation Powered by AI" in two scopes — *Basic* (S/4HANA Cloud Private 2027): cube + existing dimensions from a RAP business object. *Extended* (BTP ABAP 2608 / S/4HANA Cloud Public 2608 / Private 2027): also generates *new* dimensions and accepts DDIC tables as input.
+
+The AI-enhanced wizard outputs (1) one cube view with `@Analytics.dataCategory: #CUBE` + measures; (2) N dimension views with `@Analytics.dataCategory: #DIMENSION`; (3) text views with `#TEXT`; (4) foreign-key associations linking the three. For RAP-BO input, field semantics (amount/currency/quantity/unit) are inferred from the BO. For DDIC input the LLM relies on data-element semantics.
+
+ARC-1's prerequisite plumbing is already in place: `SAPWrite(batch_create, activateAtEnd: true)` (PR 270) was effectively pre-emptive infrastructure for exactly this multi-object scaffold — the activator resolves cross-references in one terminal pass. RAP BO root entity discovery exists via `parseClassMetadata` in `src/adt/xml-parser.ts` (consumed by `src/adt/rap-generate.ts:200`). DDIC table read works via `SAPRead(type=TABL)`.
+
+This plan adds the skill `generate-analytics-star-schema` and an optional analytical-DDLS AFF schema variant. No ARC-1 source code change is required — only the skill is mandatory.
+
+See [`docs/research/joule-2026-roadmap-feature-assessment.md §3-4`](../research/joule-2026-roadmap-feature-assessment.md) for the full feature assessment.
+
+## Context
+
+### Current State
+
+- `SAPWrite(batch_create, activateAtEnd: true)` is shipped (PR 270) — see CLAUDE.md row "Add SAPWrite batch_create `activateAtEnd`"
+- RAP BO root entity is parsed via `<class:rootEntityRef>` in class metadata, captured in `src/adt/xml-parser.ts` `parseClassMetadata()`, consumed in `src/adt/rap-generate.ts:200`
+- `SAPRead(type=TABL)` exists for DDIC tables and structures (`getTabl()` in `src/adt/client.ts:450`)
+- AFF DDLS schema `src/aff/schemas/ddls-v1.json` validates a freeform DDLS envelope
+- No skill in `skills/` orchestrates cube + dimensions + texts as one analytical model
+
+### Target State
+
+- New skill `skills/generate-analytics-star-schema/SKILL.md` orchestrates:
+  1. Discover input: RAP BO via class metadata, OR DDIC table via `SAPRead`
+  2. Read candidate dimensions via `SAPSearch(tadir_lookup, source='adt')` filtered to the BO/table's package + parents
+  3. LLM composes cube DDLS + N dimension DDLS + N text DDLS using templates the skill ships
+  4. `SAPWrite(batch_create, activateAtEnd: true)` for the full set — one terminal activate
+- Optional: AFF schema variant `src/aff/schemas/ddls-analytical-v1.json` enforces analytical-specific annotations (`@Analytics.dataCategory`, `@Semantics.amount.currencyCode`, `@ObjectModel.dataCategory`); registered in `src/aff/validator.ts` `TYPE_MAP` at line 10
+- E2E test covers the cube + 1 dimension + 1 text batch create on a fixture DDIC table
+- README, roadmap, feature matrix, CLAUDE.md updated
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `skills/generate-analytics-star-schema/SKILL.md` | New: the skill content |
+| `skills/generate-cds-analytical-query/SKILL.md` | Reference: sibling skill for the *query* layer on top of the cube |
+| `skills/generate-rap-service-researched/SKILL.md` | Reference: research-first orchestration pattern |
+| `src/aff/schemas/ddls-analytical-v1.json` | (Optional) Analytical DDLS schema variant |
+| `src/aff/validator.ts` | (Optional) Register the new schema in `TYPE_MAP` (line 10) |
+| `tests/unit/aff/validator.test.ts` | (Optional) Unit tests for the new schema |
+| `tests/e2e/cds-analytics-model.e2e.test.ts` | New: E2E test for the skill's batch_create path |
+| `tests/e2e/fixtures.ts` | Add a DDIC source-table fixture for the model generation |
+| `README.md`, `docs/index.md`, `docs/roadmap.md`, `compare/00-feature-matrix.md`, `CLAUDE.md` | Documentation updates |
+
+### Design Principles
+
+1. **Skill-first.** ARC-1 has all primitives; this is a template + few-shot authoring task. The AFF schema variant is opt-in polish.
+2. **Use `batch_create + activateAtEnd: true`.** Per-object inline activation can't resolve cross-references between cube↔dimension↔text. Deferred terminal activation is the *only* mechanism that works for multi-object analytical models.
+3. **Two input modes.** RAP BO (discover root entity from `<class:rootEntityRef>`) and DDIC table (`SAPRead(type=TABL)`). The skill must support both — extended-scope feature requires DDIC.
+4. **Field-semantics inference is the LLM's job.** ARC-1 supplies metadata; the LLM uses data-element semantics + annotations to decide `@Semantics.amount.currencyCode` etc. Don't try to encode this in TS code.
+5. **Cross-link to the analytical-query skill.** The analytical model produces a cube; the analytical query skill projects on it. These are siblings.
+
+## Development Approach
+
+- Task 1: Skill authoring (the deliverable)
+- Task 2: E2E test
+- Task 3: (Optional) AFF schema variant
+- Task 4: Documentation
+- Task 5: Final verification
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:e2e`
+
+### Task 1: Author the `generate-analytics-star-schema` skill
+
+**Files:**
+- Create: `skills/generate-analytics-star-schema/SKILL.md`
+
+The core deliverable. Self-contained skill that drives the standard read/batch_write/activate loop with analytical-model-specific templates.
+
+- [ ] Create `skills/generate-analytics-star-schema/` directory
+- [ ] Write `SKILL.md` with frontmatter: `name: generate-analytics-star-schema`, `description: Generate a CDS analytical model (cube + dimensions + text views) on top of a RAP business object or DDIC table. Use when the user asks to "create a star schema", "generate analytical cube + dimensions", or "make a RAP BO analytical".`
+- [ ] Smart Defaults table at the top: input type auto-detected; default package = source object's package (or $TMP if not transportable); ATC = no; batch + terminal activation = always.
+- [ ] Step 1 — Resolve input:
+  - If user names a RAP BO (e.g. `ZBP_R_TRAVEL`): read class metadata via `SAPRead(type=CLAS, name=<class>)`, extract `rootEntityRef` (the bound CDS root view)
+  - If user names a DDIC table (e.g. `ZTRAVEL`): `SAPRead(type=TABL, name=<table>)`, capture the field list
+  - Reject ambiguity by asking
+- [ ] Step 2 — Discover candidate dimensions:
+  - `SAPSearch(searchType='tadir_lookup', source='adt', objectType='DDLS', namePattern='ZI_*_DIM')` (and `*_TEXT`)
+  - Filter to the BO/table's package + parent packages
+  - Present the candidate list; user can confirm subset or add new dimensions
+- [ ] Step 3 — Look up canonical analytical-model semantics: `mcp-sap-docs search` for `@Analytics.dataCategory: #CUBE`, `@Analytics.dataCategory: #DIMENSION`, `@Analytics.dataCategory: #FACT|#AGGREGATIONLEVEL`, `@Semantics.amount.currencyCode`, `@Semantics.quantity.unitOfMeasure`. Cite doc IDs in the skill output.
+- [ ] Step 4 — LLM composes the model. Skill ships templates:
+  - **Cube template** — `@Analytics.dataCategory: #CUBE` + `@AccessControl.authorizationCheck: #NOT_REQUIRED` (for $TMP) + measures (numeric fields → `@Aggregation.default: #SUM`) + dimension associations + currency/unit annotations
+  - **Dimension template** — `@Analytics.dataCategory: #DIMENSION` + key field + text association
+  - **Text template** — `@Analytics.dataCategory: #TEXT` + language field + text field
+- [ ] Step 5 — Show the LLM's plan to the user as a tree:
+  ```
+  Cube: ZI_TRAVEL_CUBE on ZBP_R_TRAVEL
+    Measures: BookingFee, TotalPrice
+    Dimensions:
+      ZI_CUSTOMER_DIM (new) → ZI_CUSTOMER_TEXT
+      ZI_AGENCY_DIM (existing) → ZI_AGENCY_TEXT
+  ```
+  Confirm before writing.
+- [ ] Step 6 — Write via `SAPWrite(action='batch_create', activateAtEnd: true, objects: [cube, ...dimensions, ...texts])`. If `activateAtEnd` is not honored on this system (older release), fall back to per-object create + a single final activate over all created URIs.
+- [ ] Step 7 — Verify with `SAPRead(type='DDLS', name='<cube>', include='elements')` to confirm associations and measures are live
+- [ ] Step 8 — Cross-link: *"To create an analytical query (projection view) on top of this cube, invoke `generate-cds-analytical-query` with the cube name."*
+- [ ] Edge cases: package allowlist blocks the target package → suggest a $TMP draft first; SAP_BASIS < 7.58 may reject some annotations → check `SAPManage(action='features')` first; cube already exists → ask user to rename or update
+- [ ] Verify: `cat skills/generate-analytics-star-schema/SKILL.md | head -10` shows the frontmatter
+
+### Task 2: E2E test for the batch_create + activateAtEnd path
+
+**Files:**
+- Create: `tests/e2e/cds-analytics-model.e2e.test.ts`
+- Modify: `tests/e2e/fixtures.ts`
+- Create: `tests/fixtures/abap/ztravel_source.tabl.json` + `.tabl.xml` for the source table
+
+Exercise the underlying tool calls (the skill itself is prompt-engineering; the tool path is testable).
+
+- [ ] Add `ZTRAVEL_SOURCE_TEST` table fixture to `PERSISTENT_OBJECTS` in `tests/e2e/fixtures.ts` (minimal: client, id, agency, currency, amount fields)
+- [ ] Create the table fixture XML in `tests/fixtures/abap/` so `npm run test:e2e:fixtures` can sync it
+- [ ] Create `tests/e2e/cds-analytics-model.e2e.test.ts` following the `tests/e2e/rap-write.e2e.test.ts` pattern (transient objects with try/finally cleanup)
+- [ ] Test: `SAPWrite batch_create cube + dimension + text on ZTRAVEL_SOURCE_TEST with activateAtEnd: true` — verify all three are created and active; verify cross-references resolved (the dimension association in the cube points to a real dimension view); cleanup via batch delete
+- [ ] Test: `batch_create without activateAtEnd fails or returns partial results when cross-references are present` — verify the contrast (this documents *why* activateAtEnd matters)
+- [ ] Use `requireOrSkip(ctx, rapAvailable, 'RAP_NOT_AVAILABLE')` for skip gating
+- [ ] Tag cleanup catches with `// best-effort-cleanup`
+- [ ] Run `npm run test:e2e -- cds-analytics-model` — all tests pass or skip with valid reason
+
+### Task 3: (Optional) Add analytical-DDLS AFF schema variant
+
+**Files:**
+- Create: `src/aff/schemas/ddls-analytical-v1.json`
+- Modify: `src/aff/validator.ts`
+- Modify: `tests/unit/aff/validator.test.ts`
+
+Strictly opt-in polish. Worth doing if the skill produces too many round-trips on annotation errors. The schema enforces the analytical-specific annotation surface so failures are caught client-side.
+
+- [ ] Create `src/aff/schemas/ddls-analytical-v1.json` modeled on `src/aff/schemas/ddls-v1.json`. Required annotations: `@Analytics.dataCategory` (enum: CUBE | DIMENSION | TEXT | FACT | AGGREGATIONLEVEL), plus optional `@Semantics.amount.currencyCode`, `@ObjectModel.dataCategory`
+- [ ] In `src/aff/validator.ts`, add a `TABL_ANALYTICAL` or `DDLS_ANALYTICAL` row to `TYPE_MAP` at line 10. `getAffSchema()` (line 28) will resolve it via the map — no new function needed.
+- [ ] Note: this is a SECOND variant for DDLS; the existing `ddls-v1.json` stays as the default. Activation order: callers opting into the analytical schema pass `type='DDLS_ANALYTICAL'`. Document the opt-in in `docs/tools.md`.
+- [ ] Add unit tests (~3 tests) to `tests/unit/aff/validator.test.ts`: valid cube envelope, missing `@Analytics.dataCategory` rejected, wrong enum value rejected
+- [ ] Run `npm test` — all tests pass
+
+### Task 4: Documentation updates
+
+**Files:**
+- Modify: `README.md`, `docs/index.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+- Modify: `docs/roadmap.md` (if exists)
+- Modify: `skills/README.md` (if exists)
+
+- [ ] Add the skill to the README/skills index with a one-liner: *"Generate CDS analytical model (cube + dimensions + texts) on top of a RAP BO or DDIC table"*
+- [ ] In `compare/00-feature-matrix.md`, add or update an Analytics row: ARC-1 ✅ (via skill); SAP roadmap GA window noted
+- [ ] In `CLAUDE.md`, add to "Key Files for Common Tasks": `| Add or update analytical model generation logic | skills/generate-analytics-star-schema/SKILL.md (+ optional src/aff/schemas/ddls-analytical-v1.json) |`
+- [ ] Update `compare/00-feature-matrix.md` "Last Updated" header
+- [ ] If `docs/roadmap.md` exists, mark "CDS Analytical Model Generation parity" completed and link to this plan + the research doc
+- [ ] Cross-link the new skill from `skills/generate-cds-analytical-query/SKILL.md` if it exists (the sibling)
+- [ ] Run `npm run lint` — Markdown formatting passes
+
+### Task 5: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Run E2E: `npm run test:e2e -- cds-analytics-model` — passes or skips with valid reason
+- [ ] Manually invoke the skill via Claude Code: `/generate-analytics-star-schema` on a RAP BO and on a DDIC table; verify both flows end-to-end
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/joule-cds-analytical-query-skill.md
+++ b/docs/plans/joule-cds-analytical-query-skill.md
@@ -1,0 +1,165 @@
+# Joule Roadmap Feature 1 — CDS Analytical Query Generation (skill)
+
+> **Status (2026-06-03): Skill IMPLEMENTED + live-verified.** `skills/generate-cds-analytical-query/SKILL.md` is written and its tool sequence was verified end-to-end against live A4H (S/4HANA 2023, SAP_BASIS 758) via `arc1-cli`: a `define transient view entity … provider contract analytical_query as projection on <cube>` was created (`SAPWrite create`) and activated (`SAPActivate`) successfully, then read back (`SAPRead include=elements`) and deleted. **Remaining (optional/deferred):** Task 3 (pre-write lint hint), Task 2 (E2E test file), Task 4 (README/roadmap/feature-matrix/CLAUDE.md doc updates).
+
+## Overview
+
+SAP's Joule for Developers 2026 roadmap announces "CDS Analytical Query Generation powered by AI" — a wizard in Eclipse ADT that generates `DEFINE TRANSIENT VIEW ENTITY ... AS PROJECTION ON <cube> PROVIDER CONTRACT ANALYTICAL_QUERY` views on top of analytical models (`@Analytics.dataCategory: #CUBE`). Planned release: SAP BTP ABAP environment 2608 / S/4HANA Cloud Public 2608 / S/4HANA Cloud Private 2027.
+
+ARC-1 already exposes every primitive this feature needs: `SAPSearch` for finding cubes, `SAPRead(type=DDLS)` for reading them, `SAPWrite(create, type=DDLS)` for writing the new analytical query, and `SAPActivate` for activation. The AFF schema in `src/aff/schemas/ddls-v1.json` validates the envelope. The capability gap is purely a **prompt + template library** so an LLM can compose a valid `ANALYTICAL_QUERY` projection.
+
+This plan adds a new Claude skill `generate-cds-analytical-query` that drives the standard read/write/activate loop with analytical-query-specific templates and few-shot examples. Optionally it also adds an ARC-1-native pre-write hint that flags missing `@Analytics.query: true` on a transient projection view, mirroring the existing TABL `%admin` draft hint at `src/lint/pre-write-hints.ts`. The skill alone closes the parity gap; the lint hint is an opt-in quality polish.
+
+See [`docs/research/joule-2026-roadmap-feature-assessment.md §1`](../research/joule-2026-roadmap-feature-assessment.md) for the full feature assessment.
+
+## Context
+
+### Current State
+
+- ARC-1 ships generic DDLS read/write/activate, but no analytical-query templates
+- The AFF DDLS schema `src/aff/schemas/ddls-v1.json` validates a freeform DDLS envelope
+- `src/lint/pre-write-hints.ts` ships a TABL `%admin draft include` semantic hint (the pattern to mirror for analytical-query annotation hints)
+- No skill in `skills/` covers analytical query generation; the existing `generate-rap-service` and `generate-rap-logic` skills cover transactional RAP only
+- `mcp-sap-docs` exposes SAP Help / SAP Community / ABAP Keyword Docs, including the [Analytical Query Views](https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENCDS_ANALYTICAL_QUERY_APV.html) reference
+
+### Target State
+
+- New skill `skills/generate-cds-analytical-query/SKILL.md` orchestrates `SAPSearch` → `SAPRead` (cube) → LLM composes analytical-query DDLS → `SAPWrite(create, type=DDLS)` → `SAPActivate`
+- The skill ships canonical templates: simple projection, projection with KPI measures + filter prompts, projection with dimension drilldowns
+- Optionally: a new pre-write hint `inspectAnalyticalQueryDdlsSource()` in `src/lint/pre-write-hints.ts` that warns when a transient projection view (`DEFINE TRANSIENT VIEW ENTITY ... AS PROJECTION`) is missing `@Analytics.query: true` or projects on an entity without `@Analytics.dataCategory: #CUBE`
+- E2E test covers create → activate → cleanup of a minimal analytical query on a cube fixture
+- README, roadmap, feature matrix, CLAUDE.md updated to advertise the skill
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `skills/generate-cds-analytical-query/SKILL.md` | New: the skill content |
+| `skills/explain-abap-code/SKILL.md` | Reference: skill format / frontmatter / step structure |
+| `skills/generate-rap-service-researched/SKILL.md` | Reference: research-first skill pattern, MCP tool usage |
+| `src/lint/pre-write-hints.ts` | (Optional) Add analytical-query pre-write hint |
+| `src/lint/lint.ts` | (Optional) Wire the new hint into `validateBeforeWrite()` |
+| `tests/unit/lint/pre-write-hints.test.ts` | (Optional) Unit tests for the new hint |
+| `tests/e2e/rap-write.e2e.test.ts` | Reference: pattern for E2E RAP-type writes (try/finally cleanup) |
+| `tests/e2e/cds-analytical-query.e2e.test.ts` | New: E2E test for the analytical query skill flow |
+| `tests/e2e/fixtures.ts` | Add an analytical cube fixture |
+| `tests/fixtures/abap/` | New: cube CDS view fixture + expected analytical-query template |
+| `README.md`, `docs/index.md`, `docs/roadmap.md`, `compare/00-feature-matrix.md`, `CLAUDE.md` | Documentation updates |
+
+### Design Principles
+
+1. **Skill-first** — no ARC-1 code change is required for parity; only the skill is mandatory. The pre-write hint is a quality polish (opt-in task).
+2. **Use the existing read/write loop** — `SAPSearch` → `SAPRead(DDLS)` → `SAPWrite(create)` → `SAPActivate`. No new tools.
+3. **Templates over freestyle** — ship 3 canonical analytical-query templates as few-shot examples in the skill, not freeform prose.
+4. **Source the cube first** — never let the LLM hallucinate a cube; resolve via `SAPSearch` and read the cube source so element names are grounded.
+5. **mcp-sap-docs integration** — the skill must query `mcp-sap-docs` for [`@Analytics.query`](https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENCDS_ANALYTICAL_QUERY_APV.html) and `PROVIDER CONTRACT ANALYTICAL_QUERY` semantics before generation, the same pattern `explain-abap-code` uses.
+
+## Development Approach
+
+- Task 1: Skill content authoring (the deliverable)
+- Task 2: E2E coverage of the skill's read/write/activate path
+- Task 3: (Optional) Pre-write hint + unit tests
+- Task 4: Documentation updates
+- Task 5: Final verification
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:e2e` (requires running MCP server)
+
+### Task 1: Author the `generate-cds-analytical-query` skill
+
+**Files:**
+- Create: `skills/generate-cds-analytical-query/SKILL.md`
+
+This is the core deliverable. The skill must be self-contained and follow the format of existing skills (frontmatter `name` + `description`, then steps). Reference `skills/explain-abap-code/SKILL.md` for tone and `skills/generate-rap-service-researched/SKILL.md` for the research-first pattern.
+
+- [ ] Create the directory `skills/generate-cds-analytical-query/`
+- [ ] Write `SKILL.md` with frontmatter: `name: generate-cds-analytical-query`, `description: Generate analytical CDS projection views (PROVIDER CONTRACT ANALYTICAL_QUERY) on top of existing analytical cubes. Use when the user asks to "create an analytical query", "build a KPI projection", or "generate ANALYTICAL_QUERY DDLS".`
+- [ ] Step 1 — Resolve the cube: call `SAPSearch(query="<user_input>")` to find candidate cubes; if multiple matches, present them and let the user choose; for ambiguous input, accept package + name filter
+- [ ] Step 2 — Read the cube source: `SAPRead(type="DDLS", name="<cube>", include="elements")` to get the field list; verify the cube has `@Analytics.dataCategory: #CUBE`. If not, stop and explain.
+- [ ] Step 3 — Look up canonical semantics: `mcp-sap-docs search` for `PROVIDER CONTRACT ANALYTICAL_QUERY` and `@Analytics.query` annotation; cite the resulting doc IDs (don't embed the full text)
+- [ ] Step 4 — Compose the analytical query DDLS. Ship 3 templates in the skill:
+  - **Template A (simple projection):** `DEFINE TRANSIENT VIEW ENTITY <name> PROVIDER CONTRACT ANALYTICAL_QUERY AS PROJECTION ON <cube> { <element_list> }`
+  - **Template B (KPI projection with filter):** like A but with `@Consumption.filter` parameters on key dimensions
+  - **Template C (drilldown projection):** like A but with `@AnalyticsDetails.query.axis: #ROWS|#COLUMNS|#FREE` per element
+- [ ] Step 5 — Validate the LLM's draft against the user's intent before writing. Show the draft, confirm dimensions / measures / filter dimensions
+- [ ] Step 6 — Write: `SAPWrite(action="create", type="DDLS", name="<name>", package="<pkg>", source="<draft>")`. If the user has not specified `package`, default to `$TMP` and warn.
+- [ ] Step 7 — Activate: `SAPActivate(name="<name>", type="DDLS")`. On activation errors, surface them verbatim and let the user re-prompt; do NOT auto-retry.
+- [ ] Step 8 — Verify: `SAPRead(type="DDLS", name="<name>", include="elements")` to confirm the projection is live.
+- [ ] Include a "Smart Defaults" table at the top: object type DDLS, default package $TMP, ask before transportable package, don't run ATC by default
+- [ ] Include an "Edge cases" section: cube is inactive → stop; user wants to project on a non-cube → suggest the Star Schema Generator skill instead; LLM proposes `@Analytics.dataCategory: #DIMENSION` → reject (this is a query, not a dimension)
+- [ ] Cross-link to `skills/generate-analytics-star-schema/SKILL.md` (the future skill from plan 3) — *"To build the underlying cube + dimensions first, use `generate-analytics-star-schema`."*
+- [ ] Final verification: `cat skills/generate-cds-analytical-query/SKILL.md | head -5` shows the frontmatter; no `## Validation Commands` is needed in the skill itself
+
+### Task 2: E2E test for the skill's read/write/activate path
+
+**Files:**
+- Create: `tests/e2e/cds-analytical-query.e2e.test.ts`
+- Modify: `tests/e2e/fixtures.ts`
+- Create: `tests/fixtures/abap/zi_analyticalcube_test.ddls.asabapdoc`
+
+E2E coverage of the skill's underlying MCP tool flow. Skill content itself isn't unit-tested (it's prompt-engineering); the tool calls it makes are.
+
+- [ ] Add a persistent fixture cube `ZI_ANALYTICALCUBE_TEST` to `PERSISTENT_OBJECTS` in `tests/e2e/fixtures.ts` with `@Analytics.dataCategory: #CUBE` and a couple of dimension associations + measures
+- [ ] Create the ABAP/DDL source for the cube in `tests/fixtures/abap/zi_analyticalcube_test.ddls.asabapdoc` — minimal: `define view entity zi_analyticalcube_test ...` with `@Analytics.dataCategory: #CUBE`, one numeric measure, one foreign-key dim
+- [ ] Run `npm run test:e2e:fixtures` to sync the fixture (it should create the cube against the test SAP system; rapAvailable check skips if RAP unsupported)
+- [ ] Create `tests/e2e/cds-analytical-query.e2e.test.ts` following the `tests/e2e/rap-write.e2e.test.ts` pattern (transient objects with try/finally)
+- [ ] Test: `SAPWrite create DDLS analytical query on ZI_ANALYTICALCUBE_TEST` — write a minimal `PROVIDER CONTRACT ANALYTICAL_QUERY` projection (`define transient view entity zq_aq_test_<uuid> provider contract analytical_query as projection on zi_analyticalcube_test { … }`), `SAPActivate` it, `SAPRead` it back, cleanup via `SAPWrite(action="delete")`
+- [ ] Test: `SAPWrite create rejected when projection target is not a cube` — try to project on a non-cube; verify activation returns the expected SAP error and the test cleans up
+- [ ] Both tests use `requireOrSkip(ctx, rapAvailable, 'RAP_NOT_AVAILABLE')` for skip-on-non-RAP systems
+- [ ] Tag cleanup catches with `// best-effort-cleanup`
+- [ ] Run `npm run test:e2e -- cds-analytical-query` — all tests pass
+
+### Task 3: (Optional) Add analytical-query pre-write hint
+
+**Files:**
+- Modify: `src/lint/pre-write-hints.ts`
+- Modify: `src/lint/lint.ts`
+- Modify: `tests/unit/lint/pre-write-hints.test.ts`
+- Modify: `tests/unit/lint/lint.test.ts`
+
+Mirror the existing TABL `%admin draft include` hint. The new hint warns when a DDLS source declares `DEFINE TRANSIENT VIEW ENTITY ... AS PROJECTION ON <X>` without `@Analytics.query: true`, OR when the target `<X>` does not look like a cube (heuristic: name doesn't match `Z?I_*` or `*CUBE*`).
+
+- [ ] Add `inspectAnalyticalQueryDdlsSource(source: string, name: string): LintResult[]` to `src/lint/pre-write-hints.ts`. Returns warnings (severity 'warning'), not errors — never block a write. Strip ABAP-style `--` and block comments before pattern-matching. Mixed case must be tolerated.
+- [ ] Patterns to detect:
+  - `/DEFINE\s+TRANSIENT\s+VIEW\s+ENTITY\s+\w+\s+(?:[\s\S]*?)AS\s+PROJECTION\s+ON\s+(\w+)/i` — captures the projection target
+  - Look for `PROVIDER\s+CONTRACT\s+ANALYTICAL_QUERY` (any case)
+  - Look for `@Analytics\s*\.\s*query\s*:\s*true` (any case)
+  - If `PROVIDER CONTRACT ANALYTICAL_QUERY` present AND `@Analytics.query: true` absent → warn
+  - If `PROVIDER CONTRACT ANALYTICAL_QUERY` present AND projection target doesn't match a cube-naming heuristic → softer warn (hint, not blocker)
+- [ ] Wire into `validateBeforeWrite()` in `src/lint/lint.ts`, filename-gated by `.ddls.acds` / `.ddls.asabapdoc` extension. Follow the same pattern as the TABL hint.
+- [ ] Add unit tests (~5 tests): positive case (has analytical_query + missing annotation → warning), negative case (no analytical_query keyword → no warning), comments are stripped, mixed-case detection works, target heuristic fires on non-cube name
+- [ ] Add a `validateBeforeWrite` integration test that exercises the full pipeline (1 test)
+- [ ] Run `npm test` — all tests pass
+
+### Task 4: Documentation updates
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/index.md`
+- Modify: `docs/roadmap.md` (if it exists; otherwise skip)
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `CLAUDE.md`
+- Modify: `skills/README.md` (the skills index)
+
+- [ ] In `README.md`, add a row to the skills section announcing `generate-cds-analytical-query`
+- [ ] In `docs/index.md`, mirror the README addition
+- [ ] In `compare/00-feature-matrix.md`, find the "CDS / Analytics" section (or create one) and add a row for "Analytical Query Generation" with ✅ ARC-1 (via skill) and the SAP roadmap GA date (BTP 2608)
+- [ ] In `CLAUDE.md`, add a skill-related row to "Key Files for Common Tasks" pointing to the new skill: `| Add or update analytical-query generation logic | skills/generate-cds-analytical-query/SKILL.md`
+- [ ] In `CLAUDE.md`, if a "Skills" or "Skills inventory" section exists, add the new skill to it
+- [ ] Update `compare/00-feature-matrix.md` "Last Updated" header to today's date
+- [ ] If `docs/roadmap.md` exists, mark "CDS Analytical Query Generation parity" as completed and link to this plan + the research doc
+- [ ] If a skill index `skills/README.md` exists, add the new skill
+- [ ] Run `npm run lint` (Markdown formatting may be linted)
+
+### Task 5: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Run E2E: `npm run test:e2e` — analytical query test passes (or skips with `RAP_NOT_AVAILABLE` on non-RAP test systems)
+- [ ] Manually invoke the skill via Claude Code: `/generate-cds-analytical-query` on a fixture cube, verify the generated DDLS activates
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/joule-extensibility-assistant.md
+++ b/docs/plans/joule-extensibility-assistant.md
@@ -1,0 +1,291 @@
+# Joule Roadmap Feature 5 — Extensibility Assistant (TABL APPEND + BAdI scaffold + skill)
+
+## Overview
+
+SAP's Joule for Developers 2026 roadmap announces "Extensibility Assistant" (S/4HANA Cloud Private 2027; already GA on Public Cloud for *key users*). It is a Joule chat surface in the S/4HANA Cloud UI that finds the right extension option (custom field, BAdI, value help) and creates it. SAP's example: *"I want to create a custom field in the sales order header area and make it relevant for pricing."*
+
+This is the only roadmap feature where SAP's surface is **outside ADT** (Key User Extensibility apps). For an ABAP developer using ARC-1, the analogous capabilities are: (a) **append structures** (TABL subtype `R3TR APPS`) — extend a standard table with custom fields; (b) **BAdI implementations** — implement an enhancement spot's interface. Both touch **classic** ABAP types that `adt-ls` does not serve — this is **permanently ARC-1's domain**.
+
+This plan delivers three independent code changes plus the orchestrating skill:
+
+1. **5a — TABL APPEND structure subtype.** New `appendStructureXml()` in `src/adt/ddic-xml.ts`; new `tabl-v1.json` AFF schema (currently absent); wire `appendOf` through `buildCreateXml()` in `src/handlers/intent.ts:2709` and the SAPWrite schema chain.
+2. **5b — BAdI implementation scaffold.** New `src/adt/badi-scaffold.ts` (pure module mirroring `src/adt/rap-handlers.ts`); new `SAPWrite action='scaffold_badi_impl'`; reads the BAdI definition's interface, emits a CLAS stub.
+3. **5c — `extensibility-assistant` skill.** Orchestrates BAdI search → BAdI definition read → impl-class scaffold; or append-structure scaffold for the field-extension workflow.
+
+See [`docs/research/joule-2026-roadmap-feature-assessment.md §5`](../research/joule-2026-roadmap-feature-assessment.md) for the full feature assessment.
+
+## Context
+
+### Current State
+
+- TABL writes exist for base transparent tables and structures (`buildCreateXml()` at `src/handlers/intent.ts:2709` has a `case 'TABL'`)
+- AFF schemas exist for `bdef, clas, ddls, intf, prog, srvb, srvd` — **no `tabl-v1.json` yet** (gap to close in 5a)
+- `src/aff/validator.ts` line 10 has `TYPE_MAP` mapping object type → schema filename; line 28 has `getAffSchema(type)` that resolves from the map
+- `getEnhancementImplementation()` exists at `src/adt/client.ts:595` — reads ENHO and parses BAdI implementations via `parseEnhancementImplementation()` at `src/adt/xml-parser.ts:643`
+- No `getBadiDefinition()` reader exists — needed to read the BAdI interface signature before scaffolding the implementation class
+- `src/adt/rap-handlers.ts` (1233 LOC) is the canonical pattern for a scaffold module: `extractRapHandlerRequirements()`, `applyRapHandlerSignatures()`, `ensureRapHandlerSkeletons()`, with `case 'scaffold_rap_handlers'` dispatch in `handleSAPWrite`
+- No skill exists for extensibility tasks
+
+### Target State
+
+- **5a:** `SAPWrite(action='create', type='TABL', appendOf='<parent_table>', source='...', package='Z*')` creates an append structure. The XML envelope uses `R3TR APPS` semantics and includes `<r3tr:appendOf>`. The TABL AFF schema validates the envelope.
+- **5b:** `SAPWrite(action='scaffold_badi_impl', badiDefinition='<spot_def>', implementationClass='ZCL_MY_IMPL', implementationName='ZMY_IMPL', enhancementSpot='Z_SPOT')` reads the BAdI definition's interface and writes a CLAS stub implementing it. The class declaration follows the canonical SAP pattern: `CLASS zcl_my_impl DEFINITION PUBLIC FINAL CREATE PUBLIC. PUBLIC SECTION. INTERFACES <badi_interface>. ENDCLASS.`
+- **5c:** Skill drives discovery (`SAPSearch tadir_lookup` for ENHS/BADI_DEF) → user picks a BAdI → `getBadiDefinition` reads the interface → `scaffold_badi_impl` writes the stub → `SAPActivate`.
+- Unit tests + integration tests for each piece
+- Documentation updated end-to-end
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/ddic-xml.ts` | Add `appendStructureXml()` ~ near `dtelXml`/`domaXml` (file is 418 LOC; existing builders end around line 309) |
+| `src/handlers/intent.ts` | Extend `buildCreateXml()` (line 2709) `case 'TABL'` to branch on `args.appendOf`; add `case 'scaffold_badi_impl'` in `handleSAPWrite` |
+| `src/handlers/schemas.ts` | Add `appendOf?` to TABL slice of `SAPWriteSchema`; add `scaffold_badi_impl` action |
+| `src/handlers/tools.ts` | Mirror the schema additions in JSON Schema |
+| `src/authz/policy.ts` | Add `'SAPWrite.scaffold_badi_impl': 'write'` |
+| `src/aff/schemas/tabl-v1.json` | New TABL AFF schema (prerequisite — doesn't exist) |
+| `src/aff/validator.ts` | Add TABL row to `TYPE_MAP` at line 10 |
+| `src/adt/badi-scaffold.ts` | New pure module: `extractBadiRequirements`, `applyBadiImplementationStubs` |
+| `src/adt/client.ts` | Add `getBadiDefinition(name)` near `getEnhancementImplementation()` (line 595) |
+| `src/adt/xml-parser.ts` | Add `parseBadiDefinition()` for the BAdI definition response |
+| `src/adt/types.ts` | New types: `BadiDefinitionInfo`, `BadiRequirement` |
+| `tests/unit/adt/ddic-xml.test.ts` | Tests for `appendStructureXml` |
+| `tests/unit/adt/badi-scaffold.test.ts` | New: pure-function tests |
+| `tests/unit/handlers/intent.test.ts` | Handler tests for both new actions |
+| `tests/integration/adt.integration.test.ts` | Integration tests against a4h |
+| `skills/extensibility-assistant/SKILL.md` | New: orchestration skill |
+| `docs/tools.md`, `CLAUDE.md`, `README.md`, `compare/00-feature-matrix.md` | Documentation |
+
+### Design Principles
+
+1. **Mirror `scaffold_rap_handlers`.** `scaffold_badi_impl` follows the same pattern as the existing RAP handler scaffold in `src/adt/rap-handlers.ts`: pure module with `extract*` + `apply*` functions, plus handler dispatch in `intent.ts`. Don't reinvent the structure.
+2. **TABL append is a subtype, not a new type.** Keep `type='TABL'` and route on `appendOf` to preserve the existing TABL infrastructure (lock/unlock, transport, activation).
+3. **AFF schema must be created.** `tabl-v1.json` is a *prerequisite* — without it, no AFF validation runs for TABL writes today, which is a latent gap.
+4. **Three-file schema sync, atomically.** All new properties / actions must land in `tools.ts`, `schemas.ts`, `intent.ts`, and `authz/policy.ts` in the same commit.
+5. **Each piece is independently testable.** 5a (TABL APPEND), 5b (BAdI scaffold), 5c (skill) ship in that order — no circular dependencies.
+6. **Never bypass `checkOperation`.** Both new write actions are gated by `OperationType.Create` (TABL APPEND) and `OperationType.Update` (scaffold_badi_impl — it modifies CLAS plus optionally ENHO).
+7. **Package allowlist applies normally.** Append structures inherit the parent table's package gate naturally; BAdI impl classes are gated by `args.package`.
+
+## Development Approach
+
+- Tasks 1-3: 5a TABL APPEND (schema + builder + wiring)
+- Tasks 4-5: 5a tests (unit + integration)
+- Tasks 6-8: 5b BAdI scaffold module + handler + tests
+- Task 9: 5c skill
+- Task 10: Documentation
+- Task 11: Final verification
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:integration` (requires TEST_SAP_URL)
+
+### Task 1: Create the TABL AFF schema and register it
+
+**Files:**
+- Create: `src/aff/schemas/tabl-v1.json`
+- Modify: `src/aff/validator.ts`
+
+Prerequisite for 5a. The TABL AFF schema doesn't exist yet (`ls src/aff/schemas/` shows bdef/clas/ddls/intf/prog/srvb/srvd only). Without it, no validation runs for any TABL write today. Adding it is independent value beyond the APPEND subtype.
+
+- [ ] Create `src/aff/schemas/tabl-v1.json` modeled on `src/aff/schemas/ddls-v1.json` envelope structure. Validate:
+  - Top-level object with `header { name, description, originalLanguage, abapLanguageVersion }`
+  - `tabl { fields: [{ name, dataType, length?, decimals?, isKey, notNull }, ...] }`
+  - Optional `appendOf: { tableName: <string> }` block — indicates this is an APPEND structure
+  - When `appendOf` is set: `header.name` must start with `Z` or `Y` and end with a special char (or follow the customer-namespace rule); ABAP language version must be present
+- [ ] In `src/aff/validator.ts`, add to `TYPE_MAP` at line 10: `TABL: 'tabl-v1.json'`. The existing `getAffSchema()` at line 28 resolves it automatically.
+- [ ] Add unit tests to `tests/unit/aff/validator.test.ts` (~4 tests): valid plain table envelope, valid APPEND envelope, missing required field rejected, `appendOf` set without table name rejected
+- [ ] Run `npm test` — all tests pass
+
+### Task 2: Add `appendStructureXml()` XML builder
+
+**Files:**
+- Modify: `src/adt/ddic-xml.ts`
+- Modify: `tests/unit/adt/ddic-xml.test.ts`
+
+Mirror the existing `buildDataElementXml()` / `buildDomainXml()` exports in `src/adt/ddic-xml.ts` (the file is 418 LOC with builders ending around line 309).
+
+- [ ] Add `interface AppendStructureCreateParams { name: string; description: string; appendOf: string; fields: AppendField[]; package: string; abapLanguageVersion?: string }`
+- [ ] Add `interface AppendField { name: string; dataType: string; length?: number; decimals?: number }`
+- [ ] Add `export function buildAppendStructureXml(params: AppendStructureCreateParams): string` that emits:
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <blue:appendStructure xmlns:blue="http://www.sap.com/wbobj/blue" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:name="{name}" adtcore:type="TABL/APP" adtcore:description="{description}" adtcore:language="EN" adtcore:masterLanguage="EN" adtcore:masterSystem="...">
+    <blue:appendOf adtcore:name="{appendOf}" adtcore:type="TABL/TT"/>
+    <blue:fields>
+      <blue:field blue:fieldName="{f.name}" blue:dataType="{f.dataType}" blue:length="{f.length}" blue:decimals="{f.decimals}"/>
+      ...
+    </blue:fields>
+    <blue:package adtcore:name="{package}"/>
+  </blue:appendStructure>
+  ```
+  Verify root element + namespace against the existing DDIC builders. The exact root name TBD against live a4h on first integration run — use `R3TR APPS` semantics.
+- [ ] Use the existing `escapeXml()` helper for all attribute values
+- [ ] Add unit tests (~4 tests): happy path, empty fields list rejected, name validation (starts with Z/Y), special characters escaped correctly
+- [ ] Run `npm test -- ddic-xml` — all tests pass
+
+### Task 3: Wire `appendOf` through `buildCreateXml` and schemas
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/tools.ts`
+
+Extend the TABL create path to branch on `args.appendOf`. NOTE: `buildCreateXml()` lives in `src/handlers/intent.ts:2709` (NOT in `src/adt/crud.ts` despite what older docs said).
+
+- [ ] In `src/handlers/intent.ts`, find `buildCreateXml()` at line 2709. In its `case 'TABL'` branch, add: `if (args.appendOf) { return buildAppendStructureXml({ name, description, appendOf: args.appendOf, fields: args.fields ?? [], package: pkg, abapLanguageVersion: args.abapLanguageVersion }); }` before the existing TABL XML builder call.
+- [ ] In `src/handlers/schemas.ts`, find `validateSapWriteInput()` at line 352 and extend the TABL slice of `SAPWriteSchema` to accept `appendOf: z.string().min(3).optional()` and `fields: z.array(z.object({ name: z.string(), dataType: z.string(), length: z.number().optional(), decimals: z.number().optional() })).optional()`. Add cross-validation: `appendOf` requires `fields` to be non-empty.
+- [ ] In `src/handlers/tools.ts`, add `appendOf` and `fields` to the SAPWrite TABL JSON Schema with clear descriptions:
+  - `appendOf`: "Parent table name (e.g. 'MARA'). When set, creates an APPEND structure (R3TR APPS) extending the parent table. Required for append structures."
+  - `fields`: "Array of fields to add to the parent table. Required when appendOf is set. Each field: { name, dataType, length?, decimals? }"
+- [ ] In `src/authz/policy.ts`, no change needed — TABL APPEND uses the same `SAPWrite.create` policy as base TABL
+- [ ] Verify three-file sync: `grep -rn "appendOf" src/handlers/` should hit all three files
+- [ ] Run `npm run typecheck` — no errors
+- [ ] Run `npm test` — all tests pass
+
+### Task 4: Integration test for TABL APPEND
+
+**Files:**
+- Modify: `tests/integration/adt.integration.test.ts`
+
+Live integration test against a standard table on a4h. Use a Z-namespace append.
+
+- [ ] Use `getTestClient()` from `tests/integration/helpers.ts`
+- [ ] Pick a parent table that exists on a4h (e.g. `MARA` for materials, or `T000` for clients — verify the table is present first via `SAPRead(type=TABL, name=...)`). If neither exists, skip via `requireOrSkip(ctx, parentTablePresent, 'APPEND_PARENT_NOT_PRESENT')`.
+- [ ] Test: `SAPWrite create TABL appendOf=MARA name=ZMARA_<unique> fields=[{name: 'ZZ_TEST_FIELD', dataType: 'CHAR', length: 10}]` → expect 201 / success; then `SAPActivate`; then `SAPRead(type=TABL, name=ZMARA_<unique>)` to verify the append is live; cleanup with `SAPWrite(action='delete')`
+- [ ] Test: rejects an append whose name doesn't start with Z/Y (sanity check on the schema)
+- [ ] Tag cleanup catches with `// best-effort-cleanup`
+- [ ] Capture the actual XML response root element from the first successful create — if it differs from the placeholder in Task 2, update both the builder and parser
+- [ ] Run `TEST_SAP_URL=... npm run test:integration -- TABL.*APPEND` — test passes or skips
+
+### Task 5: Final 5a verification
+
+- [ ] Run unit tests: `npm test -- (ddic-xml|validator|intent)` — all pass
+- [ ] Run integration: `npm run test:integration -- TABL` — passes or skips
+- [ ] Verify three-file sync: `appendOf` appears in `tools.ts`, `schemas.ts`, `intent.ts` ✅
+- [ ] Verify AFF schema loads: write a TABL create call with a malformed envelope and confirm the validator catches it
+
+### Task 6: Create the BAdI scaffold pure module
+
+**Files:**
+- Create: `src/adt/badi-scaffold.ts`
+- Modify: `src/adt/types.ts`
+- Create: `tests/unit/adt/badi-scaffold.test.ts`
+
+Pure module mirroring `src/adt/rap-handlers.ts` (1233 LOC — read its header comment for the design pattern). The scaffold module takes a parsed BAdI requirement and an existing CLAS source, returns updated CLAS source with method declarations + empty implementations.
+
+- [ ] In `src/adt/types.ts`, add:
+  - `interface BadiDefinitionInfo { name: string; interfaceName: string; isMultiple: boolean; isFilterDependent: boolean; methods: BadiMethod[] }`
+  - `interface BadiMethod { name: string; signature: string; description: string }`
+  - `interface BadiRequirement { interfaceName: string; methods: BadiMethod[] }`
+  - `interface BadiScaffoldResult { classSource: string; inserted: BadiMethod[]; changed: boolean }`
+- [ ] Create `src/adt/badi-scaffold.ts` exporting pure functions:
+  - `extractBadiRequirements(badiDef: BadiDefinitionInfo): BadiRequirement[]` — given a parsed BAdI definition, return one `BadiRequirement` per method that needs implementation
+  - `applyBadiImplementationStubs(req: BadiRequirement, classSource: string): BadiScaffoldResult` — splice `INTERFACES <interface>` into the class definition section and add `METHOD <interface>~<method>. ENDMETHOD.` blocks to the implementation section
+  - `buildEmptyBadiImplClass(className: string, badiInterface: string): string` — emit a minimal CLAS source `CLASS <name> DEFINITION PUBLIC FINAL CREATE PUBLIC. PUBLIC SECTION. INTERFACES <badiInterface>. ENDCLASS. CLASS <name> IMPLEMENTATION. ENDCLASS.`
+- [ ] Add unit tests (~10 tests): valid scaffold from empty class, scaffold preserves existing methods, multiple BAdI methods in one class, BAdI with filter parameter, splices INTERFACES into the right section, idempotent (running twice doesn't duplicate)
+- [ ] Run `npm test -- badi-scaffold` — all tests pass
+
+### Task 7: Add `getBadiDefinition` client method and XML parser
+
+**Files:**
+- Modify: `src/adt/client.ts`
+- Modify: `src/adt/xml-parser.ts`
+- Create: `tests/fixtures/xml/badi-definition.xml`
+
+Adds the reader needed by Task 8's `scaffold_badi_impl` handler.
+
+- [ ] In `src/adt/client.ts`, add `async getBadiDefinition(name: string): Promise<BadiDefinitionInfo>` near `getEnhancementImplementation()` at line 595. Endpoint: `/sap/bc/adt/enhancements/badi_definitions/<name>` — verify the exact path against the abap-adt-api library if uncertain.
+- [ ] In `src/adt/xml-parser.ts`, add `parseBadiDefinition(xml: string): BadiDefinitionInfo` near `parseEnhancementImplementation()` at line 643. Parse the BAdI definition XML to extract: interface name, isMultiple flag, isFilterDependent flag, list of methods (name + signature + ABAP-Doc).
+- [ ] Create a fixture XML in `tests/fixtures/xml/badi-definition.xml` based on a real BAdI (capture from a4h or copy from abap-adt-api fixtures)
+- [ ] Add unit tests to `tests/unit/adt/xml-parser.test.ts` for `parseBadiDefinition` (~3 tests): happy path, missing interface attribute, multi-method BAdI
+- [ ] Add unit tests to `tests/unit/adt/client.test.ts` for `getBadiDefinition` using mock-fetch (~2 tests): happy path + 404
+- [ ] Run `npm test` — all tests pass
+
+### Task 8: Wire `SAPWrite action='scaffold_badi_impl'` through the three-file sync
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/tools.ts`
+- Modify: `src/authz/policy.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+New SAPWrite action that reads the BAdI definition + writes a new CLAS stub. Optionally registers the implementation under an enhancement spot (deferred — out of scope for v1).
+
+- [ ] In `src/handlers/intent.ts`, add `case 'scaffold_badi_impl'` in `handleSAPWrite` near the existing `case 'scaffold_rap_handlers'`. Body:
+  - Read the BAdI definition via `client.getBadiDefinition(args.badiDefinition)`
+  - Call `extractBadiRequirements(def)` to get the method list
+  - Call `buildEmptyBadiImplClass(args.implementationClass, def.interfaceName)` to get the starter CLAS source
+  - Call `applyBadiImplementationStubs(req, starterSource)` to splice in the method stubs
+  - Create the CLAS via the existing CLAS write path (`SAPWrite.create` internally — call `buildCreateXml('CLAS', ...)` then `createObject()`)
+  - Optionally activate (`SAPActivate`) if `args.activate !== false`
+  - Return the URI of the new class + the scaffold result summary as JSON
+- [ ] In `src/handlers/schemas.ts`, add the `scaffold_badi_impl` action to the SAPWrite action union with args `{ badiDefinition: string, implementationClass: string, implementationName: string, package: string, enhancementSpot?: string, activate?: boolean (default true) }`
+- [ ] In `src/handlers/tools.ts`, mirror the schema in the JSON Schema with descriptions referencing the BAdI/ENHS terminology
+- [ ] In `src/authz/policy.ts`, add `'SAPWrite.scaffold_badi_impl': 'write'`
+- [ ] Add unit tests to `tests/unit/handlers/intent.test.ts` (~5 tests): happy path with mock BAdI def, BAdI def not found returns clean error, write failure returns error, allowWrites=false rejected, package allowlist enforced
+- [ ] Run `npm test` — all tests pass
+- [ ] Verify three-file sync: `grep -rn "scaffold_badi_impl" src/handlers/ src/authz/` — all four files
+
+### Task 9: Author the `extensibility-assistant` skill
+
+**Files:**
+- Create: `skills/extensibility-assistant/SKILL.md`
+
+Skill that orchestrates either the field-extension flow (append structure) or the BAdI implementation flow.
+
+- [ ] Create `skills/extensibility-assistant/` directory
+- [ ] Write `SKILL.md` with frontmatter: `name: extensibility-assistant`, `description: ABAP extensibility helper — extend a standard SAP table with an APPEND structure, or implement a BAdI. Use when user asks to "add a custom field to MARA", "create a BAdI implementation for X", "extend standard SAP", or "find the right BAdI for Y".`
+- [ ] Step 1 — Detect intent: field-extension vs BAdI implementation. Ask if unclear.
+- [ ] **Field-extension branch:**
+  1. User names the target table (e.g. `MARA`)
+  2. `SAPRead(type='TABL', name='<target>')` — confirm the table exists and read its current field list
+  3. Look up `mcp-sap-docs search` for "APPEND structure" + the table's BAdI/extension recommendations
+  4. Compose the append source: `Z<TARGET>_<PURPOSE>` name, fields from user requirements
+  5. `SAPWrite(action='create', type='TABL', appendOf='<target>', name='Z<TARGET>_<PURPOSE>', fields=[...], package='$TMP' or user-specified)`
+  6. `SAPActivate`
+  7. Verify via `SAPRead`
+- [ ] **BAdI implementation branch:**
+  1. User describes the BAdI or business scenario
+  2. `SAPSearch(searchType='tadir_lookup', source='adt', objectType='ENHS')` — find enhancement spots; OR `SAPSearch(query='BAdI: <description>')` — fuzzy search
+  3. Read the chosen BAdI definition (currently via SAPRead type=ENHS to read the spot; the per-BAdI getBadiDefinition is internal to the scaffold action)
+  4. `SAPWrite(action='scaffold_badi_impl', badiDefinition='<spot>~<badi>', implementationClass='ZCL_MY_IMPL', implementationName='ZMY_IMPL', enhancementSpot='<spot>', package='$TMP')`
+  5. Show the scaffolded class
+  6. Iterate via `SAPWrite(action='edit_method')` to fill in business logic
+- [ ] Edge cases: target table is in a restricted package → suggest $TMP; BAdI not found → ask for an alternative description; BAdI is filter-dependent → explain filter values are required at runtime
+- [ ] Cross-link: *"For RAP-style behavior extensions (not BAdI), see `generate-rap-logic`."*
+- [ ] Verify: `cat skills/extensibility-assistant/SKILL.md | head -10` shows the frontmatter
+
+### Task 10: Documentation
+
+**Files:**
+- Modify: `docs/tools.md`
+- Modify: `CLAUDE.md`
+- Modify: `README.md`, `docs/index.md`
+- Modify: `compare/00-feature-matrix.md`
+- Modify: `docs/roadmap.md` (if exists)
+
+- [ ] In `docs/tools.md`, document:
+  - `SAPWrite type='TABL' appendOf=<parent>` — APPEND structure semantics, args, examples
+  - `SAPWrite action='scaffold_badi_impl'` — args, return shape, examples
+- [ ] In `CLAUDE.md`, add to "Key Files for Common Tasks":
+  - `| Add TABL APPEND structure subtype | src/adt/ddic-xml.ts (buildAppendStructureXml), src/aff/schemas/tabl-v1.json, src/aff/validator.ts (TYPE_MAP), src/handlers/intent.ts (buildCreateXml line 2709), src/handlers/schemas.ts, src/handlers/tools.ts, tests/unit/adt/ddic-xml.test.ts, tests/integration/adt.integration.test.ts |`
+  - `| Add BAdI implementation scaffold | src/adt/badi-scaffold.ts (pure module), src/adt/client.ts (getBadiDefinition near line 595), src/adt/xml-parser.ts (parseBadiDefinition near line 643), src/handlers/intent.ts (case 'scaffold_badi_impl'), src/handlers/schemas.ts, src/handlers/tools.ts, src/authz/policy.ts, skills/extensibility-assistant/SKILL.md |`
+- [ ] Update README/docs/index with the new SAPWrite capabilities + the skill
+- [ ] In `compare/00-feature-matrix.md`, add or update Extensibility section: ARC-1 ✅ APPEND + BAdI scaffold; SAP Joule Extensibility Assistant noted as a UI-side equivalent
+- [ ] Update the feature matrix "Last Updated" header
+- [ ] If `docs/roadmap.md` exists, mark "Extensibility Assistant parity" completed and link to this plan
+- [ ] Run `npm run lint` — passes
+
+### Task 11: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Run integration: `npm run test:integration` — passes or skips with valid reason
+- [ ] Verify three-file sync for both new features (TABL `appendOf` and `scaffold_badi_impl`)
+- [ ] Manually invoke the skill via Claude Code for both branches: APPEND on MARA, BAdI scaffold on a real spot
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/joule-fugr-explain.md
+++ b/docs/plans/joule-fugr-explain.md
@@ -1,0 +1,275 @@
+# Joule Roadmap Feature 7 — AI Explain for Function Groups
+
+> **Status (2026-06-03): SELECTED AS THE NEXT FEATURE TO BUILD.** Fully live-verifiable on A4H (classic function groups with FUNC sub-modules, dynpros, and GUI status exist), and it's ARC-1's classic-type moat — SAP's `adt-ls` does not serve these types. Implementation tracked in its own branch/PR.
+
+## Overview
+
+SAP's Joule for Developers 2026 roadmap announces "ABAP AI Explain for Function Groups" — explanations of *"the flow logic, business purpose, and screen flow of function groups."* Planned release: SAP BTP ABAP environment 2608 / S/4HANA Cloud Public 2608 / S/4HANA Cloud Private 2027.
+
+The high-value bit is "screen flow" — most legacy logic lives in function modules + SAPGUI dynpros, and explaining a function group requires walking the include tree: top FUGR include → all FUNC sub-modules → all dynpros (SCRP) → flow logic (PBO/PAI modules) → GUI status (CUA menu + function codes).
+
+FUGR/FUNC are **classic** ABAP object types — `adt-ls` returns a `.jsonc` placeholder for them. This feature is **permanently ARC-1's domain**. ARC-1 already exposes FUGR/FUNC source reads but lacks:
+1. **FUNC sub-module walk** when `expand_includes=true` (current implementation at `src/handlers/intent.ts:1505-1526` follows only explicit `INCLUDE` statements via regex + `client.getInclude()` — it does NOT enumerate the function group's FUNC children under `/sap/bc/adt/functions/groups/<name>/fmodules/`)
+2. **Dynpro (SCRP) read**
+3. **GUI status (CUA) read**
+
+This plan delivers three small reader additions + a skill extension to `explain-abap-code` so the LLM has all four artifact classes in context when explaining a FUGR.
+
+See [`docs/research/joule-2026-roadmap-feature-assessment.md §7`](../research/joule-2026-roadmap-feature-assessment.md) for the full feature assessment.
+
+## Context
+
+### Current State
+
+- `SAPRead(type='FUGR')` exists; `getFunctionGroup(name)` at `src/adt/client.ts:345` returns `{ name, functions: string[] }`
+- `getFunctionGroupSource(name, opts)` at `src/adt/client.ts:352` returns the top include source
+- `getInclude(name, opts)` at `src/adt/client.ts:358` reads any INCL by name
+- `expand_includes` is wired for FUGR in `handleSAPRead` at `src/handlers/intent.ts:1505-1526`:
+  - regex-matches `^[^*\n]*\bINCLUDE\s+(\S+)\s*\.` lines
+  - calls `getInclude()` per match
+  - concatenates source with `=== <name> ===` separators
+- This catches explicit `INCLUDE` statements but **NOT** FUNC sub-modules (which are not present as INCLUDE statements in the FUGR top include — they live under `/sap/bc/adt/functions/groups/<name>/fmodules/<func>/`)
+- No SAPRead support for dynpros: there's no `case 'DYNPRO'` or `case 'SCRP'`
+- No SAPRead support for GUI status / CUA
+- `getFunction()` exists for reading individual FUNC modules (the `SLASH_TYPE_MAP` has FUNC → `/sap/bc/adt/functions/groups/<group>/fmodules/<name>`)
+- `expand_includes` schema property declared at `src/handlers/schemas.ts:7141`
+- `expand_includes` description at `src/handlers/tools.ts:519` says: *"For FUGR type only. When true, expands all INCLUDE statements and returns the full source of each include inline."*
+
+### Target State
+
+- `SAPRead(type='FUGR', expand_includes=true)` returns:
+  - Top FUGR include source
+  - All `INCLUDE <name>.` source (current behavior preserved)
+  - All FUNC sub-modules' source (new)
+  - All dynpros' source + flow logic (new)
+  - All GUI status definitions (new)
+- New SAPRead types `DYNPRO` (with composite name `<prog>:<dynnr>`) and `CUA` (with composite name `<prog>:<status>`) for standalone reads of dynpros/statuses outside the FUGR context
+- `getFunctionGroupExpanded(name, opts)` in `src/adt/client.ts` orchestrates the multi-artifact read with cached + revalidation-friendly fetches
+- Unit tests cover happy + per-artifact failure modes; integration test covers a fixture FUGR on a4h
+- `explain-abap-code` skill extended to invoke `expand_includes=true` for FUGR
+- Documentation updated
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/client.ts` | Add `getFunctionGroupExpanded()` near line 345; add `getDynpro()`, `getCuaStatus()` |
+| `src/adt/xml-parser.ts` | Add `parseDynpro()`, `parseCuaStatus()` |
+| `src/adt/types.ts` | New types: `FunctionGroupExpanded`, `DynproInfo`, `CuaStatusInfo` |
+| `src/handlers/intent.ts` | Rewrite the FUGR `expand_includes=true` branch (line 1505-1526); add DYNPRO and CUA cases |
+| `src/handlers/schemas.ts` | Add DYNPRO and CUA to SAPRead type enum |
+| `src/handlers/tools.ts` | Update FUGR `expand_includes` description (line 519); add DYNPRO and CUA descriptions |
+| `research/abap-types/types/dynpro.md` | New evidence file (citation guard for new slash types) |
+| `research/abap-types/types/cua.md` | Same |
+| `tests/unit/adt/client.test.ts` | Tests for the new client methods |
+| `tests/unit/adt/xml-parser.test.ts` | Tests for the new parsers |
+| `tests/unit/handlers/intent.test.ts` | Tests for the FUGR expand_includes + DYNPRO + CUA handlers |
+| `tests/fixtures/xml/dynpro.xml`, `cua-status.xml`, `function-group-fmodules.xml` | New fixtures |
+| `tests/integration/adt.integration.test.ts` | Integration test against a4h |
+| `skills/explain-abap-code/SKILL.md` | Add FUGR explanation branch |
+| `docs/tools.md`, `CLAUDE.md`, `README.md`, `compare/00-feature-matrix.md` | Documentation |
+
+### Design Principles
+
+1. **Extend, don't fork.** The existing INCLUDE-statement regex loop at `intent.ts:1505` must keep working. Just add FUNC sub-modules + dynpros + CUA to the same bundle.
+2. **Standalone DYNPRO/CUA reads are bonus.** The primary use case is FUGR expand_includes. Exposing DYNPRO/CUA standalone via slash types is a small additional surface for power users.
+3. **Citation guard.** Adding new SAPRead slash types requires evidence files under `research/abap-types/types/*.md` per the CLAUDE.md "Add new ADT slash alias" row. Each new type needs a verified Eclipse apidoc + `<adtcore:type>` capture.
+4. **Cache + ETag-friendly.** Reuse the existing `cachedGet()` pattern in `intent.ts` so each individual sub-artifact participates in source caching independently.
+5. **Per-artifact failure tolerance.** If a single dynpro or CUA status fails to read (deleted, locked, etc.), the bundled response includes a placeholder `[Could not read X: <reason>]` — never aborts the whole FUGR read.
+6. **Cache key disambiguation.** When multiple artifacts share a key (e.g. dynpro 0100 vs dynpro 0200 of the same program), the cache key must include the disambiguator (programName + dynproNumber).
+
+## Development Approach
+
+- Task 1: Types + `getFunctionGroupExpanded()` (FUNC sub-module walk)
+- Task 2: `getDynpro()` + parser + fixture
+- Task 3: `getCuaStatus()` + parser + fixture
+- Task 4: Rewrite FUGR `expand_includes=true` handler branch
+- Task 5: Add DYNPRO and CUA standalone SAPRead types
+- Task 6: Integration test
+- Task 7: Skill extension
+- Task 8: Documentation
+- Task 9: Final verification
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:integration` (requires TEST_SAP_URL)
+
+### Task 1: Add `getFunctionGroupExpanded()` for FUNC sub-module walk
+
+**Files:**
+- Modify: `src/adt/client.ts`
+- Modify: `src/adt/types.ts`
+- Modify: `tests/unit/adt/client.test.ts`
+- Create: `tests/fixtures/xml/function-group-fmodules.xml`
+
+The FUGR object metadata at `/sap/bc/adt/functions/groups/<name>` returns a list of child FUNC modules via discovery. This task extends `getFunctionGroup()` to enumerate them and read each source.
+
+- [ ] In `src/adt/types.ts`, add:
+  - `interface FuncSubmodule { name: string; source: string }`
+  - `interface DynproEntry { number: string; source: string; flowLogic: string }`
+  - `interface CuaStatusEntry { name: string; menu: string; functionCodes: string[] }`
+  - `interface FunctionGroupExpanded { groupSource: string; explicitIncludes: { name: string; source: string }[]; functions: FuncSubmodule[]; dynpros: DynproEntry[]; statuses: CuaStatusEntry[] }`
+- [ ] In `src/adt/client.ts`, add `async getFunctionGroupExpanded(name: string, opts?: SourceReadOptions): Promise<FunctionGroupExpanded>` near line 360. Body:
+  - Read top source via `this.getFunctionGroupSource(name, opts)`
+  - Regex-match explicit `INCLUDE` statements (mirror the existing `intent.ts:1505` pattern) and read each via `this.getInclude(inclName, opts)`
+  - Enumerate FUNC children via `this.getFunctionGroup(name)` (which currently returns `{ functions: string[] }`), then read each via `this.getFunction(group, funcName)` — keep the existing pattern; do not invent a new endpoint
+  - Best-effort dynpro list: GET `/sap/bc/adt/programs/programs/SAPL<name>/dynpros/` (catalog) and enumerate; for each dynpro, call `this.getDynpro()` (added in Task 2). Catalog endpoint TBD against a4h — verify on first integration run.
+  - Best-effort CUA list: GET `/sap/bc/adt/programs/programs/SAPL<name>/cuastatus/` (catalog); for each, call `this.getCuaStatus()` (added in Task 3)
+  - Per-artifact failures resolve to a placeholder entry with `source: '[Could not read: ...]'`, not a thrown error
+- [ ] Add a fixture: `tests/fixtures/xml/function-group-fmodules.xml` capturing a real FUGR's FUNC children list
+- [ ] Add unit tests to `tests/unit/adt/client.test.ts` (~6 tests): happy path with all artifacts, empty FUNC list, dynpro catalog 404 yields empty list, CUA catalog 404 yields empty list, per-FUNC read failure yields placeholder, INCLUDE statement plus FUNC sub-module both expanded
+- [ ] Run `npm test -- client` — all tests pass
+
+### Task 2: Add `getDynpro()` and parser
+
+**Files:**
+- Modify: `src/adt/client.ts`
+- Modify: `src/adt/xml-parser.ts`
+- Create: `tests/fixtures/xml/dynpro.xml`
+- Create: `research/abap-types/types/dynpro.md`
+- Modify: `tests/unit/adt/client.test.ts`, `tests/unit/adt/xml-parser.test.ts`
+
+Adds the per-dynpro read primitive used by the FUGR expand_includes bundle and standalone reads.
+
+- [ ] In `src/adt/client.ts`, add `async getDynpro(programName: string, dynproNumber: string, opts?: SourceReadOptions): Promise<DynproEntry>` near the existing getInclude. Endpoint: `/sap/bc/adt/programs/programs/<prog>/dynpros/<dynnr>` (verify against `abap-adt-api` if uncertain; capture the exact response on first call). Returns the parsed `DynproEntry`.
+- [ ] In `src/adt/xml-parser.ts`, add `parseDynpro(xml: string): DynproEntry`. Expected XML shape (verify on first live call):
+  ```xml
+  <dynpro:dynpro xmlns:dynpro="...">
+    <dynpro:source>...</dynpro:source>
+    <dynpro:flowLogic>...</dynpro:flowLogic>
+    <dynpro:elements>...</dynpro:elements>
+  </dynpro:dynpro>
+  ```
+- [ ] Create `tests/fixtures/xml/dynpro.xml` with a minimal real dynpro response
+- [ ] Create `research/abap-types/types/dynpro.md` with evidence per CLAUDE.md "Add new ADT slash alias" guard: cite Eclipse apidoc URL, capture a real `<adtcore:type>` value from a4h
+- [ ] Add unit tests (~3 each): client (happy + 404 + parse error), parser (happy + missing flowLogic + malformed)
+- [ ] Run `npm test -- (client|xml-parser)` — all pass
+
+### Task 3: Add `getCuaStatus()` and parser
+
+**Files:**
+- Modify: `src/adt/client.ts`
+- Modify: `src/adt/xml-parser.ts`
+- Create: `tests/fixtures/xml/cua-status.xml`
+- Create: `research/abap-types/types/cua.md`
+- Modify: `tests/unit/adt/client.test.ts`, `tests/unit/adt/xml-parser.test.ts`
+
+Mirror Task 2 for CUA status.
+
+- [ ] In `src/adt/client.ts`, add `async getCuaStatus(programName: string, statusName: string, opts?: SourceReadOptions): Promise<CuaStatusEntry>`. Endpoint: `/sap/bc/adt/programs/programs/<prog>/cuastatus/<status>`.
+- [ ] In `src/adt/xml-parser.ts`, add `parseCuaStatus(xml: string): CuaStatusEntry`. Extract `name`, `menu`, `functionCodes`.
+- [ ] Create `tests/fixtures/xml/cua-status.xml`
+- [ ] Create `research/abap-types/types/cua.md` evidence file
+- [ ] Add unit tests (~3 each): same shape as Task 2
+- [ ] Run `npm test` — all pass
+
+### Task 4: Rewrite FUGR `expand_includes=true` handler
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+Replace the INCLUDE-statement regex loop at `intent.ts:1505-1526` with a call to `getFunctionGroupExpanded()`. Preserve the existing output format (`=== <name> ===\n<source>` markdown blocks) so existing skill prompts keep working.
+
+- [ ] In `src/handlers/intent.ts` at line 1505, find `case 'FUGR':` and rewrite the `expand_includes=true` branch:
+  ```ts
+  case 'FUGR': {
+    const expand = Boolean(args.expand_includes);
+    if (expand) {
+      const bundle = await client.getFunctionGroupExpanded(name, { version: effectiveVersion });
+      const parts: string[] = [`=== FUGR ${name} (main) ===\n${bundle.groupSource}`];
+      for (const incl of bundle.explicitIncludes) parts.push(`\n=== ${incl.name} ===\n${incl.source}`);
+      for (const fn of bundle.functions) parts.push(`\n=== FUNC ${fn.name} ===\n${fn.source}`);
+      for (const dyn of bundle.dynpros) parts.push(`\n=== DYNPRO ${dyn.number} ===\n${dyn.source}\n\n--- Flow logic ---\n${dyn.flowLogic}`);
+      for (const cua of bundle.statuses) parts.push(`\n=== CUA ${cua.name} ===\n${cua.menu}`);
+      return textResult(parts.join('\n'));
+    }
+    const fg = await client.getFunctionGroup(name);
+    return textResult(JSON.stringify(fg, null, 2));
+  }
+  ```
+- [ ] Update `src/handlers/tools.ts` line 519 description from *"expands all INCLUDE statements"* to *"For FUGR type only. When true, expands the function group's full artifact tree: explicit INCLUDE statements, FUNC sub-modules, dynpros (SCRP), and GUI status (CUA). Each artifact prefixed with === name === markers."*
+- [ ] Add unit tests to `tests/unit/handlers/intent.test.ts` (~4 tests): expand_includes=true returns bundled markdown with all 4 artifact types; expand_includes=false returns the lightweight JSON (existing behavior preserved); per-artifact failure yields a placeholder; expand_includes=false on a FUGR with no INCLUDE still returns the group source
+- [ ] Run `npm test` — all tests pass
+
+### Task 5: Add DYNPRO and CUA standalone SAPRead types
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `src/handlers/schemas.ts`
+- Modify: `src/handlers/tools.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+Expose `getDynpro()` and `getCuaStatus()` via SAPRead for power users. Use composite name `<programName>:<dynproNumber>` and `<programName>:<status>` per the existing CLAUDE.md pattern for composite names.
+
+- [ ] In `src/handlers/intent.ts` `handleSAPRead`, add `case 'DYNPRO': { const [prog, dynnr] = name.split(':'); if (!prog || !dynnr) throw ...; const dyn = await client.getDynpro(prog, dynnr, { version: effectiveVersion }); return textResult(JSON.stringify(dyn, null, 2)); }` and similar for `case 'CUA':`
+- [ ] In `src/handlers/schemas.ts`, add `'DYNPRO'` and `'CUA'` to the SAPRead `type` enum + validation that the name follows the `prog:dynnr` (or `prog:status`) composite pattern
+- [ ] In `src/handlers/tools.ts`, add DYNPRO and CUA to the SAPRead type enum with descriptions explaining the composite name format
+- [ ] In `src/handlers/intent.ts`, add the new types to `SLASH_TYPE_MAP` (and `SLASH_TYPE_EVIDENCE` + `KNOWN_BASE_TYPES`) per CLAUDE.md "Add new ADT slash alias" row
+- [ ] Add unit tests (~4): happy path each, malformed composite name rejected, 404 surfaces cleanly
+- [ ] Verify the citation guard test in `tests/unit/handlers/slash-type-map.test.ts` passes (it checks each new short type has an evidence file under `research/abap-types/types/`)
+- [ ] Run `npm test` — all tests pass
+
+### Task 6: Integration test
+
+**Files:**
+- Modify: `tests/integration/adt.integration.test.ts`
+
+Live test against a4h. Pick a real function group with at least one dynpro + GUI status (e.g. `BAPI_USER_CREATE`'s SAP-shipped FUGR — verify which FUGR has all four artifact classes on a4h before locking in the choice).
+
+- [ ] Add `describe('SAPRead FUGR expand_includes deep bundle')`:
+  - Pick a FUGR with FUNC + dynpro + CUA artifacts (use `SAPSearch` to discover candidates; document the choice)
+  - Call `SAPRead(type='FUGR', name=<choice>, expand_includes=true)`
+  - Assert the response contains `=== FUGR `, `=== FUNC `, `=== DYNPRO `, `=== CUA ` headers
+  - Assert the total response length > 200 chars (sanity)
+- [ ] Add tests for standalone DYNPRO and CUA reads if a test program with dynpros + statuses is available
+- [ ] Skip via `requireOrSkip(ctx, fugrPresent, 'TEST_FUGR_NOT_AVAILABLE')` if the chosen FUGR isn't on the test system
+- [ ] On first integration run, capture the actual response XML shapes — if they differ from the placeholders in Tasks 2 and 3, update the parsers and re-run
+- [ ] Tag cleanup catches with `// best-effort-cleanup` (no cleanup needed — all reads)
+- [ ] Run `TEST_SAP_URL=... npm run test:integration -- FUGR` — passes
+
+### Task 7: Extend `explain-abap-code` skill for FUGR
+
+**Files:**
+- Modify: `skills/explain-abap-code/SKILL.md`
+
+Add a FUGR-specific branch to the existing skill so it pulls the expanded artifact bundle and structures the LLM prompt accordingly.
+
+- [ ] In the existing `skills/explain-abap-code/SKILL.md`, add a FUGR-specific Step 1 variant:
+  - For type FUGR: `SAPRead(type='FUGR', name=<name>, expand_includes=true)` — bundle includes group source, FUNCs, dynpros, GUI statuses
+  - Prompt structure: "Explain this function group covering (1) overall business purpose; (2) per-FUNC responsibility; (3) screen flow (dynpros + flow logic); (4) GUI status / function-code dispatch."
+- [ ] Add a "Smart Defaults" row for FUGR: `expand_includes=true`
+- [ ] Update the skill's `description` frontmatter to mention FUGR explicitly: *"...including function groups (FUGR — bundles FUNC + dynpros + GUI status)..."*
+- [ ] Note: the skill is prompt-engineering; tests for the underlying tool path are in Task 6
+
+### Task 8: Documentation
+
+**Files:**
+- Modify: `docs/tools.md`
+- Modify: `CLAUDE.md`
+- Modify: `README.md`, `docs/index.md`
+- Modify: `compare/00-feature-matrix.md`
+
+- [ ] In `docs/tools.md`, update the SAPRead FUGR section to describe the expand_includes bundle (4 artifact classes); document DYNPRO and CUA types
+- [ ] In `CLAUDE.md`, add to "Key Files for Common Tasks":
+  - `| Extend FUGR expand_includes to enumerate FUNC sub-modules + dynpros + GUI status | src/adt/client.ts (getFunctionGroupExpanded, getDynpro, getCuaStatus), src/adt/xml-parser.ts (parseDynpro, parseCuaStatus), src/handlers/intent.ts (case 'FUGR' expand branch line 1505), src/handlers/schemas.ts, src/handlers/tools.ts (description line 519), research/abap-types/types/{dynpro,cua}.md, tests/unit/adt/* |`
+  - `| Add Dynpro (SCRP) SAPRead | src/adt/client.ts (getDynpro), src/adt/xml-parser.ts (parseDynpro), src/handlers/intent.ts (case 'DYNPRO'), src/handlers/{schemas,tools}.ts, research/abap-types/types/dynpro.md |`
+  - `| Add CUA / GUI status SAPRead | src/adt/client.ts (getCuaStatus), src/adt/xml-parser.ts (parseCuaStatus), src/handlers/intent.ts (case 'CUA'), src/handlers/{schemas,tools}.ts, research/abap-types/types/cua.md |`
+- [ ] Update README/docs/index to mention "AI Explain for Function Groups parity" capability
+- [ ] In `compare/00-feature-matrix.md`, update or add a row for "Function Group deep read (FUNC + dynpros + CUA)" — ARC-1 ✅, most competitors ❌ (adt-ls doesn't serve classic types)
+- [ ] Update the "Last Updated" header
+- [ ] If `docs/roadmap.md` exists, mark this feature completed
+- [ ] Run `npm run lint` — passes
+
+### Task 9: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] Run integration: `npm run test:integration -- FUGR` — passes or skips
+- [ ] Verify citation guard: every new short type (`DYNPRO`, `CUA`) has an evidence file under `research/abap-types/types/` and the `tests/unit/handlers/slash-type-map.test.ts` guard passes
+- [ ] Manually invoke `/explain-abap-code` on a real FUGR via Claude Code — verify the explanation covers all four artifact classes
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/research/joule-2026-roadmap-feature-assessment.md
+++ b/docs/research/joule-2026-roadmap-feature-assessment.md
@@ -1,0 +1,786 @@
+# Joule for Developers 2026 Roadmap — Per-Feature ARC-1 Implementation Assessment
+
+> **Scope:** SAP's 8 announced Joule for Developers / ABAP AI roadmap features (release windows 2608/2611/2702/2027) and the upcoming **MCP Tool for ABAP Object Search**.
+> **Question:** For each, can ARC-1 deliver the same capability today? If not, what is the cheapest path — ARC-1 code change, a Claude skill, a sister MCP server, or "wait for SAP"?
+> **Method:** Code audit of `src/handlers/intent.ts`, `src/adt/*`, and `src/aff/schemas/*`; web research across SAP Help + SAP Community + Sapphire 2026 sessions; GitHub code search for ADT REST endpoints (`marcellourbani/abap-adt-api`, `abapify/adt-cli`, `SAP/open-ux-tools`); cross-reference with prior research in [`compare/J4D/01-joule-for-developers.md`](../../compare/J4D/01-joule-for-developers.md) and [`compare/J4D/02-sap-abap-mcp-server-vscode.md`](../../compare/J4D/02-sap-abap-mcp-server-vscode.md).
+> **Date:** 2026-05-13.
+
+---
+
+## TL;DR
+
+| # | Roadmap feature | ARC-1 today | Cheapest path to parity | Effort |
+|---|----------------|-------------|-------------------------|--------|
+| 1 | CDS Analytical Query Generation | DDLS read/write works; no analytical scaffold | New skill `generate-cds-analytical-query` + AFF-validated DDLS templates | **S** (skill only) |
+| 2 | Semi-automated Clean-Core ATC Fixes | `SAPDiagnose(quickfix/apply_quickfix)` already wraps `/sap/bc/adt/quickfixes/evaluation` (verified live a4h 2026-04-14); skills `sap-clean-core-atc` + `migrate-custom-code` exist | Polish existing skills; add ATC-finding → quickfix correlation helper | **XS** (already shipped) |
+| 3 | CDS Analytical Model Generation (basic — cube + existing dims from RAP BO) | DDLS create works; no cube scaffold | New skill `generate-analytics-star-schema` (already proposed in J4D compare matrix) | **S** (skill only) |
+| 4 | CDS Analytical Model Generation (extended — cube + new dims from RAP BO **or** DDIC tables) | Same as #3; TABL read works | Same skill, broader templates | **S** (skill only) |
+| 5 | Extensibility Assistant (custom field, BAdI, value help) | ENHO read works; no append-structure scaffold or BAdI impl-class stub generator | New skill `extensibility-assistant` + small ARC-1 code: APPEND structure subtype on `TABL`, BAdI impl-class scaffold | **M** (skill + code) |
+| 6 | RAP Model-Driven Joule Integration | SRVB read works; OData V4 publish works | Cannot replicate — this is Joule runtime exposing RAP BOs to *Joule's agentic engine*. Different problem domain. | **N/A** (out of scope) |
+| 7 | AI Explain for Function Groups | FUGR source read works; `expand_includes` already follows explicit `INCLUDE` statements; **no FUNC sub-module walk, no dynpro read, no GUI status read** | Extend existing `explain-abap-code` skill **+** small ARC-1 code: widen FUGR `expand_includes` to cover FUNC sub-modules, plus new dynpro and GUI status readers | **M** (skill + small code) |
+| 8 | AI Explain for Behavior Definitions | BDEF source + bound CLAS read works | Extend existing `explain-abap-code` skill; no ARC-1 code needed | **XS** (skill only) |
+| 9 | MCP Tool for ABAP Object Search | `SAPSearch(quick_search\|tadir_lookup)` + `SAPRead(WHERE_USED)` already cover the announced surface | None — already shipped (and arrived 6 months before SAP's 2611/2702 GA) | **0** (done) |
+
+**Net:** 7 of 9 features are reachable via skill-only changes; 1 needs minor ARC-1 code (FUGR include traversal); 1 needs both (Extensibility Assistant); 1 is genuinely out of scope (RAP→Joule agentic runtime).
+
+---
+
+## Methodology & Assumptions
+
+**What Joule actually does at the wire level.** SAP Joule for Developers does *not* expose a public `/sap/bc/adt/abapaiexplain/` or `/sap/bc/adt/joule/` REST endpoint. Aggressive GitHub-code search across `marcellourbani/abap-adt-api`, `abapify/adt-cli`, `SAP/open-ux-tools`, `kennyhml/abap-language-server`, and `The-Nefarious-Developer/zjoule` returned zero hits for `abapaiservices`, `abapaiexplain`, `joulechat`, or `com.sap.adt.aiservices`. The published [SAP Help: Joule for Developers, ABAP AI capabilities](https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide/joule-for-developers-abap-ai-capabilities) and the [BTP ABAP setup guide](https://community.sap.com/t5/technology-blog-posts-by-sap/joule-for-developers-with-sap-btp-abap-environment-setup-guide/ba-p/14207462) describe a different architecture: the Eclipse ADT plugin (`com.sap.adt.tools.abapcloud.joule.*`, closed source) gathers IDE context locally, then forwards the prompt + context to **SAP AI Core (GenAI Hub)** on BTP through a destination of type `AIC_ADT_HTTP_PROXY` registered via `APPLDESTCC`. Authorisation gate on the ABAP side: business role catalog `SAP_A4C_BC_DEV_AIQ_PC` + auth object `S_AIQADTLO` with `AIQ_TYPE ∈ {JADC_CODE, JADC_TEXT}` and `ACTVT=AF`.
+
+**Implication.** The "AI" in Joule is BTP-side. The half that is reachable from ABAP is **context aggregation + write-back** — exactly the half ARC-1 already automates via `SAPRead`, `SAPContext`, `SAPWrite`, `SAPActivate`, `SAPDiagnose`. Replacing Joule's LLM with the user's LLM (Claude / GPT-4 / Gemini) over MCP requires zero new ABAP-side endpoints. The model behind J4D is **SAP-ABAP-1** ([AI Core docs](https://help.sap.com/docs/AI_CORE/b9f48eb4a993445b863a55dd4d38f64d/d1972706d69a46acb01873ebe0c54689.html)) — a closed model, but exposed via the GenAI Hub Orchestration service, so any MCP client backed by an LLM can match its outputs once given equivalent context.
+
+**SAP's own MCP server is IDE-embedded, not customer-hosted.** Per the [Sapphire 2026 announcement](https://community.sap.com/t5/technology-blog-posts-by-sap/entering-the-new-era-of-agentic-ai-for-abap-development/ba-p/14394643) and session [BTP2573](https://www.sap.com/events/sapphire/orlando/flow/sap/so26/catalog/page/catalog/session/1774374412394001bVsg), the ABAP MCP Server **ships as part of the VS Code extension and Eclipse plugin**. There is no documented BTP-hosted MCP gateway. Auth = whatever the developer already configured for their ADT session (basic / BTP service-key OAuth / SSO). ARC-1's central XSUAA + per-user principal propagation + BTP audit log is the enterprise-hosted alternative SAP does **not** ship.
+
+---
+
+## 1. CDS Analytical Query Generation powered by AI
+
+> *"With the AI-based generation tooling a developer is able to generate analytical CDS projection views on top of existing analytical models to optimize their running business processes."*
+> **Releases:** BTP ABAP 2608 · S/4HANA Cloud Public 2608 · S/4HANA Cloud Private 2027
+
+### What SAP is actually building
+
+A wizard inside Eclipse ADT (sister to the existing [Star Schema Generator](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/b8b846ac2bd84ee4ba8c895b74270bd8.html)) that generates `DEFINE TRANSIENT VIEW ENTITY ... AS PROJECTION ON <analytical-cube> PROVIDER CONTRACT ANALYTICAL_QUERY` ([ABAP Keyword Docu](https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENCDS_ANALYTICAL_QUERY_APV.html)). Requires SAP_BASIS 7.58+ per the [ABAP Feature Matrix](https://software-heroes.com/en/abap-feature-matrix). Embedded analytics consumption only — these are *transient* views, no DB view is created.
+
+### ARC-1 today
+
+| Primitive | Status | File:Line |
+|-----------|--------|-----------|
+| Read existing analytical CDS (cube) | ✅ | `src/handlers/intent.ts` SAPRead type=DDLS; `src/adt/client.ts` `getDdls()` |
+| Search for analytical cubes | ✅ | `src/handlers/intent.ts` SAPSearch quick_search + tadir_lookup |
+| Create new DDLS | ✅ | `src/handlers/intent.ts` SAPWrite create with DDLS; AFF schema `src/aff/schemas/ddls-v1.json` |
+| Activate | ✅ | `SAPActivate` |
+| Annotation-specific scaffold (`@Analytics.query: true`, `@Consumption.valueHelpDefault`, measure aggregation) | ❌ | Not present in any template |
+
+### Gap and fix
+
+The capability gap is purely in the *prompt and template library* an LLM needs to generate a valid analytical query view. ARC-1's primitives are sufficient.
+
+**Recommended path:** new skill `generate-cds-analytical-query`. The skill should:
+1. `SAPSearch` for analytical models in the user's project scope (filter on `@Analytics.dataCategory: #CUBE`).
+2. `SAPRead` the chosen cube + its dimension associations.
+3. Prompt the LLM with the cube source + the analytical-query template surface ([SAP Help: Analytical Query Views](https://help.sap.com/docs/ABAP_Cloud/...) — exact link to be added once skill is authored).
+4. `SAPWrite(create)` the new DDLS, then `SAPActivate`.
+
+No ARC-1 code change needed. Effort: **~1 day** for the skill.
+
+---
+
+## 2. Semi-Automated Fixes of Clean Core ATC Findings
+
+> *"...generate code proposals to fix Clean Core related ATC findings via the ADT Joule Chat. One example is the migration of SQL statements on SAP database tables towards released SAP CDS views."*
+> **Release:** S/4HANA Cloud Private 2027 (only)
+
+### What SAP is actually building
+
+The developer-facing edition of the broader [Mass S/4 Custom Code Conversion Agent](https://community.sap.com/t5/technology-blog-posts-by-sap/entering-the-new-era-of-agentic-ai-for-abap-development/ba-p/14394643) (Q2 2026, separate). Joule reads an ATC finding (typically a `CHECK_RULE_ID` from the [SAP_CP_CCM_TRANSITION_S4_2025_CLOUD ATC variant](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-test-cockpit-atc-recommendations-for-governance-of-clean-core-abap/ba-p/14186130)), proposes a code transformation, and applies it via the standard ADT quickfix machinery.
+
+### ARC-1 today — already shipped
+
+This feature is **already implemented end-to-end** in ARC-1, verified against a live SAP A4H system on 2026-04-14 ([`docs/plans/completed/fix-proposals-auto-fix-from-atc.md`](../plans/completed/fix-proposals-auto-fix-from-atc.md)):
+
+| Primitive | Endpoint | ARC-1 wrapper |
+|-----------|----------|---------------|
+| Run ATC | `/sap/bc/adt/atc/runs` (POST) | `runAtcCheck()` in `src/adt/devtools.ts:551` |
+| Per-finding fix proposals | `/sap/bc/adt/quickfixes/evaluation` (POST) — query `uri=<src_uri>#start=<line>,<col>` (URL-encoded); body raw source; response root `<qf:evaluationResults>` with `<adtcore:objectReference>` + `<userContent>` blocks | `getFixProposals()` in `src/adt/devtools.ts:593` |
+| Apply proposal | POST proposal URI with `<quickfixes:proposalRequest>` body (source + opaque `<userContent>`); response = ranged delta replacements | `applyFixProposal()` in `src/adt/devtools.ts:621` |
+| Batch auto-quickfix worklist | `/sap/bc/adt/atc/autoqf/worklist` (backed by `CL_SATC_ADT_RES_AUTOQUICKFIX`) | Not yet wired |
+| Re-run ATC after fix | (same as Run ATC) | ✅ |
+
+**Skills already exist:** [`skills/sap-clean-core-atc/SKILL.md`](../../skills/sap-clean-core-atc/SKILL.md), [`skills/migrate-custom-code/SKILL.md`](../../skills/migrate-custom-code/SKILL.md).
+
+### Gap
+
+Only one minor capability is missing: the **batch auto-quickfix worklist** endpoint (`/sap/bc/adt/atc/autoqf/worklist`) is not wrapped yet. Findings carry `<atcfinding:quickfixes manual="..." automatic="..." pseudo="..."/>` attributes that flag which are machine-applicable; ARC-1 could expose a one-shot "fix everything automatic on this package" operation. This is a **6-month lead** over SAP's 2027 GA on S/4HANA Cloud Private. Worth doing as an `SAPDiagnose action=batch_quickfix` follow-up — separate one-page plan, modest effort.
+
+---
+
+## 3 & 4. CDS Analytical Model Generation (Basic + Extended)
+
+> *Basic:* generates **cube + identifies existing dimensions** from a RAP BO.
+> *Extended:* also generates **new dimensions**, accepts **DDIC tables** as input (not just RAP BO).
+> **Releases:** Basic — S/4HANA Cloud Private 2027 only. Extended — BTP ABAP 2608 / S/4HANA Cloud Public 2608 / S/4HANA Cloud Private 2027.
+
+### What SAP is actually building
+
+AI-enhanced wrapper around the existing [CDS Analytical Model generator / Star Schema Generator](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/b8b846ac2bd84ee4ba8c895b74270bd8.html). Outputs:
+- One cube view (`@Analytics.dataCategory: #CUBE`) with measures
+- N dimension views (`@Analytics.dataCategory: #DIMENSION`) and text views (`#TEXT`)
+- Foreign-key associations between cube and dimensions
+- For RAP-BO input, the field semantics (amount, currency, quantity, unit) are inferred from the BO; for DDIC input the LLM has to guess from data-element semantics.
+
+### ARC-1 today
+
+| Primitive | Status | Comment |
+|-----------|--------|---------|
+| Read RAP BO root entity | ✅ | `getRapRootEntityRef()` in `src/adt/rap-generate.ts:200` (parsed from `<class:rootEntityRef>` on behavior pool class metadata) |
+| Read DDIC table | ✅ | SAPRead type=TABL (covers `/tables/` and `/structures/` with auto-fallback) |
+| Batch create DDLS objects with terminal activation | ✅ | SAPWrite `batch_create` with `activateAtEnd:true` (PR 270 in CLAUDE.md) — pure model is *exactly* the multi-object cube+dimensions+text scenario |
+| Field semantics inference (currency/quantity/unit detection) | ⚠️ | LLM job; ARC-1 just supplies the table/BO metadata |
+| Cube/dimension/text DDLS templates | ❌ | Not authored |
+
+### Gap and fix
+
+**Recommended path:** new skill `generate-analytics-star-schema` (already on the J4D compare matrix as "to create"). The skill:
+1. Discover input: RAP BO via class metadata, or DDIC table via SAPRead.
+2. Read all candidate dimensions (associated entities or texts views in scope).
+3. Generate cube DDLS + dimension DDLS + text DDLS (LLM uses templates the skill ships).
+4. `SAPWrite(batch_create, activateAtEnd: true)` — one terminal activate resolves all cross-references in a single pass.
+
+The existing batch_create+activateAtEnd mechanism makes the orchestration almost trivial — that PR was effectively pre-emptive plumbing for exactly this kind of multi-object scaffold. Effort: **~2-3 days** for the skill (most of the work is template authoring + few-shot examples). No ARC-1 code change.
+
+---
+
+## 5. Extensibility Assistant
+
+> *"...find the right extension option (e.g. custom field, BAdI) in the SAP applications and to create it."*
+> **Release:** S/4HANA Cloud Private 2027 (already GA on S/4HANA Cloud Public Edition for *key users*, per [J4D What's New](https://help.sap.com/docs/ABAP_AI/7b88d647742f4cdb82dadebf3b8481ed/bfbab3f3e8a84fa29b2b6e798c8fd1e7.html))
+
+### What SAP is actually building
+
+A Joule chat surface *inside the S/4HANA Cloud UI* (Key User Extensibility apps), not inside ADT — this is the only one of the eight that targets functional/key users rather than ABAP developers in Eclipse. Capabilities (per [SAP YouTube demo](https://www.youtube.com/watch?v=RyAaBBKILUg)): creating custom fields, finding business contexts, finding value-help views, enabling business scenarios, finding the right BAdI.
+
+### ARC-1 today
+
+| Primitive | Status | Comment |
+|-----------|--------|---------|
+| Search BAdIs / enhancement spots | ✅ | SAPSearch tadir_lookup with R3TR filter; ENHO/ENHS searchable |
+| Read enhancement implementation | ✅ | SAPRead type=ENHO; `parseEnhancementImplementation()` in `src/adt/xml-parser.ts:639` |
+| Read TABL metadata | ✅ | SAPRead type=TABL |
+| Create custom CDS view | ✅ | SAPWrite type=DDLS |
+| Append-structure (TABL subtype) scaffold | ❌ | No append-specific schema; current AFF TABL schema covers base tables/structures, not appends |
+| BAdI implementation class stub | ❌ | No `SAPWrite action=scaffold_badi_impl` |
+| Business-context / Custom-Object UI discovery (Key User Extensibility framework REST endpoints) | ❌ | None of the Key User Extensibility OData services are wrapped |
+
+### Gap and fix
+
+This is the only roadmap feature where the user-facing surface is **outside ADT** (Key User Extensibility = S/4 Cloud UI). Most "key user" actions go through OData services like `/sap/opu/odata/sap/SCFD_REGISTRY` (custom fields), `/sap/opu/odata/SAP/CTX_BUSINESS_CONTEXT` (business contexts), and `/sap/opu/odata/sap/UI_FACETED_SEARCH` (value helps) — none of which are ADT REST endpoints.
+
+**Recommended path — two-track:**
+
+1. **Skill `extensibility-assistant`** for the developer flow (BAdI search/scaffold, append-structure scaffold via DDIC). Effort: ~2 days.
+2. **ARC-1 code change** for the *append structure* TABL subtype: the AFF TABL schema needs an `appendOf` field; `src/adt/ddic-xml.ts` needs the corresponding XML emitter; `src/adt/crud.ts` needs the create path. Effort: ~1-2 days, mirroring the existing TABL/DTEL pattern.
+3. **BAdI implementation scaffold** could be a new `SAPWrite action=scaffold_badi_impl` (parallels the existing `scaffold_rap_handlers` in `src/adt/rap-handlers.ts`). It would take a `BADI_DEF` name + implementation class name, read the BADI definition's interface, and emit a CLAS stub implementing that interface. Effort: ~3 days.
+4. **Key User Extensibility OData** — out of scope unless the user owns S/4 Cloud Public. Defer.
+
+---
+
+## 6. RAP Model-Driven Joule Integration
+
+> *"...expose the business capabilities built with the ABAP RESTful Application Programming Model (RAP) to the agentic runtime of Joule."*
+> **Releases:** BTP ABAP 2608 / S/4HANA Cloud Public 2608 / S/4HANA Cloud Private 2027
+
+### What SAP is actually building
+
+A *runtime* feature, not an IDE feature. At request time, Joule's agentic engine (in the Joule app, Joule Studio, or SAP Build agents) calls RAP-exposed business operations directly — i.e., RAP BOs become first-class Joule "skills". Likely mechanism: a Joule-side adapter consumes RAP service-binding metadata (the same metadata that drives `/sap/opu/odata4/...` V4 services) and surfaces CRUD + actions as agent tools. Today's predecessors are [Custom Joule Skills via RFC](https://community.sap.com/t5/technology-blog-posts-by-sap/building-custom-joule-skills-via-rfc-guide-for-sap-s-4hana-and-ecc/ba-p/14363568) and the [Joule custom MCP architecture POC](https://community.sap.com/t5/technology-blog-posts-by-sap/connecting-custom-joule-agents-to-mcp-servers-a-poc-architecture-for/ba-p/14356644).
+
+### ARC-1's role
+
+**Out of scope as a direct competitor.** This is Joule consuming RAP runtime, not ARC-1 doing development work. ARC-1 *helps build* the RAP BOs that #6 then exposes. Two adjacent points worth noting:
+
+1. **Joule Studio can already attach to remote MCP servers** ([Joule Studio docs](https://help.sap.com/docs/joule), [ARC-1 + Joule Studio blog](https://blog.zeis.de/posts/2026-05-08-arc-1-joule-studio-clean-core/)) — destination type Streamable HTTP, no interactive OAuth. ARC-1 *itself* can already plug into Joule Studio as a generic tool layer; this is a deployment-pattern win, not a feature competition.
+2. **Joule will know how to call RAP BOs natively** — meaning fewer human-written "skills" need to wrap RAP operations. ARC-1's overlap is essentially zero here; we don't compete with Joule's runtime engine.
+
+**Recommendation:** monitor the SAP/SAP-samples repos for the wire format Joule uses when consuming RAP service bindings as agentic tools; document any reusable metadata reading paths in `compare/J4D/` once SAP publishes the format. No ARC-1 code change.
+
+---
+
+## 7. ABAP AI Explain for Function Groups
+
+> *"...explanations of the flow logic, business purpose, and screen flow of function groups."*
+> **Releases:** BTP ABAP 2608 / S/4HANA Cloud Public 2608 / S/4HANA Cloud Private 2027
+
+### What SAP is actually building
+
+Extension of the existing AI Explain (currently for reports/classes/dynpros) to FUGR. The high-value bit is "screen flow" — most legacy logic lives in FMs + SAPGUI dynpros, and explaining a function group requires walking the include tree: top FUGR include → all FUNC includes → all dynpros (SCRP) → flow logic (PBO/PAI modules) → GUI status (MENU + function codes).
+
+### ARC-1 today
+
+| Primitive | Status | File:Line |
+|-----------|--------|-----------|
+| FUGR source read (top include) | ✅ | SAPRead type=FUGR / FUNC; `getFunctionGroup()` in `src/adt/client.ts` |
+| FUNC parameter-aware read | ✅ | `includeSignature=true` returns JSON `{source, signature: {importing, exporting, ...}}` (issue #252) |
+| `expand_includes` for FUGR (partial) | ⚠️ | Implemented at `src/handlers/intent.ts:1505` — regex-matches explicit `INCLUDE` statements only; does not enumerate FUNC sub-modules, dynpros, or GUI statuses |
+| Dynpro / SCRP read | ❌ | Not exposed as a SAPRead type |
+| GUI status / menu read | ❌ | Not exposed |
+| FUGR object graph traversal | ❌ | No helper "list all artifacts in this FUGR" |
+
+### Gap and fix
+
+Along with Feature 5 (Extensibility Assistant), this is one of two roadmap items that needs ARC-1 code changes — and the one with the most read-side surface (three new artifact types to support):
+
+1. **Extend `expand_includes` for FUGR** to walk FUNC sub-modules (under `/sap/bc/adt/functions/groups/<name>/fmodules/`) in addition to the explicit `INCLUDE` statements it already follows. The current loop lives at `src/handlers/intent.ts:1505-1526`; extend in place. Effort: ~1 day.
+2. **Add Dynpro/SCRP read** as a new SAPRead type — `/sap/bc/adt/programs/programs/<prog>/dynpros/<dynnr>`. Effort: ~1 day, follows existing read patterns.
+3. **Add GUI status read** — `/sap/bc/adt/programs/programs/<prog>/cuastatus/<status>`. Effort: ~1 day.
+4. **Skill `explain-abap-code` already exists** ([`skills/explain-abap-code/SKILL.md`](../../skills/explain-abap-code/SKILL.md)) — extend it to accept FUGR and pull the expanded artifact bundle.
+
+Combined effort: **~3-4 days** of ARC-1 code + ~half-day of skill extension. The skill already exists, so the marginal cost is mostly the new readers.
+
+**Wire-level reference for SCRP/CUA:** the Eclipse ADT REST surface for dynpros and CUA status is sparsely documented but covered in `marcellourbani/abap-adt-api`. Use those as the wire-format reference rather than reverse-engineering from Eclipse plugin bytecode.
+
+---
+
+## 8. ABAP AI Explain for Behavior Definitions
+
+> *"...explanations of the business purpose, business logic, and dependencies associated with behavior definitions."*
+> **Releases:** BTP ABAP 2611 / S/4HANA Cloud Public 2702 / S/4HANA Cloud Private 2027
+
+### What SAP is actually building
+
+The RAP-native equivalent of #7 — instead of digesting a function group's flow logic, the model summarises a BDEF's CRUD/action graph, determinations, validations, side effects, and authorization scopes. Behavior definitions are an ABAP RAP construct (SAP_BASIS 7.53+, per [ABAP Feature Matrix](https://software-heroes.com/en/abap-feature-matrix)).
+
+### ARC-1 today — ready to go
+
+| Primitive | Status | File:Line |
+|-----------|--------|-----------|
+| BDEF source read | ✅ | SAPRead type=BDEF |
+| Bound CLAS discovery (BDEF → behavior pool class) | ✅ | Manual parse of `implementation in class` in BDEF source; OR via `<class:rootEntityRef>` on class metadata (`src/adt/rap-generate.ts:200`) |
+| CLAS read (handler class with determinations/validations) | ✅ | SAPRead type=CLAS, method-level surgery available |
+| RAP preflight (deterministic rules: TABL/BDEF/DDLX/DDLS) | ✅ | `src/adt/rap-preflight.ts` — gives the LLM structured "what is wrong / what is wired" signal |
+| Where-used to find consumers | ✅ | SAPRead WHERE_USED + cds-impact classifier (`src/adt/cds-impact.ts`) |
+
+### Gap and fix
+
+No primitives missing. The `explain-abap-code` skill can be extended trivially. Effort: **~half a day** (just add BDEF-specific prompt templates that walk: BDEF source → root CDS → bound CLAS → key handler methods).
+
+---
+
+## 9. MCP Tool for ABAP Object Search
+
+> *"You can now use an MCP tool to find ABAP development objects based on various search criteria, similar to the Ctrl + Shift + A search, as well as reference searches."*
+> **Releases:** BTP ABAP 2611 / S/4HANA Cloud Public 2702 / S/4HANA Cloud Private 2027
+
+### What SAP is actually shipping — critical
+
+This is the public-facing slice of SAP's broader **ABAP MCP Server** (GA Q2 2026 per [Sonja Liénard's Sapphire blog](https://community.sap.com/t5/technology-blog-posts-by-sap/entering-the-new-era-of-agentic-ai-for-abap-development/ba-p/14394643) and [Introducing the Next Era of ABAP Development](https://community.sap.com/t5/technology-blog-posts-by-sap/introducing-the-next-era-of-abap-development/ba-p/14260522)). Hosting model — **IDE-embedded local stdio MCP**, not customer-hosted:
+- SAP's MCP server ships inside Eclipse ADT and ADT for VS Code (`mcp.json` configuration, same pattern as [CAP/UI5/Fiori Elements MCP servers](https://community.sap.com/t5/technology-blog-posts-by-members/accelerating-sap-fiori-amp-cap-development-with-sap-mcp-server-github/ba-p/14391413)).
+- Agents connect to a *local* MCP endpoint exposed by the IDE plugin.
+- Auth = whatever the developer's ADT session uses (basic / BTP service-key OAuth / SSO ticket). **No XSUAA scope model published, no central audit log, no central deny-list.**
+- Initial scope = Fiori service development. The "object search" tool extends this in Q4 2026 / Q1 2027.
+- Multi-client by design: SAP names GitHub Copilot, Amazon Q, OpenAI, Anthropic, Google, IBM, Mistral as compatible.
+
+The "object search" feature itself is **already shipped in ARC-1**:
+
+| Required capability | Eclipse Ctrl+Shift+A surface | ARC-1 wrapper |
+|---------------------|------------------------------|---------------|
+| Free-text object search (name + short text) | `/sap/bc/adt/repository/informationsystem/search` | `SAPSearch action=quick_search` (`src/handlers/intent.ts`) |
+| Type-filtered search (DDLS, CLAS, FUGR, ...) | same endpoint, `objectType=` param | `SAPSearch objectType=...` |
+| TADIR lookup by name (canonical) | + `/sap/opu/odata/...` direct DB read | `SAPSearch tadir_lookup source=adt\|db\|both` (PR 270 — `db` and `both` escalate to SQL scope so viewer profiles can't piggyback) |
+| Where-used / reference search | `/sap/bc/adt/repository/informationsystem/usageReferences` | `SAPRead WHERE_USED`; `findReferences()` in `src/adt/codeintel.ts:101` |
+
+### Strategic posture
+
+ARC-1 has a **6+ month lead** on SAP's 2611/2702 GA, and the *deployment model* is fundamentally different:
+
+| | SAP ABAP MCP Server | ARC-1 |
+|--|--------------------|-------|
+| Hosting | IDE-local (per-developer) | Centrally hosted on BTP CF / Docker / npm |
+| Auth | Inherited from IDE/ADT session | XSUAA + per-user principal propagation + API key |
+| Audit | Implicit (IDE-side) | Central, BTP Audit Log Service sink + file/stderr sinks |
+| Safety ceiling | Not published | Per-instance `allowWrites`, package allowlist, deny-actions, scope intersection |
+| Multi-client | Yes (LLM-agnostic, IDE-embedded) | Yes (LLM-agnostic, transport-agnostic — Claude Desktop, Copilot Studio, Joule Studio, Cursor, VS Code Copilot, Gemini CLI) |
+| Cross-system | One IDE instance per system | One ARC-1 deployment can serve many users against one (or many) SAP backends |
+| On-premise reach | Same ADT REST surface ⇒ same reach for non-AI ops; AI features tied to BTP AI Core | Any system with ADT (incl. ECC 7.4+) — no AI-feature gating |
+
+ARC-1's enduring differentiation is **shared multi-tenant agentic flows** (Copilot Studio agents, Joule Studio agents on BTP, multi-user team setups) — a category SAP's local-IDE-bound model does not address. No ARC-1 code change needed for #9.
+
+---
+
+## Eclipse ADT Internals — What Cannot Be Replicated by Wire Re-implementation
+
+A cross-cutting finding from the wire-level research: **the "AI" half of every Joule feature is not at an ADT endpoint**. There is no `/sap/bc/adt/abapai*` collection. All AI work happens on the BTP-side AI Core (GenAI Hub) routed through the `AIC_ADT_HTTP_PROXY` destination set up in `APPLDESTCC`. The Eclipse plugin aggregates IDE context locally and posts the prompt + context to AI Core.
+
+**Consequence for ARC-1.** We can't reach into SAP-ABAP-1 the same way Joule does (it is not exposed as a customer endpoint for the IDE feature; only via the separate GenAI Hub Orchestration API). What we *can* do — and what ARC-1 already does — is **be a richer context aggregator than Joule** via `SAPRead` + `SAPContext` + `SAPDiagnose` + `SAPLint` (pre-write hints) + `mcp-sap-docs` retrieval. The user's LLM-of-choice then replaces SAP-ABAP-1.
+
+The empirical evidence is the open-source [zjoule plugin](https://github.com/The-Nefarious-Developer/zjoule) — an Eclipse plugin that bypasses Joule entirely and talks directly to AI Core / OpenAI / Ollama. Its source confirms that **the value-add of Joule is context aggregation + UX**, not a privileged backend endpoint. The MCP-server equivalent (ARC-1) just moves that aggregation to a tool surface a generic LLM client can call.
+
+---
+
+## SAP's Official Stack — GA State as of June 2026
+
+SAP shipped both the ABAP Language Server (ADT-LS) and the ABAP MCP Server bundled inside one VS Code extension on **2026-05-29**, four days before Sapphire 2026. The picture is now concrete instead of speculative — and meaningfully *narrower* than the pre-GA roadmap suggested. Key verified facts (see [`compare/J4D/02-sap-abap-mcp-server-vscode.md`](../../compare/J4D/02-sap-abap-mcp-server-vscode.md) for the historical baseline that this updates):
+
+### Distribution
+
+- **One VSIX, two components.** `SAPSE.adt-vscode` v1.0.0 on the VS Code Marketplace (~7,125 installs by 2026-06-02, 2.47/5 average rating). Inside: TypeScript shell over a Java Language Server (`com.sap.adt.ls_1.0.0` + sibling JARs). The ABAP MCP Server lives in `com.sap.adt.mcp.core_3.58.1.jar` and runs inside the same JVM as the LS.
+- **Same JAR also ships in Eclipse ADT** (`tools.hana.ondemand.com/latest`) — SAP confirmed in the [GA FAQ Q2](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-your-questions-answered/ba-p/14400848) that VS Code and Eclipse offer the same MCP tool set.
+- **No standalone, no npm, no Docker, no separate VSIX.** The MCP server "only runs while Visual Studio Code is running" ([FAQ Q13](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-your-questions-answered/ba-p/14400848)). Standalone release is "under discussion" — no date.
+- **Closed source.** SAP says it would "like to pursue [open-sourcing] in the future" but has not committed. SAP Developer License v3.2 explicitly forbids third-party redistribution of "APIs, Tools or Software" — embedding the LS in ARC-1 is **not** legally available without an OEM deal.
+
+### Transport, auth, reach
+
+- **HTTP on `localhost:2236`** with a per-start Bearer token (settings key `adt.mcpServer.token`). Off by default (`adt.mcpServer.enabled: false`, tagged `experimental`). No stdio, no SSE, no Streamable-HTTP. A `DNSRebindingProtectionFilter` is the only network hardening.
+- **MCP-server → ABAP** uses the same `/sap/bc/adt/*` REST surface ARC-1 calls. No new backend endpoints introduced. Destination management lives in VS Code workspace config (`adt-vscode.openDestinationsJson`), **not** in `~/.adtls/destinations.json` (that file was pre-GA preview only).
+- **System reach.** Backend works on NW 7.3 EHP1 SP04+ — but every MCP tool except `abap_list_destinations` requires the ABAP Cloud Generator, which is **only on BTP ABAP / S/4HANA Cloud Public / S/4HANA Cloud Private 2021+**. On NW 7.x and classic ECC the tool set is effectively dead.
+- **Multi-client status.** Only **GitHub Copilot** reliably auto-discovers the server via VS Code 1.105+ `mcpServerDefinitionProviders` ("zero-config MCP"). Community testing reports Claude Code "did not recognize the virtual file system" and Codex "did not find any files/objects" against the SAP MCP — `http://localhost:2236/mcp` requires manual configuration plus token retrieval.
+
+### Tool surface at GA (14 tools, extracted from the actual JAR constant pool)
+
+| Family | Tools | What they do |
+|--------|-------|--------------|
+| Destinations | `abap_list_destinations` | List configured ABAP system destinations |
+| Activation + test | `abap_activate_objects`, `abap_run_unit_tests` | Activate; run ABAP Unit |
+| Create (4-step chain) | `abap_creation-get_all_creatable_objects`, `abap_creation-get_object_type_details`, `abap_creation-run_validation`, `abap_creation-create_object` | Blank-slate create of supported types — 4 round-trips per object |
+| Business services | `abap_business_services-fetch_services`, `abap_business_services-fetch_service_information` | Read SRVB services + OData $metadata |
+| RAP generators | `abap_generators-list_generators`, `abap_generators-get_schema`, `abap_generators-generate_objects` | Scaffold RAP via server-side `cl_abap_generator_*` |
+| Transports | `abap_transport-get`, `abap_transport-create` | Find / create CTS request |
+
+**What's missing at GA — confirmed by SAP's GA blog and the community ["Unboxing"](https://community.sap.com/t5/abap-blog-posts/unboxing-sap-abap-tools-for-vs-code-mcp-a-small-announcement/ba-p/14408635) review:** no source read, no source update, no object search, no syntax check, no ATC, no find-references / where-used, no SQL, no runtime diagnostics, no git/abapGit/gCTS, no FLP/UI5 repository tools. *"You can't read source code. You cannot search for objects. You cannot update objects… these are pretty significant gaps."* SAP roadmap teaser: ATC + transport unified diff in "the next release" — no firm date.
+
+### Legal / API-Policy posture
+
+- **API Policy v.4.2026a §1.2** explicitly authorises "custom-developed ABAP interfaces in private cloud and on-premise" — covers ARC-1's `/sap/bc/adt/*` use the same way it covers `marcellourbani/vscode_abap_remote_fs` and Eclipse ADT.
+- **§2.2.2 introduces an "agentic AI" clause** prohibiting non-endorsed pathways for "(semi-)autonomous or generative AI systems that plan, select, or execute sequences of API calls." This is *new* and material — ARC-1 should document its position as a "customer-developed ABAP interface" with admin-controlled package/safety allowlists (which it already is), not as an unrestricted agentic gateway.
+- **§3 anti-circumvention** is a risk vector for any MCP server in general; ARC-1's safety ceiling + audit log + explicit deny-action grammar is the right defensive posture.
+
+### Implications for ARC-1 (read this as a delta to the earlier sections)
+
+1. **Tool-name collisions.** When both servers load in one Copilot/Claude session, four pairs overlap directly: `abap_activate_objects` ↔ `SAPActivate.activate`; `abap_transport-get|create` ↔ `SAPTransport.find|create`; `abap_business_services-*` ↔ `SAPRead(type=SRVB)`; `abap_run_unit_tests` ↔ `SAPDiagnose action=run_unit_tests`. Add a one-page "MCP coexistence" doc and consider an optional `arc1__` tool-name prefix.
+2. **The four genuinely new tools to consider adopting** (these are MCP capabilities SAP ships and ARC-1 does not): `abap_generators-list_generators`, `abap_generators-get_schema`, `abap_generators-generate_objects` (calls the server-side ABAP Cloud Generator — strictly Cloud-model object scaffolding), and `abap_business_services-fetch_service_information` (live OData $metadata read). Wrapping the generator endpoint `/sap/bc/adt/businessservices/generators` is already documented via `marcellourbani/abap-adt-api/src/api/rapgenerator.ts`. ~2-3 dev-days for all four.
+3. **The Eclipse ADT Internals section above is now superseded for the MCP-specific claim.** "There is no `/sap/bc/adt/abapai*` endpoint" remains true (AI runs on BTP AI Core), but "SAP has no MCP server" is no longer accurate — SAP has 14 tools today, and 0 of them touch the AI hub. The earlier "richer context aggregator than Joule" framing is still correct for AI features; the new framing for source/search/diagnostics is "ARC-1 covers what SAP's MCP doesn't, on systems SAP's MCP can't reach."
+4. **Don't pivot to a VS Code extension.** SAP confirmed Eclipse + VS Code are the only first-party hosts. Cursor / Theia / Neovim / CLI is where the long tail of MCP clients lives; ARC-1 is already positioned for that.
+5. **Don't try to embed the ADT-LS.** License blocks bundling; no standalone delivery date; JVM dependency would break ARC-1's pure-Node deployment; same backend surface anyway. Replicate where it makes sense, ignore the rest.
+
+### Big picture — per-feature, one statement each
+
+| # | Feature | Big-picture change for ARC-1 |
+|---|---------|------------------------------|
+| 1 | CDS Analytical Query | **Skill-only.** Author `generate-cds-analytical-query`; SAP's MCP doesn't ship this today. ARC-1 lands the capability first. |
+| 2 | Clean-Core ATC Fixes | **One tiny code add + skill polish.** Wrap `/sap/bc/adt/atc/autoqf/worklist` as `SAPDiagnose batch_quickfix`. SAP's MCP has **zero ATC tools** at GA — full ATC surface is a clean differentiation. |
+| 3 + 4 | CDS Analytical Model (basic + extended) | **Skill-only.** `batch_create activateAtEnd` infrastructure already shipped (PR 270). SAP's `abap_generators-*` family doesn't include analytical models at GA. |
+| 5 | Extensibility Assistant | **Most code-heavy ARC-1 work** (~850 LOC): add `TABL` AFF schema + APPEND-structure subtype + BAdI scaffold action. The on-prem / S/4 PCE customer segment SAP's solution cannot reach is exactly where this matters. |
+| 6 | RAP → Joule Runtime | **Out of scope.** This is Joule's agentic engine consuming RAP, not development tooling. ARC-1 already plugs into Joule Studio via Streamable HTTP. Monitor SAP for the consumption wire format. |
+| 7 | AI Explain for FUGR | **Three small read primitives** (~390 LOC): widen FUGR `expand_includes` to FUNC sub-modules, add Dynpro and CUA readers. SAP's MCP has no source-read tool at all — ARC-1 is the only practical FUGR-explain path even on the systems SAP supports. |
+| 8 | AI Explain for BDEF | **Skill-only.** All primitives ready (BDEF read + bound CLAS read + RAP preflight). Extend `explain-abap-code`. |
+| 9 | MCP Tool ABAP Object Search | **Already shipped + 6-month lead.** `SAPSearch` (quick_search + tadir_lookup) + `SAPRead WHERE_USED` cover the announced 2611/2702 surface. SAP's GA MCP doesn't have search at all — gap is wider than projected. |
+| ★ | (New) ABAP Cloud Generator wrapper | **Optional code add** (~2-3 days). Wrap `/sap/bc/adt/businessservices/generators` so ARC-1 can call the same server-side RAP scaffolder SAP's MCP exposes — keeps tool-surface parity for clients that load both servers. |
+
+---
+
+## SAP's Official ABAP MCP Server + `adt-ls` — Wire-Level Anatomy
+
+This section is grounded in a **decompile of `adt-ls` 1.0.0.202605281240** (the language server shipped inside `sapse.adt-vscode`) and our working sibling project [`arc-1-lsp`](https://github.com/marianfoo/arc-1-lsp), which already drives adt-ls headless. Authoritative references (live-verified against S/4HANA 2023 / kernel 7.58):
+
+- [`arc-1-lsp/docs/adt-ls-reference.md`](https://github.com/marianfoo/arc-1-lsp/blob/main/docs/adt-ls-reference.md) — capability matrix, URI model, lifecycle, gotchas
+- [`arc-1-lsp/docs/research/adt-ls-capability-map.md`](https://github.com/marianfoo/arc-1-lsp/blob/main/docs/research/adt-ls-capability-map.md) — decompiled-server inventory (23 `adtLs/*` segments, ~92 methods, all DTO shapes)
+- [`arc-1-lsp/docs/arc-1-feature-parity.md`](https://github.com/marianfoo/arc-1-lsp/blob/main/docs/arc-1-feature-parity.md) — ARC-1 vs arc-1-lsp per-tool comparison
+
+### Three surfaces inside adt-ls
+
+| Surface | What | Count |
+|---------|------|-------|
+| **Standard LSP** `textDocument/*` | go-to, references, hover, completion, symbols, type-hierarchy, diagnostics — the IDE-style code intel | 11 providers advertised |
+| **Custom `adtLs/*` JSON-RPC** | The real ADT surface: transport, activation, ATC, coverage, creation, srvb, run, debugger | **23 segments / ~92 methods** |
+| **Embedded MCP server** (`/mcp`) | Streamable-HTTP MCP endpoint adt-ls hosts on localhost — this IS "SAP's ABAP MCP Server" | **7 static + N dynamic tools** |
+
+### The embedded MCP server in detail
+
+Source: `com.sap.adt.mcp.core_3.58.1.jar` (34 classes). Architecture:
+
+- **Transport:** official `io.modelcontextprotocol` Java SDK; `HttpServletStreamableServerTransportProvider`; Streamable HTTP at `/mcp`; serverInfo `("ADT MCP Server", "1.0.0")`; Jetty bound to **localhost only**; 30-second request timeout.
+- **Auth:** `TokenAuthenticationFilter` requires `Authorization: Bearer <token>`. Token is auto-generated (`SecureRandom` 16 bytes Base64url) unless the LSP client supplies one, and returned over LSP in `AdtMcpServerInitializationInfo{port, token}`. `DNSRebindingProtectionFilter` allows only `Host: localhost|127.0.0.1`.
+- **Tool collection (`AdtMCPToolsRegistry.collectAllTools`):**
+  1. **7 static tools** registered via Eclipse extension point `com.sap.adt.mcp.core.adtMcpTools`:
+     `abap_activate_objects`, `abap_run_unit_tests`, `abap_creation-get_all_creatable_objects`, `abap_creation-get_object_type_details`, `abap_creation-run_validation`, `abap_creation-create_object`, plus the destinations-list tool.
+  2. **N dynamic tools** harvested via `AdtMCPToolsIdeActionCollector`: fetches the connected ABAP backend's IDE-Actions (AIA), filters those whose title starts with `MCP`, renames `mcp_` → `abap_`, and exposes each with backend-authored schema. **This means the MCP tool list is system-dependent and re-enumerated on every `setDestination`.** Example: `abap_transport-get` and `abap_transport-create` are NOT in `plugin.xml` — they are `MCP_TRANSPORT-*` AIA actions on the backend.
+
+### Critical implication: the AI half is NOT in adt-ls or its MCP
+
+`adtLs/joule/getJouleDestination` exists, but it merely returns *"the side-by-side Joule AI destination for the project"* — i.e., a routing pointer to BTP AI Core. **No `adtLs/aiExplain`, no `adtLs/chat`, no Joule-AI MCP tool.** The "AI Explain", "Generate analytical query", "Clean-core ATC fix" features all execute in the IDE plugin's **AI orchestration layer** *above* adt-ls; they post the IDE context (which adt-ls supplies via `readFile`/`hover`/`semanticTokens`/`atc/runCheck`) plus a prompt to SAP AI Core through the `AIC_ADT_HTTP_PROXY` destination. There is **no headless API to drive Joule's AI itself**.
+
+What this means: **the same context + a Claude/GPT-4 prompt = the same outcome.** The hard part is the context aggregation — and that's what ARC-1 (hand-rolled HTTP) and arc-1-lsp (via adt-ls) both already do.
+
+### The big boundary: object type coverage
+
+adt-ls's `objectCreation/getCreatableObjectTypes` enumerates **14 creatable types** (CLAS, INTF, DCLS, DRAS, BDEF, DRTY, CHDO, DDLS, DDLX, NROB, NONT, RONT, SRVB, SRVD). `readFile` only returns source for **modern ABAP-Cloud / RAP** types. **Classic types** (PROG, TABL, FUGR, FUNC, DOMA, DTEL, MSAG, TTYP, XSLT, SHLP, ENHO, …) return a `.jsonc` placeholder: *"not supported in ADT in VS Code. Please use ADT in Eclipse."*
+
+The decompile of the other ~80 `com.sap.adt.*_3.58.x` backend plugins confirms the classic-type support **exists at the backend** (`ddic.{domain,dataelement,table,structure,…}`, `programs`, `functions`, `messageclass`, `enho.model`, …) but is **deliberately not wired in the LS front-end**. SAP could expose it later (a watch-item); today it is **permanently ARC-1's domain**.
+
+### What's reachable for each Joule feature via adt-ls
+
+| Joule feature | adt-ls primitive | arc-1-lsp wiring status | Verdict |
+|---------------|------------------|-------------------------|---------|
+| 1. Analytical Query (DDLS) | `objectGenerator/generateObjects` could host an analytical-query generator if SAP ships one in `MCP_*` AIA; otherwise `objectCreation/create` + `writeFile` for raw DDLS | `generate_objects` ✅; raw create/write ✅ | adt-ls path is plausible *once SAP ships the generator*; raw DDLS write works today |
+| 2. ATC Clean-Core fixes | `atc/runCheck` returns findings, but `AtcRunFinding` has **NO quickfix/exemption data** — report-only. The quickfix endpoint `/sap/bc/adt/quickfixes/evaluation` is **NOT exposed via adt-ls**. | `run_atc` ✅; quickfix ❌ | **adt-ls cannot drive quickfixes — ARC-1's hand-rolled `getFixProposals`/`applyFixProposal` is the only path.** |
+| 3-4. Analytical Model | `objectGenerator/{fetchAllGenerators,getSchemaForObjectGeneration,getListOfObjectsToBeGenerated,generateObjects}` — a 4-step wizard backend-driven by the connected SAP system | `generate_objects` ✅ (1-shot); 4-step pipeline not wired | adt-ls **is** the cleanest path if S/4HANA backend exposes an analytical-model generator; ARC-1's `batch_create + activateAtEnd` is the hand-rolled equivalent |
+| 5. Extensibility Assistant | TABL APPEND structures and BAdI definitions are **classic types** — not in adt-ls's creatable set | ❌ (out of scope) | **adt-ls cannot do this. Only ARC-1 hand-rolled can.** |
+| 6. RAP→Joule runtime | `joule/getJouleDestination` (pointer) + `businessservice/srvb/publishandUnpublishAction` (makes the OData service Joule will consume go live) | `publish_service_binding` ✅ | Out of scope as a feature; both ARC-1 and arc-1-lsp already cover the build-side. The runtime side is Joule's. |
+| 7. AI Explain for FUGR | FUGR is **classic** — not in adt-ls's served types. `readFile` returns a `.jsonc` placeholder. | ❌ | **adt-ls cannot do this. Only ARC-1 hand-rolled can.** |
+| 8. AI Explain for BDEF | `readFile` ✅ + `hover` on BDEF (DDLS-style inline parse) + `textDocument/{definition,references,typeHierarchy}` for traversal | All wired ✅ | arc-1-lsp **is the cleaner path** today; ARC-1 has equivalent reads but no `hover` |
+| 9. MCP Object Search | `repository/quickSearch` ✅; `textDocument/references` for where-used ✅ | `search_objects` + `find_references` ✅ | Both ARC-1 (`SAPSearch`) and arc-1-lsp already implement this. SAP's Q4 2026 / Q1 2027 GA matches the existing surface. |
+
+### One refactoring gap worth flagging
+
+The decompile shows the backend has four refactorings (`BackendRenameRefactoringHandler`, `BackendExtractMethodRefactoringHandler`, `ExtractClif*`, `ChangePackageRefactoringHandler`) — but **none is reachable headless** because there is no `adtLs/refactoring` JSON-RPC segment and LSP `rename`/`codeAction` providers are unadvertised. Both ARC-1 and arc-1-lsp lose this capability until SAP exposes it. Out of scope for the eight Joule roadmap items, but a high-value future ask logged in `arc-1-lsp/docs/research/adt-ls-capability-map.md §9`.
+
+---
+
+## Big-Picture ARC-1 Code Change Per Feature
+
+One-line statement per roadmap feature. *Modern* = a feature for which adt-ls covers the target object types (CLAS / INTF / DDLS / BDEF / SRVB / SRVD / DDLX / DCLS / DRAS); *classic* = the feature touches PROG / FUGR / TABL / DOMA / DTEL / MSAG / ENHO etc., where adt-ls is silent.
+
+| # | Feature | Object class | One-line statement on what ARC-1 needs |
+|---|---------|-------------|---------------------------------------|
+| 1 | CDS Analytical Query Generation | modern | **No ARC-1 code change.** Author skill `generate-cds-analytical-query`; existing `SAPRead`/`SAPWrite`/`SAPActivate` cover all primitives. Optionally add a pre-write hint for `@Analytics.query` annotations. |
+| 2 | Clean-Core ATC Fixes | modern + classic | **One small code change.** Wrap `/sap/bc/adt/atc/autoqf/worklist` as new `SAPDiagnose action='batch_quickfix'` (~150 LOC); per-finding quickfix is already shipped. `adt-ls` cannot help — it has no quickfix endpoint. |
+| 3 | Analytical Model — basic | modern | **No ARC-1 code change.** Author skill `generate-analytics-star-schema`; `SAPWrite(batch_create, activateAtEnd:true)` (PR 270) is the orchestration primitive. |
+| 4 | Analytical Model — extended | modern | Same as #3. Same skill. |
+| 5 | Extensibility Assistant | **classic** (TABL APPEND, BAdI) | **Two code changes**: (a) new TABL APPEND subtype in `buildCreateXml` (`intent.ts:2709`) + new `tabl-v1.json` AFF schema (~250 LOC); (b) new `SAPWrite action='scaffold_badi_impl'` + `src/adt/badi-scaffold.ts` (~600 LOC). adt-ls doesn't serve these types — only ARC-1 hand-rolled covers them. |
+| 6 | RAP Model-Driven Joule | runtime | **No ARC-1 code change.** Runtime feature — Joule consumes RAP at request time. ARC-1 already builds the bindings (`SAPWrite(create, type=SRVB)` + `SAPActivate`). |
+| 7 | AI Explain for FUGR | **classic** | **Three small code changes**: (a) extend `expand_includes` for FUGR at `intent.ts:1505` to also enumerate FUNC sub-modules (~120 LOC); (b) new Dynpro/SCRP read (~150 LOC); (c) new GUI status read (~120 LOC). FUGR is classic — adt-ls returns a placeholder, so ARC-1 is the only path. |
+| 8 | AI Explain for BDEF | modern | **No ARC-1 code change.** Extend existing `explain-abap-code` skill; BDEF read + bound CLAS read already work. |
+| 9 | MCP Tool for Object Search | both | **Already shipped.** `SAPSearch quick_search/tadir_lookup` + `SAPRead WHERE_USED` cover the announced surface. SAP's Q4 2026 / Q1 2027 GA adds nothing not already there. |
+
+### Cross-cutting recommendation: dual-path strategy
+
+ARC-1 should **continue covering classic + modern types** (its enduring moat — adt-ls won't serve these). arc-1-lsp should remain the **modern-only, SAP-tracking edition** that benefits automatically when adt-ls / the embedded MCP server gains new features.
+
+The Joule features split cleanly:
+
+- **Features 1, 3, 4, 6, 8** (modern, skill-only) — implementing in ARC-1 also works in arc-1-lsp with minimal porting (most are skill-level).
+- **Features 5, 7** (classic, requires hand-rolled code) — **ARC-1 only**, permanently.
+- **Feature 2** (ATC quickfixes) — **ARC-1 only**, because adt-ls's ATC surface is report-only.
+- **Feature 9** (object search) — already shipped in both.
+
+Net new ARC-1 code across the roadmap stays at **~1,390 LOC across six sub-items** — the adt-ls/MCP-server research does not reduce that number (in fact it confirms it, since features 5 and 7 are permanently ARC-1's territory) but it clarifies *why* every line of that code matters: **classic-type and quickfix coverage is structurally absent from SAP's own MCP server.**
+
+---
+
+## Detailed ARC-1 Implementation Plan
+
+This section is the engineering counterpart to the per-feature analysis above. For every roadmap item that requires ARC-1 *code* changes (not skill-only), it enumerates: exact files to touch, the pattern in the existing codebase to mirror, schema-sync obligations, tests to add, and expected diff size. Skill-only items are listed for completeness but kept short — they don't touch the TypeScript codebase.
+
+The implementation plan follows three architectural invariants from [`CLAUDE.md`](../../CLAUDE.md):
+
+- **Tool schema three-file sync.** Every property must exist in `src/handlers/tools.ts` (JSON Schema for LLMs), `src/handlers/schemas.ts` (Zod), and `src/handlers/intent.ts` (handler). Batch schemas live separately from top-level schemas — update both when relevant.
+- **Safety guard at every ADT endpoint.** Every `http.{get,post,put,delete}` call must be preceded by `checkOperation(this.safety, OperationType.X, 'Y')`. No unguarded HTTP.
+- **Audit + scope.** New SAPDiagnose / SAPWrite / SAPSearch actions must be added to `src/authz/policy.ts` `ACTION_POLICY` with the correct required scope. Without this, the runtime check + tool-list pruning go out of sync.
+
+---
+
+### Feature 1 — CDS Analytical Query Generation: skill only, zero ARC-1 changes
+
+No code changes. Authoring effort lives entirely in `skills/generate-cds-analytical-query/SKILL.md`. The skill drives the standard read/write loop already exposed: `SAPSearch` → `SAPRead(type=DDLS)` → LLM completes the analytical-query DDLS → `SAPWrite(create, type=DDLS)` → `SAPActivate`. The AFF DDLS schema in [`src/aff/schemas/ddls-v1.json`](../../src/aff/schemas/ddls-v1.json) already validates the source-body envelope. Activation surfaces any annotation errors via the standard `formatErrorForLLM` path.
+
+**Optional polish (not required for parity):** add an ARC-1-native pre-write hint for analytical-query DDLS — verify `@Analytics.query: true` is present and the projection is `ON` an entity with `@Analytics.dataCategory: #CUBE`. Mirrors the existing TABL `%admin draft include` hint in [`src/lint/pre-write-hints.ts`](../../src/lint/pre-write-hints.ts) and is wired through `validateBeforeWrite()` in [`src/lint/lint.ts`](../../src/lint/lint.ts). ~1 day if pursued.
+
+---
+
+### Feature 2 — Clean Core ATC Fixes: one new SAPDiagnose action (`batch_quickfix`)
+
+Single-finding flow is shipped. The remaining gap is the **batch auto-quickfix worklist** endpoint `/sap/bc/adt/atc/autoqf/worklist` (backed by ABAP class `CL_SATC_ADT_RES_AUTOQUICKFIX`). It enumerates findings tagged `<atcfinding:quickfixes automatic="true"/>` and applies them in one server-side pass.
+
+**Files to touch:**
+
+| File | Change | Pattern to mirror |
+|------|--------|-------------------|
+| [`src/adt/devtools.ts`](../../src/adt/devtools.ts) | Add `runAutoQuickfixWorklist(http, safety, opts)` ~ near `getFixProposals()` at line 593. POST to `/sap/bc/adt/atc/autoqf/worklist` with the ATC run UUID. Guard with `checkOperation(safety, OperationType.Update, 'BatchQuickfix')`. | The existing `getFixProposals` / `applyFixProposal` pair (lines 593/621). |
+| [`src/adt/types.ts`](../../src/adt/types.ts) | Add `AutoQuickfixWorklistResult { applied: number; skipped: AutoQuickfixSkip[]; remaining: number }`. | `AtcFinding[]` shape. |
+| [`src/adt/xml-parser.ts`](../../src/adt/xml-parser.ts) | Parse the `<autoqf:worklistResult>` response (root element TBD against a4h — capture from first real call). | Existing `parseAtcWorklist`. |
+| [`src/handlers/intent.ts`](../../src/handlers/intent.ts) | Add `case 'batch_quickfix'` in `handleSAPDiagnose`. Args: `{ atcRunId: string, packageScope?: string, maxFindings?: number }`. | Existing `case 'quickfix'` / `case 'apply_quickfix'` dispatch in `handleSAPDiagnose`. |
+| [`src/handlers/schemas.ts`](../../src/handlers/schemas.ts) | Add `batch_quickfix` to `SAPDiagnoseSchema` action union at line 672. | Sibling `quickfix` / `apply_quickfix` entries. |
+| [`src/handlers/tools.ts`](../../src/handlers/tools.ts) | Add `batch_quickfix` to the SAPDiagnose JSON Schema action enum + per-action property descriptors. | Sibling actions. |
+| [`src/authz/policy.ts`](../../src/authz/policy.ts) | Add `'SAPDiagnose.batch_quickfix': 'write'` (or `'admin'` if you want it gated harder). | `SAPDiagnose.apply_quickfix` row. |
+| [`tests/unit/adt/devtools.test.ts`](../../tests/unit/adt/devtools.test.ts) | Mock-fetch test for the new endpoint (happy path + 4xx + partial-failure). | Existing `runAtcCheck` tests. |
+| [`tests/integration/adt.integration.test.ts`](../../tests/integration/adt.integration.test.ts) | Optional integration test, gated on `TEST_SAP_URL` + a published Clean Core ATC variant. | Existing `runAtcCheck` integration. |
+
+**Estimated diff:** ~150 lines TS + ~80 lines tests. Effort: **~2 dev-days** including live verification on a4h.
+
+**Skill side:** extend the existing [`skills/sap-clean-core-atc/SKILL.md`](../../skills/sap-clean-core-atc/SKILL.md) to call `batch_quickfix` when `automatic="true"` finding count exceeds a threshold; fall back to one-by-one `apply_quickfix` otherwise.
+
+---
+
+### Features 3 & 4 — CDS Analytical Model Generation (basic + extended): skill only
+
+No code changes. The prerequisite plumbing — `SAPWrite(batch_create, activateAtEnd: true)` — already shipped in PR 270 (see CLAUDE.md row "Add SAPWrite batch_create `activateAtEnd`"). That feature was effectively pre-emptive infrastructure for the multi-object cube + dimensions + texts scaffold this feature needs.
+
+The skill `skills/generate-analytics-star-schema/SKILL.md` orchestrates:
+
+1. Discover input — `SAPRead(type=CLAS, includeMethods=false)` for a RAP behavior pool to pull `<class:rootEntityRef>` (already extracted via `parseClassMetadata` in [`src/adt/xml-parser.ts`](../../src/adt/xml-parser.ts) and consumed in [`src/adt/rap-generate.ts:200`](../../src/adt/rap-generate.ts)). Alternative input: `SAPRead(type=TABL)`.
+2. Read candidate dimensions — `SAPSearch(tadir_lookup, source='adt')` with `objectType=DDLS` filtered to the BO's package + parent packages.
+3. LLM composes cube DDLS + N dimension DDLS + N text DDLS using templates the skill ships.
+4. `SAPWrite(batch_create, activateAtEnd: true)` with the array of objects. SAP's activator resolves the cube → dimension → text foreign-key associations in a single pass.
+
+**Optional polish:** add an AFF schema variant `ddls-analytical-v1.json` enforcing the analytical-specific annotations (`@Analytics.dataCategory`, `@Semantics.amount.currencyCode`, `@ObjectModel.dataCategory`). Wire via [`src/aff/validator.ts`](../../src/aff/validator.ts) `TYPE_MAP` (line 10) — `getAffSchema()` (line 28) resolves from there. ~1 day. Worth doing if the skill produces too many round-trips on annotation errors.
+
+---
+
+### Feature 5 — Extensibility Assistant: TABL APPEND subtype + BAdI implementation scaffold
+
+The largest in-scope code change set. Two independent additions, then a skill that uses both.
+
+#### 5a. TABL APPEND structure subtype
+
+Today's `SAPWrite(type=TABL)` handles base transparent tables and structures via `src/adt/ddic-xml.ts`. APPEND structures (TYPE `R3TR APPS`) need their own subtype because:
+- They reference a *parent* table via `<r3tr:appendOf>` in the XML envelope
+- Their activation reorders the parent table's field list
+- They have stricter naming rules (`Z*`, `Y*`, must end in special chars on standard tables)
+
+**Files to touch:**
+
+| File | Change | Pattern to mirror |
+|------|--------|-------------------|
+| [`src/adt/ddic-xml.ts`](../../src/adt/ddic-xml.ts) | Add `appendStructureXml(args)` ~ 80 lines. Mirrors `dtelXml` / `domaXml` (file is 418 lines total today). | `dtelXml` / `domaXml` functions. |
+| [`src/handlers/intent.ts`](../../src/handlers/intent.ts) | Extend `buildCreateXml()` at line 2709 (NOTE: lives in `intent.ts`, not `crud.ts`) — its `case 'TABL'` branch must accept `args.appendOf` and call `appendStructureXml` when set. Keep `CONTENT_TYPE_FALLBACKS` in `crud.ts` narrow — no changes needed there. | Existing TABL branch inside `buildCreateXml`. |
+| [`src/aff/schemas/tabl-v1.json`](../../src/aff/schemas/) | **Doesn't exist yet** — file lists only `bdef-v1.json`, `clas-v1.json`, `ddls-v1.json`, `intf-v1.json`, `prog-v1.json`, `srvb-v1.json`, `srvd-v1.json`. Adding TABL AFF support is a prerequisite. New file ~80 lines, modeled on `ddls-v1.json`. | Existing `ddls-v1.json` envelope. |
+| [`src/aff/validator.ts`](../../src/aff/validator.ts) | Add `TABL` → schema filename mapping to `TYPE_MAP` (line 10). `getAffSchema()` (line 28) resolves it automatically via the map — no separate registration call. | Existing DDLS/BDEF rows in `TYPE_MAP`. |
+| [`src/handlers/schemas.ts`](../../src/handlers/schemas.ts) | Add `appendOf?: string` to the TABL slice of `SAPWriteSchema`. Add validation: `appendOf` only valid when `type=TABL`. | Existing `include` field on CLAS writes. |
+| [`src/handlers/tools.ts`](../../src/handlers/tools.ts) | Add `appendOf` to the SAPWrite JSON Schema TABL section. | The CLAS `include` property in the same file. |
+| [`src/handlers/intent.ts`](../../src/handlers/intent.ts) | Wire `appendOf` through `handleSAPWrite create` to the XML builder. | The existing TABL create path. |
+| [`src/adt/safety.ts`](../../src/adt/safety.ts) | No change — `allowedPackages` already gates by parent-object package. APPEND structures inherit the parent table's package gate naturally. | n/a |
+| [`tests/unit/adt/ddic-xml.test.ts`](../../tests/unit/adt/ddic-xml.test.ts) | Add `appendStructureXml` unit tests (happy + invalid `appendOf` reference). | DTEL / DOMA tests. |
+| [`tests/integration/adt.integration.test.ts`](../../tests/integration/adt.integration.test.ts) | CRUD lifecycle on a Z-prefixed append against a standard table (use `MARA` or a Z-test table; skip if not available). | Existing TABL CRUD test. |
+
+**Estimated diff:** ~250 lines TS (schema + builder + handler wiring) + ~150 lines tests. Effort: **~2 dev-days**.
+
+#### 5b. BAdI implementation scaffold
+
+A new `SAPWrite action='scaffold_badi_impl'` that mirrors the existing `scaffold_rap_handlers` in [`src/adt/rap-handlers.ts`](../../src/adt/rap-handlers.ts) (1233 lines — read the file's header comment for the design pattern). Input: BAdI definition name + implementation class name. Output: a CLAS stub implementing the BAdI's filter-defined interface, plus a registration entry in an enhancement implementation.
+
+**Files to touch:**
+
+| File | Change | Pattern to mirror |
+|------|--------|-------------------|
+| New `src/adt/badi-scaffold.ts` | Pure module: `extractBadiRequirements(badiSource)` → list of methods to implement; `applyBadiImplementationStubs(requirements, classSource)` → updated CLAS source with method declarations + empty implementations. | `src/adt/rap-handlers.ts` `extractRapHandlerRequirements` + `applyRapHandlerImplementationStubs` (lines 1037+ for `ensureRapHandlerSkeletons`). |
+| [`src/adt/client.ts`](../../src/adt/client.ts) | `getEnhancementImplementation(name)` already exists at line 595 (returns `EnhancementImplementationInfo` with `badiImplementations` array). Add `getBadiDefinition(name)` that reads `/sap/bc/adt/enhancements/badi_definitions/<name>`. Returns the BAdI interface name + filter signature. | `getEnhancementImplementation` at line 595. |
+| [`src/handlers/intent.ts`](../../src/handlers/intent.ts) | New `case 'scaffold_badi_impl'` in `handleSAPWrite`. Args: `{ badiDefinition: string, implementationClass: string, implementationName: string, enhancementSpot?: string }`. Reads the BAdI definition + interface, scaffolds the class via `badi-scaffold.ts`, writes the new CLAS, registers the implementation via the enhancement implementation update path. | `case 'scaffold_rap_handlers'` dispatch in `handleSAPWrite`. |
+| [`src/handlers/schemas.ts`](../../src/handlers/schemas.ts) | Add to `SAPWriteSchema` action union + per-action validation. | `scaffold_rap_handlers` entries. |
+| [`src/handlers/tools.ts`](../../src/handlers/tools.ts) | Add to JSON Schema action enum + per-action fields. | `scaffold_rap_handlers` JSON Schema block. |
+| [`src/authz/policy.ts`](../../src/authz/policy.ts) | `'SAPWrite.scaffold_badi_impl': 'write'`. | `SAPWrite.scaffold_rap_handlers` row. |
+| `tests/unit/adt/badi-scaffold.test.ts` | New file. Pure-function tests on extract + apply. | `tests/unit/adt/rap-handlers.test.ts`. |
+| [`tests/integration/adt.integration.test.ts`](../../tests/integration/adt.integration.test.ts) | Integration test against a published BAdI (skip if not available). | RAP-handler integration tests. |
+
+**Estimated diff:** ~600 lines TS (pure module + handler) + ~300 lines tests. Effort: **~3 dev-days**.
+
+#### 5c. Skill `extensibility-assistant`
+
+After 5a and 5b land. Drives BAdI search (`SAPSearch tadir_lookup` with `objectType=BDEF` — confusingly the same canonical short type as RAP behavior definitions; use the slash alias `BADI_DEF` or filter via R3TR class), reads the chosen BAdI definition, prompts the user for the implementation behavior, scaffolds + writes. Effort: **~2 dev-days**.
+
+---
+
+### Feature 6 — RAP Model-Driven Joule Integration: no ARC-1 changes
+
+Joule consumes RAP at runtime. ARC-1 is a development-time tool. The closest adjacent work is **none**. Monitor SAP for the wire format Joule uses when consuming RAP service bindings as agentic tools, and document under `compare/J4D/04-rap-joule-runtime.md` (new file) once SAP publishes it. ~half a day of investigation work, no code.
+
+---
+
+### Feature 7 — AI Explain for Function Groups: three new readers + one skill extension
+
+This is the only feature requiring more than one ARC-1 read primitive. The FUGR explain quality depends on having all four artifacts in the LLM context: top FUGR source, all FUNC sources, all dynpros (flow logic + screen), and the GUI status.
+
+#### 7a. `expand_includes` for FUGR — extend, don't add
+
+`expand_includes` for FUGR is **already partially implemented** in [`src/handlers/intent.ts:1505-1526`](../../src/handlers/intent.ts) (schema property declared at `src/handlers/schemas.ts:7141`, tool description at `tools.ts:519`). Current behaviour: pull FUGR top source, regex-match `INCLUDE <name>.` statements, fetch each via `client.getInclude()`, concatenate.
+
+The gap: it follows only **explicit `INCLUDE` statements**, not the function group's **FUNC sub-modules** (which appear as separate top-level objects under `/sap/bc/adt/functions/groups/<name>/fmodules/`), and has no awareness of dynpros or GUI status. For a Joule-quality FUGR explanation, all four artifact classes must be in scope.
+
+**Files to touch:**
+
+| File | Change | Pattern to mirror |
+|------|--------|-------------------|
+| [`src/adt/client.ts`](../../src/adt/client.ts) | Extend `getFunctionGroup(name)` (line 345) — today it already returns `{ name, functions: string[] }`. Add a sibling `getFunctionGroupExpanded(name, opts)` returning `{ groupSource, includes: Array<{name, source}>, functions: Array<{name, source}>, dynpros: Array<{number, source}>, statuses: Array<{name, source}> }`. Reuse `getFunctionGroupSource` (line 352) and `getInclude` (line 358). | Existing `getFunctionGroup` + `getFunctionGroupSource` (lines 345, 352, 358). |
+| [`src/handlers/intent.ts`](../../src/handlers/intent.ts) | Replace the in-place INCLUDE-regex loop in `case 'FUGR'` (line 1505) with a call to `getFunctionGroupExpanded`. Serialise to the same `=== <name> ===\n<source>` markdown blocks the loop currently emits so existing skill prompts keep working. | The block at lines 1505–1526 itself — extend, don't fork. |
+| [`src/handlers/schemas.ts`](../../src/handlers/schemas.ts) | No change — `expand_includes` already accepted (line 7141). | n/a |
+| [`src/handlers/tools.ts`](../../src/handlers/tools.ts) | Update the description at line 519 to mention FUNC sub-modules, dynpros, and GUI status are included when expand=true. | The existing description string. |
+| [`tests/unit/adt/client.test.ts`](../../tests/unit/adt/client.test.ts) | Mock-fetch tests for `getFunctionGroupExpanded` (happy + empty + per-artifact failure modes). | Existing FUGR / FUNC tests. |
+
+**Estimated diff:** ~120 lines TS + ~80 lines tests. Effort: **~1 dev-day**.
+
+#### 7b. Dynpro (SCRP) read
+
+**Files to touch:**
+
+| File | Change | Pattern to mirror |
+|------|--------|-------------------|
+| [`src/adt/client.ts`](../../src/adt/client.ts) | New `getDynpro(programName, dynproNumber)`. Endpoint: `/sap/bc/adt/programs/programs/<prog>/dynpros/<dynnr>` (returns XML with `<dynpro:source>` + `<dynpro:flowLogic>` + `<dynpro:elements>`). | The existing PROG / FUNC reads. |
+| [`src/adt/xml-parser.ts`](../../src/adt/xml-parser.ts) | New `parseDynpro(xml)` returning `DynproInfo { number, attributes, elements, flowLogic }`. | `parseEnhancementImplementation` (line 643). |
+| [`src/adt/types.ts`](../../src/adt/types.ts) | Add `DynproInfo` + `DynproElement` types. | n/a |
+| [`src/handlers/intent.ts`](../../src/handlers/intent.ts) | New `case 'DYNPRO'` (or fold into FUGR expand_includes — preferred, to avoid surface-area bloat). For standalone reads expose via slash type `DYNPRO` mapped in `SLASH_TYPE_MAP`. | `case 'PROG'` source-read branch. |
+| [`src/handlers/schemas.ts`](../../src/handlers/schemas.ts) | Add `DYNPRO` to SAPRead `type` enum (or document that dynpros are accessed via FUGR expand). | Existing SAPRead type list. |
+| [`src/handlers/tools.ts`](../../src/handlers/tools.ts) | Mirror schema. | Existing types. |
+| [Citation guard](../../research/abap-types/types/) | If exposing standalone DYNPRO type, add `research/abap-types/types/dynpro.md` evidence file per CLAUDE.md "Add new ADT slash alias" row. | Existing evidence files. |
+| [`tests/unit/adt/client.test.ts`](../../tests/unit/adt/client.test.ts) + [`tests/fixtures/xml/`](../../tests/fixtures/xml/) | Mock fixture + parser test. | Existing CLAS/PROG fixtures. |
+
+**Estimated diff:** ~150 lines TS + ~100 lines tests + 1 XML fixture. Effort: **~1 dev-day**.
+
+#### 7c. GUI status / CUA status read
+
+**Files to touch:**
+
+| File | Change | Pattern to mirror |
+|------|--------|-------------------|
+| [`src/adt/client.ts`](../../src/adt/client.ts) | New `getCuaStatus(programName, statusName)`. Endpoint: `/sap/bc/adt/programs/programs/<prog>/cuastatus/<status>`. | Same as dynpro. |
+| [`src/adt/xml-parser.ts`](../../src/adt/xml-parser.ts) | New `parseCuaStatus(xml)` returning `{ name, menu: MenuEntry[], functionCodes: FCode[] }`. | n/a |
+| Other files | Mirror 7b. | n/a |
+
+**Estimated diff:** ~120 lines TS + ~80 lines tests. Effort: **~1 dev-day**.
+
+#### 7d. Skill extension
+
+Extend [`skills/explain-abap-code/SKILL.md`](../../skills/explain-abap-code/SKILL.md) to accept FUGR + dispatch to `SAPRead(type=FUGR, expand_includes=true)`. ~half a day.
+
+---
+
+### Feature 8 — AI Explain for Behavior Definitions: skill-only
+
+No code changes. Extend [`skills/explain-abap-code/SKILL.md`](../../skills/explain-abap-code/SKILL.md) to:
+
+1. `SAPRead(type=BDEF)` for the source.
+2. Parse `implementation in class <ZBP_...>` to discover the behavior pool.
+3. `SAPRead(type=CLAS)` for the pool, with `expand_includes=true` so CCDEF/CCIMP/test classes come too.
+4. Optionally `SAPDiagnose(action='rap_preflight')` for structured "what is wired / what is broken" signal — already implemented in [`src/adt/rap-preflight.ts`](../../src/adt/rap-preflight.ts).
+5. Optionally `SAPRead(WHERE_USED)` on the BDEF to surface consumers.
+6. LLM composes the explanation.
+
+Effort: **~half a day** of skill authoring.
+
+---
+
+### Feature 9 — MCP Tool for ABAP Object Search: no ARC-1 changes
+
+Shipped. The announced surface maps cleanly onto:
+- `SAPSearch action='quick_search'` (file: `src/handlers/intent.ts` `handleSAPSearch`)
+- `SAPSearch action='tadir_lookup' source='adt'|'db'|'both'` (PR 270, three sources)
+- `SAPRead action='WHERE_USED'` / `findReferences()` in [`src/adt/codeintel.ts:101`](../../src/adt/codeintel.ts)
+
+The two non-functional differences worth promoting in ARC-1 marketing copy (not code changes):
+
+1. **Multi-tenant hosting.** Document the BTP CF deployment pattern (XSUAA + Cloud Connector + per-user PP) prominently in the README — SAP's MCP server has nothing equivalent.
+2. **Cross-system aggregation.** ARC-1 can address multiple SAP systems from one instance via destination switching. SAP's IDE-local model is bound to one ADT session.
+
+---
+
+### Cross-cutting code touchpoints
+
+A consolidated view of the files most affected, useful for predicting merge-conflict surface and reviewer assignment:
+
+| File | Feature(s) requiring change | Net new LOC estimate |
+|------|----------------------------|----------------------|
+| [`src/adt/client.ts`](../../src/adt/client.ts) | 7a, 7b, 7c, 5b | ~300 |
+| [`src/adt/devtools.ts`](../../src/adt/devtools.ts) | 2 | ~80 |
+| [`src/adt/ddic-xml.ts`](../../src/adt/ddic-xml.ts) | 5a | ~80 |
+| [`src/adt/xml-parser.ts`](../../src/adt/xml-parser.ts) | 7b, 7c, 2 | ~150 |
+| [`src/adt/types.ts`](../../src/adt/types.ts) | all coded features | ~80 |
+| New `src/adt/badi-scaffold.ts` | 5b | ~400 |
+| [`src/handlers/intent.ts`](../../src/handlers/intent.ts) | 2, 5a, 5b, 7a, 7b, 7c | ~250 |
+| [`src/handlers/schemas.ts`](../../src/handlers/schemas.ts) | 2, 5a, 5b, 7a, 7b, 7c | ~120 |
+| [`src/handlers/tools.ts`](../../src/handlers/tools.ts) | 2, 5a, 5b, 7a, 7b, 7c | ~150 |
+| [`src/authz/policy.ts`](../../src/authz/policy.ts) | 2, 5b | ~10 |
+| New `src/aff/schemas/tabl-v1.json` | 5a | ~80 |
+| [`src/aff/validator.ts`](../../src/aff/validator.ts) | 5a | ~10 |
+| **Total** | | **~1700 lines** |
+
+Plus ~1000 lines of tests (unit + integration). **Total ARC-1 work: ~2700 lines, ~15-17 dev-days.** The remainder of the parity budget is skill authoring (~5-6 dev-days), arriving at the ~17-19 dev-day total cited in the executive summary.
+
+---
+
+### Required CLAUDE.md updates (after the work lands)
+
+Each new operation requires a row in CLAUDE.md "Key Files for Common Tasks" so future contributors can find the touchpoints. Specifically:
+
+- **Add SAPDiagnose batch_quickfix** — Feature 2.
+- **Add TABL APPEND structure subtype** — Feature 5a.
+- **Add BAdI implementation scaffold (`scaffold_badi_impl`)** — Feature 5b.
+- **Extend FUGR `expand_includes` to enumerate FUNC sub-modules** (current implementation at `intent.ts:1505` only follows `INCLUDE` statements) — Feature 7a.
+- **Add Dynpro (SCRP) read** — Feature 7b.
+- **Add CUA / GUI status read** — Feature 7c.
+- **Add TABL AFF schema** — Feature 5a (prerequisite).
+
+The rows should follow the existing format: action verb + brief description + comma-separated file:line citations, mirroring rows like "Add new read operation" or "Add release-gated content-type fallback".
+
+---
+
+## Cross-Cutting Recommendations
+
+1. **Author the three missing skills.** `generate-cds-analytical-query`, `generate-analytics-star-schema`, `extensibility-assistant`. The primitives all exist; this is template + few-shot authoring work. Skip `explain-abap-code` extensions for FUGR/BDEF — extend the existing skill instead.
+2. **Add three small read operations** for FUGR explain parity: `expand_includes` for FUGR, dynpro/SCRP read, GUI status read. Each is ~1 day, follows existing read patterns in `src/adt/client.ts`. Document the entry points in CLAUDE.md "Add new read operation" with file:line.
+3. **Add an append-structure TABL subtype + BAdI implementation scaffold** for the Extensibility Assistant skill. Append structure mirrors the existing DTEL/DOMA flow in `src/adt/ddic-xml.ts`; BAdI scaffold mirrors `src/adt/rap-handlers.ts`. ~5 days combined.
+4. **Wrap `/sap/bc/adt/atc/autoqf/worklist`** as `SAPDiagnose action=batch_quickfix`. The existing single-finding flow is solid; batch is the remaining gap. ~2 days.
+5. **Don't try to compete with #6** (RAP Model-Driven Joule). It's a Joule-runtime feature, not a development-tools feature. Monitor SAP for the wire format Joule uses to consume RAP service bindings as agentic tools; if it stabilises as a standard (akin to MCP), document it in `compare/J4D/`.
+6. **Position publicly on #9** (MCP Tool for ABAP Object Search). ARC-1 ships the announced functionality today, with an enterprise-grade deployment model SAP does not match. The right framing in marketing copy is: *"SAP's MCP server runs in your IDE for personal productivity. ARC-1 runs on BTP for shared multi-tenant agentic workflows — Copilot Studio, Joule Studio agents, team setups, multi-system aggregation."*
+
+### Effort summary
+
+| Bucket | Items | Total effort |
+|--------|-------|--------------|
+| New skills (no code change) | `generate-cds-analytical-query`, `generate-analytics-star-schema`, FUGR/BDEF extensions to `explain-abap-code` | ~5-6 days |
+| ARC-1 read primitives (FUGR include traversal, SCRP, GUI status) | 3 readers | ~3-4 days |
+| ARC-1 write primitives (TABL append subtype, BAdI scaffold action) | 2 features | ~5 days |
+| ARC-1 ATC batch quickfix wrapper | 1 endpoint | ~2 days |
+| Skill `extensibility-assistant` | depends on append/BAdI primitives | ~2 days |
+| **Total** | | **~17-19 dev-days** to reach functional parity with 7 of 9 announced features |
+
+Compare with SAP's 2608-2702 GA windows: features 1, 3-4, 6, 7 land Q2-Q3 2026 on BTP/Public Cloud; features 2, 8, 9 land Q4 2026 / Q1 2027; everything Private-Edition is 2027. ARC-1 can realistically be feature-complete on its 7 in-scope items within a single development sprint — and is the only path for customers on **on-premise S/4HANA, ECC 7.4+, and S/4HANA Cloud Private Edition pre-2027**.
+
+---
+
+## Sources
+
+### SAP-published
+
+- [SAP Help: AI / SAP Joule for Developers, ABAP AI Capabilities (canonical feature list)](https://help.sap.com/docs/ABAP_PLATFORM_CROSS/f2afdaf444844c38909aefc7bc792cdb/7f716223a88c40e0992777c8d9febccf.html)
+- [SAP Help: J4D What's New (per-feature lifecycle + release dates)](https://help.sap.com/docs/ABAP_AI/7b88d647742f4cdb82dadebf3b8481ed/bfbab3f3e8a84fa29b2b6e798c8fd1e7.html)
+- [SAP Help: J4D Availability (per-landscape capability matrix)](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/40d35806b38e4bcfa6989531a45ecf1d.html)
+- [SAP Help: Embedded Analytics Star Schema Generator Powered by AI](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/b8b846ac2bd84ee4ba8c895b74270bd8.html)
+- [SAP Help: SAP-ABAP-1 foundation model (AI Core)](https://help.sap.com/docs/AI_CORE/b9f48eb4a993445b863a55dd4d38f64d/d1972706d69a46acb01873ebe0c54689.html)
+- [SAP Help: Joule for Developers, ABAP AI capabilities (auth catalog + setup)](https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide/joule-for-developers-abap-ai-capabilities)
+- [SAP Roadmap Explorer (J4D / ABAP AI board)](https://roadmaps.sap.com/board?PRODUCT=73554900100800001562&PRODUCT=73555000100800001164&range=CURRENT-LAST)
+- [ABAP Keyword Documentation: ABENCDS_ANALYTICAL_QUERY_APV](https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENCDS_ANALYTICAL_QUERY_APV.html)
+- [Integrating Joule with SAP Solutions (PDF)](https://help.sap.com/doc/de3af3c0f81642dbaa4d36172ed57a72/CLOUD/en-US/79bfc83ab386450c8cd9c7937ce26a3a.pdf)
+
+### SAP Community (blog posts / roadmap announcements)
+
+- [Entering the New Era of Agentic AI for ABAP Development (Sonja Liénard, Sapphire 2026)](https://community.sap.com/t5/technology-blog-posts-by-sap/entering-the-new-era-of-agentic-ai-for-abap-development/ba-p/14394643)
+- [Introducing the Next Era of ABAP Development (TechEd 2025)](https://community.sap.com/t5/technology-blog-posts-by-sap/introducing-the-next-era-of-abap-development/ba-p/14260522)
+- [Our 2026 Roadmap for Joule for Developers ABAP AI capabilities (Karl Kessler)](https://community.sap.com/t5/technology-blog-posts-by-sap/our-2026-roadmap-for-joule-for-developers-abap-ai-capabilities/ba-p/14360358)
+- [Joule for Developers with SAP BTP ABAP Environment — Setup Guide](https://community.sap.com/t5/technology-blog-posts-by-sap/joule-for-developers-with-sap-btp-abap-environment-setup-guide/ba-p/14207462)
+- [ATC Recommendations for Governance of Clean Core ABAP](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-test-cockpit-atc-recommendations-for-governance-of-clean-core-abap/ba-p/14186130)
+- [Building Custom Joule Skills via RFC](https://community.sap.com/t5/technology-blog-posts-by-sap/building-custom-joule-skills-via-rfc-guide-for-sap-s-4hana-and-ecc/ba-p/14363568)
+- [Connecting Custom Joule Agents to MCP Servers — POC architecture](https://community.sap.com/t5/technology-blog-posts-by-sap/connecting-custom-joule-agents-to-mcp-servers-a-poc-architecture-for/ba-p/14356644)
+- [Accelerating SAP Fiori & CAP Development With SAP MCP Server + GitHub Copilot in VS Code (`mcp.json` pattern + API Policy Q37)](https://community.sap.com/t5/technology-blog-posts-by-members/accelerating-sap-fiori-amp-cap-development-with-sap-mcp-server-github/ba-p/14391413)
+- [Joys and sorrows of the ABAP Developer Tools API](https://community.sap.com/t5/application-development-and-automation-blog-posts/joys-and-sorrows-of-the-abap-developer-tools-api/ba-p/13409390)
+
+### Open-source ADT REST surface references
+
+- [`marcellourbani/abap-adt-api`](https://github.com/marcellourbani/abap-adt-api) — most complete TS wrapper around ADT REST, notably `src/api/refactor.ts` (quickfix evaluation), `src/api/rapgenerator.ts` (`/sap/bc/adt/businessservices/generators`), `src/api/cds.ts` (CDS / DDLS endpoints), `src/api/atc.ts` (ATC worklist/exemption)
+- [`abapify/adt-cli`](https://github.com/abapify/adt-cli) — 530-endpoint discovery inventory; reveals `/sap/bc/adt/ana/aqd` (Analytical custom query) and `/sap/bc/adt/atc/autoqf/worklist`
+- [`SAP/open-ux-tools`](https://github.com/SAP/open-ux-tools) — `packages/axios-extension/test/abap/mockResponses/discovery-*.xml` — SAP's own mock discovery (notably no `/abapai*` or `/joule*` collections)
+- [`kennyhml/abap-language-server`](https://github.com/kennyhml/abap-language-server) — Java LSP server with `discovery.xml` referencing `autoqf/worklist`
+- [`The-Nefarious-Developer/zjoule`](https://github.com/The-Nefarious-Developer/zjoule) — open-source Eclipse plugin that bypasses Joule and talks directly to AI Core / OpenAI / Ollama (empirical evidence that the IDE plugin is the orchestrator, not a privileged backend)
+- [`SAP/abap-file-formats`](https://github.com/SAP/abap-file-formats) — file-format spec referenced by SAP's VS Code extension
+
+### Prior ARC-1 research (this repo)
+
+- [`compare/J4D/01-joule-for-developers.md`](../../compare/J4D/01-joule-for-developers.md) — full J4D feature-to-skill mapping (12 capabilities)
+- [`compare/J4D/02-sap-abap-mcp-server-vscode.md`](../../compare/J4D/02-sap-abap-mcp-server-vscode.md) — strategic analysis of SAP's Q2 2026 ABAP MCP Server
+- [`compare/abap-adt-api/evaluations/issue-37-quickfix.md`](../../compare/abap-adt-api/evaluations/issue-37-quickfix.md) — confirms `/sap/bc/adt/quickfixes/evaluation` + `/application`
+- [`docs/plans/completed/fix-proposals-auto-fix-from-atc.md`](../plans/completed/fix-proposals-auto-fix-from-atc.md) — live a4h verification of the quickfix wire format
+- [`docs/research/sapphire-2026-abap-ai-impact.md`](sapphire-2026-abap-ai-impact.md) — SAP AI strategic landscape
+
+### Sapphire 2026 sessions (timing references)
+
+- [BTP2573 — Build smarter: Agentic ABAP development tools for VS Code](https://www.sap.com/events/sapphire/orlando/flow/sap/so26/catalog/page/catalog/session/1774374412394001bVsg)
+- [JOU1428 — Agentic ABAP with SAP Joule for Developers](https://www.sap.com/events/sapphire/orlando/flow/sap/so26/catalog/page/catalog/session/1770220933562001wFEi)
+
+### Third-party reference
+
+- [ABAP Feature Matrix (Software Heroes)](https://software-heroes.com/en/abap-feature-matrix)
+- [ARC-1 + Joule Studio Clean Core integration blog (Marian Zeis, May 2026)](https://blog.zeis.de/posts/2026-05-08-arc-1-joule-studio-clean-core/)
+- [SAP YouTube: Using the Extensibility AI Assistant](https://www.youtube.com/watch?v=RyAaBBKILUg)
+
+### Post-GA sources (June 2026 — for the SAP MCP Server + ADT-LS section)
+
+- [VS Code Marketplace listing: SAPSE.adt-vscode v1.0.0](https://marketplace.visualstudio.com/items?itemName=SAPSE.adt-vscode) (published 2026-05-29)
+- [SAP Community: ABAP development tools for VS Code is now available on the marketplace (2026-06-01)](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-is-now-available-on-the-vs/ba-p/14402120)
+- [SAP Community: ABAP development tools for VS Code — Your Questions Answered (2026-06-01)](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-your-questions-answered/ba-p/14400848) — definitive FAQ on architecture (Q3 Java LS), parity (Q2 same JAR), standalone status (Q13)
+- [SAP Community: The Future of ABAP is Here — VS Code ADT, Zero-Config MCP, and AI Co-pilots (community walkthrough, 2026-06-01)](https://community.sap.com/t5/technology-blog-posts-by-members/the-future-of-abap-is-here-vs-code-adt-zero-config-mcp-and-ai-co-pilots/ba-p/14408186)
+- [SAP Community: Unboxing SAP ABAP Tools for VS Code + MCP (community first-look, 2026-06-01)](https://community.sap.com/t5/abap-blog-posts/unboxing-sap-abap-tools-for-vs-code-mcp-a-small-announcement/ba-p/14408635) — confirms missing source-read/write/search/ATC
+- [SAP Community: Sapphire 2026 recap — Joule for Developers Agentic ABAP AI (2026-05-28)](https://community.sap.com/t5/technology-blog-posts-by-sap/sapphire-2026-recap-joule-for-developers-agentic-abap-ai/ba-p/14405739)
+- [`SAP-samples/abap-platform-rap130`](https://github.com/SAP-samples/abap-platform-rap130) — RAP130 tutorial documenting 9 of the 14 GA tools
+- [SAP Developer License v3.2](https://tools.hana.ondemand.com/developer-license-3_2.txt) — redistribution clause (relevant for "can ARC-1 embed the LS?")
+- [SAP API Policy v.4.2026a](https://help.sap.com/doc/sap-api-policy/latest/en-US/API_Policy_latest.pdf) — §1.2 customer-developed interface carve-out; §2.2.2 agentic-AI clause; §3 anti-circumvention
+- [`marcellourbani/vscode_abap_remote_fs`](https://github.com/marcellourbani/vscode_abap_remote_fs) — closest community LSP that talks to ADT REST; useful reference for the §1.2 precedent
+- [`abaplint/vscode-abaplint`](https://github.com/abaplint/vscode-abaplint) — standalone ABAP LSP (no SAP backend); reference for the LSP capability surface ARC-1 could optionally expose
+- [`SAP/abap-cleaner`](https://github.com/SAP/abap-cleaner) — Apache-2.0 ABAP source cleaner (Java); SAP plans to wire into ADT-LS for `textDocument/formatting`

--- a/docs/research/joule-vs-sap-mcp-vs-arc1-comparison.md
+++ b/docs/research/joule-vs-sap-mcp-vs-arc1-comparison.md
@@ -1,0 +1,231 @@
+# SAP Joule + ABAP MCP Server vs ARC-1 + Skills — Feature Comparison
+
+> **Question:** SAP is rolling out Joule for Developers ABAP AI capabilities and the official ABAP MCP Server (GA Q2 2026). For each announced capability, does an existing ARC-1 + skills deployment already cover it? Where doesn't it?
+> **Answer in one line:** **All eight announced Joule developer-AI roadmap features are reachable today with ARC-1 + a thin skills layer.** Six are skill-only; two require small hand-rolled code; one (RAP→Joule runtime) is genuinely Joule's domain. SAP's IDE-local MCP server overlaps ARC-1 on object search but lacks central hosting, principal propagation, and on-prem / classic-type reach.
+> **Date:** 2026-06-03. Companion to [`joule-2026-roadmap-feature-assessment.md`](joule-2026-roadmap-feature-assessment.md) (the engineering plan per feature) and [`compare/J4D/01-joule-for-developers.md`](../../compare/J4D/01-joule-for-developers.md) (the J4D capability map).
+
+---
+
+## TL;DR positioning
+
+| Stack | What it is | Hosting | Auth | Type reach | AI runtime | Status |
+|-------|-----------|---------|------|-----------|------------|--------|
+| **SAP Joule for Developers** (J4D) | AI copilot embedded in Eclipse ADT | Eclipse plugin → BTP AI Core via `AIC_ADT_HTTP_PROXY` destination | ABAP role `SAP_A4C_BC_DEV_AIQ_PC` + auth object `S_AIQADTLO` + BTP license | RISE / Public Cloud / BTP only — no on-prem | SAP-ABAP-1 foundation model on BTP AI Core | GA, expanding |
+| **SAP ABAP MCP Server** | MCP endpoint inside the IDE | Local stdio inside Eclipse ADT + VS Code extension; Streamable HTTP on `localhost` only | Bearer token (auto-generated `SecureRandom` 16-byte Base64url), inherits IDE/ADT session for upstream | Modern ABAP-Cloud only (CLAS, INTF, DDLS, BDEF, SRVB, SRVD, DCLS, DDLX, DRAS) | Optional — the MCP server exposes capabilities "with and without embedded AI" | GA Q2 2026; "object search" tool BTP 2611 / S/4 Cloud Public 2702 / Private 2027 |
+| **ARC-1 + skills** | Multi-tenant MCP server hand-rolling ADT HTTP + a library of Claude skills | BTP CF / Docker / npm / stdio — anywhere | XSUAA OAuth + OIDC + API key; per-user principal propagation via BTP Destination Service | **Classic + modern** — any object type ADT exposes, including FUGR/FUNC/PROG/TABL/DOMA/DTEL/MSAG/ENHO/XSLT | Any LLM the user wires (Claude, GPT-4, Gemini, Mistral) | Production, write-capable, multi-user |
+| **arc-1-lsp** (sibling edition) | ARC-1 shell delegating to adt-ls headless | Local stdio or Docker (single-tenant) | adt-ls reentrance ticket / API key | Modern ABAP-Cloud only (adt-ls boundary) | Any LLM | Working; 39 tools live-verified |
+
+The strategic pattern: **SAP's MCP runs in your IDE for personal productivity; ARC-1 runs on BTP for shared multi-tenant agentic workflows** (Copilot Studio agents, Joule Studio agents, team setups, multi-system aggregation, on-prem reach).
+
+---
+
+## Joule for Developers — capability map at a glance
+
+J4D's full capability surface (per [SAP Help Portal — ADT AI Tools](https://help.sap.com/docs/ABAP_Cloud/bbcee501b99848bdadecd4e290db3ae4) and the [2026 roadmap blog](https://community.sap.com/t5/technology-blog-posts-by-sap/our-2026-roadmap-for-joule-for-developers-abap-ai-capabilities/ba-p/14360358)):
+
+| # | J4D capability | Slash cmd / surface | ARC-1 + skills coverage | Status |
+|---|----------------|---------------------|-------------------------|--------|
+| 1 | Joule Chat (default) | *(default)* | ✅ Inherent — any MCP client + LLM | Covered |
+| 2 | Explain Code | `/explain` | ✅ Skill `explain-abap-code` exists | Covered |
+| 3 | ABAP Unit Test Generation | `/aunit` | ⚠️ Skill `generate-abap-unit-test` exists; J4D's sub-features (dep analysis, test doubles, splitting, refactor instructions) need polish | Partial |
+| 4 | CDS Unit Test Generation | *(wizard)* | ✅ Skill `generate-cds-unit-test` exists | Covered |
+| 5 | OData Client Consume | `/consume` | ⚠️ Building blocks exist; no dedicated skill yet | Partial |
+| 6 | Documentation Chat | `/docs` | ✅ `mcp-sap-docs` MCP — broader than J4D's 4 guides | Covered |
+| 7 | Predictive Code Completion | toolbar/inline | ❌ N/A — IDE-native real-time feature | Out of scope |
+| 8 | OData UI Service from Scratch | wizard | ✅ Skill `generate-rap-service` exists | Covered |
+| 9 | RAP Business Logic Prediction | Quick Fix Ctrl+1 | ✅ Skill `generate-rap-logic` exists | Covered |
+| 10 | Custom Code Migration | `/docs` + CCM | ✅ Skills `migrate-custom-code` + `sap-clean-core-atc` exist | Covered |
+| 11 | Star Schema Generator (analytical) | wizard | 📅 Skill `generate-analytics-star-schema` planned ([plan](../plans/joule-cds-analytical-model-skill.md)) | Plan ready |
+| 12 | Extensibility Assistant | context-menu / Key User UI | 📅 Skill + code planned ([plan](../plans/joule-extensibility-assistant.md)) | Plan ready |
+| 13 | ABAP AI SDK with ISLM | ABAP-side runtime | ❌ N/A — ABAP runtime SDK, different domain | Out of scope |
+
+Summary: **9 of 13 covered today; 2 with plans ready; 2 genuinely out of scope** (IDE-native completion, ABAP runtime SDK).
+
+---
+
+## 2026 Joule roadmap — eight new features
+
+The newest roadmap items (release windows 2608 / 2611 / 2702 / 2027) and their ARC-1 + skills coverage. Each links to a ralphex implementation plan.
+
+| # | Roadmap feature | SAP GA window | Object class | ARC-1 + skills path | Plan |
+|---|----------------|---------------|--------------|---------------------|------|
+| 1 | CDS Analytical Query Generation | BTP 2608 / S/4 Cloud Public 2608 / Private 2027 | modern (DDLS) | Skill only | [`joule-cds-analytical-query-skill.md`](../plans/joule-cds-analytical-query-skill.md) |
+| 2 | Clean-Core ATC Fixes | S/4 Cloud Private 2027 only | both | Per-finding ALREADY SHIPPED; small code change for batch (`SAPDiagnose batch_quickfix`) | [`joule-atc-batch-quickfix.md`](../plans/joule-atc-batch-quickfix.md) |
+| 3 | Analytical Model — basic (cube + existing dims from RAP BO) | S/4 Cloud Private 2027 only | modern | Skill only | [`joule-cds-analytical-model-skill.md`](../plans/joule-cds-analytical-model-skill.md) |
+| 4 | Analytical Model — extended (cube + new dims from RAP BO **or** DDIC) | BTP 2608 / S/4 Cloud Public 2608 / Private 2027 | modern + classic input | Skill only (same skill as #3) | [`joule-cds-analytical-model-skill.md`](../plans/joule-cds-analytical-model-skill.md) |
+| 5 | Extensibility Assistant (custom field, BAdI) | S/4 Cloud Private 2027 (already GA on Public Cloud for key users) | **classic** | Code + skill: TABL APPEND subtype + BAdI implementation scaffold + orchestration skill | [`joule-extensibility-assistant.md`](../plans/joule-extensibility-assistant.md) |
+| 6 | RAP Model-Driven Joule Integration | BTP 2608 / S/4 Cloud Public 2608 / Private 2027 | runtime | Out of scope — runtime feature, not development | — |
+| 7 | AI Explain for Function Groups | BTP 2608 / S/4 Cloud Public 2608 / Private 2027 | **classic** | Code + skill ext: FUNC sub-module walk + dynpro read + CUA read + skill branch | [`joule-fugr-explain.md`](../plans/joule-fugr-explain.md) |
+| 8 | AI Explain for Behavior Definitions | BTP 2611 / S/4 Cloud Public 2702 / Private 2027 | modern | Skill only (extend `explain-abap-code`) | [`joule-bdef-explain-skill.md`](../plans/joule-bdef-explain-skill.md) |
+| 9 | MCP Tool for ABAP Object Search | BTP 2611 / S/4 Cloud Public 2702 / Private 2027 | both | **Already shipped** — `SAPSearch quick_search/tadir_lookup` + `SAPRead WHERE_USED` | — |
+
+**Net:** 7 of 9 deliverable via ARC-1 + skills; 1 out of scope (RAP runtime); 1 already shipped.
+
+### Code-change budget summary
+
+Six independent code-change buckets across three roadmap features:
+
+| Feature | Sub-item | LOC | Effort |
+|---------|----------|-----|--------|
+| 2 | `batch_quickfix` SAPDiagnose action | ~150 | 2 d |
+| 5a | TABL APPEND subtype + `tabl-v1.json` AFF schema | ~250 | 2 d |
+| 5b | BAdI implementation scaffold module + action | ~600 | 3 d |
+| 7a | Extend FUGR `expand_includes` for FUNC sub-modules | ~120 | 1 d |
+| 7b | Dynpro (SCRP) read | ~150 | 1 d |
+| 7c | CUA/GUI status read | ~120 | 1 d |
+| **Total** | | **~1,390 LOC** | **~10 dev-days** |
+
+Plus ~5–6 dev-days of skill authoring (features 1, 3+4, 7d, 8) = **~17–19 dev-days total** to ship every roadmap item that can be shipped. SAP's GA windows run Q2 2026 through 2027.
+
+---
+
+## SAP ABAP MCP Server — wire-level facts
+
+Source: decompiled `com.sap.adt.mcp.core_3.58.1.jar` (34 classes), verified against [`arc-1-lsp`](https://github.com/marianfoo/arc-1-lsp) which federates to it headless.
+
+### Transport + auth
+
+- Streamable HTTP at `/mcp` on `localhost:<auto-port>`
+- Bearer token: auto-generated `SecureRandom` 16-byte Base64url; returned to LSP client in `AdtMcpServerInitializationInfo{port, token}`
+- DNS-rebinding filter restricts `Host:` to `localhost` / `127.0.0.1`
+- Server info: `("ADT MCP Server", "1.0.0")`
+- 30-second request timeout
+
+### Static tool surface (7 tools)
+
+Registered via Eclipse extension point `com.sap.adt.mcp.core.adtMcpTools`:
+
+| Tool | Purpose |
+|------|---------|
+| `abap_activate_objects` | Activate one or more URIs; returns syntax diagnostics on failure |
+| `abap_run_unit_tests` | Run ABAP Unit on given URIs |
+| `abap_creation-get_all_creatable_objects` | Enumerate the 14 creatable object types on the bound destination |
+| `abap_creation-get_object_type_details` | Fetch the per-type form schema |
+| `abap_creation-run_validation` | Pre-create validation (package exists, name legal, type-specific) |
+| `abap_creation-create_object` | Create an object; returns the AFF filePath |
+| Destinations list tool | List configured destinations |
+
+### Dynamic tool surface (N tools per destination)
+
+`AdtMCPToolsIdeActionCollector` harvests the connected ABAP backend's **IDE-Actions (AIA)**, keeps those whose title starts with `MCP`, and exposes each as an MCP tool with backend-authored schema. Naming transform: lowercase, `mcp_`→`abap_`, `mcp-`→`abap_`. The registry **swaps** the dynamic set on every `setDestination`. Example dynamic tools: `abap_transport-get`, `abap_transport-create`.
+
+**Critical:** the dynamic tool list is **system-dependent**. A given S/4HANA release ships a specific set of `MCP_*` AIA actions, and that set evolves. arc-1-lsp federates to this MCP and re-enumerates tools on every `setDestination`.
+
+### What is NOT in the MCP
+
+- No `aiExplain`, no Joule chat endpoint — AI orchestration lives **above** adt-ls in the IDE plugin
+- No quickfix evaluation/apply — `atc/runCheck` returns findings (`AtcRunFinding`) but no quickfix data
+- No classic ABAP types (PROG, FUGR, TABL, DOMA, …) — adt-ls's `readFile` returns a `.jsonc` placeholder for them
+- No free SQL, no git, no transport release/delete
+- No refactoring — the backend has Rename/Extract Method/Extract CLIF/Change Package but they're not reachable headless
+
+---
+
+## adt-ls headless capability summary
+
+23 `adtLs/*` JSON-RPC segments, ~92 methods. Lives inside `com.sap.adt.ls_1.0.0.202605281240.jar` (736 classes). The full inventory is in [`arc-1-lsp/docs/research/adt-ls-capability-map.md`](https://github.com/marianfoo/arc-1-lsp/blob/main/docs/research/adt-ls-capability-map.md). Highlights:
+
+| Segment | Methods | What for |
+|---------|---------|----------|
+| `adtLs/repository` | `quickSearch`, `getLsUri`, `getUsers` | Full RIS object search + name→URI resolver |
+| `adtLs/objectCreation` | `getCreatableObjectTypes`, `getCreationUiModelAndContent`, `sideEffects`, `validate`, `create` | The 4-step creation pipeline (richer than `writeFile`) |
+| `serverExtension/objectGenerator` | `fetchAllGenerators`, `getSchemaForObjectGeneration`, `getListOfObjectsToBeGenerated`, `generateObjects` | RAP scaffolding wizard — **this is where SAP would surface analytical-model generators** |
+| `adtLs/atc` | `runCheck`, `getCheckVariants` | ATC (report-only — no quickfix) |
+| `adtLs/abapUnit` | `runTests`, `capabilities`, `validateRunParams` | Unit-test run with structured results |
+| `adtLs/coverage` | `getCoverage`, `loadStatementResults` | Coverage measurement |
+| `adtLs/cts/transport` | `checkTransportForObjectLock`, `createTransportForObjectLock`, `assignTransportToObject`, `searchTransports` | Native transport (typed; preferred over dynamic MCP `abap_transport-*`) |
+| `adtLs/activation` | `activate`, `getInactiveObjects` | Batch activate, force-activation; the real activation primitive |
+| `adtLs/businessservice/srvb` | `publishandUnpublishAction`, `getServiceBindingDetails`, `getServiceEntitySet`, `getPreviewURL` | RAP service binding control |
+| `adtLs/run` | `runApplication` | Run `if_oo_adt_classrun` class → console output |
+| `adtLs/codePrediction` | `getCodePredictions`, `reportCodePredictionInsertion` | **AI ghost-text** — gated by `adt.joule.editor.predictiveCodeCompletion` config + AIA backend |
+| `adtLs/joule` | `getJouleDestination` | Returns BTP-side Joule destination pointer (no AI here directly) |
+| Standard LSP | `documentSymbol`, `definition`, `references`, `typeHierarchy`, `hover`, `completion`, `diagnostic`, … | IDE code-intel |
+
+**Boundary:** `readFile` and `create` serve **only the 14 modern creatable types** (CLAS / INTF / DCLS / DRAS / BDEF / DRTY / CHDO / DDLS / DDLX / NROB / NONT / RONT / SRVB / SRVD). Classic types return placeholders. The backend ships full classic support (~75 `com.sap.adt.*_3.58.x` feature plugins) but the LS front-end deliberately doesn't wire them — a watch-item, not a defect.
+
+---
+
+## Side-by-side: agentic capability access
+
+| Capability | SAP Joule (in ADT) | SAP ABAP MCP Server (IDE-local) | ARC-1 + skills (BTP-hosted) | arc-1-lsp (delegated to adt-ls) |
+|------------|--------------------|---------------------------------|----------------------------|----------------------------------|
+| AI code generation | ✅ via SAP-ABAP-1 on BTP AI Core | ✅ via the IDE plugin's AI layer (not the MCP itself) | ✅ via the user's LLM (Claude / GPT-4 / etc.) | ✅ same |
+| Object search (modern) | ✅ Ctrl+Shift+A | ✅ — Q4 2026 / Q1 2027 GA | ✅ already shipped | ✅ already shipped |
+| Object search (classic) | ✅ (Eclipse only) | ❌ classic types not served | ✅ already shipped | ❌ adt-ls boundary |
+| Where-used / references | ✅ | ✅ — `textDocument/references` (timeout-guarded) | ✅ `SAPRead WHERE_USED` | ✅ |
+| Code create/update — modern types | ✅ | ✅ | ✅ | ✅ |
+| Code create/update — **classic types** (PROG/FUGR/TABL/DOMA/…) | ✅ Eclipse only | ❌ | ✅ | ❌ adt-ls boundary |
+| AI Explain — classes/programs | ✅ `/explain` | n/a (Joule layer above) | ✅ skill `explain-abap-code` | ✅ + adt-ls `hover` bonus |
+| AI Explain — **function groups** (FUGR) | 📅 BTP 2608 | ❌ adt-ls boundary | 📅 [plan ready](../plans/joule-fugr-explain.md) | ❌ adt-ls boundary |
+| AI Explain — **behavior definitions** (BDEF) | 📅 BTP 2611 | n/a | 📅 [plan ready](../plans/joule-bdef-explain-skill.md) | ✅ via adt-ls hover |
+| Analytical model / query generation | 📅 BTP 2608 | n/a (Joule layer) | 📅 [plans ready](../plans/joule-cds-analytical-query-skill.md) | ✅ via adt-ls `objectGenerator` when SAP ships it |
+| Extensibility — append structure | n/a | ❌ classic | 📅 [plan ready](../plans/joule-extensibility-assistant.md) | ❌ adt-ls boundary |
+| Extensibility — BAdI scaffold | 📅 S/4 Private 2027 | ❌ classic | 📅 [plan ready](../plans/joule-extensibility-assistant.md) | ❌ adt-ls boundary |
+| Clean-core ATC fixes | 📅 S/4 Private 2027 | ❌ ATC is report-only | ✅ per-finding shipped; 📅 [batch plan](../plans/joule-atc-batch-quickfix.md) | ❌ adt-ls ATC is report-only |
+| RAP→Joule runtime | 📅 BTP 2608 | n/a — runtime feature | n/a — runtime feature | n/a — runtime feature |
+| Free SQL | ❌ | ❌ | ✅ `SAPQuery` (gated) | ❌ |
+| Git (gCTS / abapGit) | ❌ | ❌ | ✅ `SAPGit` | ❌ |
+| Transport — release/delete | ❌ | ❌ | ✅ `SAPTransport` (gated) | ❌ |
+| Runtime diagnostics (ST22 dumps) | ❌ | ❌ | ✅ `SAPDiagnose` (dumps, profiler traces, system messages) | ❌ |
+| Per-user principal propagation | n/a | ❌ inherits IDE session | ✅ XSUAA + BTP Destination Service | 📅 plan 05 |
+| Central audit log | n/a | ❌ implicit IDE-side | ✅ BTP Audit Log Service sink | 📅 |
+| Multi-tenant hosting | ❌ (per-developer) | ❌ (per-developer) | ✅ BTP CF | ❌ (single-tenant) |
+| Compatible LLMs | SAP-managed | SAP-managed | Claude · GPT-4 · Gemini · Mistral · IBM · Anthropic · OpenAI · Google · Amazon | same |
+| Compatible MCP clients | Eclipse only | Eclipse + VS Code | Claude Desktop · Copilot Studio · Joule Studio · Cursor · VS Code Copilot · Gemini CLI · JetBrains | Same as ARC-1 |
+| Type-system reach | RISE / Public Cloud / BTP only (no on-prem) | Same | **Any** SAP system with ADT (incl. ECC 7.4+, on-prem S/4HANA, on-prem NetWeaver) | Modern-type only on any ADT system |
+| Licensed | ✅ Separate license (SAP Note 3571857) | Bundled with the IDE extension | ✅ Open source (MIT) | ✅ Open source (MIT) |
+
+---
+
+## The roadmap is already shippable — pre-emptive infrastructure that paid off
+
+The most striking thing about reading SAP's 2026 roadmap against ARC-1's recent commit history: **multiple ARC-1 features that shipped months ago turn out to be exactly the primitives the Joule roadmap needs.** Examples:
+
+| Joule roadmap item | ARC-1 pre-emptive primitive | When ARC-1 shipped it |
+|-------------------|------------------------------|----------------------|
+| Analytical Model Gen (cube + N dimensions + texts in one go) | `SAPWrite batch_create activateAtEnd: true` — terminal activation that resolves cross-references in one pass | PR 270, 2026-05-10 |
+| Clean-Core ATC Fix Proposals | `SAPDiagnose quickfix` / `apply_quickfix` wrapping `/sap/bc/adt/quickfixes/evaluation` + `/sap/bc/adt/quickfixes/application` | 2026-04-14 (live-verified on a4h) |
+| AI Explain for BDEF | `SAPRead BDEF` + `parseClassMetadata` `<class:rootEntityRef>` extraction + `expand_includes` for CLAS CCDEF/CCIMP + `SAPDiagnose rap_preflight` | PRs 257/260/261, 2026-05-10 |
+| MCP Tool for ABAP Object Search | `SAPSearch quick_search` / `tadir_lookup` (source=adt/db/both, PR 270) + `SAPRead WHERE_USED` + `findReferences` in codeintel | Multiple, 2025–2026 |
+| Generate Behavior Implementation | `SAPWrite scaffold_rap_handlers` + `SAPWrite generate_behavior_implementation` — one-shot RAP behavior pool orchestrator | PRs 260/261, 2026-05-10 |
+
+The ARC-1 + skills layer didn't anticipate the *exact* Joule features but it implemented the *primitives* those features require, plus the writer-side safety / authz / package allowlist infrastructure SAP's IDE-local MCP doesn't carry. **The roadmap's GA window of 2026–2027 is therefore catch-up; the capability is shippable today**, where each Joule announcement maps either to an existing skill, an existing tool, or a small (~1–3 dev-day) ARC-1 plan.
+
+---
+
+## Strategic positioning — who picks which stack?
+
+| Situation | Pick |
+|-----------|------|
+| Personal productivity in Eclipse ADT, RISE/Cloud system, willing to pay for the J4D license | **Joule for Developers** — the integrated UX is unbeatable for a single developer |
+| Personal productivity in VS Code, modern types only | **SAP's ABAP MCP Server** when GA Q2 2026; **arc-1-lsp** today |
+| Team / multi-user setup, shared BTP deployment, central XSUAA + audit + safety policy | **ARC-1** — the only stack with multi-tenant hosting + per-user principal propagation |
+| On-prem S/4HANA, ECC 7.4+, or NetWeaver 7.5x | **ARC-1** — SAP's stacks all require RISE/Cloud/BTP for AI; ARC-1 works anywhere ADT does |
+| Classic ABAP heavy (FUGR, PROG, TABL, MSAG, DOMA/DTEL, enhancements) | **ARC-1** — adt-ls doesn't serve these and won't unless SAP changes the LS front-end |
+| Agentic flows on Copilot Studio / Joule Studio / agentic CI | **ARC-1** — HTTP Streamable + JWT auth + remote MCP is the only deployment model these platforms accept |
+| Migration / Clean-Core remediation at scale | **ARC-1** — quickfix `batch_quickfix` + transport mgmt + SQL + git + runtime diagnostics combine for migration workflows SAP's MCP doesn't reach |
+| Free / open-source / vendor-neutral | **ARC-1 + arc-1-lsp** (both MIT) |
+
+---
+
+## What ARC-1 + skills does NOT compete with
+
+1. **IDE-native UX** — predictive code completion ghost text, in-line Quick Fix UI, integrated debugger. MCP is RPC; you can't beat an IDE's UI primitives with tool calls.
+2. **SAP-ABAP-1 model itself** — Joule's foundation model is fine-tuned on the S/4HANA codebase and may produce better ABAP than Claude/GPT-4 on specific edge cases. ARC-1's bet is *good enough + much wider deployment*.
+3. **RAP→Joule runtime adapter** — exposing RAP BOs as first-class Joule skills is a runtime feature; ARC-1 helps build the RAP BOs but doesn't consume them at request time.
+
+---
+
+## Sources
+
+- [`docs/research/joule-2026-roadmap-feature-assessment.md`](joule-2026-roadmap-feature-assessment.md) — engineering plan per feature
+- [`compare/J4D/01-joule-for-developers.md`](../../compare/J4D/01-joule-for-developers.md) — full J4D capability map
+- [`compare/J4D/02-sap-abap-mcp-server-vscode.md`](../../compare/J4D/02-sap-abap-mcp-server-vscode.md) — SAP ABAP MCP Server strategic analysis
+- [`arc-1-lsp/docs/adt-ls-reference.md`](https://github.com/marianfoo/arc-1-lsp/blob/main/docs/adt-ls-reference.md) — adt-ls live-verified capability matrix
+- [`arc-1-lsp/docs/research/adt-ls-capability-map.md`](https://github.com/marianfoo/arc-1-lsp/blob/main/docs/research/adt-ls-capability-map.md) — decompiled-server inventory
+- [`arc-1-lsp/docs/arc-1-feature-parity.md`](https://github.com/marianfoo/arc-1-lsp/blob/main/docs/arc-1-feature-parity.md) — ARC-1 vs arc-1-lsp per-tool
+- [SAP Help: ADT AI Tools](https://help.sap.com/docs/ABAP_Cloud/bbcee501b99848bdadecd4e290db3ae4)
+- [SAP Help: AI / SAP Joule for Developers, ABAP AI Capabilities (canonical feature list)](https://help.sap.com/docs/ABAP_PLATFORM_CROSS/f2afdaf444844c38909aefc7bc792cdb/7f716223a88c40e0992777c8d9febccf.html)
+- [Our 2026 Roadmap for Joule for Developers ABAP AI capabilities (Karl Kessler, SAP)](https://community.sap.com/t5/technology-blog-posts-by-sap/our-2026-roadmap-for-joule-for-developers-abap-ai-capabilities/ba-p/14360358)
+- [Entering the New Era of Agentic AI for ABAP Development (Sonja Liénard, Sapphire 2026)](https://community.sap.com/t5/technology-blog-posts-by-sap/entering-the-new-era-of-agentic-ai-for-abap-development/ba-p/14394643)
+- Plans referenced above all live in [`docs/plans/`](../plans/)


### PR DESCRIPTION
Captures the research + implementation plans produced while assessing SAP's **2026 Joule for Developers / ABAP AI roadmap** against ARC-1. Pure docs — no code, no skills, no tool-surface changes.

## What's here

**Research (`docs/research/`)**
- `joule-2026-roadmap-feature-assessment.md` — per-feature deep-dive: is each of the 9 announced roadmap features already possible via ARC-1, and what code / skill / sister-MCP changes each needs. Includes the decompiled `adt-ls` surface (23 segments / ~92 methods) and the official IDE-embedded ABAP MCP Server analysis.
- `joule-vs-sap-mcp-vs-arc1-comparison.md` — ARC-1 + skills vs SAP Joule vs the official ABAP MCP Server (hosting model, auth, type reach, per-feature parity).

**Plans (`docs/plans/`)** — one ralphex implementation plan per roadmap feature, each with file:line touchpoints, patterns to mirror, tests, and effort estimates.

## Status banners reflect what actually happened this cycle

| Plan | Status |
|------|--------|
| `joule-cds-analytical-query-skill` | ✅ implemented + live-verified (#334) |
| `joule-cds-analytical-model-skill` | ✅ implemented + live-verified (#334) |
| `joule-bdef-explain-skill` | ✅ implemented + live-verified (#334) |
| `joule-atc-batch-quickfix` | ⚠️ approach **superseded** — `runAtcCheck` bug fixed in #336; native autoqf endpoint is an opaque `step=` protocol; auto-fix unverifiable on the trial (see `atc-quickfix-surface-a4h.md` in #337) |
| `joule-fugr-explain` | 🔜 selected as the next feature to build |
| `joule-extensibility-assistant` | 📋 planned (code-heavy; partly outside ADT) |

## Why a separate PR

These are cross-feature roadmap artifacts — distinct from the per-PR code/skill changes (#334, #336, #337). Kept separate so each PR stays single-themed and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
