### PR TITLE
fix(security): enforce redirect_uri allowlist for the shared XSUAA default client

### DIFF
--- a/docs/research/security-audit-2026-06-oauth-and-scope.md
+++ b/docs/research/security-audit-2026-06-oauth-and-scope.md
@@ -116,17 +116,38 @@ HMAC-signed `client_id` and re-derived deterministically by `getClient` (no shar
 the check rejects redirect-substitution on any instance. This covers the documented primary
 clients (Claude Desktop, Cursor, VS Code, Copilot CLI).
 
-### Residual — pre-registered XSUAA default client (follow-up)
+### Residual — pre-registered XSUAA default client — CLOSED (follow-up)
+
+> Originally shipped as a documented residual; **closed** in the follow-up change described
+> below.
 
 The shared XSUAA default client (`StatelessDcrClientStore.xsuaaClient`, used by "Manual" OAuth
-configs) accepts dynamically-added redirect URIs via `ensureRedirectUri()` at `/authorize`
+configs) accepted dynamically-added redirect URIs via `ensureRedirectUri()` at `/authorize`
 time. Because that in-memory list is the same object `getClient` returns, on a single instance
-an attacker-supplied `redirect_uri` is auto-registered during `/authorize` and would satisfy
-the callback `includes()` check — so the fix does **not** fully close the vector for the
-default client. It is regression-free (all manifests are `instances: 1`; `ensureRedirectUri`
-is a no-op for DCR clients). **Recommended follow-up:** enforce an allowlist (e.g. the
-`xs-security.json` redirect patterns) for the shared client instead of trusting arbitrary
-auto-registered URIs, or move clients off the shared client onto DCR.
+an attacker-supplied `redirect_uri` was auto-registered during `/authorize` and would satisfy
+the callback `includes()` check — so the original fix did not fully close the vector for the
+default client.
+
+**Fix (follow-up):** ARC-1 now enforces the redirect-uri allowlist that XSUAA used to enforce
+before the issue-#214 callback proxy removed XSUAA from the client-redirect path.
+
+- `src/server/stateless-client-store.ts` — `XSUAA_REDIRECT_URI_PATTERNS` vendors the
+  `xs-security.json` `oauth2-configuration.redirect-uris` patterns (xs-security.json is **not**
+  shipped at runtime — excluded by `.cfignore` / npm `files` / Dockerfile — so the patterns are
+  vendored and a unit test drift-guards them). `matchesXsuaaRedirectPattern()` does anchored,
+  case-insensitive glob matching (`*` = within a segment, `**` = across segments).
+- `ensureRedirectUri()` now registers a dynamic redirect_uri for the shared client **only if it
+  matches the allowlist** (otherwise dropped + `oauth_redirect_uri_rejected` audit event). A
+  non-matching URI then fails the SDK's exact-match at `/authorize`, before any state is minted.
+- `checkRedirectUri(clientId, uri)` centralizes the callback decision: the default client is
+  validated against the **static allowlist** (stateless — correct on any instance, not the
+  mutable in-memory list); DCR clients against their signed `redirect_uris`. `http.ts`'s
+  `/oauth/callback` calls it (replacing the inline `getClient().includes()` from PR #352).
+
+Legitimate Manual-mode clients (e.g. Copilot Studio via
+`https://global.consent.azure-apim.net/redirect/**`) are preserved because their pattern is in
+the allowlist; an attacker-controlled `redirect_uri` is not, so it is refused at both
+`/authorize` and the callback.
 
 ### Tests
 

--- a/docs/research/security-audit-2026-06-oauth-and-scope.md
+++ b/docs/research/security-audit-2026-06-oauth-and-scope.md
@@ -135,7 +135,11 @@ before the issue-#214 callback proxy removed XSUAA from the client-redirect path
   `xs-security.json` `oauth2-configuration.redirect-uris` patterns (xs-security.json is **not**
   shipped at runtime — excluded by `.cfignore` / npm `files` / Dockerfile — so the patterns are
   vendored and a unit test drift-guards them). `matchesXsuaaRedirectPattern()` does anchored,
-  case-insensitive glob matching (`*` = within a segment, `**` = across segments).
+  case-insensitive glob matching (`*` = within a segment, `**` = across segments). It first
+  `new URL()`-parses the candidate and **rejects any userinfo** (`user[:pass]@`) — without that,
+  the port-position `*` in `http://localhost:*/**` would let `http://localhost:x@evil.com/cb`
+  match as a string while parsing to host `evil.com`, re-opening code interception (caught in the
+  PR review; see "Hardening" below).
 - `ensureRedirectUri()` now registers a dynamic redirect_uri for the shared client **only if it
   matches the allowlist** (otherwise dropped + `oauth_redirect_uri_rejected` audit event). A
   non-matching URI then fails the SDK's exact-match at `/authorize`, before any state is minted.
@@ -148,6 +152,26 @@ Legitimate Manual-mode clients (e.g. Copilot Studio via
 `https://global.consent.azure-apim.net/redirect/**`) are preserved because their pattern is in
 the allowlist; an attacker-controlled `redirect_uri` is not, so it is refused at both
 `/authorize` and the callback.
+
+#### Hardening — URL userinfo smuggling in the matcher (PR review)
+
+A security review of the follow-up found that matching the glob against the **raw string** was
+unsafe: the value is later `new URL()`-parsed and used as the 302 target, and the port-position
+`*` in `http://localhost:*/**` (regex `^http://localhost:[^slash]*/…`) let `[^/]*` swallow a URL
+userinfo segment. `http://localhost:x@evil.com/cb` matched the glob as a string, yet
+`new URL(...).host === 'evil.com'` — so a victim's authorization `code` would be 302'd to the
+attacker. (The host-label wildcards like `*.hana.ondemand.com` are *not* affected: the literal
+domain must abut the authority-terminating `/`, so `@`-smuggling can't relocate their host. Only
+the localhost pattern, where the `*` is in the port slot, was bypassable.)
+
+**Fix:** `matchesXsuaaRedirectPattern()` now `new URL()`-parses the candidate, rejects anything
+that doesn't parse, and rejects any URI carrying userinfo (`username`/`password`) before the glob
+match. The `@` is the only construct that can move the authority past a same-segment wildcard, and
+no legitimate OAuth `redirect_uri` carries credentials — so after the guard, a glob match implies
+the parsed host equals the literal host in the pattern. Empirically verified (the old matcher
+returned `true` for `http://localhost:x@evil.com/cb`; the new one returns `false`) with no change
+for any legitimate client URI. Regression tests cover the userinfo variants at both the matcher
+and `/oauth/callback` layers.
 
 ### Tests
 

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -150,12 +150,27 @@ export interface OAuthClientLookupFailedEvent extends AuditEventBase {
 }
 
 /** OAuth DCR: a redirect_uri was dynamically appended to the pre-registered XSUAA
- *  default client at /authorize time. XSUAA itself is the authoritative validator
- *  via xs-security.json wildcards; this event records that ARC-1's local SDK-side
- *  list was widened so the change is auditable. */
+ *  default client at /authorize time. The URI passed ARC-1's redirect-uri
+ *  allowlist (mirrors xs-security.json — what XSUAA itself would have validated;
+ *  in the issue-#214 callback-proxy flow XSUAA no longer sees the client's
+ *  redirect_uri, so ARC-1 is the validator). This records the widening so the
+ *  change is auditable. */
 export interface OAuthRedirectUriRegisteredEvent extends AuditEventBase {
   event: 'oauth_redirect_uri_registered';
   registeredClientId: string;
+  redirectUri: string;
+}
+
+/** OAuth DCR: a dynamic redirect_uri was REJECTED for the pre-registered XSUAA
+ *  default client because it matched no entry in ARC-1's redirect-uri allowlist
+ *  (mirrors xs-security.json). Because the issue-#214 callback proxy removed
+ *  XSUAA from the client-redirect path, this allowlist is the control that
+ *  prevents authorization-code interception via an attacker-supplied
+ *  redirect_uri; a hit here is a blocked attempt and worth alerting on. */
+export interface OAuthRedirectUriRejectedEvent extends AuditEventBase {
+  event: 'oauth_redirect_uri_rejected';
+  registeredClientId: string;
+  /** The rejected redirect_uri. May be attacker-controlled — treat as untrusted. */
   redirectUri: string;
 }
 
@@ -217,6 +232,7 @@ export type AuditEvent =
   | OAuthClientRegisteredEvent
   | OAuthClientLookupFailedEvent
   | OAuthRedirectUriRegisteredEvent
+  | OAuthRedirectUriRejectedEvent
   | CorsRejectedEvent
   | AuthRateLimitedEvent
   | McpRateLimitedEvent;

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -118,7 +118,10 @@ function renderOAuthErrorPage(error: string, errorDescription: string, clientRet
  * still belong to the client that will exchange the code. For stateless DCR
  * clients (`arc1-…`) the registered redirect_uris are baked immutably into the
  * signed `client_id`, so this check deterministically rejects an attacker who
- * substitutes their own redirect_uri on a victim's `client_id`.
+ * substitutes their own redirect_uri on a victim's `client_id`. For the shared
+ * pre-registered XSUAA default client the redirect_uri is checked against the
+ * static allowlist (mirrors xs-security.json) instead — `clientStore` makes
+ * both decisions via `checkRedirectUri`.
  *
  * Exported for unit tests; mounted in `startHttpServer`. When `clientStore` is
  * omitted (legacy unit tests of the issue-#214 round-trip) the binding check is
@@ -145,23 +148,25 @@ export function createOAuthCallbackHandler(stateCodec: OAuthStateCodec, clientSt
     }
 
     // ── Client-binding validation (authorization-code interception defense) ──
-    // Verify the recovered redirect_uri is registered for the client_id that
-    // minted this state. Runs for BOTH the success and error branches below so
-    // neither a code nor an error response can be steered to an unregistered
-    // URI. Fails CLOSED on any lookup error (a terminal error page, never a
-    // redirect to an unverified target).
+    // Verify the recovered redirect_uri is an allowed target for the client_id
+    // that minted this state, BEFORE the success or error branches below — so
+    // neither a code nor an error response is ever steered to an unverified URI.
+    // The store decides per client type: a DCR client (`arc1-…`) is checked
+    // against the redirect_uris baked into its signed id; the shared XSUAA
+    // default client is checked against the static allowlist (mirrors
+    // xs-security.json), statelessly. Fails CLOSED on any lookup error.
     if (clientStore && decoded.clientId) {
-      let clientRedirectUris: string[] | undefined;
+      let verdict: 'ok' | 'unknown_client' | 'unregistered';
       try {
-        const clientInfo = await clientStore.getClient(decoded.clientId);
-        clientRedirectUris = clientInfo?.redirect_uris;
+        verdict = await clientStore.checkRedirectUri(decoded.clientId, decoded.clientRedirectUri);
       } catch (err) {
-        logger.warn('OAuth callback: client lookup threw — failing closed', {
+        logger.warn('OAuth callback: redirect_uri check threw — failing closed', {
           clientId: decoded.clientId,
           error: err instanceof Error ? err.message : String(err),
         });
+        verdict = 'unknown_client';
       }
-      if (!clientRedirectUris) {
+      if (verdict === 'unknown_client') {
         logger.warn('OAuth callback: state references unknown client_id', { clientId: decoded.clientId });
         res
           .status(400)
@@ -174,8 +179,8 @@ export function createOAuthCallbackHandler(stateCodec: OAuthStateCodec, clientSt
           );
         return;
       }
-      if (!clientRedirectUris.includes(decoded.clientRedirectUri)) {
-        logger.warn('OAuth callback: redirect_uri not registered for client', {
+      if (verdict === 'unregistered') {
+        logger.warn('OAuth callback: redirect_uri not allowed for client', {
           clientId: decoded.clientId,
           redirectUri: decoded.clientRedirectUri,
         });

--- a/src/server/stateless-client-store.ts
+++ b/src/server/stateless-client-store.ts
@@ -154,8 +154,28 @@ const XSUAA_REDIRECT_URI_REGEXPS = XSUAA_REDIRECT_URI_PATTERNS.map(redirectPatte
  * so it gives the same answer on every instance — used both to gate dynamic
  * registration (`ensureRedirectUri`) and to validate the redirect target at
  * `/oauth/callback` (`checkRedirectUri`).
+ *
+ * SECURITY — parse before matching: the value matched here is later re-parsed
+ * with `new URL()` and used as the 302 target that carries the OAuth `code`, so
+ * the glob decision MUST agree with how the URL actually parses. The patterns
+ * are string globs; a `*` sitting in the PORT position (the localhost pattern)
+ * would otherwise let a URL-userinfo segment ride inside the same-segment
+ * wildcard — `http://localhost:x@evil.com/cb` matches the `localhost:[^slash]`
+ * port glob yet `new URL(...).host === 'evil.com'`, steering a victim's code to an
+ * attacker host. So we reject anything that doesn't parse, and reject any
+ * userinfo (`user[:pass]@`) — that `@` is the only construct that can relocate
+ * the authority past a same-segment wildcard, and no legitimate OAuth
+ * redirect_uri carries credentials. After this guard, a glob match implies the
+ * parsed host is the literal host in the pattern.
  */
 export function matchesXsuaaRedirectPattern(uri: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (parsed.username !== '' || parsed.password !== '') return false;
   return XSUAA_REDIRECT_URI_REGEXPS.some((re) => re.test(uri));
 }
 

--- a/src/server/stateless-client-store.ts
+++ b/src/server/stateless-client-store.ts
@@ -90,6 +90,75 @@ const XSUAA_DEFAULT_REDIRECT_URIS = [
   'vscode://vscode.microsoft-authentication/callback', // VS Code
 ] as const;
 
+/**
+ * Redirect-URI allowlist for the pre-registered XSUAA default client — a vendored
+ * mirror of `oauth2-configuration.redirect-uris` in `xs-security.json`.
+ *
+ * ── Why ARC-1 must enforce this (not just XSUAA) ──
+ * The issue-#214 callback proxy (see `oauth-state.ts`) sends XSUAA ARC-1's OWN
+ * `/oauth/callback` as the redirect_uri and carries the client's real
+ * redirect_uri inside the signed state. XSUAA therefore no longer validates the
+ * client's redirect_uri — ARC-1 does. Without an allowlist, `ensureRedirectUri`
+ * would auto-trust ANY redirect_uri supplied at `/authorize` for the shared
+ * default client, letting an attacker steer a victim's authorization code to
+ * their own URI (security audit 2026-06, follow-up to PR #352).
+ *
+ * ── Why vendored, not read from xs-security.json ──
+ * `xs-security.json` is consumed by XSUAA at service-creation time and is NOT
+ * shipped with the running app (excluded by `.cfignore`, the npm `files`
+ * allowlist, and the Dockerfile), and the service binding does not expose the
+ * patterns — so ARC-1 cannot read them at runtime. To prevent drift,
+ * `tests/unit/server/stateless-client-store.test.ts` asserts this list stays
+ * equal to `xs-security.json`. Keep the two in sync when adding a client.
+ *
+ * Glob semantics (xs-security.json): `*` matches within a single host/path
+ * segment (never `/`), `**` matches across segments.
+ */
+export const XSUAA_REDIRECT_URI_PATTERNS = [
+  'http://localhost:*/**',
+  'https://*.hana.ondemand.com/**',
+  'https://*.applicationstudio.cloud.sap/**',
+  'https://claude.ai/api/mcp/auth_callback',
+  'https://callback.mistral.ai/v1/integrations_auth/oauth2_callback',
+  'cursor://anysphere.cursor-retrieval/**',
+  'cursor://anysphere.cursor-mcp/**',
+  'vscode://vscode.microsoft-authentication/**',
+  'https://global.consent.azure-apim.net/redirect/**',
+] as const;
+
+/** Translate one xs-security.json redirect-uri glob into an anchored,
+ *  case-insensitive RegExp. `**` → `.*` (crosses `/`); `*` → `[^/]*` (within a
+ *  segment); every other character is matched literally. The trailing `/` and
+ *  anchoring mean a host-label `*` (e.g. `*.hana.ondemand.com`) cannot be widened
+ *  to a different registrable domain. */
+function redirectPatternToRegExp(pattern: string): RegExp {
+  // Split on the wildcard tokens, keeping them (the capturing group keeps the
+  // delimiters in the result array). `**` is tried before `*`, so it tokenizes
+  // as a single token.
+  const body = pattern
+    .split(/(\*\*|\*)/)
+    .map((segment) => {
+      if (segment === '**') return '.*'; // crosses path separators
+      if (segment === '*') return '[^/]*'; // within a single segment (never `/`)
+      return segment.replace(/[.+?^${}()|[\]\\]/g, '\\$&'); // escape literal regex metachars
+    })
+    .join('');
+  return new RegExp(`^${body}$`, 'i');
+}
+
+const XSUAA_REDIRECT_URI_REGEXPS = XSUAA_REDIRECT_URI_PATTERNS.map(redirectPatternToRegExp);
+
+/**
+ * Is `uri` an allowed redirect target for the pre-registered XSUAA default
+ * client? True iff it matches an `XSUAA_REDIRECT_URI_PATTERNS` entry. Stateless,
+ * so it gives the same answer on every instance — used both to gate dynamic
+ * registration (`ensureRedirectUri`) and to validate the redirect target at
+ * `/oauth/callback` (`checkRedirectUri`).
+ */
+export function matchesXsuaaRedirectPattern(uri: string): boolean {
+  return XSUAA_REDIRECT_URI_REGEXPS.some((re) => re.test(uri));
+}
+
 // ─── Payload Schema ───────────────────────────────────────────────────
 
 /**
@@ -273,10 +342,16 @@ export class StatelessDcrClientStore implements OAuthRegisteredClientsStore {
   /**
    * Called by the MCP SDK before redirect_uri validation on `/authorize`.
    *
-   * For the pre-registered XSUAA client we mutate the in-memory list (XSUAA
-   * itself is the authoritative validator via `xs-security.json` wildcards,
-   * so the SDK's local list is decorative). The mutation is replayed on
-   * every `/authorize`, so it doesn't need to persist.
+   * For the pre-registered XSUAA client we mutate the in-memory list so the
+   * SDK's exact-match check passes. The mutation is replayed on every
+   * `/authorize`, so it doesn't need to persist. SECURITY: we register a
+   * candidate URI ONLY if it matches `XSUAA_REDIRECT_URI_PATTERNS` (the vendored
+   * mirror of xs-security.json). The issue-#214 callback proxy removed XSUAA
+   * from the client-redirect path, so an un-gated add here would let an attacker
+   * register an arbitrary redirect_uri and have the SDK accept it — the entry
+   * point for authorization-code interception (security audit 2026-06). A
+   * non-matching URI is dropped (audited); the SDK's exact-match check then
+   * rejects the `/authorize` request before any state is minted.
    *
    * For DCR (`arc1-…`) clients we are stateless by design: there's nothing
    * to mutate. The previous in-memory store implemented a percent-encoding
@@ -291,6 +366,18 @@ export class StatelessDcrClientStore implements OAuthRegisteredClientsStore {
     if (clientId !== this.xsuaaClient.client_id) return;
     if (this.xsuaaClient.redirect_uris.includes(uri)) return;
 
+    if (!matchesXsuaaRedirectPattern(uri)) {
+      logger.warn('Dynamic redirect_uri rejected for XSUAA default client (not in allowlist)', { clientId, uri });
+      logger.emitAudit({
+        timestamp: new Date().toISOString(),
+        level: 'warn',
+        event: 'oauth_redirect_uri_rejected',
+        registeredClientId: clientId,
+        redirectUri: uri,
+      });
+      return;
+    }
+
     this.xsuaaClient.redirect_uris.push(uri);
     logger.debug('Dynamic redirect_uri registered for XSUAA client', { clientId, uri });
     logger.emitAudit({
@@ -300,6 +387,29 @@ export class StatelessDcrClientStore implements OAuthRegisteredClientsStore {
       registeredClientId: clientId,
       redirectUri: uri,
     });
+  }
+
+  /**
+   * Validate that `uri` is an allowed redirect target for `clientId` at the
+   * `/oauth/callback` proxy — the control that stops authorization-code
+   * interception (security audit 2026-06, follow-up to PR #352).
+   *
+   *  - Default (pre-registered XSUAA) client → must match the redirect-uri
+   *    allowlist (`matchesXsuaaRedirectPattern`). Deliberately consults the
+   *    static allowlist, NOT the mutable in-memory list, so the verdict is
+   *    stateless and identical on every instance — a code is never forwarded to
+   *    an unlisted URI even if `/authorize` ran on a different instance.
+   *  - DCR (`arc1-…`) client → must be one of the redirect_uris baked immutably
+   *    into the signed client_id (re-derived by `getClient`). Returns
+   *    `unknown_client` when the id is unrecognised / expired / forged.
+   */
+  async checkRedirectUri(clientId: string, uri: string): Promise<'ok' | 'unknown_client' | 'unregistered'> {
+    if (clientId === this.xsuaaClient.client_id) {
+      return matchesXsuaaRedirectPattern(uri) ? 'ok' : 'unregistered';
+    }
+    const info = await this.getClient(clientId);
+    if (!info) return 'unknown_client';
+    return info.redirect_uris.includes(uri) ? 'ok' : 'unregistered';
   }
 
   // ── Internals: encode / decode / sign / verify ──

--- a/tests/unit/server/oauth-callback.test.ts
+++ b/tests/unit/server/oauth-callback.test.ts
@@ -295,4 +295,23 @@ describe('createOAuthCallbackHandler — client-binding validation (auth-code in
     expect(res.headers.location).toBeUndefined();
     expect(res.text).not.toContain('STOLEN');
   });
+
+  it('returns 400 (code NOT leaked) for a userinfo-smuggled localhost redirect on the default client', async () => {
+    // SECURITY regression (PR #355 review): `http://localhost:x@evil.com/cb` matches the
+    // `http://localhost:*/**` glob as a STRING, but parses to host `evil.com`. The callback
+    // must refuse it so the victim's code is never 302'd to the attacker's host.
+    const codec = new OAuthStateCodec(SECRET);
+    const store = buildStore();
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'http://localhost:x@evil.com/cb',
+      clientId: DEFAULT_CLIENT_ID,
+    });
+    const res = await request(buildAppWithStore(codec, store))
+      .get('/oauth/callback')
+      .query({ code: 'STOLEN', state: token });
+    expect(res.status).toBe(400);
+    expect(res.headers.location).toBeUndefined();
+    expect(res.text).not.toContain('STOLEN');
+  });
 });

--- a/tests/unit/server/oauth-callback.test.ts
+++ b/tests/unit/server/oauth-callback.test.ts
@@ -250,4 +250,49 @@ describe('createOAuthCallbackHandler — client-binding validation (auth-code in
     expect(res.status).toBe(400);
     expect(res.headers.location).toBeUndefined();
   });
+
+  // ── Shared pre-registered XSUAA default client (Manual-mode clients) ──
+  // The default client's redirect target is validated against the static
+  // allowlist (xs-security.json mirror), not the mutable in-memory list — so an
+  // attacker who steers a victim's code to their own URI via the SHARED client
+  // is blocked statelessly, while a legit allowlisted URI (e.g. Copilot Studio)
+  // still works. The store's default client_id is its first constructor arg.
+  const DEFAULT_CLIENT_ID = 'xsuaa-client';
+
+  it('forwards the code for the default client when redirect_uri is allowlisted', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const store = buildStore();
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'https://global.consent.azure-apim.net/redirect/contoso',
+      clientId: DEFAULT_CLIENT_ID,
+    });
+    const res = await request(buildAppWithStore(codec, store))
+      .get('/oauth/callback')
+      .query({ code: 'CODE1', state: token });
+    expect(res.status).toBe(302);
+    expect((res.headers.location as string).startsWith('https://global.consent.azure-apim.net/redirect/contoso')).toBe(
+      true,
+    );
+    expect(new URL(res.headers.location as string).searchParams.get('code')).toBe('CODE1');
+  });
+
+  it('returns 400 (code NOT leaked) for the default client when redirect_uri is not allowlisted', async () => {
+    const codec = new OAuthStateCodec(SECRET);
+    const store = buildStore();
+    // This is the residual the fix closes: an attacker redirect_uri on the shared
+    // default client must not receive the victim's code, even though ensureRedirectUri
+    // would once have auto-trusted it.
+    const token = codec.encode({
+      clientState: 'abc',
+      clientRedirectUri: 'https://attacker.example/cb',
+      clientId: DEFAULT_CLIENT_ID,
+    });
+    const res = await request(buildAppWithStore(codec, store))
+      .get('/oauth/callback')
+      .query({ code: 'STOLEN', state: token });
+    expect(res.status).toBe(400);
+    expect(res.headers.location).toBeUndefined();
+    expect(res.text).not.toContain('STOLEN');
+  });
 });

--- a/tests/unit/server/stateless-client-store.test.ts
+++ b/tests/unit/server/stateless-client-store.test.ts
@@ -276,6 +276,27 @@ describe('matchesXsuaaRedirectPattern (redirect-uri allowlist for the shared XSU
     expect(matchesXsuaaRedirectPattern('https://x.hana.ondemand.com.evil.com/cb')).toBe(false);
     expect(matchesXsuaaRedirectPattern('https://a.b.hana.ondemand.com/cb')).toBe(true); // extra SAP subdomain is fine
   });
