### PR TITLE
[codex] fix package recordChanges handling

### DIFF
--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -58,6 +58,12 @@ export interface PackageCreateParams {
   softwareComponent?: string;
   transportLayer?: string;
   packageType?: 'development' | 'structure' | 'main';
+  /**
+   * Whether the package records object changes in transport requests
+   * (`pak:recordChanges`, backend KORRFLAG). When omitted, ARC-1 infers it
+   * from transportability metadata and keeps literal LOCAL packages off.
+   */
+  recordChanges?: boolean;
 }
 
 export interface ServiceBindingCreateParams {
@@ -303,8 +309,11 @@ export function buildDataElementXml(params: DataElementCreateParams): string {
 export function buildPackageXml(params: PackageCreateParams): string {
   const packageType = params.packageType ?? 'development';
   const superPackage = params.superPackage ?? '';
-  const softwareComponent = params.softwareComponent ?? 'LOCAL';
-  const transportLayer = params.transportLayer ?? '';
+  const softwareComponent = params.softwareComponent?.trim() || 'LOCAL';
+  const transportLayer = params.transportLayer?.trim() ?? '';
+  const normalizedSoftwareComponent = softwareComponent.toUpperCase();
+  const isLocalSoftwareComponent = normalizedSoftwareComponent === 'LOCAL';
+  const recordChanges = params.recordChanges ?? (!isLocalSoftwareComponent || transportLayer !== '');
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <pak:package xmlns:pak="http://www.sap.com/adt/packages"
@@ -315,7 +324,7 @@ export function buildPackageXml(params: PackageCreateParams): string {
              adtcore:version="active"
              adtcore:responsible="DEVELOPER">
   <adtcore:packageRef adtcore:name="${escapeXml(params.name)}"/>
-  <pak:attributes pak:packageType="${escapeXml(packageType)}"/>
+  <pak:attributes pak:packageType="${escapeXml(packageType)}" pak:recordChanges="${boolToXml(recordChanges)}"/>
   <pak:superPackage adtcore:name="${escapeXml(superPackage)}"/>
   <pak:applicationComponent/>
   <pak:transport>

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -7518,6 +7518,7 @@ async function handleSAPManage(
       const superPackage = String(args.superPackage ?? '').trim();
       const softwareComponent = String(args.softwareComponent ?? '').trim();
       const transportLayer = String(args.transportLayer ?? '').trim();
+      const recordChanges = typeof args.recordChanges === 'boolean' ? args.recordChanges : undefined;
       const transport = String(args.transport ?? '').trim();
 
       if (!name) return errorResult('"name" is required for create_package action.');
@@ -7582,6 +7583,7 @@ async function handleSAPManage(
         superPackage: superPackage || undefined,
         softwareComponent: softwareComponent || undefined,
         transportLayer: transportLayer || undefined,
+        recordChanges,
         packageType,
       });
 

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -968,6 +968,7 @@ export const SAPManageSchema = z.object({
   superPackage: z.string().optional(),
   softwareComponent: z.string().optional(),
   transportLayer: z.string().optional(),
+  recordChanges: z.boolean().optional(),
   packageType: z.enum(['development', 'structure', 'main']).optional(),
   transport: z.string().optional(),
   objectUri: z.string().optional(),

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1379,6 +1379,11 @@ export function getToolDefinitions(
           type: 'string',
           description: 'Transport layer for create_package (optional; required by some transportable landscapes).',
         },
+        recordChanges: {
+          type: 'boolean',
+          description:
+            'Whether the created package records object changes in transport requests. Defaults to true for non-LOCAL software components or when a transport layer is set; false for literal LOCAL packages.',
+        },
         packageType: {
           type: 'string',
           enum: ['development', 'structure', 'main'],

--- a/tests/unit/adt/ddic-xml.test.ts
+++ b/tests/unit/adt/ddic-xml.test.ts
@@ -360,6 +360,7 @@ describe('ddic-xml builders', () => {
         transportLayer: 'HOME',
       });
 
+      expect(xml).toContain('<pak:attributes pak:packageType="development" pak:recordChanges="true"/>');
       expect(xml).toContain('<pak:softwareComponent pak:name="HOME"/>');
       expect(xml).toContain('<pak:transportLayer pak:name="HOME"/>');
     });
@@ -371,7 +372,7 @@ describe('ddic-xml builders', () => {
         packageType: 'structure',
       });
 
-      expect(xml).toContain('<pak:attributes pak:packageType="structure"/>');
+      expect(xml).toContain('<pak:attributes pak:packageType="structure" pak:recordChanges="false"/>');
     });
 
     it('uses defaults for packageType and superPackage', () => {
@@ -380,8 +381,53 @@ describe('ddic-xml builders', () => {
         description: 'Defaults',
       });
 
-      expect(xml).toContain('<pak:attributes pak:packageType="development"/>');
+      expect(xml).toContain('<pak:attributes pak:packageType="development" pak:recordChanges="false"/>');
       expect(xml).toContain('<pak:superPackage adtcore:name=""/>');
+    });
+
+    it('keeps recordChanges=false only for the literal LOCAL software component', () => {
+      const local = buildPackageXml({
+        name: 'ZPKG_LOCAL',
+        description: 'Local package',
+        softwareComponent: 'LOCAL',
+      });
+      const zlocal = buildPackageXml({
+        name: 'ZPKG_ZLOCAL',
+        description: 'ZLOCAL package',
+        softwareComponent: 'ZLOCAL',
+      });
+
+      expect(local).toContain('pak:recordChanges="false"');
+      expect(zlocal).toContain('pak:recordChanges="true"');
+    });
+
+    it('sets recordChanges=true when a transport layer is provided', () => {
+      const xml = buildPackageXml({
+        name: 'ZPKG_LAYER',
+        description: 'Layered package',
+        softwareComponent: 'LOCAL',
+        transportLayer: 'ZDEV',
+      });
+
+      expect(xml).toContain('pak:recordChanges="true"');
+    });
+
+    it('honors explicit recordChanges overrides', () => {
+      const forcedOff = buildPackageXml({
+        name: 'ZPKG_OFF',
+        description: 'No recording',
+        softwareComponent: 'HOME',
+        recordChanges: false,
+      });
+      const forcedOn = buildPackageXml({
+        name: 'ZPKG_ON',
+        description: 'Force recording',
+        softwareComponent: 'LOCAL',
+        recordChanges: true,
+      });
+
+      expect(forcedOff).toContain('pak:recordChanges="false"');
+      expect(forcedOn).toContain('pak:recordChanges="true"');
     });
 
     it('escapes XML special characters', () => {

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -6662,10 +6662,54 @@ ENDCLASS.`;
 
       expect(result.isError).toBeUndefined();
       const createCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/packages'));
-      expect(createCall?.body).toContain('<pak:attributes pak:packageType="structure"/>');
+      expect(createCall?.body).toContain('<pak:attributes pak:packageType="structure" pak:recordChanges="true"/>');
       expect(createCall?.body).toContain('<pak:superPackage adtcore:name="Z_PARENT"/>');
       expect(createCall?.body).toContain('<pak:softwareComponent pak:name="HOME"/>');
       expect(createCall?.body).toContain('<pak:transportLayer pak:name="HOME"/>');
+    });
+
+    it('create_package honors explicit recordChanges=false in XML payload', async () => {
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string; body?: string }) => {
+        calls.push({ method: opts?.method ?? 'GET', url: String(url), body: opts?.body });
+        return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+        action: 'create_package',
+        name: 'ZPKG_NO_RECORD',
+        description: 'No recording',
+        softwareComponent: 'HOME',
+        recordChanges: false,
+        transport: 'A4HK900701',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const createCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/packages'));
+      expect(createCall?.body).toContain('<pak:attributes pak:packageType="development" pak:recordChanges="false"/>');
+      expect(createCall?.body).toContain('<pak:softwareComponent pak:name="HOME"/>');
+    });
+
+    it('create_package defaults recordChanges=true for non-LOCAL software components', async () => {
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string; body?: string }) => {
+        calls.push({ method: opts?.method ?? 'GET', url: String(url), body: opts?.body });
+        return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+        action: 'create_package',
+        name: 'ZPKG_ZLOCAL',
+        description: 'ZLOCAL package',
+        softwareComponent: 'ZLOCAL',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const createCall = calls.find((c) => c.method === 'POST' && c.url.includes('/sap/bc/adt/packages'));
+      expect(createCall?.body).toContain('<pak:attributes pak:packageType="development" pak:recordChanges="true"/>');
+      expect(createCall?.body).toContain('<pak:softwareComponent pak:name="ZLOCAL"/>');
     });
 
     it('flp_list_catalogs returns catalog list', async () => {


### PR DESCRIPTION
Fixes #374.

## What

This updates `SAPManage(action="create_package")` and the package XML builder to set ADT package change recording explicitly via `pak:recordChanges`.

Compared with PR #375, this keeps the core fix for transportable packages and also:

- exposes `recordChanges?: boolean` in the public `SAPManage` schema and tool definition
- passes explicit `true` and `false` through the handler into `buildPackageXml()`
- defaults `pak:recordChanges="false"` only for the literal `LOCAL` software component with no transport layer
- defaults `pak:recordChanges="true"` for non-`LOCAL` software components, including `ZLOCAL`, and whenever a transport layer is supplied
- serializes `pak:recordChanges="true"` or `"false"` explicitly instead of relying on backend defaults

## Why

SAP_BASIS 816 rejects transportable package creation when the package is created without change recording active. Research showed `pak:recordChanges` is a first-class ADT package attribute, separate from the `corrNr` transport assignment.

Live S/4HANA 2023 evidence also showed that `ZLOCAL` must not be hard-coded as non-recording: on the test system, package `ZLOCAL` has `softwareComponent="ZLOCAL"`, `recordChanges="true"`, and requires a transport for child package creation. So the safe inferred default is only literal `LOCAL` => false; every named non-`LOCAL` component should record unless the caller explicitly overrides it.

## Tests

Local:

- `npm test -- tests/unit/adt/ddic-xml.test.ts tests/unit/handlers/intent.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npm test`

Live SAP checks:

- S/4HANA 2023 / SAP_BASIS 758: integration release smoke passed (`gets structured system info with user`, `gets installed components`).
- S/4HANA 2023 / SAP_BASIS 758: `SAPManage(create_package)` under `ZLOCAL` with an existing modifiable transport created a package, ADT readback returned `softwareComponent="ZLOCAL"` and `recordChanges="true"`, then `SAPManage(delete_package)` deleted it and a follow-up read returned 404.
- NetWeaver 7.50 / SAP_BASIS 750: integration release smoke passed (`gets structured system info with user`, `gets installed components`).
- NetWeaver 7.50 / SAP_BASIS 750: guarded `SAPManage(create_package)` returned ADT 404 `No suitable resource found` for `/sap/bc/adt/packages`; this confirms the package-create endpoint is not available on that 7.50 ADT stack, while general ADT connectivity works.

Note: `npm ci` was run before validation because the existing `node_modules` tree was out of sync with `package-lock.json`. The install completed with the existing Node engine warning (`current v22.21.1`, required `>=22.22.1`), and no dependency files changed.
