### PR TITLE
fix(security): close scope-router privilege escalation and bind OAuth state to client_id

### DIFF
--- a/docs/research/security-audit-2026-06-oauth-and-scope.md
+++ b/docs/research/security-audit-2026-06-oauth-and-scope.md
@@ -1,0 +1,169 @@
+# Security Audit — OAuth State Integrity & Scope Enforcement (2026-06)
+
+**Date:** 2026-06-05
+**Scope:** `src/handlers/intent.ts` (scope router), `src/server/{http,xsuaa,oauth-state,stateless-client-store}.ts` (XSUAA OAuth + DCR), `src/authz/policy.ts`, `src/adt/safety.ts`
+**Status:** Findings 1 & 2 remediated in this change set. Finding 3 deferred (rationale below).
+
+---
+
+## Executive summary
+
+A white-box review of authorization enforcement and OAuth state integrity found two
+exploitable issues plus one fail-closed usability bug:
+
+1. **High — Privilege escalation via parameter coercion** (`SAPRead` scope router). A caller
+   holding only the `read` scope could reach the `data`-scoped `TABLE_CONTENTS` /
+   `TABLE_QUERY` operations because the scope key was derived from the **raw** request
+   argument, while the handler dispatched on a **normalized** (upper-cased, coerced) copy.
+   The two values disagreed, so the gate looked up the wrong (lower) policy. **Fixed.**
+
+2. **Medium/High — Authorization-code interception via unbound OAuth state** (XSUAA callback
+   proxy). The signed `state` token bound the client's `redirect_uri` but not the DCR
+   `client_id`, so the callback would forward an auth code to whatever `redirect_uri` rode
+   inside a validly-signed state — even one substituted by an attacker on a victim's
+   `client_id`. **Fixed for DCR clients; residual on the pre-registered XSUAA default client
+   documented below.**
+
+3. **Low/Informational — Fail-closed package-rule intersection.** `deriveUserSafetyFromProfile`
+   cannot statically prove a profile sub-package is inside a server `ZFOO/**` subtree, so it
+   denies it. This is conservative-by-design (denies, never over-grants). **Deferred** — see
+   rationale.
+
+The COOP/`helmet` configuration, the mutation gates (`checkOperation`/`checkPackage`/
+`checkGit`), and the existing-object package resolution (`enforcePackageForExistingObject`)
+were reviewed and found sound (bearer-token auth, no ambient cookies → disabling COOP is safe;
+`apply_quickfix` is correctly read-classified as a dry-run delta fetch).
+
+---
+
+## Finding 1 — Privilege escalation via parameter coercion (High) — FIXED
+
+### Root cause
+
+`handleToolCall` derived the scope key (`actionOrType`) from the raw `args.type` with a
+`typeof === 'string'` guard, *before* `normalizeTypeArgsForValidation` ran. Any value that
+was not already a matching string fell through to the **tool-level base policy** (`SAPRead` →
+`read`). Normalization then canonicalized the same value into a privileged type for the
+handler and for Zod. Two inputs exploited the gap:
+
+| Input (`type`)        | Raw scope key      | Policy hit        | Normalized → handler | Effect |
+|-----------------------|--------------------|-------------------|----------------------|--------|
+| `["TABLE_CONTENTS"]`  | `typeof "object"` → `undefined` | base `SAPRead` = `read` | `String([…])` → `TABLE_CONTENTS` | `data` op runs with `read` |
+| `"table_contents"`    | `"table_contents"` (no such key) | base `SAPRead` = `read` | `.toUpperCase()` → `TABLE_CONTENTS` | `data` op runs with `read` |
+
+`normalizeObjectType` (`String(x).trim().toUpperCase()` + slash-collapse) is what makes both
+land on the data-scoped type, so the array form was the audit's headline case and the
+lowercase-string form is an equivalent vector of the same class. (The same case-mismatch also
+weakened `SAP_DENY_ACTIONS` matching for `SAPRead` types.)
+
+### Fix
+
+Derive the scope key from the **same normalized object** the handler dispatches on, computed
+once and reused for Zod validation (`src/handlers/intent.ts`, `handleToolCall`):
+
+```ts
+const normalizedArgs = normalizeTypeArgsForValidation(toolName, args);
+const rawScopeKey = toolName === 'SAPRead' ? normalizedArgs.type : normalizedArgs.action;
+let actionOrType: string | undefined =
+  rawScopeKey === undefined || rawScopeKey === null || rawScopeKey === '' ? undefined : String(rawScopeKey);
+```
+
+This closes the array, case, and slash-form variants in one place. `action`-bearing tools are
+unaffected for legitimate input (a non-string `action` is rejected by Zod regardless); the
+`String()` coercion only ensures the gate fails *closed* (resolves to the correct, possibly
+higher-scoped policy) instead of silently dropping to the base policy.
+
+> Note: this is the audit's *primary* recommendation (normalize-first). The initial draft used
+> a narrower array-only coercion that left the lowercase-string vector open; the normalize-first
+> form supersedes it.
+
+### Tests
+
+`tests/unit/handlers/intent.test.ts` (`scope enforcement`):
+- `type: ["TABLE_CONTENTS"]` + `read` scope → `Insufficient scope: 'data'`
+- `type: "table_contents"` + `read` scope → `Insufficient scope: 'data'`
+- `type: ["TABLE_CONTENTS"]` + `data` scope → not a scope rejection (legit path preserved)
+
+---
+
+## Finding 2 — Authorization-code interception via unbound state (Medium/High) — FIXED (DCR)
+
+### Root cause
+
+The issue-#214 callback proxy inserts ARC-1 into the OAuth return path: XSUAA redirects to
+ARC-1's `/oauth/callback` (not the client), and ARC-1 re-emits the code to the client's
+`redirect_uri` recovered from an HMAC-signed `state`. The signed state carried `redirect_uri`
+but **not** the `client_id`, and — crucially — in the proxy flow XSUAA validates ARC-1's
+callback URL, **not** the client's `redirect_uri`. So redirect-target validation now rests
+entirely on ARC-1, and ARC-1 wasn't performing it. An attacker could obtain a validly-signed
+state carrying their own `redirect_uri` and have a victim's code delivered to it.
+
+### Fix
+
+Bind the originating `client_id` into the signed state and verify the recovered `redirect_uri`
+is registered for that client at callback time:
+
+- `src/server/oauth-state.ts` — add `cid` to the signed payload (`encode` requires it, `decode`
+  returns it, `parsePayload` rejects a payload missing it).
+- `src/server/xsuaa.ts` — `authorize()` passes `_client.client_id` into `encode()`.
+- `src/server/http.ts` — `createOAuthCallbackHandler(stateCodec, clientStore)` looks up
+  `getClient(decoded.clientId)` and rejects (terminal 400, **no redirect**) when the client is
+  unknown or `decoded.clientRedirectUri ∉ client.redirect_uris`. Runs before **both** the
+  success and error branches and **fails closed** on lookup error.
+
+For **DCR clients** (`arc1-…`) the registered `redirect_uris` are baked immutably into the
+HMAC-signed `client_id` and re-derived deterministically by `getClient` (no shared state), so
+the check rejects redirect-substitution on any instance. This covers the documented primary
+clients (Claude Desktop, Cursor, VS Code, Copilot CLI).
+
+### Residual — pre-registered XSUAA default client (follow-up)
+
+The shared XSUAA default client (`StatelessDcrClientStore.xsuaaClient`, used by "Manual" OAuth
+configs) accepts dynamically-added redirect URIs via `ensureRedirectUri()` at `/authorize`
+time. Because that in-memory list is the same object `getClient` returns, on a single instance
+an attacker-supplied `redirect_uri` is auto-registered during `/authorize` and would satisfy
+the callback `includes()` check — so the fix does **not** fully close the vector for the
+default client. It is regression-free (all manifests are `instances: 1`; `ensureRedirectUri`
+is a no-op for DCR clients). **Recommended follow-up:** enforce an allowlist (e.g. the
+`xs-security.json` redirect patterns) for the shared client instead of trusting arbitrary
+auto-registered URIs, or move clients off the shared client onto DCR.
+
+### Tests
+
+`tests/unit/server/oauth-callback.test.ts` (new `client-binding validation` block, exercised
+with a real `StatelessDcrClientStore`):
+- registered `redirect_uri` → 302 with code forwarded
+- unregistered `redirect_uri` on a valid `client_id` → 400, no `Location`, code not leaked
+- unknown/forged `client_id` → 400
+- error branch with unregistered `redirect_uri` → 400
+
+`tests/unit/server/oauth-state.test.ts`: `cid` round-trips; existing signature/expiry/malformed
+guards still hold.
+
+> Operational note: state tokens are short-lived (10 min TTL) and single-flow, so requiring
+> `cid` does not strand cached client registrations. A login in flight across the deploy simply
+> retries.
+
+---
+
+## Finding 3 — Fail-closed package-rule intersection (Low/Info) — DEFERRED
+
+`deriveUserSafetyFromProfile.covers()` only treats a server `ZFOO/**` subtree as statically
+covering the literal root `ZFOO`. A profile that narrows to a child cannot be proven a
+descendant without the live DEVCLASS hierarchy, so it is dropped and the key fails closed
+(`[DENY_ALL_LIST_ENTRY]`). This is **intentional** (documented at `src/adt/safety.ts:410–424`)
+and the runtime `checkPackage` resolver is the authority for surviving entries.
+
+Deferred because: (a) it is a fail-*closed* usability paper-cut, not an over-grant — the only
+finding here that would *loosen* a gate; (b) the realistic case (a real sibling package such as
+`ZFOO_SUB`, not a literal `ZFOO/BAR` slash form) is not addressed by the proposed `startsWith`
+tweak anyway; (c) loosening a package gate warrants a live-hierarchy test, out of scope for this
+change. Track separately if the narrowing use case is needed.
+
+---
+
+## Verification
+
+- `npm run typecheck` — clean
+- `npm test` — 3396 passed (incl. new scope + OAuth-binding tests)
+- `npm run lint` — clean

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -1146,22 +1146,31 @@ export async function handleToolCall(
   // For SAPSearch.tadir_lookup with source='db'|'both', synthesize a sub-action key so the
   // sql-scoped policy entry kicks in (otherwise viewer-only profiles could piggyback on the
   // ADT info-system route to issue freestyle SQL).
+  //
+  // SECURITY (privilege-escalation hardening): the scope key is derived from the SAME
+  // normalized value the handler ultimately dispatches on. `normalizeTypeArgsForValidation`
+  // upper-cases + slash-collapses `type` and coerces non-string inputs via String(), so a
+  // caller cannot evade the per-type scope gate by sending a value that misses the policy key
+  // here yet is canonicalized into a privileged type just before Zod runs. Two such bypasses
+  // existed when this lookup read the RAW `args`: an array (`type: ["TABLE_CONTENTS"]` —
+  // typeof "object" → undefined key → base `read`) and a lowercase string
+  // (`type: "table_contents"` — no `SAPRead.table_contents` key → base `read`), both of which
+  // were then normalized into the data-scoped `TABLE_CONTENTS` for the handler. Normalizing
+  // first closes the array, case, and slash-form variants in one place (and keeps the
+  // SAP_DENY_ACTIONS match below consistent with the canonical form). The normalized object is
+  // reused for Zod validation below so canonicalization happens exactly once.
   // Runs BEFORE Zod validation so scope errors don't leak schema details to unauthorized callers.
+  const normalizedArgs = normalizeTypeArgsForValidation(toolName, args);
+  const rawScopeKey = toolName === 'SAPRead' ? normalizedArgs.type : normalizedArgs.action;
   let actionOrType: string | undefined =
-    toolName === 'SAPRead'
-      ? typeof args.type === 'string'
-        ? args.type
-        : undefined
-      : typeof args.action === 'string'
-        ? args.action
-        : undefined;
+    rawScopeKey === undefined || rawScopeKey === null || rawScopeKey === '' ? undefined : String(rawScopeKey);
   if (
     toolName === 'SAPSearch' &&
-    typeof args.searchType === 'string' &&
-    args.searchType === 'tadir_lookup' &&
-    typeof args.source === 'string'
+    typeof normalizedArgs.searchType === 'string' &&
+    normalizedArgs.searchType === 'tadir_lookup' &&
+    typeof normalizedArgs.source === 'string'
   ) {
-    const src = args.source.toLowerCase();
+    const src = normalizedArgs.source.toLowerCase();
     if (src === 'db' || src === 'both') {
       actionOrType = `tadir_lookup_${src}`;
     }
@@ -1212,7 +1221,10 @@ export async function handleToolCall(
   const isBtp = config.systemType === 'btp';
   const schema = getToolSchema(toolName, isBtp);
   if (schema) {
-    args = normalizeTypeArgsForValidation(toolName, args);
+    // Reuse the normalized args computed for the scope-key derivation above —
+    // re-normalizing would be redundant (the transform is idempotent) and risks
+    // the two paths drifting.
+    args = normalizedArgs;
     const parsed = schema.safeParse(args);
     if (!parsed.success) {
       const validationError = formatZodError(parsed.error, toolName);

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -36,6 +36,7 @@ import { API_KEY_PROFILES } from './config.js';
 import { logger } from './logger.js';
 import type { OAuthStateCodec } from './oauth-state.js';
 import { VERSION } from './server.js';
+import type { StatelessDcrClientStore } from './stateless-client-store.js';
 import type { ServerConfig } from './types.js';
 import type { XsuaaCredentials } from './xsuaa.js';
 
@@ -108,10 +109,23 @@ function renderOAuthErrorPage(error: string, errorDescription: string, clientRet
  * Removal condition + upstream tracking (XSUAA root cause, arc-1#214,
  * vscode#314715) are documented at the top of `oauth-state.ts`.
  *
- * Exported for unit tests; mounted in `startHttpServer`.
+ * SECURITY (authorization-code interception, security audit 2026-06): the
+ * signed state carries the originating DCR `client_id` (`decoded.clientId`).
+ * Before forwarding the auth code (or an error) to `decoded.clientRedirectUri`,
+ * we verify that redirect_uri is actually registered for that client. The
+ * signature alone is insufficient: all DCR clients share one XSUAA app, so a
+ * forged-state attack is blocked by the HMAC, but the redirect target must
+ * still belong to the client that will exchange the code. For stateless DCR
+ * clients (`arc1-…`) the registered redirect_uris are baked immutably into the
+ * signed `client_id`, so this check deterministically rejects an attacker who
+ * substitutes their own redirect_uri on a victim's `client_id`.
+ *
+ * Exported for unit tests; mounted in `startHttpServer`. When `clientStore` is
+ * omitted (legacy unit tests of the issue-#214 round-trip) the binding check is
+ * skipped; production always passes it.
  */
-export function createOAuthCallbackHandler(stateCodec: OAuthStateCodec) {
-  return (req: Request, res: Response): void => {
+export function createOAuthCallbackHandler(stateCodec: OAuthStateCodec, clientStore?: StatelessDcrClientStore) {
+  return async (req: Request, res: Response): Promise<void> => {
     const stateToken = typeof req.query.state === 'string' ? req.query.state : '';
     const decoded = stateCodec.decode(stateToken);
     if (decoded.kind !== 'ok') {
@@ -128,6 +142,54 @@ export function createOAuthCallbackHandler(stateCodec: OAuthStateCodec) {
             '</body></html>',
         );
       return;
+    }
+
+    // ── Client-binding validation (authorization-code interception defense) ──
+    // Verify the recovered redirect_uri is registered for the client_id that
+    // minted this state. Runs for BOTH the success and error branches below so
+    // neither a code nor an error response can be steered to an unregistered
+    // URI. Fails CLOSED on any lookup error (a terminal error page, never a
+    // redirect to an unverified target).
+    if (clientStore && decoded.clientId) {
+      let clientRedirectUris: string[] | undefined;
+      try {
+        const clientInfo = await clientStore.getClient(decoded.clientId);
+        clientRedirectUris = clientInfo?.redirect_uris;
+      } catch (err) {
+        logger.warn('OAuth callback: client lookup threw — failing closed', {
+          clientId: decoded.clientId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      if (!clientRedirectUris) {
+        logger.warn('OAuth callback: state references unknown client_id', { clientId: decoded.clientId });
+        res
+          .status(400)
+          .type('html')
+          .send(
+            '<!doctype html><html><body style="font-family:sans-serif;padding:2rem">' +
+              '<h1>Authentication failed</h1>' +
+              '<p>The OAuth client referenced in the state token is no longer valid. Please retry the sign-in.</p>' +
+              '</body></html>',
+          );
+        return;
+      }
+      if (!clientRedirectUris.includes(decoded.clientRedirectUri)) {
+        logger.warn('OAuth callback: redirect_uri not registered for client', {
+          clientId: decoded.clientId,
+          redirectUri: decoded.clientRedirectUri,
+        });
+        res
+          .status(400)
+          .type('html')
+          .send(
+            '<!doctype html><html><body style="font-family:sans-serif;padding:2rem">' +
+              '<h1>Authentication failed</h1>' +
+              '<p>The redirect URI in the state token is not registered for this client. Please retry the sign-in.</p>' +
+              '</body></html>',
+          );
+        return;
+      }
     }
 
     let target: URL;
@@ -575,7 +637,7 @@ export async function startHttpServer(
     // XSUAA as oauthCallbackUrl. A strip-prefix proxy maps the public path
     // back to this root route. Handler is extracted (exported) so the
     // state-round-trip contract is unit-testable without a live XSUAA.
-    app.get('/oauth/callback', createOAuthCallbackHandler(stateCodec));
+    app.get('/oauth/callback', createOAuthCallbackHandler(stateCodec, clientStore));
 
     // ─── Path-prefix-aware OAuth metadata override ────────────────
     // The MCP SDK's `mcpAuthRouter` builds endpoint URLs with

--- a/src/server/oauth-state.ts
+++ b/src/server/oauth-state.ts
@@ -77,12 +77,18 @@ interface StatePayload {
   /** The OAuth client's ORIGINAL `redirect_uri` — where ARC-1 sends the
    *  user after XSUAA returns to ARC-1's callback. */
   r: string;
+  /** The DCR `client_id` that initiated the flow. Bound into the signed
+   *  payload so the callback can verify the recovered `redirect_uri` is
+   *  actually registered for THIS client — closing the authorization-code
+   *  interception vector where an attacker substitutes their own
+   *  `redirect_uri` on a victim's signed state (security audit 2026-06). */
+  cid: string;
   /** Expiry, epoch seconds. */
   exp: number;
 }
 
 export type DecodeResult =
-  | { kind: 'ok'; clientState?: string; clientRedirectUri: string }
+  | { kind: 'ok'; clientState?: string; clientRedirectUri: string; clientId: string }
   | { kind: 'error'; reason: 'malformed' | 'bad_signature' | 'invalid_payload' | 'expired' };
 
 /**
@@ -108,11 +114,12 @@ export class OAuthStateCodec {
    *
    * @param input.now Injectable clock (epoch ms) for deterministic tests.
    */
-  encode(input: { clientState?: string; clientRedirectUri: string; now?: number }): string {
+  encode(input: { clientState?: string; clientRedirectUri: string; clientId: string; now?: number }): string {
     const nowSec = Math.floor((input.now ?? Date.now()) / 1000);
     const payload: StatePayload = {
       v: 1,
       r: input.clientRedirectUri,
+      cid: input.clientId,
       exp: nowSec + this.ttlSeconds,
     };
     if (input.clientState !== undefined) {
@@ -151,7 +158,7 @@ export class OAuthStateCodec {
       return { kind: 'error', reason: 'expired' };
     }
 
-    return { kind: 'ok', clientState: payload.s, clientRedirectUri: payload.r };
+    return { kind: 'ok', clientState: payload.s, clientRedirectUri: payload.r, clientId: payload.cid };
   }
 
   private sign(payloadB64: string): string {
@@ -179,9 +186,10 @@ function parsePayload(payloadB64: string): StatePayload | undefined {
     const obj = JSON.parse(json) as Record<string, unknown>;
     if (obj.v !== 1) return undefined;
     if (typeof obj.r !== 'string' || obj.r.length === 0) return undefined;
+    if (typeof obj.cid !== 'string' || obj.cid.length === 0) return undefined;
     if (typeof obj.exp !== 'number' || !Number.isFinite(obj.exp)) return undefined;
     if (obj.s !== undefined && typeof obj.s !== 'string') return undefined;
-    return { v: 1, s: obj.s as string | undefined, r: obj.r, exp: obj.exp };
+    return { v: 1, s: obj.s as string | undefined, r: obj.r, cid: obj.cid, exp: obj.exp };
   } catch {
     return undefined;
   }

--- a/src/server/xsuaa.ts
+++ b/src/server/xsuaa.ts
@@ -336,6 +336,7 @@ class XsuaaProxyOAuthProvider extends ProxyOAuthServerProvider {
     const arc1State = this.stateCodec.encode({
       clientState: params.state,
       clientRedirectUri: params.redirectUri,
+      clientId: _client.client_id,
     });
 
     const targetUrl = new URL(this.xsuaaAuthUrl);

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -4337,6 +4337,54 @@ lv = CONV string( 1 ).`,
       expect(result.isError).toBeUndefined();
     });
 
+    // ── Privilege-escalation regression (security audit 2026-06) ──
+    // The scope key must be derived from the SAME normalized value the handler
+    // dispatches on. Before the fix, the lookup read the RAW `type`, so a value
+    // that missed the `SAPRead.TABLE_CONTENTS` policy key here — but was then
+    // canonicalized into the data-scoped `TABLE_CONTENTS` for the handler —
+    // slipped past the gate with only `read` scope. Two such forms existed:
+    it('blocks SAPRead TABLE_CONTENTS passed as an ARRAY with read-only scope', async () => {
+      const result = await handleToolCall(
+        createClient(),
+        DEFAULT_CONFIG,
+        'SAPRead',
+        // typeof ["TABLE_CONTENTS"] === "object" → used to yield an undefined
+        // policy key → base `read`; String() coercion now maps it to the
+        // data-scoped TABLE_CONTENTS policy.
+        { type: ['TABLE_CONTENTS'], name: 'T000' },
+        readAuth,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain("Insufficient scope: 'data'");
+    });
+
+    it('blocks SAPRead TABLE_CONTENTS passed as a LOWERCASE string with read-only scope', async () => {
+      const result = await handleToolCall(
+        createClient(),
+        DEFAULT_CONFIG,
+        'SAPRead',
+        // "table_contents" matched no policy key (keys are upper-case) → base
+        // `read`; normalizing first upper-cases it before the lookup.
+        { type: 'table_contents', name: 'T000' },
+        readAuth,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain("Insufficient scope: 'data'");
+    });
+
+    it('allows SAPRead TABLE_CONTENTS in array form with data scope (normalization keeps the legit path)', async () => {
+      const result = await handleToolCall(
+        createClient(),
+        DEFAULT_CONFIG,
+        'SAPRead',
+        { type: ['TABLE_CONTENTS'], name: 'T000' },
+        dataAuth,
+      );
+      // Scope check passes (data ≥ data); it may still fail downstream for
+      // non-scope reasons, but must NOT be a scope rejection.
+      expect(result.content[0]?.text ?? '').not.toContain('Insufficient scope');
+    });
+
     it('blocks SAPWrite with read-only scope', async () => {
       const result = await handleToolCall(
         createClient(),

--- a/tests/unit/server/oauth-callback.test.ts
+++ b/tests/unit/server/oauth-callback.test.ts
@@ -3,12 +3,20 @@ import request from 'supertest';
 import { describe, expect, it } from 'vitest';
 import { createOAuthCallbackHandler } from '../../../src/server/http.js';
 import { OAuthStateCodec } from '../../../src/server/oauth-state.js';
+import { StatelessDcrClientStore } from '../../../src/server/stateless-client-store.js';
 
 const SECRET = 'callback-test-signing-secret-1234567890';
+const TEST_CLIENT_ID = 'arc1-test-client';
 
 function buildApp(codec: OAuthStateCodec): express.Express {
   const app = express();
   app.get('/oauth/callback', createOAuthCallbackHandler(codec));
+  return app;
+}
+
+function buildAppWithStore(codec: OAuthStateCodec, store: StatelessDcrClientStore): express.Express {
+  const app = express();
+  app.get('/oauth/callback', createOAuthCallbackHandler(codec, store));
   return app;
 }
 
@@ -22,7 +30,7 @@ describe('createOAuthCallbackHandler — issue #214 round-trip', () => {
   it('redirects to the client with the ORIGINAL "+" state recoverable (the fix)', async () => {
     const codec = new OAuthStateCodec(SECRET);
     const clientState = '6QadZ5GFXGvZ649+OuQi+Q==';
-    const token = codec.encode({ clientState, clientRedirectUri: 'http://127.0.0.1:33418/' });
+    const token = codec.encode({ clientState, clientRedirectUri: 'http://127.0.0.1:33418/', clientId: TEST_CLIENT_ID });
 
     const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'AUTHCODE123', state: token });
 
@@ -40,7 +48,11 @@ describe('createOAuthCallbackHandler — issue #214 round-trip', () => {
 
   it('emits %2B (not literal +) in the Location header', async () => {
     const codec = new OAuthStateCodec(SECRET);
-    const token = codec.encode({ clientState: 'a+b+c==', clientRedirectUri: 'http://localhost:1/cb' });
+    const token = codec.encode({
+      clientState: 'a+b+c==',
+      clientRedirectUri: 'http://localhost:1/cb',
+      clientId: TEST_CLIENT_ID,
+    });
     const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'x', state: token });
     const loc = res.headers.location as string;
     // The state segment must not contain a raw '+'.
@@ -51,7 +63,11 @@ describe('createOAuthCallbackHandler — issue #214 round-trip', () => {
 
   it('renders a self-hosted error page (no 302 to a possibly-dead loopback) on OAuth error', async () => {
     const codec = new OAuthStateCodec(SECRET);
-    const token = codec.encode({ clientState: 'st+ate==', clientRedirectUri: 'http://127.0.0.1:5/cb' });
+    const token = codec.encode({
+      clientState: 'st+ate==',
+      clientRedirectUri: 'http://127.0.0.1:5/cb',
+      clientId: TEST_CLIENT_ID,
+    });
     const res = await request(buildApp(codec))
       .get('/oauth/callback')
       .query({ error: 'access_denied', error_description: 'user cancelled', state: token });
@@ -71,6 +87,7 @@ describe('createOAuthCallbackHandler — issue #214 round-trip', () => {
     const token = codec.encode({
       clientState: 'st+ate==',
       clientRedirectUri: 'https://claude.ai/api/mcp/auth_callback',
+      clientId: TEST_CLIENT_ID,
     });
     const res = await request(buildApp(codec))
       .get('/oauth/callback')
@@ -87,7 +104,7 @@ describe('createOAuthCallbackHandler — issue #214 round-trip', () => {
 
   it('adds an actionable role-collection hint for invalid_scope', async () => {
     const codec = new OAuthStateCodec(SECRET);
-    const token = codec.encode({ clientRedirectUri: 'http://127.0.0.1:5/cb' });
+    const token = codec.encode({ clientRedirectUri: 'http://127.0.0.1:5/cb', clientId: TEST_CLIENT_ID });
     const res = await request(buildApp(codec)).get('/oauth/callback').query({
       error: 'invalid_scope',
       error_description: 'is invalid. not allowed any of the requested scopes',
@@ -99,7 +116,7 @@ describe('createOAuthCallbackHandler — issue #214 round-trip', () => {
 
   it('HTML-escapes a malicious error_description (no XSS)', async () => {
     const codec = new OAuthStateCodec(SECRET);
-    const token = codec.encode({ clientRedirectUri: 'http://127.0.0.1:5/cb' });
+    const token = codec.encode({ clientRedirectUri: 'http://127.0.0.1:5/cb', clientId: TEST_CLIENT_ID });
     const res = await request(buildApp(codec))
       .get('/oauth/callback')
       .query({ error: 'invalid_request', error_description: '<script>alert(1)</script>', state: token });
@@ -110,14 +127,18 @@ describe('createOAuthCallbackHandler — issue #214 round-trip', () => {
 
   it('round-trips a state with no "+" unchanged', async () => {
     const codec = new OAuthStateCodec(SECRET);
-    const token = codec.encode({ clientState: 'mElKiL3xesnEy0LnXDyKvA==', clientRedirectUri: 'http://localhost:1/cb' });
+    const token = codec.encode({
+      clientState: 'mElKiL3xesnEy0LnXDyKvA==',
+      clientRedirectUri: 'http://localhost:1/cb',
+      clientId: TEST_CLIENT_ID,
+    });
     const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'c', state: token });
     expect(clientParsedState(res.headers.location as string)).toBe('mElKiL3xesnEy0LnXDyKvA==');
   });
 
   it('omits state when the client did not send one', async () => {
     const codec = new OAuthStateCodec(SECRET);
-    const token = codec.encode({ clientRedirectUri: 'http://localhost:1/cb' });
+    const token = codec.encode({ clientRedirectUri: 'http://localhost:1/cb', clientId: TEST_CLIENT_ID });
     const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'c', state: token });
     expect(new URL(res.headers.location as string).searchParams.has('state')).toBe(false);
   });
@@ -138,6 +159,7 @@ describe('createOAuthCallbackHandler — issue #214 round-trip', () => {
     const token = codec.encode({
       clientState: 'x',
       clientRedirectUri: 'http://localhost:1/cb',
+      clientId: TEST_CLIENT_ID,
       now: 1_000_000_000_000,
     });
     const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'c', state: token });
@@ -149,5 +171,83 @@ describe('createOAuthCallbackHandler — issue #214 round-trip', () => {
     const codec = new OAuthStateCodec(SECRET);
     const res = await request(buildApp(codec)).get('/oauth/callback').query({ code: 'c' });
     expect(res.status).toBe(400);
+  });
+});
+
+describe('createOAuthCallbackHandler — client-binding validation (auth-code interception defense)', () => {
+  // A DCR client_id carries its registered redirect_uris immutably inside its
+  // HMAC-signed payload, so getClient() returns them deterministically. The
+  // callback must only forward the code/error to a redirect_uri registered for
+  // the client_id bound into the signed state — defeating the attack where a
+  // valid signed state's redirect_uri is swapped for an attacker-controlled one.
+  const buildStore = () => new StatelessDcrClientStore('xsuaa-client', 'xsuaa-secret', SECRET);
+
+  it('forwards the code when redirect_uri IS registered for the state client_id', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const store = buildStore();
+    const registered = await store.registerClient({ redirect_uris: ['https://app.example.com/cb'] });
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'https://app.example.com/cb',
+      clientId: registered.client_id,
+    });
+    const res = await request(buildAppWithStore(codec, store))
+      .get('/oauth/callback')
+      .query({ code: 'CODE1', state: token });
+    expect(res.status).toBe(302);
+    const u = new URL(res.headers.location as string);
+    expect(u.origin + u.pathname).toBe('https://app.example.com/cb');
+    expect(u.searchParams.get('code')).toBe('CODE1');
+  });
+
+  it('returns 400 (code NOT leaked) when redirect_uri is NOT registered for the client_id', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const store = buildStore();
+    const registered = await store.registerClient({ redirect_uris: ['https://app.example.com/cb'] });
+    // The attacker reuses a victim client_id but substitutes their own redirect_uri.
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'https://attacker.example/cb',
+      clientId: registered.client_id,
+    });
+    const res = await request(buildAppWithStore(codec, store))
+      .get('/oauth/callback')
+      .query({ code: 'STOLEN', state: token });
+    expect(res.status).toBe(400);
+    // No redirect at all → the authorization code is never delivered anywhere.
+    expect(res.headers.location).toBeUndefined();
+    expect(res.text).toContain('Authentication failed');
+    expect(res.text).not.toContain('STOLEN');
+  });
+
+  it('returns 400 when the state references an unknown/forged client_id', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const store = buildStore();
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'https://app.example.com/cb',
+      clientId: 'arc1-bogus.AAAAAAAAAAAAAAAAAAAAAA',
+    });
+    const res = await request(buildAppWithStore(codec, store))
+      .get('/oauth/callback')
+      .query({ code: 'CODE1', state: token });
+    expect(res.status).toBe(400);
+    expect(res.headers.location).toBeUndefined();
+  });
+
+  it('blocks the error-forwarding path too when redirect_uri is unregistered', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const store = buildStore();
+    const registered = await store.registerClient({ redirect_uris: ['https://app.example.com/cb'] });
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'https://attacker.example/cb',
+      clientId: registered.client_id,
+    });
+    const res = await request(buildAppWithStore(codec, store))
+      .get('/oauth/callback')
+      .query({ error: 'access_denied', error_description: 'denied', state: token });
+    expect(res.status).toBe(400);
+    expect(res.headers.location).toBeUndefined();
   });
 });

--- a/tests/unit/server/oauth-state.test.ts
+++ b/tests/unit/server/oauth-state.test.ts
@@ -3,6 +3,7 @@ import { OAuthStateCodec } from '../../../src/server/oauth-state.js';
 
 const SECRET = 'test-signing-secret-at-least-16-bytes-long';
 const T0 = 1_700_000_000_000; // fixed epoch ms for deterministic expiry tests
+const TEST_CLIENT_ID = 'arc1-test-client';
 
 describe('OAuthStateCodec', () => {
   it('rejects an empty signing secret', () => {
@@ -12,12 +13,18 @@ describe('OAuthStateCodec', () => {
   it('round-trips a state containing literal "+" (the issue #214 trigger)', () => {
     const codec = new OAuthStateCodec(SECRET);
     const clientState = '6QadZ5GFXGvZ649+OuQi+Q==';
-    const token = codec.encode({ clientState, clientRedirectUri: 'http://127.0.0.1:33418/', now: T0 });
+    const token = codec.encode({
+      clientState,
+      clientRedirectUri: 'http://127.0.0.1:33418/',
+      clientId: TEST_CLIENT_ID,
+      now: T0,
+    });
     const decoded = codec.decode(token, T0 + 1000);
     expect(decoded).toEqual({
       kind: 'ok',
       clientState,
       clientRedirectUri: 'http://127.0.0.1:33418/',
+      clientId: TEST_CLIENT_ID,
     });
   });
 
@@ -25,7 +32,12 @@ describe('OAuthStateCodec', () => {
     const codec = new OAuthStateCodec(SECRET);
     // Use a client state full of the dangerous characters; the token itself
     // must still be URL-safe because the payload is base64url-encoded.
-    const token = codec.encode({ clientState: 'a+b/c+d==', clientRedirectUri: 'http://localhost:9999/cb', now: T0 });
+    const token = codec.encode({
+      clientState: 'a+b/c+d==',
+      clientRedirectUri: 'http://localhost:9999/cb',
+      clientId: TEST_CLIENT_ID,
+      now: T0,
+    });
     expect(token).toMatch(/^[A-Za-z0-9_.-]+$/);
     expect(token).not.toContain('+');
     expect(token).not.toContain('/');
@@ -34,19 +46,29 @@ describe('OAuthStateCodec', () => {
 
   it('round-trips when clientState is absent (state is optional in OAuth)', () => {
     const codec = new OAuthStateCodec(SECRET);
-    const token = codec.encode({ clientRedirectUri: 'https://claude.ai/api/mcp/auth_callback', now: T0 });
+    const token = codec.encode({
+      clientRedirectUri: 'https://claude.ai/api/mcp/auth_callback',
+      clientId: TEST_CLIENT_ID,
+      now: T0,
+    });
     const decoded = codec.decode(token, T0 + 1000);
     expect(decoded).toEqual({
       kind: 'ok',
       clientState: undefined,
       clientRedirectUri: 'https://claude.ai/api/mcp/auth_callback',
+      clientId: TEST_CLIENT_ID,
     });
   });
 
   it('preserves additional base64 specials (/, multiple +, padding)', () => {
     const codec = new OAuthStateCodec(SECRET);
     for (const clientState of ['a+b+c+d==', 'aaa/bbb==', '+leading==', 'trailing+==', 'mix+/+/==']) {
-      const token = codec.encode({ clientState, clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+      const token = codec.encode({
+        clientState,
+        clientRedirectUri: 'http://localhost:1/cb',
+        clientId: TEST_CLIENT_ID,
+        now: T0,
+      });
       const decoded = codec.decode(token, T0 + 1000);
       expect(decoded.kind).toBe('ok');
       if (decoded.kind === 'ok') expect(decoded.clientState).toBe(clientState);
@@ -55,7 +77,12 @@ describe('OAuthStateCodec', () => {
 
   it('rejects a tampered payload (bad_signature)', () => {
     const codec = new OAuthStateCodec(SECRET);
-    const token = codec.encode({ clientState: 'abc', clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'http://localhost:1/cb',
+      clientId: TEST_CLIENT_ID,
+      now: T0,
+    });
     const [payloadB64, sig] = token.split('.');
     // Flip a char in the payload — signature no longer matches.
     const tamperedChar = payloadB64[0] === 'A' ? 'B' : 'A';
@@ -65,7 +92,12 @@ describe('OAuthStateCodec', () => {
 
   it('rejects a tampered signature (bad_signature)', () => {
     const codec = new OAuthStateCodec(SECRET);
-    const token = codec.encode({ clientState: 'abc', clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'http://localhost:1/cb',
+      clientId: TEST_CLIENT_ID,
+      now: T0,
+    });
     const [payloadB64] = token.split('.');
     expect(codec.decode(`${payloadB64}.AAAAAAAAAAAAAAAAAAAAAA`, T0 + 1000)).toEqual({
       kind: 'error',
@@ -76,13 +108,23 @@ describe('OAuthStateCodec', () => {
   it('rejects a token signed with a different key (bad_signature)', () => {
     const a = new OAuthStateCodec(SECRET);
     const b = new OAuthStateCodec('a-completely-different-signing-secret');
-    const token = a.encode({ clientState: 'abc', clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+    const token = a.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'http://localhost:1/cb',
+      clientId: TEST_CLIENT_ID,
+      now: T0,
+    });
     expect(b.decode(token, T0 + 1000)).toEqual({ kind: 'error', reason: 'bad_signature' });
   });
 
   it('rejects an expired token (expired)', () => {
     const codec = new OAuthStateCodec(SECRET, { ttlSeconds: 60 });
-    const token = codec.encode({ clientState: 'abc', clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'http://localhost:1/cb',
+      clientId: TEST_CLIENT_ID,
+      now: T0,
+    });
     // 61s later → past the 60s TTL.
     expect(codec.decode(token, T0 + 61_000)).toEqual({ kind: 'error', reason: 'expired' });
     // Still valid at 59s.
@@ -100,9 +142,31 @@ describe('OAuthStateCodec', () => {
   it("a fresh codec with the same secret can verify another instance's token (stateless / multi-instance)", () => {
     const writer = new OAuthStateCodec(SECRET);
     const reader = new OAuthStateCodec(SECRET); // simulates a different CF instance
-    const token = writer.encode({ clientState: 'x+y==', clientRedirectUri: 'http://localhost:1/cb', now: T0 });
+    const token = writer.encode({
+      clientState: 'x+y==',
+      clientRedirectUri: 'http://localhost:1/cb',
+      clientId: TEST_CLIENT_ID,
+      now: T0,
+    });
     const decoded = reader.decode(token, T0 + 1000);
     expect(decoded.kind).toBe('ok');
     if (decoded.kind === 'ok') expect(decoded.clientState).toBe('x+y==');
+  });
+
+  it('embeds and recovers the client_id in the signed state token', () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'http://localhost:1/cb',
+      clientId: 'arc1-my-client',
+      now: T0,
+    });
+    const decoded = codec.decode(token, T0 + 1000);
+    expect(decoded).toEqual({
+      kind: 'ok',
+      clientState: 'abc',
+      clientRedirectUri: 'http://localhost:1/cb',
+      clientId: 'arc1-my-client',
+    });
   });
 });


### PR DESCRIPTION
## Summary

Remediates two issues from a 2026-06 white-box security audit of ARC-1's authorization enforcement and XSUAA OAuth state integrity. Full write-up: [`docs/research/security-audit-2026-06-oauth-and-scope.md`](docs/research/security-audit-2026-06-oauth-and-scope.md).

### 1. Privilege escalation via parameter coercion — `SAPRead` scope router (High)
The scope key (`actionOrType`) was derived from the **raw** `args.type` with a `typeof === 'string'` guard, *before* `normalizeTypeArgsForValidation` ran — while the handler dispatched on the **normalized** copy. A `read`-scoped caller could reach the `data`-scoped `TABLE_CONTENTS`/`TABLE_QUERY` ops via either form:

| `type` input | raw scope key | policy hit | normalized → handler |
|---|---|---|---|
| `["TABLE_CONTENTS"]` | `typeof "object"` → `undefined` | base `SAPRead` = `read` | `String([…])` → `TABLE_CONTENTS` |
| `"table_contents"` | no matching key | base `SAPRead` = `read` | `.toUpperCase()` → `TABLE_CONTENTS` |

**Fix:** derive the scope key from the **same normalized object** the handler dispatches on (computed once, reused for Zod). Closes the array, case, and slash-form variants and aligns `SAP_DENY_ACTIONS` matching with the canonical form.

> The array form was the audit's headline case; the lowercase-string form is an equivalent vector of the same class found while porting. The narrower array-only coercion was superseded by this normalize-first fix (the audit's primary recommendation).

### 2. Authorization-code interception via unbound OAuth state (Medium/High)
The issue-#214 callback proxy makes ARC-1 — not XSUAA — responsible for the client redirect target, but the HMAC-signed `state` bound only `redirect_uri`, not `client_id`. So `/oauth/callback` would forward a victim's auth code to any `redirect_uri` riding inside a validly-signed state.

**Fix:** bind `cid` into the signed state (`oauth-state.ts`), pass `_client.client_id` at authorize (`xsuaa.ts`), and verify at callback that the recovered `redirect_uri` is registered for that client — failing **closed**, before both the success and error branches (`http.ts`). Deterministic for DCR clients (`arc1-…`), since their `redirect_uris` are baked immutably into the signed `client_id`.

**Residual (follow-up):** the shared pre-registered XSUAA default client auto-registers redirect URIs via `ensureRedirectUri()`, so the `includes()` check can be satisfied by an attacker-supplied URI on a single instance. Regression-free today (`instances: 1`; `ensureRedirectUri` is a no-op for DCR clients). Recommend allowlisting the shared client's redirect URIs, or moving Manual-mode clients onto DCR.

### 3. Fail-closed package-rule intersection (Low/Info) — deferred
`deriveUserSafetyFromProfile` denies a profile sub-package it can't statically prove sits under a server `ZFOO/**` subtree. This **denies** (never over-grants) and is intentional (`safety.ts:410–424`); the proposed tweak doesn't address the realistic sibling-package case and would loosen a gate without a live-hierarchy test. Tracked for separate handling.

## Test plan
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — **3396 passing**, including new regression tests:
  - scope router: array + lowercase `TABLE_CONTENTS` denied at `read`; array form allowed at `data`
  - OAuth callback client-binding: registered URI forwards; unregistered URI / unknown `client_id` / error-branch all return 400 with no redirect and no code leak; `cid` round-trips in the state codec

🤖 Generated with [Claude Code](https://claude.com/claude-code)