### PR TITLE
test: tighten integration skip hygiene

### DIFF
--- a/docs/research/abap-platform-2025-816-compatibility.md
+++ b/docs/research/abap-platform-2025-816-compatibility.md
@@ -1,6 +1,6 @@
 # ABAP Platform 2025 (SAP_BASIS 816) — arc-1 Compatibility Research & Implementation Backlog
 
-**Status:** research complete; one actionable bug + several follow-ups. Nothing here is implemented yet.
+**Status:** research complete; the 8xx abaplint false-positive blocker is implemented on `main` (PR #350, released in 0.9.11). Remaining work is 2025 write-path validation, table-entity coverage, and one server-driven-object spike.
 **Date:** 2026-06-05.
 **How verified:** live tests against `a4h-2025.marianzeis.de:50100` (SAP_BASIS **816**) and `a4h.marianzeis.de:50000` (SAP_BASIS **758**), plus tsx harnesses running arc-1's actual parsers/linter, plus SAP-sourced research (`SAP/abap-file-formats`, ABAP `ABENNEWS-816-*` docs, ABAP Platform 2025 What's New).
 **Companion docs:** [`abap-platform-2025-new-adt-apis.md`](./abap-platform-2025-new-adt-apis.md) (the 124 new ADT endpoints), PR #347 (816 added as a validated probe target).
@@ -9,21 +9,21 @@ This doc is written so a future session can pick up **any single item** and impl
 
 ---
 
-## TL;DR — what to do before/after merging #347
+## TL;DR — what to do next after release 0.9.11
 
 | # | Topic | Verdict | Action | Effort |
 |---|-------|---------|--------|--------|
-| **1.2** | **abaplint v758 false-positive-blocks 816 syntax** | ❌ **real bug** | **Demote `parser_error`/`cds_parser_error` to non-blocking when release > abaplint ceiling.** Highest priority. | S–M |
+| **2.2** | **Writes on the 2025 container** | ⚠️ **ops prerequisite** | **Apply the 2023 performance tuning to `a4h-2025`, restart, then re-run the CRUD/write slice.** Highest priority before more 816 write tests. | S (ops) |
+| **1.3** | **CDS table entity create/read** | ⚠️ routing/lint OK; live write validation blocked by 2.2 | After 2.2, add a focused table-entity lifecycle test on 816. | S |
+| **3.1** | **Server-driven-object read/write** | 🔬 spike | Seed one real 816 server-driven object, then prove read→write→activate before generic support. | M |
+| **1.2** | **abaplint v758 false-positive-blocks 816 syntax** | ✅ **implemented** | No action now. Keep `ABAPLINT_MAX_RELEASE` and release mapping coupled when abaplint gains newer grammar. | — |
 | 1.1 | Existing parsers on 816 (objectstructure etc.) | ✅ pass | None (optional: capture a 816 objectstructure fixture) | XS |
-| 1.3 | CDS table entity create/read | ⚠️ routing OK, blocked by 1.2 | Fix 1.2; then add a focused test | S (after 1.2) |
 | 2.1 | `rap-preflight` on 816 | ✅ correct | None (document) | — |
-| 2.2 | Writes on the 2025 container | ⚠️ ops | Perf-tune the container, then re-run CRUD slice | S (ops) |
 | 2.3 | gCTS / abapGit on 816 | ✅ gCTS works; abapGit absent on trial | None (document) | — |
-| 3.1 | Server-driven-object read/write | 🔬 spike | One real round-trip before building the generic path | M |
 | 3.2 | abap-file-formats `release_state` | ℹ️ not a repo field | Source release state from ADT runtime instead | — |
 | 4.x | SAP_ABA parse / discovery parse / 2025 auth | ✅ safe | None (TLS 1.2+ hygiene only) | — |
 
-**Recommendation:** **1.2 is the only behavior bug** and is worth doing before relying on arc-1 for writes on any 8xx system. It is independent of #347 and can ship as its own small PR. Everything else is either already-correct (document) or a follow-up spike.
+**Recommendation:** do not spend the next PR on lint. That bug is already fixed on current `main`. The next useful order is: **(1) tune the 2025 container for write+activate stability, (2) add the 816 CDS table-entity lifecycle validation, (3) spike one real server-driven-object round-trip**, then decide whether generic SDO support is worth implementing.
 
 ---
 
@@ -47,11 +47,11 @@ This doc is written so a future session can pick up **any single item** and impl
 
 **Verdict:** no parser regression on 816. **Optional polish:** capture a 816 `objectstructure` fixture (`tests/fixtures/xml/objectstructure-clas-a4h-816.xml`) alongside the existing `{a4h-758,npl-750}` ones so `parseClassStructure` has explicit 816 coverage. Low value; do only if touching that area.
 
-### 1.2 — abaplint v758 false-positive-blocks 816 syntax ❌ THE BUG (do this)
+### 1.2 — abaplint v758 false-positive-blocks 816 syntax ✅ IMPLEMENTED
 
 **Why it matters:** arc-1's pre-write lint pins abaplint to `v758` for any 8xx release (`mapSapReleaseToAbaplintVersion('816') → v758` — correct, since abaplint has no v759/816). But abaplint's *parser grammar* is therefore behind the release, so **legitimate new 816 syntax fails to parse**, and `parser_error`/`cds_parser_error` are treated as **blocking** write errors.
 
-**Live evidence** — `validateBeforeWrite(src, file, {abapRelease:'816', systemType:'onprem'})`:
+**Original live evidence before the fix** — `validateBeforeWrite(src, file, {abapRelease:'816', systemType:'onprem'})`:
 ```
 CDS table entity  `define table entity ZTE {...}`      → pass=false  [cds_parser_error: CDS Parser error]   ❌
 READ TABLE itab ... WHERE table_line > 2  (816)        → pass=false  [parser_error: Statement does not exist in ABAPv758, "READ"]  ❌
@@ -60,43 +60,37 @@ plain class / factorial() (controls)                   → pass=true   ✓
 ```
 And critically, **abaplint `Cloud` fails too** (tested `systemType:'btp'` → same `cds_parser_error`/`parser_error`). So **mapping 8xx→Cloud does NOT help** — abaplint has no grammar for these constructs in any version.
 
