### PR TITLE
test: close slow baseline and server coverage gaps

### DIFF
--- a/docs/plans/completed/manual-sap-slow-workflow.md
+++ b/docs/plans/completed/manual-sap-slow-workflow.md
@@ -137,6 +137,6 @@ After local validation passes, create the PR and run normal GitHub CI plus the n
 - [x] Commit, push, and create a ready PR with a conventional `ci:` title and a description covering goal, content, and validation.
 - [x] Wait for the normal PR `Test` workflow checks and the new `SAP Slow Tests` pull-request definition check to pass. Latest checked PR head `033ba0fe`: `Test` run `27061737354` passed, `SAP Slow Tests` run `27061737358` passed the definition check and skipped live slow profiles on pull request as intended, Dependency Review run `27061737351` passed, and CodeQL run `27061736790` passed.
 - [x] Confirm the runtime research document explains that the first live manual slow dispatch is post-merge because new `workflow_dispatch` workflows must exist on the default branch.
-- [ ] After merge, dispatch the new `SAP Slow Tests` workflow with slow integration and slow E2E enabled, recursive release disabled.
-- [ ] After that post-merge dispatch, update the runtime research document with the slow workflow URL, run id, runtime, pass/fail/skip counts, and any A4H 2025 lock/unlock observations.
-- [ ] Move this plan to `docs/plans/completed/` after implementation and validation are complete.
+- [x] After merge, dispatch the new `SAP Slow Tests` workflow with slow integration and slow E2E enabled, recursive release disabled. Run `27068686650` passed on `main`.
+- [x] After that post-merge dispatch, update the runtime research document with the slow workflow URL, run id, runtime, pass/fail/skip counts, and any A4H 2025 lock/unlock observations.
+- [x] Move this plan to `docs/plans/completed/` after implementation and validation are complete.

--- a/docs/research/github-actions-a4h-2025-migration-2026-06-06.md
+++ b/docs/research/github-actions-a4h-2025-migration-2026-06-06.md
@@ -240,5 +240,5 @@ Do not treat every `SAP_URL`/`SAP_USER`/`SAP_PASSWORD` string in docs or scripts
 
 ## Remaining Follow-Ups
 
