### PR TITLE
fix(lint): don't block writes on parse errors beyond abaplint's grammar (8xx / SAP_BASIS 816)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,7 @@ tests/
 | Add safety check | `src/adt/safety.ts` |
 | Add/modify PrettyPrint action | `src/adt/devtools.ts`, `src/handlers/intent.ts` (handleSAPLint), `src/handlers/tools.ts`, `src/handlers/schemas.ts` |
 | Add lint rule config | `src/lint/lint.ts`, `src/lint/config-builder.ts`, `src/lint/presets/` |
+| Adjust pre-write lint on releases beyond abaplint's grammar (8xx, e.g. SAP_BASIS 816 / ABAP Platform 2025) | `src/adt/features.ts` (`ABAPLINT_MAX_RELEASE`=758 + `isBeyondAbaplintCeiling`), `src/lint/config-builder.ts` (`buildPreWriteConfig` `parserSeverity`). abaplint v758 (its ceiling) can't parse new 816 syntax (CDS `define table entity`, `READ TABLE … WHERE`, RAP keywords) → would false-positive-block writes, so `parser_error`/`cds_parser_error` are **demoted to non-blocking warnings when `release > 758`** (activation is the definitive check); still block on ≤758. Bump `ABAPLINT_MAX_RELEASE` + the `mapSapReleaseToAbaplintVersion` ceiling together when abaplint adds a newer grammar. Tests: `tests/unit/{adt/features,lint/lint}.test.ts`. |
 | Add an ARC-1-native pre-write semantic hint for a new object type | `src/lint/pre-write-hints.ts` (add `inspect<Type>Source` → `LintResult[]` with `severity:'warning'`), `src/lint/lint.ts` (wire into `validateBeforeWrite()`, filename-gated by extension), `tests/unit/lint/{pre-write-hints,lint}.test.ts` |
 | Add dependency pattern | `src/context/deps.ts` |
 | Add CDS dependency pattern | `src/context/cds-deps.ts` |

--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -22,6 +22,7 @@ import type { FeatureConfig, FeatureMode } from './config.js';
 import { fetchDiscoveryDocument } from './discovery.js';
 import { AdtApiError } from './errors.js';
 import type { AdtHttpClient } from './http.js';
+import { parseReleaseNumber } from './release.js';
 import type { AuthProbeResult, FeatureStatus, ResolvedFeatures, SystemType } from './types.js';
 import { parseInstalledComponents, parseSyntaxConfigurations } from './xml-parser.js';
 
@@ -209,6 +210,29 @@ export function mapSapReleaseToAbaplintVersion(release: string): Version {
   if (num >= 740) return Version.v740sp02;
   if (num >= 702) return Version.v702;
   return Version.v700;
+}
+
+/**
+ * Highest SAP_BASIS release whose ABAP/CDS grammar `@abaplint/core` actually parses.
+ * Must stay in sync with the `>= 758` ceiling branch in `mapSapReleaseToAbaplintVersion`:
+ * when abaplint ships a newer grammar (e.g. a v759/816 release), bump both together.
+ */
+export const ABAPLINT_MAX_RELEASE = 758;
+
+/**
+ * True when the detected SAP_BASIS release is newer than abaplint's parser grammar
+ * (e.g. ABAP Platform 2025 = 816). On such releases abaplint emits false-positive
+ * `parser_error` / `cds_parser_error` on legitimate new syntax (CDS `define table entity`,
+ * `READ TABLE ... WHERE`, RAP keywords, ...), because its grammar predates the release —
+ * abaplint's `Cloud` target does not help either. Callers (pre-write lint) use this to
+ * stop treating parse failures as blocking on such systems.
+ *
+ * Returns false when the release is unknown / non-numeric (e.g. BTP "sap_btp") — never
+ * demote on missing data.
+ */
+export function isBeyondAbaplintCeiling(release?: string): boolean {
+  const num = parseReleaseNumber(release);
+  return num !== undefined && num > ABAPLINT_MAX_RELEASE;
 }
 
 /** Result of component-based system detection */

--- a/src/lint/config-builder.ts
+++ b/src/lint/config-builder.ts
@@ -23,7 +23,7 @@
 
 import { readFileSync } from 'node:fs';
 import { Config, Version } from '@abaplint/core';