-**How it blocks the write** (confirmed mechanism): `runPreWriteLint` (`src/handlers/intent.ts:5514`) →
+**Old blocking mechanism** (confirmed mechanism before PR #350): `runPreWriteLint` (`src/handlers/intent.ts`) →
 - `LINTABLE_TYPES = {PROG, CLAS, INTF, INCL, DDLS}` (line **5542**)
 - calls `validateBeforeWrite(..., {abapRelease: cachedFeatures?.abapRelease ?? config.abapRelease, ...})` (line **5552**)
 - `if (!result.pass)` → returns `{ blocked: true, result: errorResult('Pre-write lint check failed…') }` (lines **5557–5566**)
 - the SAPWrite caller returns that error → **the PUT never happens**.
 
-So on a 816 system, **`SAPWrite` of a CDS table entity, or any CLAS/PROG/INTF/INCL using new 816 ABAP statements, is wrongly blocked** (unless the user sets `--lint-before-write=false` or per-call `lintBeforeWrite:false` — the current workaround). This is the same failure class as the FUNC exclusion already documented at intent.ts:5534.
+Before PR #350, a 816 system could wrongly block **`SAPWrite` of a CDS table entity, or any CLAS/PROG/INTF/INCL using new 816 ABAP statements** unless the caller disabled pre-write lint. That is now fixed on `main`.
 
 **The new-816 syntax surface that trips this** (from `ABENNEWS-816-*`, on-prem docs — non-exhaustive): CDS `DEFINE TABLE ENTITY` / `DEFINE EXTERNAL ENTITY` / aspects / entity buffers / writable view entities / `EXPOSE METHOD`; RAP BDL `default function`, `auxiliary class`, `with friends`, non-root `authorization master`, `for side effects`, treeview `instance hierarchy`/`reorder action`; ABAP `READ TABLE … WHERE`, dynamic `SELECT`/`WITH`/`OPEN CURSOR`, `OPTIONS` clause, spatial `ST_*` functions, new numeric built-ins (`factorial`/`binomial`/`ERF`/`GAMMA`), `TABLE KEY … COMPONENTS`, EML `FORWARDING PRIVILEGED`. abaplint v758 knows none of these.
 
-#### Implementation plan (1.2)
+#### Implementation status (PR #350)
 
-**Goal:** when the detected release is beyond abaplint's ceiling, `parser_error`/`cds_parser_error` must NOT block the write (abaplint can't be trusted to parse the source). Keep them as advisory warnings; keep real semantic lint rules working on supported releases unchanged.
-
-- **Add a ceiling constant + helper.** In `src/adt/features.ts` (next to `mapSapReleaseToAbaplintVersion`) export `ABAPLINT_MAX_RELEASE = 758` and `isBeyondAbaplintCeiling(release?: string): boolean` (`parseReleaseNumber(release) > ABAPLINT_MAX_RELEASE`). Note `mapSapReleaseToAbaplintVersion` can't be the gate — it already collapses 816→v758, losing the distinction; you must compare the *raw* release.
-- **Demote parser errors in `runPreWriteLint`** (`src/handlers/intent.ts:5555–5566`, the surgical spot): after `validateBeforeWrite`, if `isBeyondAbaplintCeiling(configOptions.abapRelease)`, move any `parser_error`/`cds_parser_error` entries from `result.errors` into the non-blocking warning path; only set `blocked:true` if non-parser errors remain. Add a one-line note in the returned warning string: *"lint downgraded: abaplint vMAX is behind SAP_BASIS <release>; relying on activation for syntax validation."*
-  - *Alternative (more central):* do it in `src/lint/config-builder.ts` `buildPreWriteConfig` — when `isBeyondAbaplintCeiling`, set `parser_error`/`cds_parser_error` severity to `Info`/`Warning`. Cleaner globally, but also affects `SAPLint action=lint`; decide whether that's desirable (probably yes — same reasoning). The `runPreWriteLint` spot is the minimal-blast-radius choice.
-- **Keep `SAP_CHECK_BEFORE_WRITE` + activation as the real validator** on 8xx (already the design for FUNC and unsupported types).
-- **Tests** (`tests/unit/handlers/intent.test.ts` + `tests/unit/lint/lint.test.ts`):
-  - On `abapRelease:'816'`: `define table entity …` and `READ TABLE … WHERE` → `runPreWriteLint` returns `blocked:false` (with a warning).
-  - On `abapRelease:'758'`: a genuine syntax error still returns `blocked:true` (no regression — the demotion must be release-gated, not blanket).
-  - `isBeyondAbaplintCeiling('816')===true`, `('758')===false`, `('759')===true`, `(undefined)===false`.
-- **Docs:** update CLAUDE.md's lint-pipeline row + `docs/tools.md` lint section to note the 8xx behavior; mention the `--lint-before-write=false` interim workaround.
-- **Effort:** small–medium. Self-contained; no SAP needed for the unit tests (the harness in this doc is reproducible offline).
+- `src/adt/features.ts` exports `ABAPLINT_MAX_RELEASE = 758` plus `isBeyondAbaplintCeiling(release)`.
+- `src/lint/config-builder.ts` demotes `parser_error` and `cds_parser_error` to `Warning` in both `buildPreWriteConfig()` and `buildLintConfig()` when the raw SAP_BASIS release is beyond abaplint's grammar ceiling.
+- `tests/unit/adt/features.test.ts` locks the ceiling behavior: `816`, `800`, and `759` are beyond the ceiling; `758` and below are not.
+- `tests/unit/lint/lint.test.ts` proves the intended behavior: on `816`, a CDS table entity and `READ TABLE ... WHERE` no longer block pre-write lint; on `758`, the same parser failures still block.
+- `CLAUDE.md` now documents the 8xx lint behavior and the coupling between `ABAPLINT_MAX_RELEASE` and `mapSapReleaseToAbaplintVersion()`.
 
 **Re-bump path:** when `@abaplint/core` ships a v759/816 grammar, raise `ABAPLINT_MAX_RELEASE` and the `mapSapReleaseToAbaplintVersion` branch together; the demotion then self-disables for releases abaplint can parse.
 
-### 1.3 — CDS table entity (`DEFINE TABLE ENTITY`) end-to-end ⚠️ blocked by 1.2
+### 1.3 — CDS table entity (`DEFINE TABLE ENTITY`) end-to-end ⚠️ blocked by 2025 write tuning
 
 **Why it matters:** the flagship 2025 dev object. It's a **DDLS source** (which arc-1 already read/writes via `/ddic/ddl/sources`) created with `DEFINE TABLE ENTITY`, plus a separate **DTSC** buffer sidecar object (see the new-APIs doc).
 
 **Findings:**
 - **Create routing is correct:** the `intent.ts` guard `/\bdefine\s+table\s+(entity|function)\b/i` + `releaseNum < 757` (intent.ts:2814–2828) **allows** 816 (816 > 757). No routing change needed.
-- **But write is blocked by 1.2:** `define table entity` → `cds_parser_error` → blocked. So **fixing 1.2 is the prerequisite** to writing table entities through arc-1.
+- **Pre-write lint no longer blocks 816 table entities:** PR #350 demotes the expected `cds_parser_error` false positive to a warning when SAP_BASIS is beyond abaplint's ceiling.
+- **Live create/update/activate validation is still pending:** the 2025 container write path hit DDLS/TABL short dumps and 30 s timeouts before the container received the 2023 performance tuning.
 - The DTSC buffer is a separate server-driven object (see 3.1) — not required to create the entity itself.
 
-**Plan:** after 1.2 lands, add an integration test that creates a CDS table entity in `$TMP` on the 816 system and activates it (needs the tuned container — see 2.2). Until then, table-entity writes work only with `lintBeforeWrite:false`.
+**Plan:** after 2.2 tuning, add an integration test that creates a CDS table entity in `$TMP` on the 816 system and activates it. The test should keep pre-write lint enabled so it proves both the new 8xx lint demotion and the live SAP write/activation path.
 
 ---
 
@@ -148,7 +142,7 @@ Important correction for future work: **`SAP/abap-file-formats` does NOT publish
 
 ## Appendix — reproduce the live tests
 
-- **Lint false-positive harness** (offline, no SAP): `validateBeforeWrite('define table entity ZTE { key id : abap.int4; }', 'zte.ddls.asddls', {abapRelease:'816', systemType:'onprem'})` → `pass:false, errors:[cds_parser_error]`. Same with `systemType:'btp'` (Cloud) → still fails. Controls (`define view entity …`, plain class) → `pass:true`.
+- **Lint false-positive harness** (offline, no SAP): `validateBeforeWrite('define table entity ZTE { key id : abap.int4; }', 'zte.ddls.asddls', {abapRelease:'816', systemType:'onprem'})` now returns `pass:true` with `cds_parser_error` as a warning. `READ TABLE ... WHERE` on 816 likewise returns `pass:true` with `parser_error` as a warning. The same parser failures still block on `abapRelease:'758'`.
 - **Parser parity** (needs 816+758 creds from `.env.infrastructure` `SAP_A4H_2025_*`): `GET /oo/classes/CL_ABAP_TYPEDESCR/objectstructure` (`Accept: application/vnd.sap.adt.objectstructure.v2+xml`) on both → identical `CLAS/OM`-unified shape → `parseClassStructure` succeeds on both.
 - **gCTS/abapGit:** `GET /sap/bc/cts_abapvcs/system` (816→200), `GET /sap/bc/adt/abapgit/repos` (816→404, 758→400).
 

