### PR TITLE
docs: TABL APPEND-structure create spike — Feature 5 verdict (read works, create opaque)

### DIFF
--- a/docs/research/joule-2026-roadmap-feature-assessment.md
+++ b/docs/research/joule-2026-roadmap-feature-assessment.md
@@ -15,7 +15,7 @@
 | 2 | Semi-automated Clean-Core ATC Fixes | `SAPDiagnose(quickfix/apply_quickfix)` already wraps `/sap/bc/adt/quickfixes/evaluation` (verified live a4h 2026-04-14); skills `sap-clean-core-atc` + `migrate-custom-code` exist | Polish existing skills; add ATC-finding → quickfix correlation helper | **XS** (already shipped) |
 | 3 | CDS Analytical Model Generation (basic — cube + existing dims from RAP BO) | DDLS create works; no cube scaffold | New skill `generate-analytics-star-schema` (already proposed in J4D compare matrix) | **S** (skill only) |
 | 4 | CDS Analytical Model Generation (extended — cube + new dims from RAP BO **or** DDIC tables) | Same as #3; TABL read works | Same skill, broader templates | **S** (skill only) |
-| 5 | Extensibility Assistant (custom field, BAdI, value help) | ENHO read works; no append-structure scaffold or BAdI impl-class stub generator | New skill `extensibility-assistant` + small ARC-1 code: APPEND structure subtype on `TABL`, BAdI impl-class scaffold | **M** (skill + code) |
+| 5 | Extensibility Assistant (custom field, BAdI, value help) | Append **read** works today (`SAPRead type=TABL`); append/BAdI **create** is an opaque protocol ([spike](./tabl-append-create-spike-a4h.md)) | Read half: 0 code. Create half: **blocked** — needs an Eclipse wire-trace, not the `appendStructureXml` plan in §5a | **Read: done · Create: blocked** |
 | 6 | RAP Model-Driven Joule Integration | SRVB read works; OData V4 publish works | Cannot replicate — this is Joule runtime exposing RAP BOs to *Joule's agentic engine*. Different problem domain. | **N/A** (out of scope) |
 | 7 | AI Explain for Function Groups | FUGR source read works; `expand_includes` already follows explicit `INCLUDE` statements; **no FUNC sub-module walk, no dynpro read, no GUI status read** | Extend existing `explain-abap-code` skill **+** small ARC-1 code: widen FUGR `expand_includes` to cover FUNC sub-modules, plus new dynpro and GUI status readers | **M** (skill + small code) |
 | 8 | AI Explain for Behavior Definitions | BDEF source + bound CLAS read works | Extend existing `explain-abap-code` skill; no ARC-1 code needed | **XS** (skill only) |
@@ -150,7 +150,8 @@ A Joule chat surface *inside the S/4HANA Cloud UI* (Key User Extensibility apps)
 | Read enhancement implementation | ✅ | SAPRead type=ENHO; `parseEnhancementImplementation()` in `src/adt/xml-parser.ts:639` |
 | Read TABL metadata | ✅ | SAPRead type=TABL |
 | Create custom CDS view | ✅ | SAPWrite type=DDLS |
-| Append-structure (TABL subtype) scaffold | ❌ | No append-specific schema; current AFF TABL schema covers base tables/structures, not appends |
+| Append-structure (TABL subtype) **read** | ✅ | `SAPRead type=TABL` returns `extend type … with …` source today (zero code) |
+| Append-structure (TABL subtype) **create** | ⛔ opaque | Source-based `TABL/DS`; shell-then-PUT create collides (`ResourceAlreadyExists`), 1-step source create rejected (415/400). [Spike](./tabl-append-create-spike-a4h.md) |
 | BAdI implementation class stub | ❌ | No `SAPWrite action=scaffold_badi_impl` |
 | Business-context / Custom-Object UI discovery (Key User Extensibility framework REST endpoints) | ❌ | None of the Key User Extensibility OData services are wrapped |
 
@@ -513,6 +514,9 @@ The largest in-scope code change set. Two independent additions, then a skill th
 
 #### 5a. TABL APPEND structure subtype
 
+> **⛔ SUPERSEDED by live spike (2026-06-04) — see [tabl-append-create-spike-a4h.md](./tabl-append-create-spike-a4h.md).**
+> The plan below assumes appends are classic `R3TR APPS` objects created by mirroring `dtelXml`/`domaXml` (~2 dev-days). **That model is wrong on S/4HANA 2023 (SAP_BASIS 758):** an append is a *source-based* `TABL/DS` object (`extend type <base> with <append> { … }`, `<blue:blueSource>`), and its **create is an opaque protocol**. ARC-1's shell-then-PUT create fails (`ExceptionResourceAlreadyExists` / HTTP 400 — the shell pre-creates a *regular* structure whose name collides with the append), and 1-step source-body creates are rejected (HTTP 415/400 across content-types). **Append _read_ already works today with zero code** (`SAPRead type=TABL`) — that is the achievable half of Feature 5. Do **not** build the create plan below without first capturing an Eclipse "Create Append Structure" wire trace. The original plan is retained below for historical context only.
+
 Today's `SAPWrite(type=TABL)` handles base transparent tables and structures via `src/adt/ddic-xml.ts`. APPEND structures (TYPE `R3TR APPS`) need their own subtype because:
 - They reference a *parent* table via `<r3tr:appendOf>` in the XML envelope
 - Their activation reorders the parent table's field list