-import { mapSapReleaseToAbaplintVersion } from '../adt/features.js';
+import { isBeyondAbaplintCeiling, mapSapReleaseToAbaplintVersion } from '../adt/features.js';
 import type { SystemType } from '../adt/types.js';
 import { CLOUD_DISABLED_RULES, CLOUD_ERROR_RULES, CLOUD_WARNING_RULES } from './presets/cloud.js';
 import { ONPREM_DISABLED_RULES, ONPREM_ERROR_RULES, ONPREM_WARNING_RULES } from './presets/onprem.js';
@@ -90,15 +90,22 @@ export function buildPreWriteConfig(options: LintConfigOptions = {}): Config {
     rules[key] = false;
   }
 
+  // On releases newer than abaplint's parser grammar (e.g. ABAP Platform 2025 = 816),
+  // abaplint cannot parse legitimate new syntax (CDS `define table entity`,
+  // `READ TABLE ... WHERE`, RAP keywords, ...) and emits false-positive parse errors.
+  // Demote them to non-blocking warnings so the write proceeds (SAP-side activation is the
+  // definitive syntax check). Genuine parse errors on supported releases still block.
+  const parserSeverity: 'Error' | 'Warning' = isBeyondAbaplintCeiling(options.abapRelease) ? 'Warning' : 'Error';
+
   // Enable only pre-write blocking rules
   const preWriteRules: RuleOverrides = {
-    parser_error: { severity: 'Error' },
+    parser_error: { severity: parserSeverity },
     parser_missing_space: { severity: 'Error' },
     begin_end_names: { severity: 'Error' },
     unreachable_code: { severity: 'Error' },
     identical_conditions: { severity: 'Error' },
     // CDS syntax errors (catches missing commas, wrong keywords, invalid DDL constructs)
-    cds_parser_error: { severity: 'Error' },
+    cds_parser_error: { severity: parserSeverity },
   };
 
   // Add cloud-specific blocking rules

--- a/src/lint/config-builder.ts
+++ b/src/lint/config-builder.ts
@@ -61,6 +61,17 @@ export function buildLintConfig(options: LintConfigOptions = {}): Config {
   const preset = options.systemType === 'btp' ? 'cloud' : 'onprem';
   applyPreset(raw, preset);
 
+  // On releases newer than abaplint's grammar (e.g. SAP_BASIS 816), abaplint cannot parse
+  // legitimate new syntax and reports false-positive parse errors. Demote them to warnings so
+  // standalone lint doesn't mislabel valid new-syntax source as broken (matches buildPreWriteConfig).
+  // Applied before user config/overrides so an explicit user severity still wins.
+  if (isBeyondAbaplintCeiling(options.abapRelease)) {
+    applyRuleOverrides(raw, {
+      parser_error: { severity: 'Warning' },
+      cds_parser_error: { severity: 'Warning' },
+    });
+  }
+
   // Apply user config file (if provided)
   if (options.configFile) {
     applyConfigFile(raw, options.configFile);

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -247,6 +247,15 @@ describe('Feature Detection', () => {
       expect(isBeyondAbaplintCeiling('')).toBe(false);
       expect(isBeyondAbaplintCeiling('sap_btp')).toBe(false);
     });
+
+    it('stays in sync with the mapSapReleaseToAbaplintVersion ceiling (coupling guard)', () => {
+      // ABAPLINT_MAX_RELEASE is the point above which the abaplint version stops increasing.
+      // If someone adds a newer grammar (e.g. >= 759 → v759) without bumping ABAPLINT_MAX_RELEASE,
+      // this fails — forcing both to move together.
+      const ceilingVersion = mapSapReleaseToAbaplintVersion(String(ABAPLINT_MAX_RELEASE));
+      expect(mapSapReleaseToAbaplintVersion(String(ABAPLINT_MAX_RELEASE + 1))).toBe(ceilingVersion);
+      expect(mapSapReleaseToAbaplintVersion('816')).toBe(ceilingVersion);
+    });
   });
 
   // ─── System Type Detection ──────────────────────────────────────────

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it, vi } from 'vitest';
 import type { FeatureConfig } from '../../../src/adt/config.js';
 import { AdtApiError } from '../../../src/adt/errors.js';
 import {
+  ABAPLINT_MAX_RELEASE,
   classifyAuthProbeError,
   classifyFeatureProbeStatus,
   detectHanaFromComponents,
   detectHanaFromDiscovery,
   detectSystemType,
+  isBeyondAbaplintCeiling,
   mapSapReleaseToAbaplintVersion,
   probeAuthorization,
   probeFeatures,
@@ -223,6 +225,27 @@ describe('Feature Detection', () => {
       expect(mapSapReleaseToAbaplintVersion('710')).toBe(Version.v702);
       // 745 is between 740 and 750, should map to v740sp02
       expect(mapSapReleaseToAbaplintVersion('745')).toBe(Version.v740sp02);
+    });
+  });
+
+  describe('isBeyondAbaplintCeiling', () => {
+    it('is false at/below abaplint ceiling (758)', () => {
+      expect(ABAPLINT_MAX_RELEASE).toBe(758);
+      expect(isBeyondAbaplintCeiling('758')).toBe(false);
+      expect(isBeyondAbaplintCeiling('757')).toBe(false);
+      expect(isBeyondAbaplintCeiling('750')).toBe(false);
+    });
+
+    it('is true for the 8xx scheme (816 = ABAP Platform 2025) and any release > 758', () => {
+      expect(isBeyondAbaplintCeiling('816')).toBe(true);
+      expect(isBeyondAbaplintCeiling('759')).toBe(true);
+      expect(isBeyondAbaplintCeiling('800')).toBe(true);
+    });
+
+    it('is false for unknown / non-numeric / empty input (never demote on missing data)', () => {
+      expect(isBeyondAbaplintCeiling(undefined)).toBe(false);
+      expect(isBeyondAbaplintCeiling('')).toBe(false);
+      expect(isBeyondAbaplintCeiling('sap_btp')).toBe(false);
     });
   });
 