--- a/docs/research/test-suite-audit-2026-05-11.md
+++ b/docs/research/test-suite-audit-2026-05-11.md
@@ -7,12 +7,12 @@ Target SAP system used: A4H/S4 test system via local infrastructure credentials.
 
 ## Executive Summary
 
-The suite is much healthier than the earlier April reliability audit, but there are still material gaps:
+The suite is much healthier than the earlier April reliability audit, but the original 2026-05-11 audit found material gaps. Several of those gaps have since been implemented in follow-up PRs; see **Follow-Up Tracking** near the end for current status.
 
 - The main unit, integration, and E2E suites all pass against the live S4 system.
 - Current totals: 2,881 unit tests, 236 integration tests, and 137 E2E tests.
 - Unit skips are gone. E2E skip rate is low at 2.2%. Integration skip rate is 17.4%, but 33 of 41 integration skips are BTP tests in an S4-only run.
-- There are still real pseudo-skip bugs in E2E tests: several tests print `[SKIP]` or return early while Vitest records them as passed.
+- The original audit found pseudo-skip bugs in E2E tests: several tests printed `[SKIP]` or returned early while Vitest recorded them as passed. Follow-ups now reject `[SKIP]`, obsolete `skipIf`, reasonless `ctx.skip()`, and permanent integration/E2E `it.skip()` patterns with a static unit guard.
 - Cleanup is not good enough for a long-lived shared SAP system. The current run left at least one open E2E transport and one integration transport, and the live system already has many older `ZARC1*` leftovers.
 - E2E fixture setup can recreate invalid CDS fixtures, log activation failures as warnings, and still report `skipped=0`. This is the highest-risk harness issue found.
 - Runtime hotspots are concentrated and actionable: integration cache warmup, recursive transport release, E2E RAP write lifecycle, E2E where-used navigation, and E2E transport release.
@@ -87,8 +87,8 @@ By file:
 | `tests/integration/crud.lifecycle.integration.test.ts` | 5 | 0 | 20.9s | Good CRUD lifecycle signal. |
 | `tests/integration/context.integration.test.ts` | 19 | 0 | 13.4s | Good coverage for context/probe features. |
 | `tests/integration/fugr-func-params.integration.test.ts` | 2 | 0 | 6.0s | Passes, but internal skip calls lack reasons. |
-| `tests/integration/fugr-func.integration.test.ts` | 3 | 0 | 5.9s | Passes, but internal skip calls lack reasons. |
-| `tests/integration/abapgit.integration.test.ts` | 5 | 2 | 1.7s | Two hard-coded `it.skip()` tests remain. |
+| `tests/integration/fugr-func.integration.test.ts` | 3 | 0 | 5.9s | Passed in the original run; internal skip calls lacked reasons, fixed in the 2026-06-05 follow-up. |
+| `tests/integration/abapgit.integration.test.ts` | 5 | 2 | 1.7s | Original run had two hard-coded `it.skip()` tests; fixed in the 2026-06-05 follow-up as env-gated runtime skips. |
 | `tests/integration/audit-logging.integration.test.ts` | 7 | 0 | 1.0s | Good. |
 | `tests/integration/gcts.integration.test.ts` | 6 | 0 | 1.0s | Good. |
 | `tests/integration/elicitation.integration.test.ts` | 21 | 0 | 0.0s | Unit-like integration coverage; good. |
@@ -99,7 +99,7 @@ Skip interpretation:
 
 - 33/41 skips are BTP-only tests because BTP service key configuration was not provided for this S4 run.
 - 8/203 non-BTP integration tests skipped (3.9%).
-- `tests/integration/abapgit.integration.test.ts:95` and `:100` are permanent hard skips for stage/pull.
+- `tests/integration/abapgit.integration.test.ts:95` and `:100` were permanent hard skips for stage/pull in the original run; fixed in the 2026-06-05 follow-up.
 - Four transport tests skipped because optional `TEST_TRANSPORT_PACKAGE` / `TEST_TRANSPORT_OBJECT_NAME` inputs were not configured.
 - Two ADT skips were backend/fixture dependent.
 
@@ -464,7 +464,7 @@ These branches can make tests pass without executing assertions:
 
 - `tests/e2e/sktd-write.e2e.test.ts:57-58`, `:75-76`, `:86-87`, `:97-98`: `if (!sktdSupported) return;`.
 - `tests/e2e/activation-failure.e2e.test.ts:69-71` and `:88-90`: logs `[SKIP]` and returns, but the test is recorded as passed.
-- `tests/e2e/helpers.ts:205-210`: exported `skipIf()` is unused and its comment says Vitest cannot skip inside a test, which is now outdated.
+- `tests/e2e/helpers.ts:205-210`: exported `skipIf()` was unused and its comment said Vitest cannot skip inside a test, which was outdated. This helper was removed in a later follow-up.
 
 Recommended fix:
 
@@ -505,6 +505,13 @@ Recommended fix:
 - Add `ZARC1_E2E_DUMP` to persistent fixture management or delete it after the diagnostic test.
 - Convert abapGit hard skips into opt-in tests gated by `TEST_ABAPGIT_REMOTE_TESTS=true` plus a STRUST/preflight check.
 - Always provide a reason to `ctx.skip()`.
+
+Implementation status (2026-06-05 follow-up PR):
+
+- `tests/integration/abapgit.integration.test.ts` no longer uses permanent `it.skip()` for stage/pull. Those tests now run only when `TEST_ABAPGIT_REMOTE_TESTS=true`; `pullRepo` also requires `TEST_ABAPGIT_PULL_REPO_KEY` so the test no longer uses a fake hard-coded key.
+- `tests/integration/fugr-func.integration.test.ts`, `tests/integration/fugr-func-params.integration.test.ts`, and class-section-surgery integration/E2E setup paths now pass explicit backend/fixture reasons to `ctx.skip(reason)`.
+- `tests/unit/helpers/skip-discipline.test.ts` now rejects `[SKIP]`, obsolete `skipIf`, reasonless `ctx.skip()`, and test-level `it.skip()` inside integration/E2E/helper test code.
+- Remaining items in this subsection: diagnostics dump ownership/execution is still open.
 
 ### P1 - E2E Local Scripts Are Not Portable On macOS
 
@@ -613,7 +620,7 @@ Current behavior:
 
 - Some tests return early after a feature probe without calling `ctx.skip()`.
 - Some tests print `[SKIP]` and return. Vitest records these as passed tests, not skipped tests.
-- `tests/e2e/helpers.ts` still contains `skipIf()` with an outdated comment saying Vitest cannot skip inside a test.
+- In the original audit, `tests/e2e/helpers.ts` still contained `skipIf()` with an outdated comment saying Vitest cannot skip inside a test. This helper was removed in a later follow-up.
 
 Root cause:
 
@@ -691,16 +698,27 @@ Recommended correction:
 - Add a preflight that distinguishes missing STRUST/SSL/network configuration from product failures.
 - If no maintained fixture can be provided, remove the permanent tests and track the gap in docs rather than reporting a hard skip forever.
 