@@ -534,6 +538,8 @@ Today's `SAPWrite(type=TABL)` handles base transparent tables and structures via
 | [`tests/integration/adt.integration.test.ts`](../../tests/integration/adt.integration.test.ts) | CRUD lifecycle on a Z-prefixed append against a standard table (use `MARA` or a Z-test table; skip if not available). | Existing TABL CRUD test. |
 
 **Estimated diff:** ~250 lines TS (schema + builder + handler wiring) + ~150 lines tests. Effort: **~2 dev-days**.
+
+> **⚠️ Estimate invalidated by the 2026-06-04 spike.** The above assumes a `dtelXml`-style XML builder. The real append create is opaque (see callout at the top of 5a) — effort is **blocked** pending an Eclipse wire-trace capture, not ~2 dev-days. The *read* side is **0 days** (already works).
 
 #### 5b. BAdI implementation scaffold
 

--- a/docs/research/tabl-append-create-spike-a4h.md
+++ b/docs/research/tabl-append-create-spike-a4h.md
@@ -1,0 +1,71 @@
+# TABL APPEND-structure create spike — A4H (S/4HANA 2023, SAP_BASIS 758)
+
+**Date:** 2026-06-04 · **System:** a4h.marianzeis.de (S/4HANA 2023, ABAP 7.58) · **Context:** Feature 5 (Extensibility Assistant) of the [2026 Joule roadmap assessment](./joule-2026-roadmap-feature-assessment.md).
+
+## TL;DR
+
+| Capability | Verdict |
+|---|---|
+| **Read** an append structure (`SAPRead type=TABL`) | ✅ **Works today, zero code.** Returns the `extend type <base> with <append> { … }` source. |
+| **Create** an append structure via ADT REST | ⛔ **Opaque protocol.** Same class as `autoqf` and ENHO-create — not reachable through ARC-1's generic create flow, and not crackable without an Eclipse "Create Append Structure" wire trace. |
+
+This **invalidates the original Feature 5a plan** in the assessment doc, which assumed an append is a classic `R3TR APPS` object created by mirroring `dtelXml`/`domaXml` (~2 dev-days). On a modern S/4 system an append is a **source-based `TABL/DS` object** (`<blue:blueSource>`), and the create cannot be assembled from the parts ARC-1 already has.
+
+## What an append actually is on 7.58
+
+Not the classic `R3TR APPS` envelope the plan assumed. It is a **source-based DDIC structure** (subtype `TABL/DS`, `xmlns:blue="http://www.sap.com/wbobj/blue"`) whose source is:
+
+```abap
+@EndUserText.label : 'ARC append'
+extend type zarc_apnd_base with zarc_apnd_re {
+  zz_extra : abap.char(20);
+}
+```
+
+The append *is* a structure object named `ZARC_APND_RE`; its source declares that it extends `ZARC_APND_BASE`. There is no separate `<appendOf>` reference element — the parent is named in the `extend type` source.
+
+## The spike (live curl against A4H, client 001)
+
+ARC-1 creates DDIC objects **shell-then-PUT**: POST a `<blue:blueSource>` create envelope (which always materialises a *regular* structure), then PUT the source. Tested whether that flow can produce an append:
+
+| Step | Request | Result |
+|---|---|---|
+| 1. Create shell | `POST /sap/bc/adt/ddic/structures` with `<blue:blueSource>` envelope, `adtcore:type="TABL/DS"`, name `ZARC_APND_RE` | **201** — but creates a **regular structure** named `ZARC_APND_RE` |
+| 2. Lock | `POST …/structures/zarc_apnd_re?_action=LOCK&accessMode=MODIFY` (stateful) | **200** — `<LOCK_HANDLE>` returned in `asx:abap/asx:values/DATA` |
+| 3. PUT append source | `PUT …/structures/zarc_apnd_re/source/main?lockHandle=…` with the `extend type` source | **400** `ExceptionResourceAlreadyExists` — *"Can't save due to errors in source; execute check for details"* (`T100KEY SBD_MESSAGES/007`) |
+
+Then, after deleting the shell, a **1-step** create (POST the `extend type` source directly to the collection as the create body):
+
+| Content-Type | Result |
+|---|---|
+| `text/plain` | **415** Unsupported Media Type |
+| `application/vnd.sap.adt.structures.v2+xml` | **400** |
+| `application/vnd.sap.adt.ddic.structure.v1+xml` | **415** Unsupported Media Type |
+
+## Root cause
+
+The shell-then-PUT flow is **fundamentally incompatible** with appends:
+
+1. Step 1 creates a **regular structure** named `ZARC_APND_RE` (the generic `<blue:blueSource>` create has no "this is an append" marker — `adtcore:type="TABL/DS"` is just "DDIC structure").
+2. Step 3's source says `extend type zarc_apnd_base with zarc_apnd_re { … }` — i.e. "register an append **named** `ZARC_APND_RE`". But `ZARC_APND_RE` now already exists (the regular structure from step 1) → **`ResourceAlreadyExists`**.
+
+An append must be **born as an append in a single create operation**. ADT exposes no create payload for that over any content-type tried, and there is no reference implementation (abap-adt-api does not cover append creation). The lock-handle parse was confirmed correct (handle lives in `asx:abap/asx:values/DATA/LOCK_HANDLE`), so the 400 is the real create error, not a transport/lock artifact.
+
+## Why this is "opaque", not "todo"
+
+Cracking it would require **capturing the wire trace** of Eclipse ADT's *Create → Append Structure* wizard (the exact create endpoint, content-type, and body that makes SAP materialise an append rather than a regular structure). That capture needs a GUI/Eclipse session against the system — it cannot be reverse-engineered headless by probing, the same boundary already documented for:
+
+- `autoqf`/ATC batch quickfix (opaque `step=` multi-stage protocol)
+- dynpros / GUI status (SAPGUI-only, 404 via ADT REST)
+- refactoring quickfix *apply* (HTTP 500 on a4h)
+
+## Recommendation
+
+- **Keep the read win.** `SAPRead type=TABL` already returns append source — that covers the "AI Explain / discover extensions" half of Feature 5 with zero code. Worth a one-line skill mention.
+- **Do not implement Feature 5a create** as the assessment doc described — the `appendStructureXml` / `tabl-v1.json` / `appendOf` plan is based on the classic `R3TR APPS` model that doesn't apply here, and the modern create is opaque.
+- **Feature 5b (BAdI/ENHO impl create) is the same opaque-create class** and was not spiked separately on this evidence; expect the same wall (complex enhancement create, no abap-adt-api reference).
+- If pursued later, the unblocking step is a **wire-trace of the Eclipse append-create wizard**, not more headless probing.
+
+## Cleanup
+
+Test objects created during the spike were deleted from A4H: `ZARC_APND_BASE` (base table), `ZARC_APND_RE` (regular-structure shell). No strays remain.