--- a/tests/unit/lint/lint.test.ts
+++ b/tests/unit/lint/lint.test.ts
@@ -1,5 +1,6 @@
 import { Config, Version } from '@abaplint/core';
 import { describe, expect, it } from 'vitest';
+import { buildLintConfig } from '../../../src/lint/config-builder.js';
 import { detectFilename, lintAbapSource, validateBeforeWrite } from '../../../src/lint/lint.js';
 
 describe('ABAP Lint', () => {
@@ -272,6 +273,18 @@ ENDCLASS.`;
       });
       expect(result.pass).toBe(false);
       expect(result.errors.some((e) => e.rule === 'parser_error')).toBe(true);
+    });
+
+    it('standalone lint (buildLintConfig) demotes parser_error to warning on 816', () => {
+      const cfg = buildLintConfig({ abapRelease: '816', systemType: 'onprem' });
+      const parserIssue = lintAbapSource(readTableWhere, 'zcl_t.clas.abap', cfg).find((x) => x.rule === 'parser_error');
+      expect(parserIssue?.severity).toBe('warning');
+    });
+
+    it('standalone lint keeps parser_error as error on a supported release (758)', () => {
+      const cfg = buildLintConfig({ abapRelease: '758', systemType: 'onprem' });
+      const parserIssue = lintAbapSource(readTableWhere, 'zcl_t.clas.abap', cfg).find((x) => x.rule === 'parser_error');
+      expect(parserIssue?.severity).toBe('error');
     });
   });
 

--- a/tests/unit/lint/lint.test.ts
+++ b/tests/unit/lint/lint.test.ts
@@ -216,6 +216,65 @@ define view ZI_TEST as select from ztable {
     });
   });
 
+  describe('validateBeforeWrite — 8xx releases beyond abaplint ceiling demote parse errors', () => {
+    // ABAP Platform 2025 (SAP_BASIS 816) introduces syntax abaplint's v758 grammar cannot
+    // parse (CDS `define table entity`, `READ TABLE ... WHERE`, ...). On such releases the
+    // parse error must NOT block the write — it is demoted to a non-blocking warning and
+    // SAP-side activation becomes the definitive syntax check. On supported releases (<=758)
+    // it still blocks, so genuine syntax errors are still caught pre-write.
+    const tableEntity = `define table entity ZTE_TEST {
+  key id : abap.int4;
+  name : abap.char(30);
+}`;
+    const readTableWhere = `CLASS zcl_t DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    METHODS m.
+ENDCLASS.
+CLASS zcl_t IMPLEMENTATION.
+  METHOD m.
+    DATA itab TYPE TABLE OF i.
+    READ TABLE itab INTO DATA(x) WHERE table_line > 2.
+  ENDMETHOD.
+ENDCLASS.`;
+
+    it('does NOT block a CDS table entity on release 816 (cds_parser_error demoted to warning)', () => {
+      const result = validateBeforeWrite(tableEntity, 'zte_test.ddls.asddls', {
+        abapRelease: '816',
+        systemType: 'onprem',
+      });
+      expect(result.pass).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.warnings.find((w) => w.rule === 'cds_parser_error')?.severity).toBe('warning');
+    });
+
+    it('still blocks a CDS parse error on a supported release (758)', () => {
+      const result = validateBeforeWrite(tableEntity, 'zte_test.ddls.asddls', {
+        abapRelease: '758',
+        systemType: 'onprem',
+      });
+      expect(result.pass).toBe(false);
+      expect(result.errors.some((e) => e.rule === 'cds_parser_error')).toBe(true);
+    });
+
+    it('does NOT block new ABAP syntax (READ TABLE ... WHERE) on release 816', () => {
+      const result = validateBeforeWrite(readTableWhere, 'zcl_t.clas.abap', {
+        abapRelease: '816',
+        systemType: 'onprem',
+      });
+      expect(result.pass).toBe(true);
+      expect(result.warnings.some((w) => w.rule === 'parser_error')).toBe(true);
+    });
+
+    it('still blocks an ABAP parser error on a supported release (758)', () => {
+      const result = validateBeforeWrite(readTableWhere, 'zcl_t.clas.abap', {
+        abapRelease: '758',
+        systemType: 'onprem',
+      });
+      expect(result.pass).toBe(false);
+      expect(result.errors.some((e) => e.rule === 'parser_error')).toBe(true);
+    });
+  });
+
   describe('validateBeforeWrite — ARC-1 pre-write hints (TABL draft admin include)', () => {
     it('appends arc1-tabl-draft-admin-include warning for bare include in TABL source', () => {
       const source = `@EndUserText.label : 'Draft'


### PR DESCRIPTION
## Summary

Fixes a real bug found while researching SAP_BASIS **816** (ABAP Platform 2025) support: **arc-1's pre-write lint wrongly blocks writes of valid 816 syntax.**

arc-1 pins `@abaplint/core` to its highest grammar (`v758`) for any 8xx release. abaplint therefore can't parse legitimate new 816 constructs — CDS `define table entity`, `READ TABLE … WHERE`, new RAP/BDL keywords, etc. — and emits `parser_error` / `cds_parser_error`. The pre-write lint (`runPreWriteLint`) treats those as **blocking**, so `SAPWrite` of a valid 816 object is rejected before the PUT. abaplint's `Cloud` target fails identically, so mapping 8xx→Cloud is **not** a fix.

## Fix

When the detected SAP_BASIS release is beyond abaplint's grammar ceiling (`release > 758`), demote `parser_error` / `cds_parser_error` to **non-blocking warnings** in the pre-write config. SAP-side activation remains the definitive syntax check (consistent with how FUNC and unsupported types are already handled). On supported releases (`≤758`) genuine parse errors still block — no regression.

- `src/adt/features.ts`: `ABAPLINT_MAX_RELEASE` (= 758, kept in sync with the `mapSapReleaseToAbaplintVersion` ceiling) + `isBeyondAbaplintCeiling(release)`.
- `src/lint/config-builder.ts`: `buildPreWriteConfig` uses `Warning` severity for the parser-error rules when beyond the ceiling.

## Evidence (verified locally)

`validateBeforeWrite` on real 816 syntax, before vs after:

| Source | release | result |
|--------|---------|--------|
| `define table entity ZTE {…}` | 816 | **pass=true**, `cds_parser_error` → warning ✅ |
| `define table entity ZTE {…}` | 758 | pass=false, `cds_parser_error` (error) — still blocks ✅ |
| `READ TABLE itab … WHERE …` | 816 | **pass=true**, `parser_error` → warning ✅ |
| `READ TABLE itab … WHERE …` | 758 | pass=false, `parser_error` (error) — still blocks ✅ |

## Test plan

- `npm test` — 3381 pass (+7 new: `isBeyondAbaplintCeiling` in `features.test.ts`; demotion behavior in `lint.test.ts`)
- `npm run typecheck` — clean
- `npm run lint` — clean

## Notes

- **Re-bump path:** when abaplint ships a v759/816 grammar, raise `ABAPLINT_MAX_RELEASE` and the `mapSapReleaseToAbaplintVersion` ceiling together; the demotion then self-disables for releases abaplint can parse.
- Interim workaround that this replaces: `--lint-before-write=false`.
- Scope: on-prem 8xx (the verified case). BTP/Cloud has a related lag (abaplint `Cloud` is also behind) but its non-numeric release string isn't covered here — separate follow-up.
- Background: PR #347's `docs/research/abap-platform-2025-816-compatibility.md`, item 1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