+Implementation status (2026-06-05 follow-up PR):
+
+- Stage/pull are now runtime tests gated by `TEST_ABAPGIT_REMOTE_TESTS=true`.
+- `pullRepo` additionally requires `TEST_ABAPGIT_PULL_REPO_KEY`, so the test exercises an explicit linked repository instead of a fake key.
+- Missing remote trust setup is now an explicit skip reason in Vitest output rather than a permanent disabled test.
+
 FUGR/FUNC skip reasons:
 
-- The FUGR integration tests use `ctx.skip()` in backend-gap branches without useful reason text.
+- In the original audit, the FUGR integration tests used `ctx.skip()` in backend-gap branches without useful reason text.
 - This should be a small cleanup: pass the classified backend error or a specific release-gap reason into each skip.
+
+Implementation status (2026-06-05 follow-up PR):
+
+- Backend-gap branches now pass the classified lock/session-correlation reason to `ctx.skip(reason)`.
 
 Acceptance criteria:
 
 - Test names describe exactly what is asserted.
 - Long-lived fixtures are either in fixture management or explicitly cleaned.
 - No permanent `it.skip()` remains without an owner, opt-in path, and reason.
+- No reasonless `ctx.skip()` remains in integration/E2E/helper test code.
 
 ### 6. E2E Script Portability And Log Signal
 
@@ -919,12 +937,19 @@ Pseudo-skips:
 
 - `tests/e2e/sktd-write.e2e.test.ts:58`, `:76`, `:87`, `:98`
 - `tests/e2e/activation-failure.e2e.test.ts:70-71`, `:89-90`
-- `tests/e2e/helpers.ts:205-210` contains an unused/outdated `skipIf()` helper that encourages pseudo-skip behavior.
+- `tests/e2e/helpers.ts:205-210` originally contained an unused/outdated `skipIf()` helper that encouraged pseudo-skip behavior. This helper was removed in a later follow-up.
 
 Skip calls without useful reason text:
 
 - `tests/integration/fugr-func.integration.test.ts`: multiple `ctx.skip()` calls in known backend-gap branches.
 - `tests/integration/fugr-func-params.integration.test.ts`: multiple `ctx.skip()` calls in lock/backend-gap branches.
+
+Current-main follow-up scan (2026-06-05 PR):
+
+- No `it.skip(` remains in `tests/e2e`, `tests/integration`, or `tests/helpers`.
+- No bare `ctx.skip()` remains in those directories; every runtime skip passes reason text.
+- No `[SKIP]` pseudo-skip marker or obsolete `skipIf` helper remains in those directories.
+- The unit guard in `tests/unit/helpers/skip-discipline.test.ts` enforces these checks.
 
 Broad catches that should stay under observation:
 
@@ -940,9 +965,9 @@ Broad catches that should stay under observation:
 | `tests/integration/transport.integration.test.ts` | Valuable for CTS compatibility but actively creates transport requests. `createTransport` intentionally does not auto-release; recursive release is slow. With `TEST_TRANSPORT_PACKAGE=Z_LLM_TEST_PACKAGE`, the auto-corrNr tests pass but leave ghost `ZARC1_TR_*` TADIR rows and undeletable locked CTS tasks. Needs cleanup policy before any more frequent CI use. |
 | `tests/integration/crud.lifecycle.integration.test.ts` | Good registry-based lifecycle coverage. Cleanup helper is better than most live tests, though it still uses best-effort retries. |
 | `tests/integration/context.integration.test.ts` | Good context/compression coverage. Discovery fallbacks are reasonable. No current skip issue found. |
-| `tests/integration/fugr-func.integration.test.ts` | Good live FUGR/FUNC coverage. Replace bare `ctx.skip()` with reasoned skips. |
-| `tests/integration/fugr-func-params.integration.test.ts` | Good structured parameter lifecycle coverage. Replace bare `ctx.skip()` with reasoned skips. |
-| `tests/integration/abapgit.integration.test.ts` | The two hard skips are stale. Convert to opt-in with remote/STRUST preflight, or remove if no longer actionable. |
+| `tests/integration/fugr-func.integration.test.ts` | Good live FUGR/FUNC coverage. 2026-06-05 follow-up replaced bare backend-gap skips with reasoned skips. |
+| `tests/integration/fugr-func-params.integration.test.ts` | Good structured parameter lifecycle coverage. 2026-06-05 follow-up replaced lock/backend-gap skips with reasoned skips. |
+| `tests/integration/abapgit.integration.test.ts` | The two hard skips were stale. 2026-06-05 follow-up converted them to opt-in runtime skips gated by `TEST_ABAPGIT_REMOTE_TESTS=true`; `pullRepo` also requires `TEST_ABAPGIT_PULL_REPO_KEY`. |
 | `tests/integration/gcts.integration.test.ts` | Good read-only gCTS coverage. Some systems may return empty payloads; assertions still validate shape. |
 | `tests/integration/audit-logging.integration.test.ts` | Good integration signal for audit events. No major issue found. |
 | `tests/integration/elicitation.integration.test.ts` | Mostly unit-like but valuable because it covers elicitation flow/audit behavior. No skip/cleanup issue found. |
@@ -960,8 +985,8 @@ Broad catches that should stay under observation:
 | `tests/e2e/diagnostics.e2e.test.ts` | Broad diagnostic smoke coverage. The "triggers a fresh dump" name is inaccurate because it cannot execute the program and can validate any existing dump. `ZARC1_E2E_DUMP` should be managed or deleted. |
 | `tests/e2e/func-write.e2e.test.ts` | Current-run cleanup looked good. Uses best-effort helper, but no live residue with current-run names. |
 | `tests/e2e/func-params.e2e.test.ts` | Current-run cleanup looked good. Useful issue-specific lifecycle test. |
-| `tests/e2e/sktd-write.e2e.test.ts` | Current-run cleanup looked good. Pseudo-skips remain if SKTD is not supported. |
-| `tests/e2e/activation-failure.e2e.test.ts` | Valuable regression. Current-run object was deleted. Pseudo-skips and "leaving stale objects is acceptable in CI" comment should be fixed. Old `ZARC1_E2E_ACTBROKE_*` rows prove this has leaked before. |
+| `tests/e2e/sktd-write.e2e.test.ts` | Current-run cleanup looked good. Pseudo-skips from the original audit were later converted to real Vitest skips. |
+| `tests/e2e/activation-failure.e2e.test.ts` | Valuable regression. Current-run object was deleted. Pseudo-skips from the original audit were later converted to real Vitest skips; old `ZARC1_E2E_ACTBROKE_*` rows prove this test has leaked before and cleanup should stay under observation. |
 | `tests/e2e/smoke.e2e.test.ts` | Good broad smoke. Some backend-specific skips are real. Current-run generated write-policy object was deleted. |
 | `tests/e2e/cache.e2e.test.ts` | Good E2E cache behavior and cheap enough. No major issue. |
 | `tests/e2e/cds-context.e2e.test.ts` | Uses system demo DDLS discovery; reasonable. The beforeAll `[SKIP]` log is harmless because individual tests use `requireOrSkip()`. |
@@ -972,7 +997,7 @@ Broad catches that should stay under observation:
 | `tests/e2e/setup.ts` | Must be hardened. Activation errors should not be warnings unless classified. |
 | `tests/e2e/sync-fixtures.ts` | Does not print `summary.skipped`, so skipped fixtures can be hidden in CLI output. |
 | `tests/e2e/global-setup.ts` | Useful zombie preflight. Contains Unicode console art only; no behavioral issue. |
-| `tests/e2e/helpers.ts` | `skipIf()` is outdated; `expectToolSuccessOrSkip()` and `skipOnBatchCreateFailure()` are useful. |
+| `tests/e2e/helpers.ts` | Historical note: `skipIf()` was outdated and has since been removed. `expectToolSuccessOrSkip()` and `skipOnBatchCreateFailure()` are useful. |
 
 ## Runtime Improvement Plan
 