### PR DESCRIPTION
## What

Captures the live spike that closes out **Feature 5 (Extensibility Assistant)** of the 2026 Joule roadmap push.

**Verdict:** append-structure **read works today, zero code** (`SAPRead type=TABL`); append **create is an opaque protocol** — same class as autoqf / dynpro-CUA / ENHO-create.

## Why this matters

The original Feature 5a plan (in `joule-2026-roadmap-feature-assessment.md`) estimated **~2 dev-days** to add an `appendStructureXml` builder + `tabl-v1.json` AFF schema + `appendOf` field, mirroring `dtelXml`/`domaXml`. That plan assumed appends are classic `R3TR APPS` objects. **The spike disproves it:** on S/4HANA 2023 (SAP_BASIS 758) an append is a *source-based* `TABL/DS` object (`extend type <base> with <append> { … }`, `<blue:blueSource>`), and ARC-1's shell-then-PUT create cannot produce one.

## Evidence (live curl on A4H, client 001)

| Attempt | Result |
|---|---|
| `TABL/DS` shell + `extend type` source PUT (valid lock) | **400** `ExceptionResourceAlreadyExists` — shell pre-creates a *regular* structure that collides with the append name |
| 1-step source-body create, `text/plain` | **415** |
| 1-step source-body create, `…structures.v2+xml` | **400** |
| 1-step source-body create, `…ddic.structure.v1+xml` | **415** |

Lock-handle parse confirmed correct (`asx:abap/asx:values/DATA/LOCK_HANDLE`), so the 400 is the real create error.

## Changes

- **New** `docs/research/tabl-append-create-spike-a4h.md` — endpoints, payloads, failure modes, root cause, unblock path.
- **Edit** `docs/research/joule-2026-roadmap-feature-assessment.md` — superseded-callout on §5a, invalidated effort estimate, corrected top-line verdict + capability rows.

Docs-only. No code, no behavior change. Test objects (`ZARC_APND_BASE`, `ZARC_APND_RE`) cleaned up on A4H.

🤖 Generated with [Claude Code](https://claude.com/claude-code)