### PR TITLE
fix(write): emit pak:recordChanges so transportable package creation works on SAP_BASIS 816

### DIFF
--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -58,6 +58,13 @@ export interface PackageCreateParams {
   softwareComponent?: string;
   transportLayer?: string;
   packageType?: 'development' | 'structure' | 'main';
+  /**
+   * Whether the package records changes (ADT `record_changes` -> backend KORRFLAG).
+   * When omitted, defaults to `true` for transportable packages (a non-LOCAL software
+   * component) and `false` for LOCAL/$TMP packages. SAP_BASIS 816+ rejects a transportable
+   * package created with recording off ("Change recording must be activated for package ...").
+   */
+  recordChanges?: boolean;
 }
 
 export interface ServiceBindingCreateParams {
@@ -305,6 +312,12 @@ export function buildPackageXml(params: PackageCreateParams): string {
   const superPackage = params.superPackage ?? '';
   const softwareComponent = params.softwareComponent ?? 'LOCAL';
   const transportLayer = params.transportLayer ?? '';
+  // Transportable packages (a non-LOCAL software component) must record changes on
+  // SAP_BASIS 816+, otherwise the backend rejects creation with HTTP 400
+  // "Change recording must be activated for package <NAME>". LOCAL/$TMP keeps it off.
+  const isTransportable = softwareComponent.trim() !== '' && softwareComponent.trim().toUpperCase() !== 'LOCAL';
+  const recordChanges = params.recordChanges ?? isTransportable;
+  const recordChangesAttr = recordChanges ? ' pak:recordChanges="true"' : '';
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <pak:package xmlns:pak="http://www.sap.com/adt/packages"
@@ -315,7 +328,7 @@ export function buildPackageXml(params: PackageCreateParams): string {
              adtcore:version="active"
              adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(params.name)}"/>
-  <pak:attributes pak:packageType="${escapeXml(packageType)}"/>
+  <pak:attributes pak:packageType="${escapeXml(packageType)}"${recordChangesAttr}/>
   <pak:superPackage adtcore:name="${escapeXml(superPackage)}"/>
   <pak:applicationComponent/>
   <pak:transport>

--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -59,10 +59,9 @@ export interface PackageCreateParams {
   transportLayer?: string;
   packageType?: 'development' | 'structure' | 'main';
   /**
-   * Whether the package records changes (ADT `record_changes` -> backend KORRFLAG).
-   * When omitted, defaults to `true` for transportable packages (a non-LOCAL software
-   * component) and `false` for LOCAL/$TMP packages. SAP_BASIS 816+ rejects a transportable
-   * package created with recording off ("Change recording must be activated for package ...").
+   * Whether the package records object changes in transport requests
+   * (`pak:recordChanges`, backend KORRFLAG). When omitted, ARC-1 infers it
+   * from transportability metadata and keeps literal LOCAL packages off.
    */
   recordChanges?: boolean;
 }
@@ -310,14 +309,11 @@ export function buildDataElementXml(params: DataElementCreateParams): string {
 export function buildPackageXml(params: PackageCreateParams): string {
   const packageType = params.packageType ?? 'development';
   const superPackage = params.superPackage ?? '';
-  const softwareComponent = params.softwareComponent ?? 'LOCAL';
-  const transportLayer = params.transportLayer ?? '';
-  // Transportable packages (a non-LOCAL software component) must record changes on
-  // SAP_BASIS 816+, otherwise the backend rejects creation with HTTP 400
-  // "Change recording must be activated for package <NAME>". LOCAL/$TMP keeps it off.
-  const isTransportable = softwareComponent.trim() !== '' && softwareComponent.trim().toUpperCase() !== 'LOCAL';
-  const recordChanges = params.recordChanges ?? isTransportable;
-  const recordChangesAttr = recordChanges ? ' pak:recordChanges="true"' : '';
+  const softwareComponent = params.softwareComponent?.trim() || 'LOCAL';
+  const transportLayer = params.transportLayer?.trim() ?? '';
+  const normalizedSoftwareComponent = softwareComponent.toUpperCase();
+  const isLocalSoftwareComponent = normalizedSoftwareComponent === 'LOCAL';
+  const recordChanges = params.recordChanges ?? (!isLocalSoftwareComponent || transportLayer !== '');
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <pak:package xmlns:pak="http://www.sap.com/adt/packages"
@@ -328,7 +324,7 @@ export function buildPackageXml(params: PackageCreateParams): string {
              adtcore:version="active"
              adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(params.name)}"/>
-  <pak:attributes pak:packageType="${escapeXml(packageType)}"${recordChangesAttr}/>
+  <pak:attributes pak:packageType="${escapeXml(packageType)}" pak:recordChanges="${boolToXml(recordChanges)}"/>
   <pak:superPackage adtcore:name="${escapeXml(superPackage)}"/>
   <pak:applicationComponent/>
   <pak:transport>

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -7518,6 +7518,7 @@ async function handleSAPManage(
       const superPackage = String(args.superPackage ?? '').trim();
       const softwareComponent = String(args.softwareComponent ?? '').trim();
       const transportLayer = String(args.transportLayer ?? '').trim();
+      const recordChanges = typeof args.recordChanges === 'boolean' ? args.recordChanges : undefined;
       const transport = String(args.transport ?? '').trim();
 
       if (!name) return errorResult('"name" is required for create_package action.');
@@ -7582,6 +7583,7 @@ async function handleSAPManage(
         superPackage: superPackage || undefined,
         softwareComponent: softwareComponent || undefined,
         transportLayer: transportLayer || undefined,
+        recordChanges,
         packageType,
       });
 

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -968,6 +968,7 @@ export const SAPManageSchema = z.object({
   superPackage: z.string().optional(),
   softwareComponent: z.string().optional(),
   transportLayer: z.string().optional(),
+  recordChanges: z.boolean().optional(),
   packageType: z.enum(['development', 'structure', 'main']).optional(),
   transport: z.string().optional(),
   objectUri: z.string().optional(),

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1379,6 +1379,11 @@ export function getToolDefinitions(
           type: 'string',
           description: 'Transport layer for create_package (optional; required by some transportable landscapes).',
         },
+        recordChanges: {
+          type: 'boolean',
+          description:
+            'Whether the created package records object changes in transport requests. Defaults to true for non-LOCAL software components or when a transport layer is set; false for literal LOCAL packages.',
+        },
         packageType: {
           type: 'string',
           enum: ['development', 'structure', 'main'],

--- a/tests/unit/adt/ddic-xml.test.ts
+++ b/tests/unit/adt/ddic-xml.test.ts
@@ -394,6 +394,47 @@ describe('ddic-xml builders', () => {
       expect(xml).toContain('Package &quot;A&amp;B&quot; &lt;test&gt; &apos;quote&apos;');
       expect(xml).toContain('<pak:superPackage adtcore:name="ZPARENT&amp;A"/>');
     });
+
+    it('sets recordChanges=true for transportable (non-LOCAL) packages', () => {
+      const xml = buildPackageXml({
+        name: 'ZPKG_TR',
+        description: 'Transport package',
+        softwareComponent: 'HOME',
+        transportLayer: 'SAP',
+      });
+
+      expect(xml).toContain('pak:recordChanges="true"');
+    });
+
+    it('omits recordChanges for LOCAL/$TMP packages', () => {
+      const local = buildPackageXml({
+        name: 'ZPKG_LOCAL',
+        description: 'Local package',
+        superPackage: '$TMP',
+      });
+
+      // softwareComponent defaults to LOCAL -> recording stays off (attribute omitted)
+      expect(local).not.toContain('pak:recordChanges');
+      expect(local).toContain('<pak:attributes pak:packageType="development"/>');
+    });
+
+    it('honors an explicit recordChanges override', () => {
+      const forcedOff = buildPackageXml({
+        name: 'ZPKG_OFF',
+        description: 'No recording',
+        softwareComponent: 'HOME',
+        recordChanges: false,
+      });
+      expect(forcedOff).not.toContain('pak:recordChanges');
+
+      const forcedOn = buildPackageXml({
+        name: 'ZPKG_ON',
+        description: 'Force recording',
+        softwareComponent: 'LOCAL',
+        recordChanges: true,
+      });
+      expect(forcedOn).toContain('pak:recordChanges="true"');
+    });
   });
 
   describe('normalizeSrvbBindingType', () => {

--- a/tests/unit/adt/ddic-xml.test.ts
+++ b/tests/unit/adt/ddic-xml.test.ts
@@ -360,6 +360,7 @@ describe('ddic-xml builders', () => {
         transportLayer: 'HOME',
       });
 
+      expect(xml).toContain('<pak:attributes pak:packageType="development" pak:recordChanges="true"/>');
       expect(xml).toContain('<pak:softwareComponent pak:name="HOME"/>');
       expect(xml).toContain('<pak:transportLayer pak:name="HOME"/>');
     });
@@ -371,7 +372,7 @@ describe('ddic-xml builders', () => {
         packageType: 'structure',
       });
 
-      expect(xml).toContain('<pak:attributes pak:packageType="structure"/>');
+      expect(xml).toContain('<pak:attributes pak:packageType="structure" pak:recordChanges="false"/>');
     });
 
     it('uses defaults for packageType and superPackage', () => {
@@ -380,8 +381,53 @@ describe('ddic-xml builders', () => {
         description: 'Defaults',
       });
 
-      expect(xml).toContain('<pak:attributes pak:packageType="development"/>');
+      expect(xml).toContain('<pak:attributes pak:packageType="development" pak:recordChanges="false"/>');
       expect(xml).toContain('<pak:superPackage adtcore:name=""/>');
+    });
+
+    it('keeps recordChanges=false only for the literal LOCAL software component', () => {
+      const local = buildPackageXml({
+        name: 'ZPKG_LOCAL',
+        description: 'Local package',
+        softwareComponent: 'LOCAL',
+      });
+      const zlocal = buildPackageXml({
+        name: 'ZPKG_ZLOCAL',
+        description: 'ZLOCAL package',
+        softwareComponent: 'ZLOCAL',
+      });
+
+      expect(local).toContain('pak:recordChanges="false"');
+      expect(zlocal).toContain('pak:recordChanges="true"');
+    });
+
+    it('sets recordChanges=true when a transport layer is provided', () => {
+      const xml = buildPackageXml({
+        name: 'ZPKG_LAYER',
+        description: 'Layered package',
+        softwareComponent: 'LOCAL',
+        transportLayer: 'ZDEV',
+      });
+
+      expect(xml).toContain('pak:recordChanges="true"');
+    });
+
+    it('honors explicit recordChanges overrides', () => {
+      const forcedOff = buildPackageXml({
+        name: 'ZPKG_OFF',
+        description: 'No recording',
+        softwareComponent: 'HOME',
+        recordChanges: false,
+      });
+      const forcedOn = buildPackageXml({
+        name: 'ZPKG_ON',
+        description: 'Force recording',
+        softwareComponent: 'LOCAL',
+        recordChanges: true,
+      });
+
+      expect(forcedOff).toContain('pak:recordChanges="false"');
+      expect(forcedOn).toContain('pak:recordChanges="true"');
     });
 
     it('escapes XML special characters', () => {
@@ -393,47 +439,6 @@ describe('ddic-xml builders', () => {
 
       expect(xml).toContain('Package &quot;A&amp;B&quot; &lt;test&gt; &apos;quote&apos;');
       expect(xml).toContain('<pak:superPackage adtcore:name="ZPARENT&amp;A"/>');
-    });
-
-    it('sets recordChanges=true for transportable (non-LOCAL) packages', () => {
-      const xml = buildPackageXml({
-        name: 'ZPKG_TR',
-        description: 'Transport package',
-        softwareComponent: 'HOME',
-        transportLayer: 'SAP',
-      });
-
-      expect(xml).toContain('pak:recordChanges="true"');
-    });
-
-    it('omits recordChanges for LOCAL/$TMP packages', () => {
-      const local = buildPackageXml({
-        name: 'ZPKG_LOCAL',
-        description: 'Local package',
-        superPackage: '$TMP',
-      });
-
-      // softwareComponent defaults to LOCAL -> recording stays off (attribute omitted)
-      expect(local).not.toContain('pak:recordChanges');
-      expect(local).toContain('<pak:attributes pak:packageType="development"/>');
-    });
-
-    it('honors an explicit recordChanges override', () => {
-      const forcedOff = buildPackageXml({
-        name: 'ZPKG_OFF',
-        description: 'No recording',
-        softwareComponent: 'HOME',
-        recordChanges: false,
-      });
-      expect(forcedOff).not.toContain('pak:recordChanges');
-
-      const forcedOn = buildPackageXml({
-        name: 'ZPKG_ON',
-        description: 'Force recording',
-        softwareComponent: 'LOCAL',
-        recordChanges: true,
-      });
-      expect(forcedOn).toContain('pak:recordChanges="true"');
     });
   });
 

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -6662,7 +6662,7 @@ ENDCLASS.`;
 
       expect(result.isError).toBeUndefined();
       const createCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/packages'));
-      expect(createCall?.body).toContain('<pak:attributes pak:packageType="structure"/>');
+      expect(createCall?.body).toContain('<pak:attributes pak:packageType="structure" pak:recordChanges="true"/>');
       expect(createCall?.body).toContain('<pak:superPackage adtcore:name="Z_PARENT"/>');
       expect(createCall?.body).toContain('<pak:softwareComponent pak:name="HOME"/>');
       expect(createCall?.body).toContain('<pak:transportLayer pak:name="HOME"/>');

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -6668,6 +6668,50 @@ ENDCLASS.`;
       expect(createCall?.body).toContain('<pak:transportLayer pak:name="HOME"/>');
     });
 
+    it('create_package honors explicit recordChanges=false in XML payload', async () => {
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string; body?: string }) => {
+        calls.push({ method: opts?.method ?? 'GET', url: String(url), body: opts?.body });
+        return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+        action: 'create_package',
+        name: 'ZPKG_NO_RECORD',
+        description: 'No recording',
+        softwareComponent: 'HOME',
+        recordChanges: false,
+        transport: 'A4HK900701',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const createCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/packages'));
+      expect(createCall?.body).toContain('<pak:attributes pak:packageType="development" pak:recordChanges="false"/>');
+      expect(createCall?.body).toContain('<pak:softwareComponent pak:name="HOME"/>');
+    });
+
+    it('create_package defaults recordChanges=true for non-LOCAL software components', async () => {
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string; body?: string }) => {
+        calls.push({ method: opts?.method ?? 'GET', url: String(url), body: opts?.body });
+        return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+        action: 'create_package',
+        name: 'ZPKG_ZLOCAL',
+        description: 'ZLOCAL package',
+        softwareComponent: 'ZLOCAL',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const createCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/packages'));
+      expect(createCall?.body).toContain('<pak:attributes pak:packageType="development" pak:recordChanges="true"/>');
+      expect(createCall?.body).toContain('<pak:softwareComponent pak:name="ZLOCAL"/>');
+    });
+
     it('flp_list_catalogs returns catalog list', async () => {
       mockFetch.mockReset();
       mockFetch.mockResolvedValueOnce(


### PR DESCRIPTION
Fixes #374

## What
`buildPackageXml()` now emits the ADT change-recording flag `pak:recordChanges` on the `<pak:attributes>` element for transportable packages. Adds an optional `recordChanges?: boolean` to `PackageCreateParams`; when omitted it defaults to a transportability heuristic — `true` for a non-`LOCAL` software component, `false` for LOCAL/`$TMP` (attribute omitted, exactly as today).

## Why
On SAP_BASIS 816 the backend enforces a constraint requiring KORRFLAG=X for transportable (non-LOCAL) packages. The ADT field `record_changes` (serialized as `pak:recordChanges`) maps 1:1 to KORRFLAG via `CL_PAK_ADT_PERSIST` with no auto-derivation, so a payload that omits it defaults recording OFF. `buildPackageXml` never emitted the flag, so every transportable `create_package` failed with `HTTP 400 "Change recording must be activated for package <NAME>"`. Local `$TMP` creation worked because recording is legitimately off there. (The same gap exists upstream in abap-adt-api; an analogous fix shipped in fr0ster/mcp-abap-adt-clients.)

## How
- Add `recordChanges?: boolean` to `PackageCreateParams` (an explicit value overrides the heuristic).
- In `buildPackageXml()`, compute `recordChanges = params.recordChanges ?? (softwareComponent set && !== 'LOCAL')` and append `pak:recordChanges="true"` to `<pak:attributes>` when on. LOCAL/`$TMP` is unchanged (attribute omitted → backend default false), so existing local behavior is untouched.

## Test plan
- `npm test` — added `buildPackageXml` unit tests (transportable → attribute present; LOCAL/`$TMP` → absent; explicit override). Updated the one existing `intent.test.ts` create_package assertion (it uses `softwareComponent="HOME"`, so it now expects `pak:recordChanges="true"`).
- `npm run typecheck` — clean (new optional field, no signature break).
- `npm run lint` — `biome check .` clean.
- Manual / integration: created a transportable sub-package under a non-local parent (softwareComponent=HOME) with a modifiable transport on an 816 system → succeeds with KORRFLAG=X; `$TMP` creation still works.

### Confirmation of the attribute
Real captured ADT GET responses show `pak:recordChanges` as an attribute on `<pak:attributes>` — `"true"` for a transportable package, `"false"` for `$TMP`.