@@ -1193,6 +1218,12 @@ These should be fixed before runtime optimization because they determine whether
 | 6 | Convert pseudo-skips to real `ctx.skip(reason)` calls. | Bare `return` and `[SKIP]` logs are counted as passes, hiding unsupported or missing-precondition paths. | Makes skip counts honest and keeps reliability summaries useful. | `npm run test:e2e`; JSON reporter shows skipped tests instead of passed pseudo-skips. |
 | 7 | Clean up or explicitly declare `ZARC1_E2E_DUMP`. | The dump fixture behavior needs a clear ownership model: either clean it or document it as intentionally persistent. | Removes ambiguity between expected diagnostic residue and cleanup failure. | E2E diagnostics run plus live object search. |
 
+Correctness implementation update (2026-06-05):
+
+- Item 6 is now covered more broadly than the original SKTD/activation-failure fix: the static guard rejects pseudo-skip markers, obsolete `skipIf`, reasonless `ctx.skip()`, and test-level `it.skip()` in integration/E2E/helper code.
+- The abapGit hard skips are now explicit opt-in tests, not permanent disabled tests.
+- Item 7 remains open.
+
 ### Runtime Reduction
 
 Do this after correctness blockers. These changes should target the measured hotspots from GitHub Actions run `25674270461`, not broad parallelism first.
@@ -1257,6 +1288,7 @@ Implemented follow-ups:
 | P1 | Renamed reliability summary wording from `Top Skip Reasons` to `Top Skipped Tests`. | Skip Telemetry Semantics |
 | P1 | Reworked local E2E start/stop portability and made stop-script error detection handle the default text logger. | E2E Script Portability And Log Signal |
 | P1 | Converted SKTD and activation-failure pseudo-skips to real `ctx.skip()`/`requireOrSkip()` paths and added a static guard against `[SKIP]` pseudo-skip markers. | Pseudo-Skip Discipline |
+| P1 | Converted abapGit stage/pull hard skips to opt-in runtime skips, added explicit reasons to remaining backend-gap skip branches, and extended the static guard to reject reasonless `ctx.skip()` and test-level `it.skip()`. | Pseudo-Skip Discipline / Some Tests Are Weak Or Outdated |
 | P1 | Stabilized the cache warmup delta integration test by moving the strict second-run assertion from shared `$TMP` to stable `$DEMO_SOI_DRAFT`. | GitHub Actions Runtime Deep Dive |
 | P2 | Split cheap CI checks from the SAP title gate and moved SAP serialization to repository-wide integration/E2E job concurrency. | CI Gating And SAP Serialization |
 

--- a/docs/research/test-suite-audit-2026-05-11.md
+++ b/docs/research/test-suite-audit-2026-05-11.md
@@ -1213,6 +1213,7 @@ Current PR-readiness finding (2026-06-05):
 - `tests/integration/transport.integration.test.ts` timed out in suite hooks after the Vitest default `10s` hook budget while listing/checking CTS state. The suite intentionally probes and cleans live transport requests, so hook timeout must be aligned with live-SAP latency.
 - `tests/integration/adt.integration.test.ts` timed out the explicit ATC check-variant flow at the integration default `30s` test budget. ATC worklist/run/result retrieval is a live backend operation with variable latency and should use an explicit slow-test timeout.
 - This PR now sets `hookTimeout: 60000` in `vitest.integration.config.ts` and gives both live ATC flow tests explicit `90000` timeouts. A focused local S/4 run of `transport.integration.test.ts` plus the `runAtcCheck` tests passed after the change.
+- GitHub Actions run `27007816547` then passed on the updated head: `integration` completed in `6m23s`, `e2e` completed in `13m56s`, and `reliability-summary` completed successfully. This confirms the timeout changes fixed the PR-readiness failures without masking assertions.
 
 ### Correctness Blockers
 

--- a/docs/research/test-suite-audit-2026-05-11.md
+++ b/docs/research/test-suite-audit-2026-05-11.md
@@ -1207,6 +1207,13 @@ Additional PR-readiness finding:
 - A later final-check run (`26536051732`) exposed a brittle live-SAP assumption in `tests/integration/cache.integration.test.ts`: the "second warmup run skips unchanged objects" test used `$TMP`, and `$TMP` changed from `204` to `205` objects between the two warmup passes. The second pass correctly fetched the new object, but the test expected `0` fetched objects and failed.
 - This PR now moves that delta-by-hash assertion to the stable S/4 demo package `$DEMO_SOI_DRAFT`, which is already the package used by the cache reverse-dependency tests. That preserves the hash-skip contract while avoiding transient `$TMP` churn and reduces this specific check from a roughly `205` object scan to the `9` object demo package on the S4 test system.
 
+Current PR-readiness finding (2026-06-05):
+
+- PR `#353` CI run `27005945968` first had a zero-step `integration` cancellation caused by the shared SAP concurrency lane; rerunning only that job exposed two real timeout sensitivities rather than assertion failures.
+- `tests/integration/transport.integration.test.ts` timed out in suite hooks after the Vitest default `10s` hook budget while listing/checking CTS state. The suite intentionally probes and cleans live transport requests, so hook timeout must be aligned with live-SAP latency.
+- `tests/integration/adt.integration.test.ts` timed out the explicit ATC check-variant flow at the integration default `30s` test budget. ATC worklist/run/result retrieval is a live backend operation with variable latency and should use an explicit slow-test timeout.
+- This PR now sets `hookTimeout: 60000` in `vitest.integration.config.ts` and gives both live ATC flow tests explicit `90000` timeouts. A focused local S/4 run of `transport.integration.test.ts` plus the `runAtcCheck` tests passed after the change.
+
 ### Correctness Blockers
 
 These should be fixed before runtime optimization because they determine whether green integration/E2E runs are meaningful.
@@ -1290,6 +1297,7 @@ Implemented follow-ups:
 | P1 | Converted SKTD and activation-failure pseudo-skips to real `ctx.skip()`/`requireOrSkip()` paths and added a static guard against `[SKIP]` pseudo-skip markers. | Pseudo-Skip Discipline |
 | P1 | Converted abapGit stage/pull hard skips to opt-in runtime skips, added explicit reasons to remaining backend-gap skip branches, and extended the static guard to reject reasonless `ctx.skip()` and test-level `it.skip()`. | Pseudo-Skip Discipline / Some Tests Are Weak Or Outdated |
 | P1 | Stabilized the cache warmup delta integration test by moving the strict second-run assertion from shared `$TMP` to stable `$DEMO_SOI_DRAFT`. | GitHub Actions Runtime Deep Dive |
+| P1 | Raised live integration hook timeout and added explicit slow-test timeouts for ATC worklist flows after PR CI exposed timeout-only failures. | GitHub Actions Runtime Deep Dive / PR-readiness validation |
 | P2 | Split cheap CI checks from the SAP title gate and moved SAP serialization to repository-wide integration/E2E job concurrency. | CI Gating And SAP Serialization |
 
 Remaining follow-ups:

--- a/docs/testing-skip-policy.md
+++ b/docs/testing-skip-policy.md
@@ -45,7 +45,7 @@ E2E tests may require test objects (ZARC1_TEST_REPORT, ZCL_ARC1_TEST, etc.) that
 
 ```typescript
 it('finds references to ZIF_ARC1_TEST', async (ctx) => {
-  if (!hasCustomObjects) return ctx.skip();
+  if (!hasCustomObjects) return ctx.skip('Required custom E2E objects were not deployed');
   // ...test logic...
 });
 ```
