### PR TITLE
fix(write): derive created-object master language from SAP_LANGUAGE 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Copy `.env.example` to `.env`. All options live in `src/server/config.ts` (parse
 | `SAP_USER` / `--user` | SAP username |
 | `SAP_PASSWORD` / `--password` | SAP password |
 | `SAP_CLIENT` / `--client` | SAP client number (default: 100) |
-| `SAP_LANGUAGE` / `--language` | SAP language (default: EN) |
+| `SAP_LANGUAGE` / `--language` | SAP language (default: EN). Sent as the `sap-language` request param **and** used as the master/original language in object-creation XML (`adtcore:masterLanguage`), so DDIC texts of newly created DTEL/DOMA are filed under this language (issue #343). |
 | `SAP_INSECURE` / `--insecure` | Skip TLS verification (default: false) |
 | `SAP_TRANSPORT` / `--transport` | MCP transport: `stdio` (default) or `http-streamable` |
 | `ARC1_PORT` / `--port` | HTTP server port (default: `8080`). Simpler alternative to `ARC1_HTTP_ADDR` when only the port needs to change |
@@ -217,6 +217,7 @@ tests/
 | Add new tool type | `src/handlers/tools.ts`, `src/handlers/schemas.ts`, `src/handlers/intent.ts` |
 | Add/modify tool input schema | `src/handlers/schemas.ts`, `src/handlers/tools.ts` |
 | Add DDIC domain/data element write | `src/adt/ddic-xml.ts`, `src/adt/crud.ts`, `src/handlers/intent.ts` |
+| Set created-object master/original language from `SAP_LANGUAGE` (issue #343) | `src/adt/ddic-xml.ts` (`normalizeAdtLanguage` + `language?` on DOMA/DTEL/SRVB `*CreateParams`), `src/handlers/intent.ts` (`buildCreateXml(..., language)` + inline SKTD body; the 3 call sites pass `config.language`). Genuinely fixes DTEL/DOMA on the S/4 **v2** handler (per-object master `DD04L-DTELMASTER`/`DD01L-DOMMASTER` + text language `DD04T`/`DD01T-DDLANGUAGE`); cosmetic for source objects (master is `TADIR` from the `sap-language` URL param); NW 7.50 **v1** ignores the body. Default `EN` preserved. Live-verified on a4h 7.58 (HANA round-trip). See `docs/research/issue-343-masterlanguage-on-create.md`. |
 | Modify ADT service discovery / MIME types | `src/adt/discovery.ts`, `src/adt/http.ts` |
 | Improve DDIC save diagnostics + SAP-domain error hints (T100/line + lock/auth/dependency hints) | `src/adt/errors.ts` (`extractDdicDiagnostics`, `formatDdicDiagnostics`, `classifySapDomainError`), `src/handlers/intent.ts` (`enrichWithSapDetails`, `formatErrorForLLM`) |
 | Add SAP error classification (new `category` + hint) | `src/adt/errors.ts` (`extractExceptionType`/`extractLockOwner`/`classifySapDomainError`/`SapErrorClassification`), `src/handlers/intent.ts` (`formatErrorForLLM`/`classifyError`), `tests/unit/adt/errors.test.ts`. Existing categories live in the union type. Ground hints in verified SAP Notes/KBAs (use `mcp__sap-notes__search`) — no speculative tcode pointers. |

--- a/docs/plans/completed/fix-masterlanguage-hardcoded-en.md
+++ b/docs/plans/completed/fix-masterlanguage-hardcoded-en.md
@@ -1,0 +1,128 @@
+# Fix hard-coded `EN` master language in object-creation XML (issue #343)
+
+## Overview
+
+ARC-1's object-creation XML builders hard-code `adtcore:masterLanguage="EN"` (and `adtcore:language="EN"` for SRVB/FUGR/SKTD) instead of deriving the language from the configured `SAP_LANGUAGE`. On the S/4HANA v2 DDIC handler this causes **data elements (DTEL) and domains (DOMA)** created with `SAP_LANGUAGE=DE` to be stored with English as their per-object master language (`DD04L-DTELMASTER` / `DD01L-DOMMASTER` = `E`) and their German labels/descriptions **mis-filed under the English language key** (`DD04T`/`DD01T` `DDLANGUAGE=E`), while the repository directory `TADIR-MASTERLANG` is German (`D`) — a split-brain. SAP's own documentation (`ABENORIGINAL_LANGU_GUIDL`) and SAP Note 727896 state the original language must be the logon language; abapGit enforces exactly this.
+
+This plan threads the configured language (`config.language`, which ARC-1 already sends as the `sap-language` URL param on every request) into every create-XML builder, defaulting to `EN` when `SAP_LANGUAGE` is unset (no behavior change for the default case).
+
+This was empirically proven on live systems — see `docs/research/issue-343-masterlanguage-on-create.md` for the full evidence (HANA round-trip reads, real-binary reproduction, version matrix). The genuinely buggy types are **DTEL and DOMA** (DDIC types with a per-object master-language field + language-keyed text tables) on **S/4HANA (v2 handler)**; for source/container objects (PROG, CLAS, INTF, FUGR, …) the body attribute is ignored by SAP (cosmetic), and NW 7.50 (v1 handler) ignores it entirely. The fix is applied to **all** builders for consistency (it is harmless where cosmetic and corrects the Eclipse-visible echo), with acceptance testing focused on DTEL + DOMA.
+
+## Context
+
+### Current State
+
+- `src/adt/ddic-xml.ts` — `buildDomainXml` (`:171`), `buildDataElementXml` (`:246`), `buildServiceBindingXml` (`:323-324`) hard-code `EN`.
+- `src/handlers/intent.ts` — `buildCreateXml` (`:2870`) hard-codes `masterLanguage="EN"` for PROG/CLAS/INTF/INCL/DDLS/DCLS/TABL/BDEF/SRVD/DDLX/FUGR (and `language="EN"` for FUGR); the inline SKTD create body (`:4039`) hard-codes both.
+- The three `buildCreateXml` call sites — update (`~:3827`), create (`~:4087`), batch_create (`~:5202`) — pass no language.
+- `config.language` (the configured `SAP_LANGUAGE`, default `EN`) is already in scope in `handleSAPWrite` and is what `buildAdtConfig` sends as `sap-language` for both shared and per-user clients (`src/server/server.ts:187`).
+- For `isMetadataWriteType` = {DOMA, DTEL, MSAG, SRVB} (`src/handlers/intent.ts:2550`), `buildCreateXml` output is reused for create, the DTEL/MSAG follow-up label PUT (`~:4122`), and metadata UPDATE (`~:3819`) — so one builder fix covers all three paths.
+
+### Target State
+
+- Every create-XML builder emits `adtcore:masterLanguage` (and `adtcore:language` where present) derived from the configured language, normalized to upper-case 2-char (e.g. `DE`), defaulting to `EN`.
+- With `SAP_LANGUAGE=DE`, a created DTEL/DOMA has master language `DE` and its German texts filed under `D`, consistent with `TADIR`.
+- With `SAP_LANGUAGE` unset (default `EN`), output is byte-identical to today.
+- `MSAG`, `DEVC`, `FUNC` are untouched (they carry no language attribute by design).
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/ddic-xml.ts` | DOMA/DTEL/SRVB create-XML builders + their `*CreateParams` interfaces |
+| `src/handlers/intent.ts` | `buildCreateXml`, inline SKTD body, the 3 call sites in `handleSAPWrite` |
+| `tests/unit/adt/ddic-xml.test.ts` | Builder unit tests |
+| `tests/unit/handlers/intent.test.ts` | `buildCreateXml` unit tests + handler request-body assertions (mocked undici) |
+| `tests/integration/crud.lifecycle.integration.test.ts` | DTEL/DOMA CRUD lifecycle (live SAP) — add DE round-trip acceptance |
+| `CLAUDE.md` | Key Files table + config table note |
+| `docs/research/issue-343-masterlanguage-on-create.md` | Full evidence (already written) |
+
+### Design Principles
+
+- **Single source of truth:** derive the body language from `config.language` only — the exact value already sent as `sap-language`. Do NOT add an `AdtClient` property and do NOT touch `withSafety()` (the issue's suggestion to expose it from the client adds a clone hazard for no benefit).
+- **Default `EN` preserved:** normalize as `(language || 'EN').trim().toUpperCase()` so unset `SAP_LANGUAGE` keeps today's exact output.
+- **Pure builders normalize internally** (testable in isolation); call sites pass `config.language` raw.
+- **No new tool/schema parameter:** this is config-driven, not a per-call override (out of scope; possible future enhancement).
+- **Do not add a language attribute to MSAG/DEVC/FUNC** — they intentionally have none.
+
+## Development Approach
+
+Foundation first (pure builders + their unit tests), then handler wiring (call sites + mocked-request unit tests), then live integration acceptance (DTEL + DOMA DE round-trip), then docs. Each task ends by running the unit suite. Integration tests hard-fail without `TEST_SAP_URL` (no silent skips) per the project skip policy.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Thread configured language into the DDIC builders (DOMA, DTEL, SRVB)
+
+**Files:**
+- Modify: `src/adt/ddic-xml.ts`
+- Modify: `tests/unit/adt/ddic-xml.test.ts`
+
+These three builders hard-code the master language. Add an optional `language` to their params and emit it instead of the literal `EN`, defaulting to `EN`.
+
+- [ ] Add `language?: string` to `DomainCreateParams`, `DataElementCreateParams`, and `ServiceBindingCreateParams` (interfaces near the top of `src/adt/ddic-xml.ts`).
+- [ ] In `buildDomainXml`, compute `const masterLanguage = (params.language || 'EN').trim().toUpperCase();` and replace `adtcore:masterLanguage="EN"` (line ~171) with `adtcore:masterLanguage="${masterLanguage}"`.
+- [ ] In `buildDataElementXml`, do the same for `adtcore:masterLanguage="EN"` (line ~246).
+- [ ] In `buildServiceBindingXml`, compute the same `masterLanguage` and replace BOTH `adtcore:language="EN"` and `adtcore:masterLanguage="EN"` (lines ~323-324) with `${masterLanguage}`.
+- [ ] Add unit tests (~6 tests) in `tests/unit/adt/ddic-xml.test.ts`: for each of the three builders, (a) with `language: 'DE'` the XML contains `adtcore:masterLanguage="DE"` (and for SRVB also `adtcore:language="DE"`); (b) without `language` the XML still contains `adtcore:masterLanguage="EN"`. Also assert lower-case `language: 'de'` normalizes to `"DE"`.
+- [ ] Run `npm test` — all tests must pass.
+
+### Task 2: Thread configured language through `buildCreateXml`, the inline SKTD body, and the call sites
+
+**Files:**
+- Modify: `src/handlers/intent.ts`
+- Modify: `tests/unit/handlers/intent.test.ts`
+
+`buildCreateXml` (`src/handlers/intent.ts:2870`) builds the create XML for all remaining types and is reused for metadata updates and the DTEL/MSAG follow-up PUT. Add a `language` parameter, replace every literal `EN`, and pass `config.language` from the call sites.
+
+- [ ] Change the signature to `buildCreateXml(type, name, pkg, description, properties?, language?: string)`. At the top of the function compute `const masterLanguage = (language || 'EN').trim().toUpperCase();`.
+- [ ] Replace every `adtcore:masterLanguage="EN"` in the `buildCreateXml` switch (PROG, CLAS, INTF, INCL, DDLS, DCLS, TABL/DT/DS, BDEF, SRVD, DDLX) with `adtcore:masterLanguage="${masterLanguage}"`. For the FUGR case, replace both `adtcore:language="EN"` and `adtcore:masterLanguage="EN"`.
+- [ ] In the DOMA/DTEL/SRVB cases of `buildCreateXml`, set `language: masterLanguage` on the `DomainCreateParams`/`DataElementCreateParams`/`ServiceBindingCreateParams` objects passed to the sub-builders (so they receive the threaded language).
+- [ ] Leave the MSAG and FUNC cases unchanged (no language attribute).
+- [ ] Update the inline SKTD create body (`ktdBody`, line ~4039) to use the configured language for `adtcore:language="..."` and `adtcore:masterLanguage="..."`. Derive it locally: `const ktdLang = (config.language || 'EN').trim().toUpperCase();`.
+- [ ] Pass `config.language` as the new 6th arg at all three `buildCreateXml` call sites: the metadata-update path (`~:3827`), the create path (`~:4087`), and the batch_create path (`~:5202`). `config` is in scope in `handleSAPWrite` at all three.
+- [ ] Add unit tests (~6 tests) in `tests/unit/handlers/intent.test.ts`: (a) `buildCreateXml('PROG', …, 'DE')` contains `masterLanguage="DE"`; `buildCreateXml('FUGR', …, 'DE')` contains both `language="DE"` and `masterLanguage="DE"`; `buildCreateXml('DTEL'/'DOMA', …, props, 'DE')` contains `masterLanguage="DE"`. (b) Calls without the language arg still contain `masterLanguage="EN"` (guard the existing default behavior — keep/confirm the existing FUGR `"EN"` test passes).
+- [ ] Add a handler-wiring test (~2 tests) using the mocked-undici pattern (`vi.mock('undici', …)` + `mockResponse`): call `handleToolCall`/`handleSAPWrite` for a DTEL `create` with the client configured `language: 'DE'`, and assert the POSTed request body contains `adtcore:masterLanguage="DE"`. Add the same for `SAP_LANGUAGE` unset → body contains `"EN"`.
+- [ ] Run `npm test` — all tests must pass.
+
+### Task 3: Live DE round-trip acceptance for DTEL (automated) + DOMA (assertion note)
+
+**Files:**
+- Modify: `tests/integration/crud.lifecycle.integration.test.ts`
+
+Prove on a live S/4HANA (v2 handler) system that a DTEL created with the German language comes back with master language `DE`. Read `tests/integration/helpers.ts` and the existing `DTEL`/`DOMA` lifecycle tests in this file first to reuse `getTestClient()`, `generateUniqueName()`, and the create/GET helpers.
+
+**Assertion-method facts (verified live, see research doc §3-5):**
+- **DTEL**: the ADT GET metadata `adtcore:masterLanguage` echoes the **body** value (`DD04L-DTELMASTER`). Created body=EN/url=DE → GET=`"EN"`; body=DE → GET=`"DE"`. So asserting GET=`"DE"` after the fix **is a valid discriminator** (it was `"EN"` before).
+- **DOMA**: the ADT GET `adtcore:masterLanguage` echoes **`TADIR-MASTERLANG`** (the URL `sap-language`), which is already `DE`. So ADT GET **cannot** discriminate the DOMA fix — the DOMA fix lives in `DD01L-DOMMASTER` + `DD01T-DDLANGUAGE`, only readable via the DB. Do **not** write a DOMA integration assertion based on ADT GET (it would pass even unfixed and give false confidence). DOMA's deep fix is covered by the Task 2 unit test (POST body contains `masterLanguage="DE"`) plus the manual HANA verification recorded in the research doc.
+
+- [ ] Build (or obtain) an `AdtClient` configured with `language: 'DE'` (construct from the same env credentials as `getTestClient()` but with `language: 'DE'`; if `getTestClient` takes no override, instantiate `new AdtClient({ ... , language: 'DE' })` from the test env vars). Skip via `requireOrSkip(ctx, …)` when `TEST_SAP_URL` is missing — never `if (!x) return`.
+- [ ] DTEL test: create a uniquely-named DTEL with `buildCreateXml('DTEL', name, '$TMP', 'Sprachtest', { typeKind:'predefinedAbapType', dataType:'CHAR', length:10, shortLabel:'Kurz', mediumLabel:'Mittel', longLabel:'Lang', headingLabel:'Kopf' }, 'DE')` via the DE client (the DTEL follow-up label PUT also reuses this DE body), then GET the data element metadata and assert `adtcore:masterLanguage="DE"`. Clean up in `finally` (delete), tagged `// best-effort-cleanup`.
+- [ ] DOMA test: create a uniquely-named DOMA with `language: 'DE'` and assert the **create succeeds** (HTTP 2xx / success result) as a non-regression smoke check; add a code comment that the master-language correctness for DOMA is verified by the Task 2 unit test + manual HANA read (ADT GET cannot discriminate it). Clean up in `finally`.
+- [ ] Assert both success and expected-error paths (use `expectSapFailureClass` for any catch); do not leave empty catches.
+- [ ] Run `npm run test:integration` against the configured `TEST_SAP_URL` — new tests pass. (CI without SAP creds hard-fails by policy, handled by the skip harness.)
+- [ ] Run `npm test` — unit suite still green.
+
+### Task 4: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `docs/research/issue-343-masterlanguage-on-create.md` (mark status implemented once merged)
+
+- [ ] Add a Key Files row to `CLAUDE.md`: e.g. *"Set created object master/original language from SAP_LANGUAGE | `src/adt/ddic-xml.ts` (DOMA/DTEL/SRVB builders), `src/handlers/intent.ts` (`buildCreateXml` + inline SKTD + 3 call sites pass `config.language`). Genuine effect on DTEL/DOMA (per-object master + text language) on S/4 v2 handler; cosmetic for source objects; NW 7.50 v1 ignores it. Default EN preserved. See `docs/research/issue-343-masterlanguage-on-create.md`."*
+- [ ] In `CLAUDE.md`, update the `SAP_LANGUAGE` config-table row to note it now also sets the master/original language of newly created objects (not just the request `sap-language`).
+- [ ] Confirm no other doc references the hard-coded `EN` create behavior (grep `docs/` for `masterLanguage`); update any that do.
+- [ ] Run `npm test` — all tests pass (docs-only task; sanity check the suite still builds).
+
+### Task 5: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass.
+- [ ] Run typecheck: `npm run typecheck` — no errors.
+- [ ] Run lint: `npm run lint` — no errors.
+- [ ] Grep the source to confirm no remaining hard-coded `adtcore:masterLanguage="EN"` / `adtcore:language="EN"` in create paths except intentional defaults: `grep -rn 'masterLanguage="EN"\|adtcore:language="EN"' src/` should return only normalized-default expressions, not literals in builder output.
+- [ ] Confirm `SAP_LANGUAGE` unset still yields `masterLanguage="EN"` (a builder unit test asserts this).
+- [ ] Verify the live DTEL + DOMA DE round-trip (Task 3) passed against `TEST_SAP_URL`, and that all test objects were cleaned up.
+- [ ] Move this plan to `docs/plans/completed/`.

--- a/docs/research/issue-343-masterlanguage-on-create.md
+++ b/docs/research/issue-343-masterlanguage-on-create.md
@@ -1,0 +1,205 @@
+# Issue #343 — `SAP_LANGUAGE=DE` ignored by hard-coded `EN` in create metadata
+
+**Status:** Implemented & live-verified. Fix threads `config.language` into all create-XML builders.
+
+> **Post-fix verification (a4h 7.58, real fixed binary, `SAP_LANGUAGE=DE`, German labels):** DTEL `ZARC1_FIXDT` → `DD04L.DTELMASTER=D`, `DD04T.DDLANGUAGE=D`, `TADIR.MASTERLANG=D`. DOMA `ZARC1_FIXDO` → `DD01L.DOMMASTER=D`, `DD01T.DDLANGUAGE=D`, `TADIR.MASTERLANG=D`. All consistent; split-brain gone; German texts filed under `D`. (Before the fix the same path produced `DTELMASTER=E`/`DD04T=E`.)
+**Systems used:** A4H S/4HANA 2023 (kernel 7.58, HANA) `a4h.marianzeis.de:50000`; NPL NetWeaver 7.50 SP02 (ASE) `npl.marianzeis.de`.
+**Date:** 2026-06-04.
+
+> Infrastructure note: the lab host moved from `65.109.59.210` to **`176.9.72.62`** (`sap-fsn1`); the A4H container is now **`a4h-2023`** (HANA schema `SAPA4H`), and a second system **`a4h-2025`** runs on ports `50100/50101` (different credentials — not used here). `INFRASTRUCTURE.md` still lists the old IP/container name and should be refreshed.
+
+---
+
+## 1. Verdict
+
+The bug reported in [#343](https://github.com/marianfoo/arc-1/issues/343) is **real on modern S/4HANA**, but the reporter's *mechanism* and *affected-type list* are both partly wrong. The corrected picture:
+
+1. **Two different "master language" values exist** and are written from **two different inputs**:
+   - The **per-object DDIC master language** (`DD04L-DTELMASTER` for data elements, `DD01L-DOMMASTER` for domains) is taken from the **XML body** `adtcore:masterLanguage`.
+   - The **repository directory** `TADIR-MASTERLANG` is taken from the **`sap-language` URL parameter** (which ARC-1 already sets correctly from `config.language`).
+2. For **DTEL and DOMA**, the per-object master language *also drives which language bucket the texts/labels are filed under* (`DD04T`/`DD01T` `DDLANGUAGE`). So the hard-coded `EN` body causes a German shop's German labels to be **mis-filed as English**, and creates a `DTELMASTER/DOMMASTER = E` vs `TADIR.MASTERLANG = D` **split-brain**. This is a genuine data-correctness bug. **(HIGH severity.)**
+3. For **source/container objects (PROG, and by the same mechanism CLAS/INTF/FUGR/INCL/…)** the master language is read from `TADIR` (the URL param). The body `adtcore:masterLanguage` is **ignored/cosmetic** — these objects already get the correct language today. **(Cosmetic only.)**
+4. The bug is **handler/version-specific**: it reproduces on the **v2 DDIC handler (S/4HANA 7.58)**. On **NW 7.50 (v1 handler)** the body `masterLanguage` is ignored and the object correctly takes the URL language — so 7.50 is **not** affected.
+
+The reporter is nevertheless right that **the fix is to thread the configured language into the create XML** instead of hard-coding `EN`. That fix is correct for the buggy types and harmless (consistency-improving) for the cosmetic ones.
+
+---
+
+## 2. Methodology
+
+All ADT object creation goes through ARC-1's HTTP layer, which appends `sap-language=<config.language>` to **every** request (`src/adt/http.ts:1095`) for both shared and per-user clients (`buildAdtConfig` sets `language: config.language` unconditionally — `src/server/server.ts:187`). The create XML body is built by `buildDataElementXml`/`buildDomainXml`/`buildServiceBindingXml` (`src/adt/ddic-xml.ts`) and `buildCreateXml` (`src/handlers/intent.ts`), all of which **hard-code `adtcore:masterLanguage="EN"`**.
+
+To separate the body input from the URL input, I created objects via raw ADT REST calls varying each independently, then read the persisted truth directly from HANA (`SAPA4H` schema) via `hdbsql`, and finally reproduced the exact ARC-1 behavior with the **real compiled binary** (`dist/cli.js call SAPWrite`).
+
+Confirmed prerequisite: **German (`D`) is installed** on A4H (`DD04T` for standard `BUKRS` has both `E` "Company Code" and `D` "Buchungskreis"; `BUKRS` `TADIR.MASTERLANG = D`). `TADIR.MASTERLANG` stores the **1-char** SAP code (`E`/`D`); ADT `adtcore:masterLanguage` uses the **2-char** ISO code (`EN`/`DE`); SAP converts internally.
+
+---
+
+## 3. Decisive experiment (DTEL on A4H 7.58, v2 handler)
+
+Three data elements, varying body `adtcore:masterLanguage` and URL `sap-language` independently, then read back from HANA:
+
+| Object | body `masterLanguage` | URL `sap-language` | `DD04L.DTELMASTER` (per-object / Eclipse-visible) | `TADIR.MASTERLANG` (repo directory) |
+|--------|:--:|:--:|:--:|:--:|
+| LANGA = **today's ARC-1** | `EN` | `DE` | **E** | **D** |
+| LANGB = **proposed fix** | `DE` | `DE` | **D** | **D** |
+| LANGC | `DE` | `EN` | **D** | **E** |
+
+- LANGA vs LANGB (same URL, different body) → only `DTELMASTER` changed → **the body drives `DTELMASTER`**.
+- LANGA vs LANGC (the two inputs swapped) → `DTELMASTER` follows the body, `TADIR` follows the URL → **the two fields have independent sources.**
+- Activation does **not** change either value (re-read after activate: identical).
+
+The ADT **GET metadata** for a DTEL echoes the **body** value (`DTELMASTER`): LANGA GET returns `masterLanguage="EN"` even though `TADIR=D`. **This is exactly what the reporter "saw" in Eclipse/ADT** — the object's master language reads English.
+
+---
+
+## 4. Real-binary reproduction (the smoking gun)
+
+`dist/cli.js call SAPWrite` with `SAP_LANGUAGE=DE`, creating a DTEL with German labels (`Echter Test` / `Kurz` / `Mittel` / `Lang` / `Kopf`), then activate, then HANA read:
+
+```
+ARC-1 response: adtcore:masterLanguage="EN"  adtcore:language="DE"
+HANA after activation:
+  DD04L.DTELMASTER  = E      ← from hard-coded body masterLanguage="EN"
+  DD04T.DDLANGUAGE  = E   ("Echter Test", "Kurz", …)   ← German texts mis-filed as ENGLISH
+  TADIR.MASTERLANG  = D      ← from sap-language=DE URL param
+```
+
+So with the **real, unmodified ARC-1** and `SAP_LANGUAGE=DE`:
+- the data element's own master language is **English**,
+- the **German labels are stored under the English language key**, and
+- `TADIR` disagrees (German).
+
+ARC-1's DTEL create does a **follow-up label PUT that reuses the same hard-coded body** (`src/handlers/intent.ts:4122-4132`), which is why the German labels land under `E`.
+
+**Fix confirmation:** creating with body `masterLanguage="DE"` (+ `sap-language=DE`) yields `DTELMASTER=D` and `TADIR=D` (object `ZARC1_FIXED`, and LANGB above). The text bucket follows the per-object master language (established by the real-binary run above where text language == `DTELMASTER`), so body=`DE` → texts under `D`. *(End-to-end "German labels land under `D`" with a successful label PUT is the headline acceptance test for the implementation phase.)*
+
+---
+
+## 5. DOMA is also genuinely affected; PROG (source objects) is not
+
+**DOMA (A4H 7.58), body=`EN`, URL=`DE`, after activation:**
+```
+DD01L.DOMMASTER  = E
+DD01T.DDLANGUAGE = E   ("Doma Test")   ← German description mis-filed as ENGLISH
+TADIR.MASTERLANG = D
+```
+Same pattern as DTEL → **DOMA is genuinely buggy.** (Note: the DOMA ADT *GET* echoes `masterLanguage="DE"` from `TADIR`, which is misleading — the persisted `DOMMASTER` and text language are `E`.)
+
+**PROG (A4H 7.58), body=`EN`, URL=`DE`:**
+```
+ADT GET echo    : masterLanguage="DE"
+TADIR.MASTERLANG: D
+TRDIRT (title)  : SPRSL = D   ← title correctly under German
+```
+→ **PROG ignores the body `masterLanguage`; it follows `sap-language`/`TADIR`. Cosmetic only.** Source/container objects (CLAS, INTF, FUGR, INCL) work the same way: their original language lives only in `TADIR`.
+
+**Why the difference:** DTEL/DOMA are DDIC objects with a *per-object* master-language field (`DTELMASTER`/`DOMMASTER`) plus language-keyed text tables (`DD04T`/`DD01T`). The ADT v2 create handler honors the body `masterLanguage` for that field and files the texts under it. Source objects have no such per-object field.
+
+---
+
+## 6. Version dependency (NPL 7.50, v1 handler)
+
+NW 7.50 rejects the v2 DTEL content type (`415`) and requires `application/vnd.sap.adt.dataelements.v1+xml` (ARC-1 already auto-falls-back — PR #169). With v1, body `masterLanguage="EN"` + `sap-language=DE`:
+```
+create 201; ADT GET echo: masterLanguage="DE"
+```
+→ On **7.50 the body is ignored** and the object takes the URL language. **7.50 is not affected.** The bug is specific to the **v2 DDIC handler on S/4HANA** — the primary modern target, consistent with the reporter's environment.
+
+---
+
+## 7. SAP Notes corroboration
+
+The "original language vs text language" mismatch is a recognized, consequential problem class:
+- **2408957** "Wrong language used in data elements" — field labels in German even when logged on in English.
+- **3659876** "Activation for data element may delete texts in original language" — DTEL original language is tied to text persistence.
+- **3382553 / 3031206 / …** multiple "Correction of original language" notes for individual data elements — SAP itself ships corrections when a DTEL's original language was set wrong.
+
+These confirm `DTELMASTER`/original-language is a real attribute with downstream impact on label language and translation — exactly the field ARC-1 mis-sets to `EN`.
+
+---
+
+## 8. External client behavior & SAP doc (reference)
+
+**SAP is explicit that the master language = logon language, not `EN`.**
+
+- **SAP ABAP doc — "Original Language" guideline** (`ABENORIGINAL_LANGU_GUIDL`): *"When a repository object is created … its original language must be specified. This is specified implicitly by the current logon language … When a repository object is created, its original language is the logon language."* → https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENORIGINAL_LANGU_GUIDL.html
+- **SAP Note 727896** — documents this *exact* defect: DDIC objects (a domain, several `TABL`s, a `DEVC`) ended up with the wrong original language because they "have not been developed in logon language DE"; SAP's correction reset the original language to German. This is the arc-1 bug, named by SAP.
+- **SAP Note 1433092** — DDIC objects have a per-object original language distinct from modification language; texts are filed per language (matches the `DD04T`/`DD01T` `DDLANGUAGE` behavior observed here).
+
+**Reference clients:**
+
+| Client | How it sets create master language | Takeaway |
+|---|---|---|
+| **abapGit** (ABAP, reference impl) | repo main language = `sy-langu` (logon); deserialize/create **blocked unless logon == main language**; sets `TADIR-MASTERLANG` from it; DTEL via `DDIF_DTEL_PUT`/`dd04v`, DOMA via `DDIF_DOMA_PUT`/`dd01v` keyed by `ddlanguage` | **logon language** (enforced) — validates the fix |
+| **vibing-steampunk** (Go) | **omits** `masterLanguage`/`language` from the POST body → SAP applies logon-language default | logon language (by omission) |
+| **abap-adt-api** (TS) | `masterLanguage = options.masterLanguage \|\| options.language \|\| "EN"` — caller param, **defaults EN**, never auto-threads logon language | opt-in; EN default |
+| **fr0ster/mcp-abap-adt-clients** (TS) | hard-codes `adtcore:language="EN"` + `adtcore:masterLanguage="EN"` across DOMA/TABL/CLAS/… | **same anti-pattern as arc-1** |
+
+The authoritative consensus (SAP docs + Note 727896 + abapGit) is **master language = logon/session language**. ARC-1 already sends that as `sap-language=config.language`; the body must match it. Two valid implementations: set the attributes to `config.language` (Eclipse/abap-adt-api style — chosen here, and empirically proven by LANGB/`ZARC1_FIXED`), or omit them entirely (vibing-steampunk style). Setting explicitly is more deterministic and is what the fix does.
+
+**adt-ls / sapse.adt-vscode:** SAP's ABAP language server is closed-source; it drives the same ADT REST endpoints under the hood, so the documented logon-language semantics above govern it too. No code-level inspection possible.
+
+---
+
+## 9. ARC-1 affected code
+
+All create-XML builders hard-code `EN`. Full inventory (the issue lists only 7 of these):
+
+**`src/adt/ddic-xml.ts`**
+| Builder | Type | Line | Severity |
+|---|---|---|---|
+| `buildDomainXml` | DOMA | `:171` `masterLanguage="EN"` | **Genuine (texts mis-filed)** |
+| `buildDataElementXml` | DTEL | `:246` `masterLanguage="EN"` | **Genuine (texts mis-filed)** — headline |
+| `buildServiceBindingXml` | SRVB | `:323-324` `language="EN"`+`masterLanguage="EN"` | Cosmetic (metadata type; not individually verified) |
+
+**`src/handlers/intent.ts` `buildCreateXml`**
+| Type | Line | Severity |
+|---|---|---|
+| PROG | `:2885` | Cosmetic (verified) |
+| CLAS | `:2897` | Cosmetic (source object) |
+| INTF | `:2909` | Cosmetic (source object) |
+| INCL | `:2921` | Cosmetic (source object) |
+| DDLS | `:2933` | Cosmetic (source object) |
+| DCLS | `:2945` | Cosmetic (source object) |
+| TABL/DT/DS | `:2963` | Cosmetic (source-based; not individually verified) |
+| BDEF | `:2978` | Cosmetic (source object) |
+| SRVD | `:2990` | Cosmetic (source object) |
+| DDLX | `:3023` | Cosmetic (source object) |
+| FUGR | `:3101` `language="EN"`+`masterLanguage="EN"` | Cosmetic (container) |
+
+**Inline SKTD builder** in `handleSAPWrite`: `src/handlers/intent.ts:4039` `language="EN"`+`masterLanguage="EN"`.
+
+**Not affected (no language attribute — do NOT add one):** MSAG (`buildMessageClassXml`), DEVC (`buildPackageXml`), FUNC (inherits from parent FUGR).
+
+**Reuse paths that inherit the fix automatically:** for `isMetadataWriteType` = {DOMA, DTEL, MSAG, SRVB} (`src/handlers/intent.ts:2550`), `buildCreateXml` is reused for **create**, the **DTEL/MSAG follow-up label PUT** (`:4122-4145`), and **metadata UPDATE** (`:3819-3838`). Three `buildCreateXml` call sites: update `:3827`, create `:4087`, batch_create `:5202`.
+
+---
+
+## 10. Root cause & correct fix
+
+**Root cause:** the create-XML builders hard-code `adtcore:masterLanguage="EN"` (and `adtcore:language="EN"` for SRVB/FUGR/SKTD) instead of deriving from the configured language. On the S/4HANA v2 DDIC handler this sets `DTELMASTER`/`DOMMASTER`=`E` and files texts under English, contradicting `sap-language=DE`.
+
+**Fix:** thread the configured language into the builders. **`config.language` is the correct single source of truth** — it is exactly what `buildAdtConfig` uses for the `sap-language` URL param on every client (shared and PP), so the body will always match the URL. `config` is already in scope in `handleSAPWrite`; **no `AdtClient` property and no `withSafety()` change is needed** (the issue's suggestion to expose it from the client would introduce a clone hazard for nothing).
+
+- Add `language?: string` to `DomainCreateParams` / `DataElementCreateParams` / `ServiceBindingCreateParams`; emit `adtcore:masterLanguage="${escapeXml((language||'EN').trim().toUpperCase())}"` (and `adtcore:language` where present).
+- Add a `language` parameter to `buildCreateXml(...)` and replace every literal `"EN"` with it; default `'EN'` preserves today's behavior when `SAP_LANGUAGE` is unset.
+- Pass `config.language` from the three `buildCreateXml` call sites and into the inline SKTD body.
+
+**Regression risk: low.** Default-`EN` is preserved, so existing builder unit tests that pass no language still hold (e.g. the FUGR test asserting `masterLanguage="EN"`). KTD-envelope and read-side `masterLanguage` fixtures are inputs, unaffected.
+
+---
+
+## 11. Recommended scope, acceptance tests, open items
+
+**Scope:** apply the fix to **all** builders (matches the issue's "broader fix" and fixes the Eclipse-visible echo for every type), but **focus acceptance on DTEL + DOMA** (the only genuinely buggy types).
+
+**Acceptance (run on A4H 7.58 with `SAP_LANGUAGE=DE`):**
+1. Create DTEL with German labels → assert `DD04L.DTELMASTER='D'`, `DD04T.DDLANGUAGE='D'`, `TADIR.MASTERLANG='D'` (all German, no split-brain). *This is the headline test.*
+2. Create DOMA with German description → assert `DD01L.DOMMASTER='D'`, `DD01T.DDLANGUAGE='D'`, `TADIR.MASTERLANG='D'`.
+3. Default (`SAP_LANGUAGE` unset → `EN`) → builders still emit `masterLanguage="EN"`.
+4. Unit: each builder with `language:'DE'` emits `masterLanguage="DE"`; without it, `"EN"`.
+
+**Open / not individually verified:** SRVB and TABL persistence behavior (classified cosmetic by analogy; fix is harmless either way). NW 7.50 is unaffected (v1 ignores the body) so the fix is a no-op there.
+
+**Cleanup:** all test objects created during this research (`ZARC1_LANGA/B/C`, `ZARC1_REAL1`, `ZARC1_FIXED`, `ZARC1_DOMALANG`, `ZARC1_PROGLANG` on A4H; `ZARC1_NPLLANG` on NPL) were deleted.

--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -24,6 +24,8 @@ export interface DomainCreateParams {
   lowercase?: boolean;
   fixedValues?: DomainFixedValue[];
   valueTable?: string;
+  /** ADT master/original language (2-char, e.g. "DE"). Defaults to "EN" when unset. */
+  language?: string;
 }
 
 export interface DataElementCreateParams {
@@ -45,6 +47,8 @@ export interface DataElementCreateParams {
   setGetParameter?: string;
   defaultComponentName?: string;
   changeDocument?: boolean;
+  /** ADT master/original language (2-char, e.g. "DE"). Defaults to "EN" when unset. */
+  language?: string;
 }
 
 export interface PackageCreateParams {
@@ -65,6 +69,8 @@ export interface ServiceBindingCreateParams {
   category?: '0' | '1';
   version?: string;
   odataVersion?: string;
+  /** ADT master/original language (2-char, e.g. "DE"). Defaults to "EN" when unset. */
+  language?: string;
 }
 
 /**
@@ -110,6 +116,21 @@ const DTEL_MAX_LABEL_LENGTHS = {
   heading: 55,
 } as const;
 
+/**
+ * Normalize an ADT master/original language to the 2-char upper-case form ADT
+ * expects (e.g. "de" → "DE"). Defaults to "EN" when unset or blank, preserving
+ * the legacy hard-coded behavior for callers that pass no language.
+ *
+ * The created object's master language must match the developer's logon language
+ * (SAP doc ABENORIGINAL_LANGU_GUIDL; SAP Note 727896). ARC-1 already sends that
+ * as the `sap-language` URL param; this keeps the create-XML body consistent so
+ * DDIC texts (DD04T/DD01T) are filed under the correct language. See issue #343
+ * and docs/research/issue-343-masterlanguage-on-create.md.
+ */
+export function normalizeAdtLanguage(language?: string): string {
+  return (language ?? '').trim().toUpperCase() || 'EN';
+}
+
 function escapeXml(s: string): string {
   return s
     .replace(/&/g, '&amp;')
@@ -144,6 +165,7 @@ function boolToXml(value: boolean | undefined): string {
 }
 
 export function buildDomainXml(params: DomainCreateParams): string {
+  const masterLanguage = normalizeAdtLanguage(params.language);
   const fixedValues = params.fixedValues ?? [];
   const valueTable = params.valueTable?.trim();
   const fixValuesXml =
@@ -168,7 +190,7 @@ export function buildDomainXml(params: DomainCreateParams): string {
              adtcore:description="${escapeXml(params.description)}"
              adtcore:name="${escapeXml(params.name)}"
              adtcore:type="DOMA/DD"
-             adtcore:masterLanguage="EN"
+             adtcore:masterLanguage="${masterLanguage}"
              adtcore:masterSystem="H00"
              adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>
@@ -230,6 +252,7 @@ export function buildMessageClassXml(params: MessageClassCreateParams): string {
 }
 
 export function buildDataElementXml(params: DataElementCreateParams): string {
+  const masterLanguage = normalizeAdtLanguage(params.language);
   const typeKind = params.typeKind ?? (params.dataType ? 'predefinedAbapType' : 'domain');
   const shortLabel = params.shortLabel ?? '';
   const mediumLabel = params.mediumLabel ?? '';
@@ -243,7 +266,7 @@ export function buildDataElementXml(params: DataElementCreateParams): string {
             adtcore:description="${escapeXml(params.description)}"
             adtcore:name="${escapeXml(params.name)}"
             adtcore:type="DTEL/DE"
-            adtcore:masterLanguage="EN"
+            adtcore:masterLanguage="${masterLanguage}"
             adtcore:masterSystem="H00"
             adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>
@@ -313,6 +336,7 @@ export function buildServiceBindingXml(params: ServiceBindingCreateParams): stri
   // Explicit odataVersion from params takes precedence, then parsed from bindingType
   const odataVersion = params.odataVersion?.trim().toUpperCase() || normalized.odataVersion;
   const serviceVersion = params.version?.trim() || '0001';
+  const masterLanguage = normalizeAdtLanguage(params.language);
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <srvb:serviceBinding xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings"
@@ -320,8 +344,8 @@ export function buildServiceBindingXml(params: ServiceBindingCreateParams): stri
                      adtcore:description="${escapeXml(params.description)}"
                      adtcore:name="${escapeXml(params.name)}"
                      adtcore:type="SRVB/SVB"
-                     adtcore:language="EN"
-                     adtcore:masterLanguage="EN"
+                     adtcore:language="${masterLanguage}"
+                     adtcore:masterLanguage="${masterLanguage}"
                      adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>
   <srvb:services srvb:name="${escapeXml(params.name)}">

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -74,6 +74,7 @@ import {
   type DomainCreateParams,
   decodeKtdText,
   type MessageClassCreateParams,
+  normalizeAdtLanguage,
   type PackageCreateParams,
   rewriteKtdText,
   type ServiceBindingCreateParams,
@@ -2873,7 +2874,13 @@ export function buildCreateXml(
   pkg: string,
   description: string,
   properties?: Record<string, unknown>,
+  language?: string,
 ): string {
+  // Master/original language for the created object. Derived from the configured
+  // SAP_LANGUAGE (passed by callers as config.language) so the create-XML body
+  // matches the sap-language URL param ARC-1 already sends. Defaults to "EN" when
+  // unset, preserving legacy output. See issue #343.
+  const masterLanguage = normalizeAdtLanguage(language);
   switch (type) {
     case 'PROG':
       return `<?xml version="1.0" encoding="UTF-8"?>
@@ -2882,7 +2889,7 @@ export function buildCreateXml(
                      adtcore:description="${escapeXml(description)}"
                      adtcore:name="${escapeXml(name)}"
                      adtcore:type="PROG/P"
-                     adtcore:masterLanguage="EN"
+                     adtcore:masterLanguage="${masterLanguage}"
                      adtcore:masterSystem="H00"
                      adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
@@ -2894,7 +2901,7 @@ export function buildCreateXml(
                  adtcore:description="${escapeXml(description)}"
                  adtcore:name="${escapeXml(name)}"
                  adtcore:type="CLAS/OC"
-                 adtcore:masterLanguage="EN"
+                 adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
                  adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
@@ -2906,7 +2913,7 @@ export function buildCreateXml(
                     adtcore:description="${escapeXml(description)}"
                     adtcore:name="${escapeXml(name)}"
                     adtcore:type="INTF/OI"
-                    adtcore:masterLanguage="EN"
+                    adtcore:masterLanguage="${masterLanguage}"
                     adtcore:masterSystem="H00"
                     adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
@@ -2918,7 +2925,7 @@ export function buildCreateXml(
                      adtcore:description="${escapeXml(description)}"
                      adtcore:name="${escapeXml(name)}"
                      adtcore:type="PROG/I"
-                     adtcore:masterLanguage="EN"
+                     adtcore:masterLanguage="${masterLanguage}"
                      adtcore:masterSystem="H00"
                      adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
@@ -2930,7 +2937,7 @@ export function buildCreateXml(
                adtcore:description="${escapeXml(description)}"
                adtcore:name="${escapeXml(name)}"
                adtcore:type="DDLS/DF"
-               adtcore:masterLanguage="EN"
+               adtcore:masterLanguage="${masterLanguage}"
                adtcore:masterSystem="H00"
                  adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
@@ -2942,7 +2949,7 @@ export function buildCreateXml(
                adtcore:description="${escapeXml(description)}"
                adtcore:name="${escapeXml(name)}"
                adtcore:type="DCLS/DL"
-               adtcore:masterLanguage="EN"
+               adtcore:masterLanguage="${masterLanguage}"
                adtcore:masterSystem="H00"
                adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
@@ -2960,7 +2967,7 @@ export function buildCreateXml(
                  adtcore:description="${escapeXml(description)}"
                  adtcore:name="${escapeXml(name)}"
                  adtcore:type="${adtType}"
-                 adtcore:masterLanguage="EN"
+                 adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
                  adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
@@ -2975,7 +2982,7 @@ export function buildCreateXml(
                  adtcore:description="${escapeXml(description)}"
                  adtcore:name="${escapeXml(name)}"
                  adtcore:type="BDEF/BDO"
-                 adtcore:masterLanguage="EN"
+                 adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
                  adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
@@ -2987,7 +2994,7 @@ export function buildCreateXml(
                  adtcore:description="${escapeXml(description)}"
                  adtcore:name="${escapeXml(name)}"
                  adtcore:type="SRVD/SRV"
-                 adtcore:masterLanguage="EN"
+                 adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
                  adtcore:responsible="DEVELOPER"
                  srvd:srvdSourceType="S">
@@ -3010,6 +3017,7 @@ export function buildCreateXml(
         category,
         version: properties?.version ? String(properties.version) : undefined,
         odataVersion: properties?.odataVersion ? String(properties.odataVersion) : undefined,
+        language: masterLanguage,
       };
       return buildServiceBindingXml(params);
     }
@@ -3020,7 +3028,7 @@ export function buildCreateXml(
                  adtcore:description="${escapeXml(description)}"
                  adtcore:name="${escapeXml(name)}"
                  adtcore:type="DDLX/EX"
-                 adtcore:masterLanguage="EN"
+                 adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
                      adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
@@ -3048,6 +3056,7 @@ export function buildCreateXml(
         lowercase: toBoolean(properties?.lowercase),
         fixedValues,
         valueTable: properties?.valueTable ? String(properties.valueTable) : undefined,
+        language: masterLanguage,
       };
       return buildDomainXml(params);
     }
@@ -3074,6 +3083,7 @@ export function buildCreateXml(
         setGetParameter: properties?.setGetParameter ? String(properties.setGetParameter) : undefined,
         defaultComponentName: properties?.defaultComponentName ? String(properties.defaultComponentName) : undefined,
         changeDocument: toBoolean(properties?.changeDocument),
+        language: masterLanguage,
       };
       return buildDataElementXml(params);
     }
@@ -3098,7 +3108,7 @@ export function buildCreateXml(
       // with Content-Type: application/vnd.sap.adt.functions.groups.v3+xml.
       // Verified live on a4h S/4HANA 2023 (issue #250).
       return `<?xml version="1.0" encoding="UTF-8"?>
-<group:abapFunctionGroup xmlns:group="http://www.sap.com/adt/functions/groups" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${escapeXml(description)}" adtcore:language="EN" adtcore:name="${escapeXml(name)}" adtcore:type="FUGR/F" adtcore:masterLanguage="EN">
+<group:abapFunctionGroup xmlns:group="http://www.sap.com/adt/functions/groups" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${escapeXml(description)}" adtcore:language="${masterLanguage}" adtcore:name="${escapeXml(name)}" adtcore:type="FUGR/F" adtcore:masterLanguage="${masterLanguage}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </group:abapFunctionGroup>`;
     case 'FUNC': {
@@ -3824,7 +3834,7 @@ async function handleSAPWrite(
         const mergedProps = await mergeMetadataWriteProperties(client, type, name, metadataProps);
         const description = String(args.description ?? mergedProps._description ?? name);
         const pkg = String(args.package ?? existingPackage ?? mergedProps._package ?? '$TMP');
-        const body = buildCreateXml(type, name, pkg, description, mergedProps);
+        const body = buildCreateXml(type, name, pkg, description, mergedProps, config.language);
         await safeUpdateObject(
           client.http,
           client.safety,
@@ -4035,8 +4045,9 @@ async function handleSAPWrite(
         const refParentType = refType.split('/')[0] ?? '';
         const refUri = `${objectBasePath(refParentType)}${encodeURIComponent(refName.toLowerCase())}`;
 
+        const ktdLang = normalizeAdtLanguage(config.language);
         const ktdBody = `<?xml version="1.0" encoding="UTF-8"?>
-<sktd:docu xmlns:sktd="http://www.sap.com/wbobj/texts/sktd" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:language="EN" adtcore:name="${escapeXml(name)}" adtcore:type="SKTD/TYP" adtcore:masterLanguage="EN">
+<sktd:docu xmlns:sktd="http://www.sap.com/wbobj/texts/sktd" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:language="${ktdLang}" adtcore:name="${escapeXml(name)}" adtcore:type="SKTD/TYP" adtcore:masterLanguage="${ktdLang}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
   <sktd:refObject adtcore:description="${escapeXml(refDescription)}" adtcore:name="${escapeXml(refName)}" adtcore:type="${escapeXml(refType)}" adtcore:uri="${escapeXml(refUri)}"/>
 </sktd:docu>`;
@@ -4084,7 +4095,7 @@ async function handleSAPWrite(
       // SAP ADT requires the root element to match the object type —
       // a generic objectReferences body returns 400 "System expected the element ...".
       const metadataProperties = getMetadataWriteProperties(args);
-      const body = buildCreateXml(type, name, pkg, description, metadataProperties);
+      const body = buildCreateXml(type, name, pkg, description, metadataProperties, config.language);
 
       // Step 1: Create the object (metadata only)
       const createUrl = objectUrl.replace(/\/[^/]+$/, ''); // parent collection URL
@@ -5199,7 +5210,7 @@ async function handleSAPWrite(
           const objUrl = objectUrlForType(objType, objName);
           const createUrl = objUrl.replace(/\/[^/]+$/, '');
           const objMetadataProps = getMetadataWriteProperties(obj);
-          const body = buildCreateXml(objType, objName, objPackage, objDescription, objMetadataProps);
+          const body = buildCreateXml(objType, objName, objPackage, objDescription, objMetadataProps, config.language);
           const contentType = createContentTypeForType(objType);
           const needsPackageParam =
             objType === 'BDEF' || objType === 'TABL' || objType === 'TABL/DT' || objType === 'TABL/DS';

--- a/tests/integration/crud.lifecycle.integration.test.ts
+++ b/tests/integration/crud.lifecycle.integration.test.ts
@@ -242,6 +242,97 @@ describe('CRUD lifecycle', () => {
     }
   }, 60_000);
 
+  // issue #343: a DTEL created with a German session must carry German as its
+  // master language (not hard-coded EN), so its labels are filed under DE. The
+  // DTEL ADT metadata echoes DD04L-DTELMASTER (= the create-body masterLanguage),
+  // so this is a valid discriminator (it was "EN" before the fix). On NW 7.50 the
+  // v1 handler ignores the body language — skipped via ddicSkipReason there.
+  it('DTEL create with SAP_LANGUAGE=DE persists masterLanguage=DE (issue #343)', async (ctx) => {
+    const deClient = getTestClient('DE');
+    const name = generateUniqueName('ZARC1_LDE');
+    const url = `/sap/bc/adt/ddic/dataelements/${name}`;
+    try {
+      const xml = buildCreateXml(
+        'DTEL',
+        name,
+        '$TMP',
+        'Sprachtest',
+        { typeKind: 'predefinedAbapType', dataType: 'CHAR', length: 10, shortLabel: 'Kurz', mediumLabel: 'Mittel' },
+        'DE',
+      );
+      expect(xml).toContain('adtcore:masterLanguage="DE"');
+      const createResp = await createObject(
+        deClient.http,
+        deClient.safety,
+        '/sap/bc/adt/ddic/dataelements',
+        xml,
+        DATAELEMENT_V2_CONTENT_TYPE,
+      );
+      registry.register(url, 'DTEL', name);
+      // The create response echoes the persisted DTELMASTER.
+      expect(createResp).toContain('adtcore:masterLanguage="DE"');
+      // Re-read the persisted metadata to confirm (not just the create echo).
+      // Note: Accept must not carry a charset param (SAP returns 406 otherwise).
+      const meta = await deClient.http.get(url, { Accept: 'application/vnd.sap.adt.dataelements.v2+xml' });
+      expect(meta.body).toContain('adtcore:masterLanguage="DE"');
+    } catch (err) {
+      const skip = ddicSkipReason(err);
+      if (skip) {
+        requireOrSkip(ctx, undefined, skip);
+      }
+      throw err;
+    } finally {
+      if (registry.getAll().some((entry) => entry.name === name)) {
+        try {
+          await deleteWithLock(url);
+          registry.remove(name);
+        } catch {
+          // best-effort-cleanup
+        }
+      }
+    }
+  }, 60_000);
+
+  // issue #343: DOMA smoke check. The DOMA ADT GET echoes TADIR-MASTERLANG (the
+  // sap-language URL param, already DE), NOT the body, so ADT cannot discriminate
+  // the DOMMASTER/DD01T text-language fix here — that is covered by the unit test
+  // (POST body carries masterLanguage="DE") plus the manual HANA verification in
+  // docs/research/issue-343-masterlanguage-on-create.md. This only asserts that a
+  // DE-language DOMA create still succeeds (non-regression).
+  it('DOMA create with SAP_LANGUAGE=DE succeeds (issue #343 non-regression)', async (ctx) => {
+    const deClient = getTestClient('DE');
+    const name = generateUniqueName('ZARC1_LDO');
+    const url = `/sap/bc/adt/ddic/domains/${name}`;
+    try {
+      const xml = buildCreateXml('DOMA', name, '$TMP', 'Sprachtest', { dataType: 'CHAR', length: 10 }, 'DE');
+      expect(xml).toContain('adtcore:masterLanguage="DE"');
+      const createResp = await createObject(
+        deClient.http,
+        deClient.safety,
+        '/sap/bc/adt/ddic/domains',
+        xml,
+        DOMAIN_V2_CONTENT_TYPE,
+      );
+      registry.register(url, 'DOMA', name);
+      expect(typeof createResp).toBe('string');
+    } catch (err) {
+      const skip = ddicSkipReason(err);
+      if (skip) {
+        requireOrSkip(ctx, undefined, skip);
+      }
+      throw err;
+    } finally {
+      if (registry.getAll().some((entry) => entry.name === name)) {
+        try {
+          await deleteWithLock(url);
+          registry.remove(name);
+        } catch {
+          // best-effort-cleanup
+        }
+      }
+    }
+  }, 60_000);
+
   it('DTEL CRUD lifecycle', async (ctx) => {
     const dataElementName = generateUniqueName('ZARC1_TDEL');
     const dataElementUrl = `/sap/bc/adt/ddic/dataelements/${dataElementName}`;

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -56,15 +56,20 @@ export function hasBtpCredentials(): boolean {
 /** Skip reason message */
 export const SKIP_REASON = 'No SAP credentials configured (set TEST_SAP_URL or SAP_URL in .env)';
 
-/** Create an ADT client configured for integration tests */
-export function getTestClient(): AdtClient {
+/**
+ * Create an ADT client configured for integration tests.
+ *
+ * @param languageOverride - optional SAP language to use instead of the env
+ *   default (e.g. 'DE' for the issue #343 master-language round-trip test).
+ */
+export function getTestClient(languageOverride?: string): AdtClient {
   requireSapCredentials();
 
   const url = process.env.TEST_SAP_URL || process.env.SAP_URL || '';
   const username = process.env.TEST_SAP_USER || process.env.SAP_USER || '';
   const password = process.env.TEST_SAP_PASSWORD || process.env.SAP_PASSWORD || '';
   const client = process.env.TEST_SAP_CLIENT || process.env.SAP_CLIENT || '100';
-  const language = process.env.TEST_SAP_LANGUAGE || process.env.SAP_LANGUAGE || 'EN';
+  const language = languageOverride || process.env.TEST_SAP_LANGUAGE || process.env.SAP_LANGUAGE || 'EN';
   const insecure = (process.env.TEST_SAP_INSECURE || process.env.SAP_INSECURE) === 'true';
   const disableSaml = (process.env.TEST_SAP_DISABLE_SAML || process.env.SAP_DISABLE_SAML) === 'true';
 

--- a/tests/unit/adt/ddic-xml.test.ts
+++ b/tests/unit/adt/ddic-xml.test.ts
@@ -11,6 +11,87 @@ import {
 } from '../../../src/adt/ddic-xml.js';
 
 describe('ddic-xml builders', () => {
+  // issue #343: created object master language must follow the configured SAP_LANGUAGE,
+  // not a hard-coded EN. Genuinely affects DTEL/DOMA text language on the S/4 v2 handler.
+  describe('master language (issue #343)', () => {
+    it('buildDomainXml emits the configured language as masterLanguage', () => {
+      const xml = buildDomainXml({
+        name: 'ZD',
+        description: 'd',
+        package: '$TMP',
+        dataType: 'CHAR',
+        length: 1,
+        language: 'DE',
+      });
+      expect(xml).toContain('adtcore:masterLanguage="DE"');
+    });
+
+    it('buildDomainXml defaults to EN when no language given', () => {
+      const xml = buildDomainXml({ name: 'ZD', description: 'd', package: '$TMP', dataType: 'CHAR', length: 1 });
+      expect(xml).toContain('adtcore:masterLanguage="EN"');
+    });
+
+    it('buildDataElementXml emits the configured language as masterLanguage', () => {
+      const xml = buildDataElementXml({
+        name: 'ZE',
+        description: 'd',
+        package: '$TMP',
+        typeKind: 'predefinedAbapType',
+        dataType: 'CHAR',
+        length: 10,
+        language: 'DE',
+      });
+      expect(xml).toContain('adtcore:masterLanguage="DE"');
+    });
+
+    it('buildDataElementXml defaults to EN when no language given', () => {
+      const xml = buildDataElementXml({ name: 'ZE', description: 'd', package: '$TMP' });
+      expect(xml).toContain('adtcore:masterLanguage="EN"');
+    });
+
+    it('buildServiceBindingXml emits the configured language for both language and masterLanguage', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB',
+        description: 'd',
+        package: '$TMP',
+        serviceDefinition: 'ZSD',
+        bindingType: 'ODATA V4 - UI',
+        language: 'DE',
+      });
+      expect(xml).toContain('adtcore:language="DE"');
+      expect(xml).toContain('adtcore:masterLanguage="DE"');
+    });
+
+    it('buildServiceBindingXml defaults to EN when no language given', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB',
+        description: 'd',
+        package: '$TMP',
+        serviceDefinition: 'ZSD',
+        bindingType: 'ODATA V4 - UI',
+      });
+      expect(xml).toContain('adtcore:language="EN"');
+      expect(xml).toContain('adtcore:masterLanguage="EN"');
+    });
+
+    it('normalizes a lower-case 2-char language to upper case', () => {
+      const xml = buildDataElementXml({ name: 'ZE', description: 'd', package: '$TMP', language: 'de' });
+      expect(xml).toContain('adtcore:masterLanguage="DE"');
+    });
+
+    it('treats a blank language as the EN default', () => {
+      const xml = buildDomainXml({
+        name: 'ZD',
+        description: 'd',
+        package: '$TMP',
+        dataType: 'CHAR',
+        length: 1,
+        language: '   ',
+      });
+      expect(xml).toContain('adtcore:masterLanguage="EN"');
+    });
+  });
+
   describe('buildDomainXml', () => {
     it('builds basic domain XML', () => {
       const xml = buildDomainXml({

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -11403,9 +11403,93 @@ ENDCLASS.`;
     });
   });
 
+  // ─── SAPWrite create master language wiring (issue #343) ────────────
+
+  describe('SAPWrite create — master language wiring (issue #343)', () => {
+    function dtelCreatePostBody(): string | undefined {
+      const call = mockFetch.mock.calls.find(
+        (c: any[]) => String(c[0]).includes('/sap/bc/adt/ddic/dataelements') && c[1]?.method === 'POST',
+      );
+      return call?.[1]?.body as string | undefined;
+    }
+
+    it('threads config.language into the DTEL create POST body', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(201, '<blue:wbobj/>', { 'x-csrf-token': 't' }));
+      const result = await handleToolCall(createClient(), { ...DEFAULT_CONFIG, language: 'DE' }, 'SAPWrite', {
+        action: 'create',
+        type: 'DTEL',
+        name: 'ZARC1_LANG_UNIT',
+        description: 'Sprachtest',
+        package: '$TMP',
+        typeKind: 'predefinedAbapType',
+        dataType: 'CHAR',
+        length: 10,
+      });
+      expect(result.isError).toBeFalsy();
+      const body = dtelCreatePostBody();
+      expect(body).toBeDefined();
+      expect(body).toContain('adtcore:masterLanguage="DE"');
+    });
+
+    it('defaults the DTEL create POST body to EN when SAP_LANGUAGE is unset', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(201, '<blue:wbobj/>', { 'x-csrf-token': 't' }));
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'create',
+        type: 'DTEL',
+        name: 'ZARC1_LANG_UNIT',
+        description: 'Lang test',
+        package: '$TMP',
+        typeKind: 'predefinedAbapType',
+        dataType: 'CHAR',
+        length: 10,
+      });
+      expect(result.isError).toBeFalsy();
+      expect(dtelCreatePostBody()).toContain('adtcore:masterLanguage="EN"');
+    });
+  });
+
   // ─── buildCreateXml ─────────────────────────────────────────────────
 
   describe('buildCreateXml', () => {
+    // issue #343: master language must follow the configured SAP_LANGUAGE (6th arg),
+    // defaulting to EN when unset. Source objects ignore it server-side (cosmetic), but
+    // the body must still match the sap-language URL param for DTEL/DOMA correctness.
+    describe('master language (issue #343)', () => {
+      it('threads the configured language into masterLanguage for source objects', () => {
+        const xml = buildCreateXml('PROG', 'ZHELLO', 'ZPACKAGE', 'Hello', undefined, 'DE');
+        expect(xml).toContain('adtcore:masterLanguage="DE"');
+      });
+
+      it('threads the configured language into FUGR language + masterLanguage', () => {
+        const xml = buildCreateXml('FUGR', 'ZFG', '$TMP', 'FG', undefined, 'DE');
+        expect(xml).toContain('adtcore:language="DE"');
+        expect(xml).toContain('adtcore:masterLanguage="DE"');
+      });
+
+      it('threads the configured language into DOMA create XML', () => {
+        const xml = buildCreateXml('DOMA', 'ZDOM', '$TMP', 'Dom', { dataType: 'CHAR', length: 1 }, 'DE');
+        expect(xml).toContain('adtcore:masterLanguage="DE"');
+      });
+
+      it('threads the configured language into DTEL create XML', () => {
+        const xml = buildCreateXml('DTEL', 'ZEL', '$TMP', 'El', { dataType: 'CHAR', length: 10 }, 'DE');
+        expect(xml).toContain('adtcore:masterLanguage="DE"');
+      });
+
+      it('defaults masterLanguage to EN when no language arg is passed', () => {
+        expect(buildCreateXml('PROG', 'ZHELLO', 'ZPACKAGE', 'Hello')).toContain('adtcore:masterLanguage="EN"');
+        expect(buildCreateXml('DTEL', 'ZEL', '$TMP', 'El', { dataType: 'CHAR', length: 10 })).toContain(
+          'adtcore:masterLanguage="EN"',
+        );
+      });
+
+      it('normalizes a lower-case language to upper case', () => {
+        expect(buildCreateXml('CLAS', 'ZCL', '$TMP', 'C', undefined, 'de')).toContain('adtcore:masterLanguage="DE"');
+      });
+    });
+
     it('returns correct XML for PROG', () => {
       const xml = buildCreateXml('PROG', 'ZHELLO', 'ZPACKAGE', 'Hello Program');
       expect(xml).toContain('<program:abapProgram');


### PR DESCRIPTION
Fixes #343.

## Summary

Object-creation XML builders hard-coded `adtcore:masterLanguage="EN"` (and `adtcore:language="EN"` for SRVB/FUGR/SKTD) instead of deriving the language from the configured `SAP_LANGUAGE`. This PR threads `config.language` — the value ARC-1 already sends as the `sap-language` URL param — into every create-XML builder, defaulting to `EN` when `SAP_LANGUAGE` is unset (no change for the default case).

## What I found (the issue's mechanism was incomplete)

I verified the behavior empirically on live systems (A4H S/4HANA 2023 / kernel 7.58 + NPL NetWeaver 7.50), reading the persisted truth straight from HANA. The full write-up with the version matrix is in [`docs/research/issue-343-masterlanguage-on-create.md`](docs/research/issue-343-masterlanguage-on-create.md).

The body `adtcore:masterLanguage` and the `sap-language` URL param write to **two different fields**:

- **per-object DDIC master language** (`DD04L-DTELMASTER`, `DD01L-DOMMASTER`) ← the **XML body**, and it drives which language bucket the texts are filed under (`DD04T`/`DD01T` `DDLANGUAGE`)
- **`TADIR-MASTERLANG`** (repo directory) ← the **`sap-language` URL param**

So with `SAP_LANGUAGE=DE`, today's hard-coded `EN` body makes a DTEL/DOMA's German labels get **filed under the English language key**, with a `TADIR`-vs-object split-brain. SAP's own docs ([`ABENORIGINAL_LANGU_GUIDL`](https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/ABENORIGINAL_LANGU_GUIDL.html)) and **SAP Note 727896** say the original language must be the logon language; abapGit enforces exactly this.

Refinements vs. the issue text:
- **Genuinely buggy:** DTEL + DOMA on the **S/4 v2 DDIC handler**.
- **Cosmetic** (body ignored by SAP — already correct): PROG/CLAS/INTF/FUGR and other source/container objects (master lives in `TADIR`, from the URL param).
- **Not affected:** NW 7.50 (v1 handler ignores the body); MSAG/DEVC/FUNC (no language attribute — left untouched).

The fix is applied to all builders for consistency (harmless where cosmetic, corrects the Eclipse-visible echo), with acceptance focused on DTEL/DOMA.

## Live before/after (a4h 7.58, real binary, `SAP_LANGUAGE=DE`, German labels)

| field | before (today) | after (this PR) |
|---|---|---|
| DTEL `DD04L.DTELMASTER` | `E` | **`D`** |
| DTEL `DD04T.DDLANGUAGE` (label lang) | `E` | **`D`** |
| DOMA `DD01L.DOMMASTER` | `E` | **`D`** |
| DOMA `DD01T.DDLANGUAGE` (text lang) | `E` | **`D`** |
| `TADIR.MASTERLANG` (both) | `D` | `D` |

After the fix every field is consistently German — split-brain gone, German texts filed under `D`.

## Changes

- `src/adt/ddic-xml.ts` — `normalizeAdtLanguage()` helper; `language?` added to DOMA/DTEL/SRVB `*CreateParams`; builders emit it instead of `EN`.
- `src/handlers/intent.ts` — `buildCreateXml(..., language)` replaces all `EN` literals; inline SKTD body uses it; the 3 call sites (create / metadata-update / batch_create) pass `config.language`. This also covers the DTEL/MSAG follow-up label PUT and metadata UPDATE, which reuse `buildCreateXml`.
- `CLAUDE.md` — Key Files row + `SAP_LANGUAGE` config note.

## Testing

- **Unit** (`npm test`): 3328 pass. New tests in `tests/unit/adt/ddic-xml.test.ts` (builders emit configured language; default EN; case-normalization) and `tests/unit/handlers/intent.test.ts` (`buildCreateXml` language threading + mocked-undici handler-wiring asserting the POST body carries `masterLanguage="DE"`).
- **Integration** (`tests/integration/crud.lifecycle.integration.test.ts`, live a4h): DTEL `SAP_LANGUAGE=DE` round-trip asserts `masterLanguage="DE"` (a valid discriminator — the DTEL ADT GET echoes the body value); DOMA non-regression smoke (ADT GET can't discriminate DOMA — that's covered by the unit test + the HANA verification above).
- `npm run typecheck` + `npm run lint` clean.

Default `EN` is preserved, so existing fixtures/tests asserting `masterLanguage="EN"` still hold — low regression risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