+
+  it('rejects URL userinfo smuggling — the string matches the glob but parses to a foreign host', () => {
+    // SECURITY regression: `http://localhost:*/**` → `^http://localhost:[^/]*/.*$`,
+    // and `[^/]*` (the port-position wildcard) greedily swallows `x@evil.com`, so the
+    // raw string matches — yet `new URL("http://localhost:x@evil.com/cb").host` is
+    // `evil.com`. Matching must reject the userinfo so the OAuth code can't be steered
+    // to an attacker host. (Found by security review of PR #355.)
+    expect(new URL('http://localhost:x@evil.com/cb').host).toBe('evil.com'); // documents the parse
+    expect(matchesXsuaaRedirectPattern('http://localhost:x@evil.com/cb')).toBe(false);
+    expect(matchesXsuaaRedirectPattern('http://localhost:@evil.com/x')).toBe(false);
+    expect(matchesXsuaaRedirectPattern('http://localhost:1234@evil.com/cb')).toBe(false);
+    // userinfo on an otherwise-exact host is rejected too
+    expect(matchesXsuaaRedirectPattern('https://user:pass@claude.ai/api/mcp/auth_callback')).toBe(false);
+    // a credential-free loopback redirect (the legitimate use of the localhost pattern) still passes
+    expect(matchesXsuaaRedirectPattern('http://localhost:6274/oauth/callback')).toBe(true);
+  });
+
+  it('rejects values that are not parseable URLs', () => {
+    expect(matchesXsuaaRedirectPattern('not a url')).toBe(false);
+    expect(matchesXsuaaRedirectPattern('http://')).toBe(false);
+  });
 });
 
 describe('StatelessDcrClientStore.checkRedirectUri', () => {

--- a/tests/unit/server/stateless-client-store.test.ts
+++ b/tests/unit/server/stateless-client-store.test.ts
@@ -7,10 +7,16 @@
  * client_secret is deterministic from the client_id.
  */
 
+import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import type { AuditEvent } from '../../../src/server/audit.js';
 import { logger } from '../../../src/server/logger.js';
-import { StatelessDcrClientStore, validateRedirectUri } from '../../../src/server/stateless-client-store.js';
+import {
+  matchesXsuaaRedirectPattern,
+  StatelessDcrClientStore,
+  validateRedirectUri,
+  XSUAA_REDIRECT_URI_PATTERNS,
+} from '../../../src/server/stateless-client-store.js';
 
 const SIGNING = 'test-signing-secret';
 const XSUAA_ID = 'sb-arc1!t599384';
@@ -203,13 +209,21 @@ describe('StatelessDcrClientStore', () => {
     expect(registered.client_id.length).toBeLessThan(800);
   });
 
-  it('mutates redirect_uris on the XSUAA default client via ensureRedirectUri', () => {
+  it('mutates redirect_uris on the XSUAA default client via ensureRedirectUri (allowlisted URI)', () => {
     const store = makeStore();
-    store.ensureRedirectUri(XSUAA_ID, 'https://new-mcp-client.example.com/cb');
+    // Matches the `https://*.hana.ondemand.com/**` allowlist pattern.
+    store.ensureRedirectUri(XSUAA_ID, 'https://abc.hana.ondemand.com/login/callback');
     // Re-fetch and confirm the new URI is on the list.
     return store.getClient(XSUAA_ID).then((c) => {
-      expect(c?.redirect_uris).toContain('https://new-mcp-client.example.com/cb');
+      expect(c?.redirect_uris).toContain('https://abc.hana.ondemand.com/login/callback');
     });
+  });
+
+  it('does NOT register a non-allowlisted redirect_uri on the XSUAA default client', async () => {
+    const store = makeStore();
+    store.ensureRedirectUri(XSUAA_ID, 'https://attacker.example/cb');
+    const c = await store.getClient(XSUAA_ID);
+    expect(c?.redirect_uris).not.toContain('https://attacker.example/cb');
   });
 
   it('is a no-op for ensureRedirectUri on DCR clients (stateless)', async () => {
@@ -218,6 +232,82 @@ describe('StatelessDcrClientStore', () => {
     store.ensureRedirectUri(registered.client_id, 'https://other.example.com/cb');
     const fetched = await store.getClient(registered.client_id);
     expect(fetched?.redirect_uris).toEqual(['https://example.com/cb']);
+  });
+});
+
+describe('matchesXsuaaRedirectPattern (redirect-uri allowlist for the shared XSUAA client)', () => {
+  it('accepts URIs covered by the allowlist patterns', () => {
+    const allowed = [
+      'http://localhost:6274/oauth/callback', // http://localhost:*/**
+      'http://localhost:3000/oauth/callback',
+      'https://abc.hana.ondemand.com/login/callback', // https://*.hana.ondemand.com/**
+      'https://dev-xyz.applicationstudio.cloud.sap/cb', // https://*.applicationstudio.cloud.sap/**
+      'https://claude.ai/api/mcp/auth_callback', // exact
+      'https://callback.mistral.ai/v1/integrations_auth/oauth2_callback', // exact
+      'cursor://anysphere.cursor-retrieval/oauth/callback', // cursor://anysphere.cursor-retrieval/**
+      'cursor://anysphere.cursor-mcp/cb',
+      'vscode://vscode.microsoft-authentication/callback',
+      'https://global.consent.azure-apim.net/redirect/contoso', // Copilot Studio (Manual mode)
+    ];
+    for (const uri of allowed) {
+      expect(matchesXsuaaRedirectPattern(uri), uri).toBe(true);
+    }
+  });
+
+  it('rejects attacker-controlled and out-of-allowlist URIs', () => {
+    const rejected = [
+      'https://attacker.example/cb',
+      'https://claude.ai.attacker.com/api/mcp/auth_callback', // suffix-graft on an exact host
+      'https://attacker.com/claude.ai/api/mcp/auth_callback', // path can't impersonate host
+      'https://hana.ondemand.com.attacker.com/cb', // subdomain-suffix trick must NOT match *.hana.ondemand.com
+      'http://evil.com/cb', // non-loopback http not in allowlist
+      'https://global.consent.azure-apim.net.evil.com/redirect/x', // host-suffix graft
+      'javascript:alert(1)',
+    ];
+    for (const uri of rejected) {
+      expect(matchesXsuaaRedirectPattern(uri), uri).toBe(false);
+    }
+  });
+
+  it("a host-label '*' does not cross a path separator (so it cannot reach a foreign host)", () => {
+    // `https://*.hana.ondemand.com/**`: the `*` is one host label, bounded by the
+    // literal `.hana.ondemand.com/`. A URL whose authority is a different domain
+    // cannot satisfy it regardless of path.
+    expect(matchesXsuaaRedirectPattern('https://x.hana.ondemand.com.evil.com/cb')).toBe(false);
+    expect(matchesXsuaaRedirectPattern('https://a.b.hana.ondemand.com/cb')).toBe(true); // extra SAP subdomain is fine
+  });
+});
+
+describe('StatelessDcrClientStore.checkRedirectUri', () => {
+  it("default client → 'ok' for an allowlisted URI, 'unregistered' otherwise (stateless, ignores in-memory list)", async () => {
+    const store = makeStore();
+    expect(await store.checkRedirectUri(XSUAA_ID, 'https://claude.ai/api/mcp/auth_callback')).toBe('ok');
+    expect(await store.checkRedirectUri(XSUAA_ID, 'https://global.consent.azure-apim.net/redirect/x')).toBe('ok');
+    expect(await store.checkRedirectUri(XSUAA_ID, 'https://attacker.example/cb')).toBe('unregistered');
+  });
+
+  it("DCR client → 'ok' only for a redirect_uri baked into its signed client_id", async () => {
+    const store = makeStore();
+    const reg = await store.registerClient({ redirect_uris: ['https://app.example.com/cb'] });
+    expect(await store.checkRedirectUri(reg.client_id, 'https://app.example.com/cb')).toBe('ok');
+    expect(await store.checkRedirectUri(reg.client_id, 'https://attacker.example/cb')).toBe('unregistered');
+  });
+
+  it("returns 'unknown_client' for an unrecognised/forged client_id", async () => {
+    const store = makeStore();
+    expect(await store.checkRedirectUri('arc1-bogus.AAAAAAAAAAAAAAAAAAAAAA', 'https://app.example.com/cb')).toBe(
+      'unknown_client',
+    );
+  });
+});
+
+describe('XSUAA_REDIRECT_URI_PATTERNS stays in sync with xs-security.json (drift guard)', () => {
+  it('matches oauth2-configuration.redirect-uris exactly', () => {
+    // The runtime allowlist is a vendored mirror (xs-security.json is not shipped
+    // with the app — see .cfignore / npm files / Dockerfile). This test fails if
+    // the two diverge, forcing the code copy to be updated alongside the config.
+    const xs = JSON.parse(readFileSync(new URL('../../../xs-security.json', import.meta.url), 'utf8'));
+    expect([...XSUAA_REDIRECT_URI_PATTERNS]).toEqual(xs['oauth2-configuration']['redirect-uris']);
   });
 });
 
@@ -385,12 +475,30 @@ describe('StatelessDcrClientStore audit events', () => {
     const events = captureAuditEvents();
     const store = makeStore();
 
-    store.ensureRedirectUri(XSUAA_ID, 'https://new.example.com/cb');
+    // Matches `https://global.consent.azure-apim.net/redirect/**` (Copilot Studio).
+    store.ensureRedirectUri(XSUAA_ID, 'https://global.consent.azure-apim.net/redirect/contoso');
 
     const evt = events.find((e) => e.event === 'oauth_redirect_uri_registered');
     expect(evt).toBeDefined();
-    expect(evt && 'redirectUri' in evt && evt.redirectUri).toBe('https://new.example.com/cb');
+    expect(evt && 'redirectUri' in evt && evt.redirectUri).toBe(
+      'https://global.consent.azure-apim.net/redirect/contoso',
+    );
     expect(evt?.registeredClientId).toBe(XSUAA_ID);
+  });
+
+  it('emits oauth_redirect_uri_rejected (warn) when a non-allowlisted URI is refused', async () => {
+    const events = captureAuditEvents();
+    const store = makeStore();
+
+    store.ensureRedirectUri(XSUAA_ID, 'https://attacker.example/cb');
+
+    const evt = events.find((e) => e.event === 'oauth_redirect_uri_rejected');
+    expect(evt).toBeDefined();
+    expect(evt && 'redirectUri' in evt && evt.redirectUri).toBe('https://attacker.example/cb');
+    expect(evt?.registeredClientId).toBe(XSUAA_ID);
+    expect(evt?.level).toBe('warn');
+    // And no "registered" event fired.
+    expect(events.find((e) => e.event === 'oauth_redirect_uri_registered')).toBeUndefined();
   });
 
   it('does not emit oauth_redirect_uri_registered when ensureRedirectUri is a no-op (DCR client)', async () => {


### PR DESCRIPTION
## Summary

Follow-up to **#352** (security audit 2026-06). #352 bound the originating `client_id` into the signed OAuth `state` and validated the callback `redirect_uri` for **DCR clients**, but explicitly left a **residual** on the *shared pre-registered XSUAA default client* (used by "Manual"-mode clients such as Copilot Studio). This closes it.

> 🔗 **Stacked on #352** — based on its branch so the diff below is only this follow-up. GitHub will auto-retarget this PR to `main` when #352 merges. (Review/merge #352 first.)

### The residual
`ensureRedirectUri()` auto-registered **any** `redirect_uri` supplied at `/authorize` for the shared client. Because that in-memory list is the same object `getClient()` returns, on a single instance an attacker-supplied URI was registered during `/authorize` and then satisfied the callback `includes()` check from #352 — so a victim's authorization code could still be intercepted via the shared client.

**Root cause:** the issue-#214 callback proxy takes XSUAA out of the client-redirect path (XSUAA only ever sees ARC-1's own `/oauth/callback`), so the `xs-security.json` redirect-uri allowlist XSUAA *used* to enforce was no longer enforced by anyone.

### The fix — ARC-1 enforces the allowlist itself
- **`stateless-client-store.ts`**: `XSUAA_REDIRECT_URI_PATTERNS` vendors the `xs-security.json` `oauth2-configuration.redirect-uris` patterns. `xs-security.json` is **not shipped at runtime** (excluded by `.cfignore`, the npm `files` allowlist, and the Dockerfile; the service binding doesn't expose it), so the patterns are vendored and a **unit test drift-guards** them against the file. `matchesXsuaaRedirectPattern()` does anchored, case-insensitive glob matching (`*` = within a segment, `**` = across segments; a host-label `*` like `*.hana.ondemand.com` can't be widened to a foreign registrable domain).
- **`ensureRedirectUri()`** registers a dynamic `redirect_uri` for the shared client **only if it matches the allowlist** (otherwise dropped + new `oauth_redirect_uri_rejected` audit event). A non-matching URI then fails the SDK's exact-match at `/authorize`, **before any state is minted**.
- **`checkRedirectUri(clientId, uri)`** (new) centralizes the callback decision: default client → **static allowlist** (stateless, so it's correct on *any* instance, not the mutable in-memory list); DCR client → signed `redirect_uris`. `http.ts` `/oauth/callback` calls it (replacing #352's inline `getClient().includes()`), still **fails closed**.

Legitimate Manual-mode clients are preserved — Copilot Studio's `https://global.consent.azure-apim.net/redirect/**` is in the allowlist; an attacker `redirect_uri` is not, so it's refused at **both** `/authorize` and the callback.

## Test plan
- `npm run typecheck` clean · `npm run lint` clean · `npm test` → **3407 passing** (+11)
- New tests:
  - `matchesXsuaaRedirectPattern`: allowlisted clients accepted; `attacker.example`, `claude.ai.attacker.com`, `*.hana.ondemand.com.evil.com` host-suffix grafts, non-loopback http → rejected
  - `ensureRedirectUri`: allowlisted URI registered; non-allowlisted dropped + `oauth_redirect_uri_rejected` audit event
  - `checkRedirectUri`: default→allowlist, DCR→signed uris, unknown id→`unknown_client`
  - callback: default client + allowlisted redirect → 302; + attacker redirect → 400, no `Location`, code not leaked
  - **drift guard**: `XSUAA_REDIRECT_URI_PATTERNS` deep-equals `xs-security.json` `oauth2-configuration.redirect-uris`

🤖 Generated with [Claude Code](https://claude.com/claude-code)