@@ -143,8 +143,12 @@ The shared helper at `tests/helpers/skip-policy.ts` exports these standard const
 | Constant | Value | When to use |
 |----------|-------|-------------|
 | `NO_CREDENTIALS` | SAP credentials not configured | Per-test runtime prerequisite (not suite-level gating) |
+| `NO_FIXTURE` | Required test fixture not found on SAP system | Persistent or transient test object is unavailable |
 | `NO_DDLS` | No DDLS object found on system | CDS/DDLS tests when no view is available |
 | `NO_DUMPS` | No short dumps found on system | Diagnostics tests on clean systems |
+| `NO_TRANSPORT_PACKAGE` | TEST_TRANSPORT_PACKAGE not configured (transportable package required) | Optional transport-package tests |
+| `TRANSPORT_RELEASE_DISABLED` | TEST_TRANSPORT_RELEASE_TESTS not enabled (transport release is permanent on the shared SAP test system) | Permanent transport release paths |
+| `BACKEND_UNSUPPORTED` | Backend feature not supported on this SAP system | Release, product, or optional component lacks the tested endpoint |
 
 Use these constants for consistency. Add new constants to the helper when a new skip category emerges.
 
@@ -160,13 +164,13 @@ Use these constants for consistency. Add new constants to the helper when a new 
 The canonical example of correct skip usage is `tests/e2e/navigate.e2e.test.ts`. It demonstrates:
 
 - A `hasCustomObjects` flag set in `beforeAll` via a lightweight probe
-- Individual tests calling `ctx.skip()` when the flag is false
+- Individual tests calling `ctx.skip(reason)` when the flag is false
 - Tests that run when objects are present make real assertions (not just "defined" checks)
 
 ```typescript
 // From tests/e2e/navigate.e2e.test.ts
 it('finds references to ZIF_ARC1_TEST', async (ctx) => {
-  if (!hasCustomObjects) return ctx.skip();
+  if (!hasCustomObjects) return ctx.skip('Required custom E2E objects were not deployed');
   const result = await callTool(client, 'SAPNavigate', { ... });
   const text = expectToolSuccess(result);
   const refs = JSON.parse(text);

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -90,7 +90,7 @@ E2E_MCP_URL=http://$E2E_SERVER:3000/mcp npm run test:e2e:fixtures
 E2E_MCP_URL=http://$E2E_SERVER:3000/mcp npm run test:e2e:fixtures:clean
 ```
 
-**Skip behavior:** Navigate tests still have runtime `ctx.skip()` guards as a fallback if custom objects are unavailable (for example, if fixture sync is bypassed). DDLS-dependent tests use `requireOrSkip()` from `tests/helpers/skip-policy.ts`. All skips appear as SKIPPED (not PASSED) in test reports.
+**Skip behavior:** Navigate tests still have runtime `ctx.skip(reason)` guards as a fallback if custom objects are unavailable (for example, if fixture sync is bypassed). DDLS-dependent tests use `requireOrSkip()` from `tests/helpers/skip-policy.ts`. All skips appear as SKIPPED (not PASSED) in test reports.
 
 ## Adding New Tests
 