-- Run the new manual **SAP Slow Tests** workflow once after `.github/workflows/sap-slow-tests.yml` is merged to `main`, then document the slow-profile GitHub baseline in `docs/research/test-runtime-profiles-and-coverage-2026-06-06.md`.
-- After that slow workflow pass, remove the old repository `SAP_*` secrets from GitHub unless another external operational process is still using them.
+- Completed: the first manual **SAP Slow Tests** workflow run after `.github/workflows/sap-slow-tests.yml` reached `main` passed as run [`27068686650`](https://github.com/marianfoo/arc-1/actions/runs/27068686650). Slow integration, slow E2E, MCP server shutdown, reliability summary, and required-execution threshold checks all passed. The baseline is documented in `docs/research/test-runtime-profiles-and-coverage-2026-06-06.md`.
+- Remaining external cleanup: remove the old repository `SAP_*` secrets from GitHub unless another external operational process is still using them. This is GitHub repository state, not a code change; current workflow files use `TEST_SAP_*` for live SAP CI and map to runtime `SAP_*` names only inside E2E server/test steps.

--- a/docs/research/test-runtime-profiles-and-coverage-2026-06-06.md
+++ b/docs/research/test-runtime-profiles-and-coverage-2026-06-06.md
@@ -40,7 +40,7 @@ Local no-SAP validation:
 - `npm run typecheck`: passed.
 - `npm run lint`: passed.
 - `npm test`: 104 files / 3,468 tests passed.
-- `npm run test:coverage`: 104 files / 3,468 tests passed; statements 82.57%, branches 73.38%, functions 88.48%, lines 83.79%.
+- `npm run test:coverage`: 104 files / 3,484 tests passed; statements 83.17%, branches 73.80%, functions 88.97%, lines 84.41%.
 - `npm run build`: passed.
 
 GitHub Actions validation:
@@ -255,9 +255,9 @@ Runtime implication:
 | integration | 8m01s | 3m50s | The default integration profile now benefits from the tuned 2025 target and stricter preflight. |
 | e2e | 8m55s | 6m26s | The default E2E profile remains sequential but is materially faster on the 2025 target. |
 
-## Follow-Up In Progress: Manual Slow SAP Workflow
+## Follow-Up Completed: Manual Slow SAP Workflow
 
-This follow-up PR adds `.github/workflows/sap-slow-tests.yml` as the operator-run path for the slow SAP profiles. The workflow has a cheap pull-request definition check so the new workflow file is validated in CI, but the live slow SAP job runs only through `workflow_dispatch`, not `push`, `pull_request`, or a schedule.
+PR [#366](https://github.com/marianfoo/arc-1/pull/366) added `.github/workflows/sap-slow-tests.yml` as the operator-run path for the slow SAP profiles. The workflow has a cheap pull-request definition check so the workflow file is validated in CI, but the live slow SAP job runs only through `workflow_dispatch`, not `push`, `pull_request`, or a schedule.
 
 Manual dispatch settings:
 
@@ -277,7 +277,7 @@ Workflow design:
 - Uploads `integration-slow.json`, `e2e-slow.json`, skip telemetry, E2E logs, and slow JUnit XML.
 - Normalizes slow JSON to `integration.json` and `e2e.json` only for the existing reliability and required-execution summary scripts.
 
-GitHub constraint: `workflow_dispatch` only receives events when the workflow file is on the default branch. Because `.github/workflows/sap-slow-tests.yml` is new in this PR, the first live manual slow run is a post-merge step. The PR validates the workflow through the pull-request definition check plus local YAML parsing; after merge, dispatch **SAP Slow Tests** from `main` or from a selected branch.
+GitHub constraint: `workflow_dispatch` only receives events when the workflow file is on the default branch. Because `.github/workflows/sap-slow-tests.yml` was new in PR #366, the first live manual slow run had to be a post-merge step.
 
 PR validation evidence checked on head `033ba0fe` before the docs refresh commit:
 
@@ -288,14 +288,37 @@ PR validation evidence checked on head `033ba0fe` before the docs refresh commit
 | `Dependency Review` | `27061737351` | passed. |
 | `CodeQL` | `27061736790` | passed; actions analysis 45s, JavaScript/TypeScript analysis 1m04s. |
 
-Baseline evidence will be filled after the first manual run:
+First manual baseline after PR #366 merged:
 
 | Evidence | Result |
 |---|---:|
-| Workflow run | pending after merge |
-| Slow integration | pending |
-| Slow E2E | pending |
-| Reliability summary | pending |
-| A4H 2025 lock/unlock routing skips | pending |
+| Workflow run | [`27068686650`](https://github.com/marianfoo/arc-1/actions/runs/27068686650), `workflow_dispatch` on `main` at `cee8ac1c` |
+| Slow live SAP profiles job | passed in 5m08s |
+| Slow integration step | passed in 51s; JSON artifact reports 7 total, 6 passed, 1 skipped |
+| Slow E2E step | passed in 3m45s; JSON artifact reports 9 total, 8 passed, 1 skipped |
+| Slow reliability summary | passed |
+| Required slow execution thresholds | passed |
+| A4H 2025 lock/unlock routing skips | none in skip telemetry |
+| Intentional recursive CTS release skips | 1 integration skip and 1 E2E skip because `TEST_TRANSPORT_RELEASE_TESTS` was not enabled |
 
 The lock/unlock count matters because PR #365 proved the tuned 2025 system can still have shared-system ADT write-session routing windows. Occasional skip-aware lock/unlock routing instability is documented as Cat 3. A persistent increase in these skips on both default and manual slow runs should be treated as SAP-side routing/ICF/session instability, not as a reason to parallelize or weaken the test assertions.
+
+The first manual run was dispatched before docs-only PR #361 was merged, so its `headSha` is `cee8ac1c`. PR #361 did not change the slow workflow or test code, and the run still proves the new manual workflow path can authenticate against A4H 2025, run both slow suites sequentially, stop the MCP server, upload artifacts, summarize reliability, and enforce slow-suite thresholds.
+
+## Follow-Up Completed: Remaining Server/XSUAA Coverage
+
+This PR closes the remaining coverage follow-up from the test-suite audit for `src/server/server.ts` and branch-heavy XSUAA/server startup paths.
+
+Implemented coverage:
+
+- `tests/unit/server/server.test.ts` now exercises the real `createServer()` `tools/list` and `tools/call` handlers without opening a transport. It covers auth-scoped tool listing with `denyActions`, blocking startup auth preflight behavior, strict principal-propagation rejection for API-key calls, and one-time stale-cookie propagation after a non-blocking cookie-file preflight 401.
+- That handler-level coverage exposed a real bug: `tools/list` passed user scopes to `filterToolsByAuthScope()` but did not pass `config.denyActions`, so deny-listed tools/actions could still be advertised even though runtime calls would reject them. `src/server/server.ts` now passes `config.denyActions` into the list-path filter.
+- `tests/unit/server/xsuaa.test.ts` now exercises XSUAA provider branches for authorize redirect rewriting, opaque callback-proxy state handoff, authorization-code exchange, refresh-token exchange, revocation non-2xx warnings, and revocation network-error logging.
+
+Focused local coverage command:
+
+```bash
+npx vitest run tests/unit/server/server.test.ts tests/unit/server/xsuaa.test.ts --coverage --coverage.include=src/server/server.ts --coverage.include=src/server/xsuaa.ts
+```
+
+Result on this branch: 68 focused tests passed. Combined `server.ts`/`xsuaa.ts` focused coverage improved from statements 38.25%, branches 37.16%, functions 47.82%, lines 38.59% to statements 53.01%, branches 49.26%, functions 60.86%, lines 53.28%.

--- a/docs/research/test-suite-audit-2026-05-11.md
+++ b/docs/research/test-suite-audit-2026-05-11.md
@@ -1270,8 +1270,8 @@ Treat this as the final phase. Parallelism is useful only after the suite has re
 Parallelism/coverage implementation update (2026-06-06):
 
 - Item 14 is implemented as `tests/e2e/concurrency-read.e2e.test.ts`. It runs three bounded read-only MCP calls concurrently and records the relevant server/rate-limit environment knobs.
-- Item 15 is partially implemented with focused coverage for `src/server/http.ts`, `src/adt/btp.ts`, and `src/extract-sap-cookies.ts`. `src/server/server.ts` and any remaining `src/server/xsuaa.ts` branch gaps remain lower-priority follow-up coverage targets.
-- The latest local coverage run after these changes reports statements `82.57%`, branches `73.38%`, functions `88.48%`, and lines `83.79%`.
+- Item 15 is implemented with focused coverage for `src/server/http.ts`, `src/adt/btp.ts`, `src/extract-sap-cookies.ts`, `src/server/server.ts`, and `src/server/xsuaa.ts`.
+- The latest local coverage run after these changes reports statements `83.17%`, branches `73.80%`, functions `88.97%`, and lines `84.41%`.
 
 ## Research Completeness
 
@@ -1325,14 +1325,12 @@ Implemented follow-ups:
 | P1 | Split slow integration/E2E profiles, moved cache warmup/release/broad where-used/full RAP-stack coverage out of the default PR path, and replaced repeated E2E feature probes with cached `SAPManage features`. | GitHub Actions Runtime Deep Dive |
 | P1 | Added a bounded read-only E2E concurrency smoke that records `ARC1_MAX_CONCURRENT`, `ARC1_AUTH_RATE_LIMIT`, and `ARC1_RATE_LIMIT`. | Parallelization Guidance |
 | P1 | Added focused unit coverage for HTTP API-key verifier behavior, BTP startup helpers, and cookie extraction helpers. | Coverage Gaps |
+| P1 | Added the manual `SAP Slow Tests` workflow and validated the first post-merge `workflow_dispatch` run on A4H 2025: slow integration, slow E2E, reliability summary, and required-execution thresholds all passed. | GitHub Actions Runtime Deep Dive |
+| P2 | Continued focused unit coverage for `src/server/server.ts` and XSUAA startup/OAuth-provider paths; the new server handler test also fixed a real `tools/list` deny-action advertisement bug. | Coverage Gaps |
 
 Remaining follow-ups:
 
-| Priority | Follow-up | Source finding |
-|---|---|---|
-| P1 | Measure the new default profile in GitHub Actions and decide whether slow profiles should become manual `workflow_dispatch` jobs, scheduled/nightly jobs, or stay local-only. | GitHub Actions Runtime Deep Dive |
-| P1 | Prepare GitHub Actions to run against the 2025 A4H system instead of the 2023 system, including secret migration, endpoint stability checks, and runtime comparison. | 2025 System Migration |
-| P2 | Continue focused unit coverage for remaining `src/server/server.ts` and branch-heavy XSUAA/server startup paths. | Coverage Gaps |
+No remaining follow-ups from this test-suite audit are open in this document. The old GitHub repository `SAP_*` secrets still exist as external repository state after the `TEST_SAP_*` migration; delete them only after confirming no out-of-band process still depends on those secret names.
 
 ## Raw Suite Summary
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -580,7 +580,7 @@ export function createServer(
 
     // When authenticated, only show tools the user has scopes for
     if (extra.authInfo) {
-      tools = filterToolsByAuthScope(tools, extra.authInfo.scopes);
+      tools = filterToolsByAuthScope(tools, extra.authInfo.scopes, config.denyActions);
     }
 
     return { tools };

--- a/src/server/xsuaa.ts
+++ b/src/server/xsuaa.ts
@@ -249,7 +249,7 @@ export function createChainedTokenVerifier(
  * Solution: Override authorize() to swap the client_id and use a custom fetch() for
  * the token exchange to inject the XSUAA credentials.
  */
-class XsuaaProxyOAuthProvider extends ProxyOAuthServerProvider {
+export class XsuaaProxyOAuthProvider extends ProxyOAuthServerProvider {
   private xsuaaClientId: string;
   private xsuaaClientSecret: string;
   private xsuaaTokenUrl: string;

--- a/tests/unit/server/server.test.ts
+++ b/tests/unit/server/server.test.ts
@@ -1,6 +1,9 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AdtApiError } from '../../../src/adt/errors.js';
 import { AdtHttpClient } from '../../../src/adt/http.js';
@@ -16,6 +19,18 @@ import {
   VERSION,
 } from '../../../src/server/server.js';
 import { DEFAULT_CONFIG } from '../../../src/server/types.js';
+
+type RequestHandler = (
+  request: Record<string, unknown>,
+  extra: { authInfo?: AuthInfo },
+) => Promise<Record<string, any>>;
+
+function requestHandler(server: Server, method: string): RequestHandler {
+  const handlers = (server as unknown as { _requestHandlers: Map<string, RequestHandler> })._requestHandlers;
+  const handler = handlers.get(method);
+  if (!handler) throw new Error(`No request handler registered for ${method}`);
+  return handler;
+}
 
 describe('MCP Server', () => {
   it('creates a server instance with correct name and version', () => {
@@ -110,6 +125,105 @@ describe('MCP Server', () => {
     expect(actionEnum).toEqual(['query']);
   });
 });
+
+describe('createServer request handlers', () => {
+  it('filters listed tools by auth scopes and denyActions', async () => {
+    const server = createServer({
+      ...DEFAULT_CONFIG,
+      allowDataPreview: true,
+      allowWrites: true,
+      allowTransportWrites: true,
+      denyActions: ['SAPRead.TABLE_CONTENTS', 'SAPManage'],
+    });
+    const handler = requestHandler(server, ListToolsRequestSchema.shape.method.value);
+
+    const result = await handler({ method: 'tools/list', params: {} }, { authInfo: readAuth() });
+    const tools = result.tools as Array<Record<string, any>>;
+
+    expect(tools.map((tool) => tool.name)).toContain('SAPRead');
+    expect(tools.map((tool) => tool.name)).not.toContain('SAPManage');
+    const sapRead = tools.find((tool) => tool.name === 'SAPRead');
+    expect(sapRead?.inputSchema.properties.type.enum).not.toContain('TABLE_CONTENTS');
+  });
+
+  it('blocks tool calls before SAP access when startup auth preflight failed', async () => {
+    const server = createServer(
+      DEFAULT_CONFIG,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      Promise.resolve({
+        status: 'failed',
+        blocking: true,
+        endpoint: '/sap/bc/adt/core/discovery',
+        checkedAt: '2026-06-06T00:00:00.000Z',
+        statusCode: 403,
+        reason: 'Access forbidden (403) during startup auth preflight.',
+      }),
+    );
+    const handler = requestHandler(server, CallToolRequestSchema.shape.method.value);
+
+    const result = await handler({ method: 'tools/call', params: { name: 'SAPRead', arguments: {} } }, {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain('Startup authentication preflight failed');
+    expect(result.content?.[0]?.text).toContain('HTTP 403');
+  });
+
+  it('rejects API-key calls in strict principal-propagation mode', async () => {
+    const server = createServer({
+      ...DEFAULT_CONFIG,
+      ppEnabled: true,
+      ppStrict: true,
+    });
+    const handler = requestHandler(server, CallToolRequestSchema.shape.method.value);
+
+    const result = await handler(
+      { method: 'tools/call', params: { name: 'SAPRead', arguments: {} } },
+      {
+        authInfo: {
+          token: 'plain-api-key',
+          clientId: 'api-key:admin',
+          scopes: ['admin'],
+          extra: {},
+        },
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain('Principal propagation requires a JWT token');
+  });
+
+  it('marks default-client cookies stale once after non-blocking cookie preflight 401', async () => {
+    const markSpy = vi.spyOn(AdtHttpClient.prototype, 'markCookiesStale').mockImplementation(() => undefined);
+    const startupAuth = Promise.resolve({
+      status: 'inconclusive' as const,
+      blocking: false,
+      endpoint: '/sap/bc/adt/core/discovery',
+      checkedAt: '2026-06-06T00:00:00.000Z',
+      statusCode: 401,
+      reason: 'stale cookie file',
+    });
+    const server = createServer(DEFAULT_CONFIG, undefined, undefined, undefined, undefined, undefined, startupAuth);
+    const handler = requestHandler(server, CallToolRequestSchema.shape.method.value);
+
+    await handler({ method: 'tools/call', params: { name: 'UnknownTool', arguments: {} } }, {});
+    await handler({ method: 'tools/call', params: { name: 'UnknownTool', arguments: {} } }, {});
+
+    expect(markSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+function readAuth(): AuthInfo {
+  return {
+    token: 'read-token',
+    clientId: 'oidc-client',
+    scopes: ['read', 'data'],
+    extra: {},
+  };
+}
 
 function writeCookieFixture(content: string): { file: string; cleanup: () => void } {
   const dir = mkdtempSync(join(tmpdir(), 'arc1-server-cookies-test-'));

--- a/tests/unit/server/xsuaa.test.ts
+++ b/tests/unit/server/xsuaa.test.ts
@@ -5,8 +5,14 @@
 
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '../../../src/server/logger.js';
 import { createChainedTokenVerifier, qualifyXsuaaScopes, RESERVED_OAUTH_SCOPES } from '../../../src/server/xsuaa.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe('qualifyXsuaaScopes', () => {
   const APP = 'arc1-mcp!t498139';
@@ -262,6 +268,44 @@ const STUB_XSUAA_CREDS = {
   verificationkey: '-----BEGIN PUBLIC KEY-----\nstub\n-----END PUBLIC KEY-----',
 };
 
+function mockFetchResponse({
+  ok,
+  status,
+  json,
+  text = '',
+}: {
+  ok: boolean;
+  status: number;
+  json?: unknown;
+  text?: string;
+}): Response {
+  return {
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(json),
+    text: vi.fn().mockResolvedValue(text),
+  } as unknown as Response;
+}
+
+async function createTestProxyProvider({
+  callbackUrl = 'https://arc1.example.com/oauth/callback',
+  stateToken = 'arc1-state-token',
+}: {
+  callbackUrl?: string;
+  stateToken?: string;
+} = {}) {
+  const { XsuaaProxyOAuthProvider } = await import('../../../src/server/xsuaa.js');
+  const stateCodec = { encode: vi.fn().mockReturnValue(stateToken) };
+  const provider = new XsuaaProxyOAuthProvider(
+    STUB_XSUAA_CREDS,
+    vi.fn(),
+    { getClient: vi.fn() } as any,
+    callbackUrl,
+    stateCodec as any,
+  );
+  return { provider: provider as any, stateCodec };
+}
+
 describe('createXsuaaOAuthProvider', () => {
   it('createXsuaaTokenVerifier returns a function', async () => {
     const { createXsuaaTokenVerifier } = await import('../../../src/server/xsuaa.js');
@@ -356,6 +400,154 @@ describe('createXsuaaOAuthProvider', () => {
     } finally {
       infoSpy.mockRestore();
     }
+  });
+
+  it('authorize redirects to XSUAA with the bound client id, callback URI, qualified scopes, and opaque state', async () => {
+    const { provider, stateCodec } = await createTestProxyProvider({
+      callbackUrl: 'https://arc1.example.com/base/oauth/callback',
+    });
+    const redirect = vi.fn();
+
+    await (provider as any).authorize(
+      { client_id: 'local-client-id', redirect_uris: ['https://client.example.com/callback'] },
+      {
+        state: 'client+state/with/slash',
+        scopes: ['openid', 'read', 'uaa.user', ''],
+        codeChallenge: 'challenge-123',
+        redirectUri: 'https://client.example.com/callback',
+        resource: new URL('https://arc1.example.com/mcp'),
+      },
+      { redirect },
+    );
+
+    const url = new URL(redirect.mock.calls[0]?.[0]);
+    expect(`${url.origin}${url.pathname}`).toBe(`${STUB_XSUAA_CREDS.url}/oauth/authorize`);
+    expect(url.searchParams.get('client_id')).toBe(STUB_XSUAA_CREDS.clientid);
+    expect(url.searchParams.get('redirect_uri')).toBe('https://arc1.example.com/base/oauth/callback');
+    expect(url.searchParams.get('code_challenge')).toBe('challenge-123');
+    expect(url.searchParams.get('scope')).toBe('openid arc1.read uaa.user');
+    expect(url.searchParams.get('resource')).toBe('https://arc1.example.com/mcp');
+    expect(url.searchParams.get('state')).toBe('arc1-state-token');
+    expect(stateCodec.encode).toHaveBeenCalledWith({
+      clientState: 'client+state/with/slash',
+      clientRedirectUri: 'https://client.example.com/callback',
+      clientId: 'local-client-id',
+    });
+  });
+
+  it('exchanges authorization codes with XSUAA credentials and ARC-1 callback URI', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockFetchResponse({
+        ok: true,
+        status: 200,
+        json: {
+          access_token: 'access-token',
+          expires_in: 3600,
+          refresh_token: 'refresh-token',
+          scope: 'openid arc1.read',
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { provider } = await createTestProxyProvider();
+
+    const token = await (provider as any).exchangeAuthorizationCode(
+      { client_id: 'local-client-id' },
+      'auth-code',
+      'verifier',
+      'https://client.example.com/callback',
+    );
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = new URLSearchParams(init.body as string);
+    expect(url).toBe(`${STUB_XSUAA_CREDS.url}/oauth/token`);
+    expect(init.method).toBe('POST');
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('code')).toBe('auth-code');
+    expect(body.get('code_verifier')).toBe('verifier');
+    expect(body.get('client_id')).toBe(STUB_XSUAA_CREDS.clientid);
+    expect(body.get('client_secret')).toBe(STUB_XSUAA_CREDS.clientsecret);
+    expect(body.get('redirect_uri')).toBe('https://arc1.example.com/oauth/callback');
+    expect(token).toMatchObject({
+      access_token: 'access-token',
+      token_type: 'bearer',
+      expires_in: 3600,
+      refresh_token: 'refresh-token',
+      scope: 'openid arc1.read',
+    });
+  });
+
+  it('throws a concise error when XSUAA authorization-code exchange fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ ok: false, status: 502, text: 'bad gateway' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    const { provider } = await createTestProxyProvider();
+
+    await expect(
+      (provider as any).exchangeAuthorizationCode({ client_id: 'local-client-id' }, 'auth-code'),
+    ).rejects.toThrow('XSUAA token exchange failed: 502');
+    expect(errorSpy).toHaveBeenCalledWith('XSUAA token exchange failed', expect.objectContaining({ status: 502 }));
+  });
+
+  it('exchanges refresh tokens with XSUAA credentials', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockFetchResponse({
+        ok: true,
+        status: 200,
+        json: {
+          access_token: 'fresh-access',
+          token_type: 'bearer',
+          refresh_token: 'fresh-refresh',
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { provider } = await createTestProxyProvider();
+
+    const token = await (provider as any).exchangeRefreshToken({ client_id: 'local-client-id' }, 'old-refresh');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('old-refresh');
+    expect(body.get('client_id')).toBe(STUB_XSUAA_CREDS.clientid);
+    expect(token).toMatchObject({ access_token: 'fresh-access', refresh_token: 'fresh-refresh' });
+  });
+
+  it('warns but does not throw when revocation returns a non-2xx response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ ok: false, status: 400, text: 'bad token' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const { provider } = await createTestProxyProvider();
+
+    await (provider as any).revokeToken(
+      { client_id: 'local-client-id' },
+      { token: 'tok', token_type_hint: 'access_token' },
+    );
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = new URLSearchParams(init.body as string);
+    expect(url).toBe(`${STUB_XSUAA_CREDS.url}/oauth/revoke`);
+    expect(init.headers).toMatchObject({
+      Authorization: `Basic ${Buffer.from(`${STUB_XSUAA_CREDS.clientid}:${STUB_XSUAA_CREDS.clientsecret}`).toString('base64')}`,
+    });
+    expect(body.get('token')).toBe('tok');
+    expect(body.get('token_type_hint')).toBe('access_token');
+    expect(warnSpy).toHaveBeenCalledWith('XSUAA token revocation failed', expect.objectContaining({ status: 400 }));
+  });
+
+  it('logs revocation network errors without throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const { provider } = await createTestProxyProvider();
+
+    await expect(
+      (provider as any).revokeToken({ client_id: 'local-client-id' }, { token: 'tok' }),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'XSUAA token revocation error',
+      expect.objectContaining({ error: 'network down' }),
+    );
   });
 });
 


### PR DESCRIPTION
## Goal

Close the remaining slow-suite baseline and coverage follow-ups after PR #361/#366 landed.

## Changes

- Documented the first post-merge manual `SAP Slow Tests` run against A4H 2025: run `27068686650` passed, with slow integration in 51s and slow E2E in 3m45s.
- Moved the manual slow workflow plan to `docs/plans/completed/` and updated the runtime/A4H/test-suite audit docs with the completed baseline.
- Added focused unit coverage for `src/server/server.ts` request-handler paths and XSUAA OAuth-provider branches.
- Fixed a real listing bug found by the new coverage: `tools/list` now applies `config.denyActions`, so denied tools/actions are not advertised to authenticated clients.
- Adjusted the XSUAA provider-method tests to use direct provider construction with fake collaborators, avoiding a CodeQL password-hash false-positive path through the OAuth state HMAC while keeping the redirect/token/revocation behavior covered.

## Validation

Local final-head checks:

- `npx vitest run tests/unit/server/server.test.ts tests/unit/server/xsuaa.test.ts`
- `npx vitest run tests/unit/server/server.test.ts tests/unit/server/xsuaa.test.ts --coverage --coverage.include=src/server/server.ts --coverage.include=src/server/xsuaa.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

GitHub validation:

- PR `Test` workflow run `27069334222`: gate, Node 22/24 unit+coverage matrix, integration, E2E, and reliability summary all passed.
- PR CodeQL run `27069333515` plus GitHub Advanced Security CodeQL check passed.
- PR Dependency Review run `27069334233` passed.
- Manual `SAP Slow Tests` run `27068686650` passed on `main`.