--- a/tests/e2e/class-section-surgery.e2e.test.ts
+++ b/tests/e2e/class-section-surgery.e2e.test.ts
@@ -52,7 +52,8 @@ async function seed(client: Client, ctx: import('vitest').TaskContext, className
     package: '$TMP',
   });
   if (create.isError) {
-    ctx.skip();
+    const detail = create.content[0]?.text ?? 'no error detail returned';
+    ctx.skip(`Cannot seed transient class ${className}: ${detail.slice(0, 200)}`);
     return false;
   }
   const write = await callTool(client, 'SAPWrite', {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -316,7 +316,7 @@ export function skipOnBatchCreateFailure(ctx: import('vitest').TaskContext, text
 }
 
 /**
- * Expect success, OR skip via `ctx.skip()` if the error matches a known release
+ * Expect success, OR skip via `ctx.skip(reason)` if the error matches a known release
  * gap / backend quirk. Returns the text content on success.
  *
  * Usage:
@@ -327,7 +327,7 @@ export function expectToolSuccessOrSkip(ctx: import('vitest').TaskContext, resul
   const skip = classifyToolErrorSkip(result);
   if (skip !== null) {
     ctx.skip(skip);
-    // Unreachable — ctx.skip() throws. Return empty to satisfy the type.
+    // Unreachable — ctx.skip(reason) throws. Return empty to satisfy the type.
     return '';
   }
   return expectToolSuccess(result);

--- a/tests/e2e/revisions.e2e.test.ts
+++ b/tests/e2e/revisions.e2e.test.ts
@@ -22,7 +22,7 @@ function parseVersionsOrSkip(
     ctx.skip(
       `Required test fixture not found on SAP system (${fixtureName} revisions) — object has no version history or endpoint unavailable`,
     );
-    // Unreachable — ctx.skip() throws. Return empty object only to satisfy the type.
+    // Unreachable — ctx.skip(reason) throws. Return empty object only to satisfy the type.
     return { object: { name: fixtureName }, revisions: [] };
   }
   let parsed: { object?: { name?: string }; revisions?: unknown };

--- a/tests/helpers/skip-policy.ts
+++ b/tests/helpers/skip-policy.ts
@@ -27,7 +27,7 @@ export const SkipReason = {
 export function requireOrSkip<T>(ctx: TaskContext, value: T | null | undefined, reason: string): asserts value is T {
   if (value === null || value === undefined) {
     ctx.skip(reason);
-    // ctx.skip() throws internally in Vitest, so the line below is normally unreachable.
+    // ctx.skip(reason) throws internally in Vitest, so the line below is normally unreachable.
     // Defensive throw in case this helper is used outside Vitest's runtime.
     throw new Error(`Test skipped: ${reason}`);
   }

--- a/tests/integration/abapgit.integration.test.ts
+++ b/tests/integration/abapgit.integration.test.ts
@@ -16,6 +16,11 @@ import { expectSapFailureClass } from '../helpers/expected-error.js';
 import { requireOrSkip, SkipReason } from '../helpers/skip-policy.js';
 import { getTestClient, requireSapCredentials } from './helpers.js';
 
+const ABAPGIT_REMOTE_TESTS_DISABLED =
+  'TEST_ABAPGIT_REMOTE_TESTS not enabled (abapGit stage/pull requires remote reachability and STRUST trust chain)';
+const abapGitRemoteTestsEnabled = process.env.TEST_ABAPGIT_REMOTE_TESTS === 'true';
+const abapGitPullRepoKey = process.env.TEST_ABAPGIT_PULL_REPO_KEY;
+
 describe('abapGit ADT bridge integration', () => {
   let client: AdtClient;
   let abapGitAvailable: boolean | undefined;
@@ -92,12 +97,28 @@ describe('abapGit ADT bridge integration', () => {
     ]);
   });
 
-  it.skip('stageRepo requires remote reachability and proper STRUST certificates', async () => {
+  it('stageRepo can stage a linked repo when remote trust is explicitly enabled', async (ctx) => {
+    requireOrSkip(ctx, abapGitAvailable ? true : undefined, SkipReason.BACKEND_UNSUPPORTED);
+    if (!abapGitRemoteTestsEnabled) {
+      ctx.skip(ABAPGIT_REMOTE_TESTS_DISABLED);
+      return;
+    }
     const repos = await listRepos(client.http, client.safety);
-    if (repos[0]) await stageRepo(client.http, client.safety, repos[0]);
+    requireOrSkip(ctx, repos[0], `${SkipReason.NO_FIXTURE}: linked abapGit repo required for stageRepo`);
+    await stageRepo(client.http, client.safety, repos[0]);
   });
 
-  it.skip('pullRepo may hang without remote trust chain in STRUST', async () => {
-    await pullRepo(client.http, client.safety, '000000000001');
+  it('pullRepo can pull a configured repo when remote trust is explicitly enabled', async (ctx) => {
+    requireOrSkip(ctx, abapGitAvailable ? true : undefined, SkipReason.BACKEND_UNSUPPORTED);
+    if (!abapGitRemoteTestsEnabled) {
+      ctx.skip(ABAPGIT_REMOTE_TESTS_DISABLED);
+      return;
+    }
+    requireOrSkip(
+      ctx,
+      abapGitPullRepoKey,
+      'TEST_ABAPGIT_PULL_REPO_KEY not configured (pullRepo needs an explicit linked repository key)',
+    );
+    await pullRepo(client.http, client.safety, abapGitPullRepoKey);
   });
 });

--- a/tests/integration/adt.integration.test.ts
+++ b/tests/integration/adt.integration.test.ts
@@ -2224,12 +2224,12 @@ describe('ADT Integration Tests', () => {
         // caused by reading the position-less catalog uri).
         if (f.uri.includes('#start=')) expect(f.line).toBeGreaterThanOrEqual(0);
       }
-    });
+    }, 90000);
 
     it('completes the flow with the system default variant (no variant passed)', async () => {
       const result = await runAtcCheck(client.http, unrestrictedSafetyConfig(), KERNEL_CLASS_URL);
       expect(Array.isArray(result.findings)).toBe(true);
-    });
+    }, 90000);
   });
 
   // ─── getFunctionGroup (objectstructure-based, non-expand FUGR read) ───

--- a/tests/integration/class-section-surgery.integration.test.ts
+++ b/tests/integration/class-section-surgery.integration.test.ts
@@ -13,10 +13,11 @@
  * Note 2727890 — pre-existing, not specific to this feature).
  */
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, type TaskContext } from 'vitest';
 import { handleToolCall } from '../../src/handlers/intent.js';
 import { DEFAULT_CONFIG } from '../../src/server/types.js';
 import { expectSapFailureClass } from '../helpers/expected-error.js';
+import { SkipReason } from '../helpers/skip-policy.js';
 import { generateUniqueName } from './crud-harness.js';
 import { getTestClient, requireSapCredentials } from './helpers.js';
 
@@ -26,6 +27,7 @@ describe('class-section surgery — live (issue #303)', () => {
   let client: ReturnType<typeof getTestClient>;
   const className = generateUniqueName('ZCL_ARC1_CSURG');
   let seeded = false;
+  let seedSkipReason: string | undefined;
 
   beforeAll(async () => {
     requireSapCredentials();
@@ -92,6 +94,7 @@ ENDCLASS.`;
       // the suite reports the cause rather than just timing out.
       try {
         expectSapFailureClass(err, [423], [/invalid lock handle/i]);
+        seedSkipReason = `${SkipReason.BACKEND_UNSUPPORTED}: cannot seed ${className} because this backend returned the known invalid lock-handle 423 during class create/update/activate setup`;
       } catch {
         // Different failure — surface it as test setup error.
         throw err;
@@ -112,11 +115,14 @@ ENDCLASS.`;
     }
   });
 
+  function requireSeeded(ctx: TaskContext): boolean {
+    if (seeded) return true;
+    ctx.skip(seedSkipReason ?? `${SkipReason.NO_FIXTURE}: transient class ${className} was not seeded`);
+    return false;
+  }
+
   it('edit_class_definition: drop FINAL (no method-set change)', async (ctx) => {
-    if (!seeded) {
-      ctx.skip();
-      return;
-    }
+    if (!requireSeeded(ctx)) return;
     const newDef = `CLASS ${className.toLowerCase()} DEFINITION PUBLIC CREATE PUBLIC.
   PUBLIC SECTION.
     METHODS hello
@@ -142,10 +148,7 @@ ENDCLASS.`;
   });
 
   it('edit_class_definition: refuses added method without IMPL stub', async (ctx) => {
-    if (!seeded) {
-      ctx.skip();
-      return;
-    }
+    if (!requireSeeded(ctx)) return;
     const badDef = `CLASS ${className.toLowerCase()} DEFINITION PUBLIC CREATE PUBLIC.
   PUBLIC SECTION.
     METHODS hello
@@ -170,10 +173,7 @@ ENDCLASS.`;
   });
 
   it('add_method: inserts METHOD + stub atomically and activates', async (ctx) => {
-    if (!seeded) {
-      ctx.skip();
-      return;
-    }
+    if (!requireSeeded(ctx)) return;
     const result = await handleToolCall(client, cfg, 'SAPWrite', {
       action: 'add_method',
       type: 'CLAS',
@@ -191,10 +191,7 @@ ENDCLASS.`;
   });
 
   it('edit_method_signature: appends DEFAULT param and re-activates', async (ctx) => {
-    if (!seeded) {
-      ctx.skip();
-      return;
-    }
+    if (!requireSeeded(ctx)) return;
     const newSig = `    METHODS greet
       IMPORTING who TYPE string
                 greeting TYPE string DEFAULT 'Hi'
@@ -215,10 +212,7 @@ ENDCLASS.`;
   });
 
   it('delete_method: removes DEFINITION + IMPLEMENTATION ranges atomically', async (ctx) => {
-    if (!seeded) {
-      ctx.skip();
-      return;
-    }
+    if (!requireSeeded(ctx)) return;
     const result = await handleToolCall(client, cfg, 'SAPWrite', {
       action: 'delete_method',
       type: 'CLAS',
@@ -247,10 +241,7 @@ ENDCLASS.`;
   });
 
   it('change_method_visibility: moves a method between sections, preserving the body', async (ctx) => {
-    if (!seeded) {
-      ctx.skip();
-      return;
-    }
+    if (!requireSeeded(ctx)) return;
     // The seeded `hello` is public and has a real body (`result = |Hello, { name }!|.`).
     // Move it to PRIVATE — the body must survive (this is the safe alternative to
     // delete_method + add_method, which would wipe it).
@@ -283,10 +274,7 @@ ENDCLASS.`;
   });
 
   it('change_method_visibility: idempotent no-op when already in the target section', async (ctx) => {
-    if (!seeded) {
-      ctx.skip();
-      return;
-    }
+    if (!requireSeeded(ctx)) return;
     // goodbye is still public; asking for public must be a no-op (no write).
     const result = await handleToolCall(client, cfg, 'SAPWrite', {
       action: 'change_method_visibility',

--- a/tests/integration/fugr-func-params.integration.test.ts
+++ b/tests/integration/fugr-func-params.integration.test.ts
@@ -24,10 +24,12 @@ import { SkipReason } from '../helpers/skip-policy.js';
 import { CrudRegistry, cleanupAll, generateUniqueName } from './crud-harness.js';
 import { getTestClient, requireSapCredentials } from './helpers.js';
 
+const FM_LOCK_SKIP_REASON = `${SkipReason.BACKEND_UNSUPPORTED}: lock-handle session correlation differs on this release (NPL 7.50 ADT gap)`;
+
 function fmSkipReason(err: unknown): string | null {
   if (!(err instanceof AdtApiError)) return null;
   if (err.statusCode === 423) {
-    return `${SkipReason.BACKEND_UNSUPPORTED}: lock-handle session correlation differs on this release (NPL 7.50 ADT gap)`;
+    return FM_LOCK_SKIP_REASON;
   }
   return null;
 }
@@ -80,7 +82,7 @@ describe('FUNC parameter lifecycle (issue #252)', () => {
       if (fugrResult.isError) {
         const msg = toolResultText(fugrResult);
         if (/lock|423/i.test(msg)) {
-          ctx.skip();
+          ctx.skip(`${FM_LOCK_SKIP_REASON}: ${msg.slice(0, 200)}`);
           return;
         }
         throw new Error(`FUGR create failed: ${msg}`);
@@ -106,7 +108,7 @@ describe('FUNC parameter lifecycle (issue #252)', () => {
       } catch (err) {
         const skip = fmSkipReason(err);
         if (skip) {
-          ctx.skip();
+          ctx.skip(skip);
           return;
         }
         throw err;
@@ -114,7 +116,7 @@ describe('FUNC parameter lifecycle (issue #252)', () => {
       if (fmCreateResult.isError) {
         const msg = toolResultText(fmCreateResult);
         if (/lock|423/i.test(msg)) {
-          ctx.skip();
+          ctx.skip(`${FM_LOCK_SKIP_REASON}: ${msg.slice(0, 200)}`);
           return;
         }
         throw new Error(`FM create failed: ${msg}`);
@@ -130,7 +132,7 @@ describe('FUNC parameter lifecycle (issue #252)', () => {
       if (activateResult.isError) {
         const msg = toolResultText(activateResult);
         if (/lock|423/i.test(msg)) {
-          ctx.skip();
+          ctx.skip(`${FM_LOCK_SKIP_REASON}: ${msg.slice(0, 200)}`);
           return;
         }
         throw new Error(`Activate failed: ${msg}`);
@@ -172,7 +174,7 @@ describe('FUNC parameter lifecycle (issue #252)', () => {
       } catch (err) {
         const skip = fmSkipReason(err);
         if (skip) {
-          ctx.skip();
+          ctx.skip(skip);
           return;
         }
         throw err;
@@ -180,7 +182,7 @@ describe('FUNC parameter lifecycle (issue #252)', () => {
       if (updateResult.isError) {
         const msg = toolResultText(updateResult);
         if (/lock|423/i.test(msg)) {
-          ctx.skip();
+          ctx.skip(`${FM_LOCK_SKIP_REASON}: ${msg.slice(0, 200)}`);
           return;
         }
         throw new Error(`FM update failed: ${msg}`);
@@ -195,7 +197,7 @@ describe('FUNC parameter lifecycle (issue #252)', () => {
       if (activate2.isError) {
         const msg = toolResultText(activate2);
         if (/lock|423/i.test(msg)) {
-          ctx.skip();
+          ctx.skip(`${FM_LOCK_SKIP_REASON}: ${msg.slice(0, 200)}`);
           return;
         }
         throw new Error(`Activate (after update) failed: ${msg}`);

--- a/tests/integration/fugr-func.integration.test.ts
+++ b/tests/integration/fugr-func.integration.test.ts
@@ -88,7 +88,7 @@ describe('FUGR + FUNC lifecycle', () => {
       } catch (err) {
         const skip = fmSkipReason(err);
         if (skip) {
-          ctx.skip();
+          ctx.skip(skip);
           return;
         }
         throw err;
@@ -107,7 +107,7 @@ describe('FUGR + FUNC lifecycle', () => {
       } catch (err) {
         const skip = fmSkipReason(err);
         if (skip) {
-          ctx.skip();
+          ctx.skip(skip);
           return;
         }
         throw err;
@@ -125,7 +125,7 @@ describe('FUGR + FUNC lifecycle', () => {
       } catch (err) {
         const skip = fmSkipReason(err);
         if (skip) {
-          ctx.skip();
+          ctx.skip(skip);
           return;
         }
         throw err;
@@ -162,7 +162,7 @@ describe('FUGR + FUNC lifecycle', () => {
     } catch (err) {
       const skip = fmSkipReason(err);
       if (skip) {
-        ctx.skip();
+        ctx.skip(skip);
         return;
       }
       // SAP returns HTTP 500 + ExceptionResourceCreationFailure: "Function group X does not exist"
@@ -189,7 +189,7 @@ describe('FUGR + FUNC lifecycle', () => {
     } catch (err) {
       const skip = fmSkipReason(err);
       if (skip) {
-        ctx.skip();
+        ctx.skip(skip);
         return;
       }
       throw err;
@@ -207,7 +207,7 @@ describe('FUGR + FUNC lifecycle', () => {
     } catch (err) {
       const skip = fmSkipReason(err);
       if (skip) {
-        ctx.skip();
+        ctx.skip(skip);
         return;
       }
       throw err;
@@ -234,7 +234,7 @@ describe('FUGR + FUNC lifecycle', () => {
     } catch (err) {
       const skip = fmSkipReason(err);
       if (skip) {
-        ctx.skip();
+        ctx.skip(skip);
         return;
       }
       // FUNC_ADT028 = "Parameter comment blocks are not allowed"

--- a/tests/unit/helpers/skip-discipline.test.ts
+++ b/tests/unit/helpers/skip-discipline.test.ts
@@ -38,4 +38,12 @@ describe('integration and e2e skip discipline', () => {
   it('does not reintroduce the obsolete skipIf helper', () => {
     expect(matchingFiles(/\bskipIf\b/)).toEqual([]);
   });
+
+  it('always passes explicit reason text to ctx.skip', () => {
+    expect(matchingFiles(/\bctx\.skip\(\s*\)/)).toEqual([]);
+  });
+
+  it('does not use permanent test-level it.skip declarations', () => {
+    expect(matchingFiles(/\bit\.skip\s*\(/)).toEqual([]);
+  });
 });

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     include: ['tests/integration/**/*.test.ts'],
     // SAP can be slow — allow 30s per test
     testTimeout: 30000,
+    // Live SAP suite hooks can list CTS state or seed objects; keep this above
+    // the default 10s so setup/cleanup does not fail before tests can skip.
+    hookTimeout: 60000,
     // Run test files one at a time — SAP has limited work processes and
     // parallel files exhaust them, causing "Service cannot be reached" errors.
     fileParallelism: false,


### PR DESCRIPTION
## Goal

Make the remaining integration/E2E skip behavior explicit and enforceable while updating the test audit and ABAP Platform 2025 research docs against current `origin/main`.

## What changed

- Converted abapGit stage/pull hard skips into opt-in runtime skips gated by `TEST_ABAPGIT_REMOTE_TESTS=true`; `pullRepo` also requires `TEST_ABAPGIT_PULL_REPO_KEY`.
- Added explicit reasons to remaining backend/fixture skip branches in FUGR/FUNC and class-section-surgery integration/E2E tests.
- Extended `tests/unit/helpers/skip-discipline.test.ts` to reject reasonless `ctx.skip()`, test-level `it.skip()`, obsolete `skipIf`, and `[SKIP]` pseudo-skip markers in integration/E2E/helper code.
- Updated skip-policy docs plus the test audit and ABAP Platform 2025 backlog so implemented items on current `main` are not reported as open.

## Validation

- `npm ci` (local Node `22.21.1` emitted the expected engine warning for project requirement `>=22.22.1`)
- `npm run lint`
- `npm run typecheck`
- `npm test -- tests/unit/helpers/skip-discipline.test.ts`
- `npm test`
- Focused live S4 integration slice using `/Users/marianzeis/DEV/arc-1/.env.infrastructure`: `npx vitest run --config vitest.integration.config.ts tests/integration/abapgit.integration.test.ts tests/integration/fugr-func.integration.test.ts tests/integration/fugr-func-params.integration.test.ts tests/integration/class-section-surgery.integration.test.ts`
  - Result: 4 files passed, 17 passed, 2 expected abapGit remote skips.
