### PR TITLE
fix(write): thread logon user into adtcore:responsible

### DIFF
--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -26,6 +26,8 @@ export interface DomainCreateParams {
   valueTable?: string;
   /** ADT master/original language (2-char, e.g. "DE"). Defaults to "EN" when unset. */
   language?: string;
+  /** ADT "person responsible" (logon user). Defaults to "DEVELOPER" when unset. */
+  responsible?: string;
 }
 
 export interface DataElementCreateParams {
@@ -49,6 +51,8 @@ export interface DataElementCreateParams {
   changeDocument?: boolean;
   /** ADT master/original language (2-char, e.g. "DE"). Defaults to "EN" when unset. */
   language?: string;
+  /** ADT "person responsible" (logon user). Defaults to "DEVELOPER" when unset. */
+  responsible?: string;
 }
 
 export interface PackageCreateParams {
@@ -64,6 +68,8 @@ export interface PackageCreateParams {
    * from transportability metadata and keeps literal LOCAL packages off.
    */
   recordChanges?: boolean;
+  /** ADT "person responsible" (logon user). Defaults to "DEVELOPER" when unset. */
+  responsible?: string;
 }
 
 export interface ServiceBindingCreateParams {
@@ -77,6 +83,8 @@ export interface ServiceBindingCreateParams {
   odataVersion?: string;
   /** ADT master/original language (2-char, e.g. "DE"). Defaults to "EN" when unset. */
   language?: string;
+  /** ADT "person responsible" (logon user). Defaults to "DEVELOPER" when unset. */
+  responsible?: string;
 }
 
 /**
@@ -137,6 +145,23 @@ export function normalizeAdtLanguage(language?: string): string {
   return (language ?? '').trim().toUpperCase() || 'EN';
 }
 
+/**
+ * Normalize the ADT "person responsible" to the form SAP expects: trimmed and
+ * upper-case (on-prem `USR02-BNAME` is upper-case). Defaults to "DEVELOPER"
+ * only as a last-resort fallback when no user is configured, preserving the
+ * legacy hard-coded value for callers that pass nothing.
+ *
+ * `adtcore:responsible` must name a user that exists on the target system. The
+ * historical hard-coded literal "DEVELOPER" only exists on SAP's own demo
+ * systems; on a real system the create fails with
+ * `HTTP 400 [?/049] "Enter a valid user, not DEVELOPER, as the person responsible"`.
+ * Threading the connection's logon user (ARC-1 passes it as `config.username`)
+ * fixes that. Mirrors the `normalizeAdtLanguage` / issue #343 master-language pattern.
+ */
+export function normalizeAdtResponsible(responsible?: string): string {
+  return (responsible ?? '').trim().toUpperCase() || 'DEVELOPER';
+}
+
 function escapeXml(s: string): string {
   return s
     .replace(/&/g, '&amp;')
@@ -172,6 +197,7 @@ function boolToXml(value: boolean | undefined): string {
 
 export function buildDomainXml(params: DomainCreateParams): string {
   const masterLanguage = normalizeAdtLanguage(params.language);
+  const responsible = normalizeAdtResponsible(params.responsible);
   const fixedValues = params.fixedValues ?? [];
   const valueTable = params.valueTable?.trim();
   const fixValuesXml =
@@ -198,7 +224,7 @@ export function buildDomainXml(params: DomainCreateParams): string {
              adtcore:type="DOMA/DD"
              adtcore:masterLanguage="${masterLanguage}"
              adtcore:masterSystem="H00"
-             adtcore:responsible="DEVELOPER">
+             adtcore:responsible="${escapeXml(responsible)}">
   <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>
   <doma:content>
     <doma:typeInformation>
@@ -259,6 +285,7 @@ export function buildMessageClassXml(params: MessageClassCreateParams): string {
 
 export function buildDataElementXml(params: DataElementCreateParams): string {
   const masterLanguage = normalizeAdtLanguage(params.language);
+  const responsible = normalizeAdtResponsible(params.responsible);
   const typeKind = params.typeKind ?? (params.dataType ? 'predefinedAbapType' : 'domain');
   const shortLabel = params.shortLabel ?? '';
   const mediumLabel = params.mediumLabel ?? '';
@@ -274,7 +301,7 @@ export function buildDataElementXml(params: DataElementCreateParams): string {
             adtcore:type="DTEL/DE"
             adtcore:masterLanguage="${masterLanguage}"
             adtcore:masterSystem="H00"
-            adtcore:responsible="DEVELOPER">
+            adtcore:responsible="${escapeXml(responsible)}">
   <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>
   <dtel:dataElement xmlns:dtel="http://www.sap.com/adt/dictionary/dataelements">
     <dtel:typeKind>${escapeXml(typeKind)}</dtel:typeKind>
@@ -314,6 +341,7 @@ export function buildPackageXml(params: PackageCreateParams): string {
   const normalizedSoftwareComponent = softwareComponent.toUpperCase();
   const isLocalSoftwareComponent = normalizedSoftwareComponent === 'LOCAL';
   const recordChanges = params.recordChanges ?? (!isLocalSoftwareComponent || transportLayer !== '');
+  const responsible = normalizeAdtResponsible(params.responsible);
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <pak:package xmlns:pak="http://www.sap.com/adt/packages"
@@ -322,7 +350,7 @@ export function buildPackageXml(params: PackageCreateParams): string {
              adtcore:name="${escapeXml(params.name)}"
              adtcore:type="DEVC/K"
              adtcore:version="active"
-             adtcore:responsible="DEVELOPER">
+             adtcore:responsible="${escapeXml(responsible)}">
   <adtcore:packageRef adtcore:name="${escapeXml(params.name)}"/>
   <pak:attributes pak:packageType="${escapeXml(packageType)}" pak:recordChanges="${boolToXml(recordChanges)}"/>
   <pak:superPackage adtcore:name="${escapeXml(superPackage)}"/>
@@ -346,6 +374,7 @@ export function buildServiceBindingXml(params: ServiceBindingCreateParams): stri
   const odataVersion = params.odataVersion?.trim().toUpperCase() || normalized.odataVersion;
   const serviceVersion = params.version?.trim() || '0001';
   const masterLanguage = normalizeAdtLanguage(params.language);
+  const responsible = normalizeAdtResponsible(params.responsible);
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <srvb:serviceBinding xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings"
@@ -355,7 +384,7 @@ export function buildServiceBindingXml(params: ServiceBindingCreateParams): stri
                      adtcore:type="SRVB/SVB"
                      adtcore:language="${masterLanguage}"
                      adtcore:masterLanguage="${masterLanguage}"
-                     adtcore:responsible="DEVELOPER">
+                     adtcore:responsible="${escapeXml(responsible)}">
   <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>
   <srvb:services srvb:name="${escapeXml(params.name)}">
     <srvb:content srvb:version="${escapeXml(serviceVersion)}">

--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -149,7 +149,10 @@ export function normalizeAdtLanguage(language?: string): string {
  * Normalize the ADT "person responsible" to the form SAP expects: trimmed and
  * upper-case (on-prem `USR02-BNAME` is upper-case). Defaults to "DEVELOPER"
  * only as a last-resort fallback when no user is configured, preserving the
- * legacy hard-coded value for callers that pass nothing.
+ * legacy hard-coded value for callers that pass nothing. In practice
+ * `config.username` is empty only under cookie-file or OAuth service-key auth
+ * (basic auth and principal propagation both supply a real user), so the
+ * "DEVELOPER" fallback realistically applies only in those two modes.
  *
  * `adtcore:responsible` must name a user that exists on the target system. The
  * historical hard-coded literal "DEVELOPER" only exists on SAP's own demo

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -75,6 +75,7 @@ import {
   decodeKtdText,
   type MessageClassCreateParams,
   normalizeAdtLanguage,
+  normalizeAdtResponsible,
   type PackageCreateParams,
   rewriteKtdText,
   type ServiceBindingCreateParams,
@@ -2918,12 +2919,19 @@ export function buildCreateXml(
   description: string,
   properties?: Record<string, unknown>,
   language?: string,
+  responsible?: string,
 ): string {
   // Master/original language for the created object. Derived from the configured
   // SAP_LANGUAGE (passed by callers as config.language) so the create-XML body
   // matches the sap-language URL param ARC-1 already sends. Defaults to "EN" when
   // unset, preserving legacy output. See issue #343.
   const masterLanguage = normalizeAdtLanguage(language);
+  // Person responsible for the created object. Derived from the configured logon
+  // user (passed by callers as config.username). The legacy hard-coded "DEVELOPER"
+  // only exists on SAP demo systems, so on a real system it fails with
+  // 400 [?/049] "Enter a valid user, not DEVELOPER, as the person responsible".
+  // Defaults to "DEVELOPER" only when no user is configured. Same threading as #343.
+  const responsibleUser = normalizeAdtResponsible(responsible);
   switch (type) {
     case 'PROG':
       return `<?xml version="1.0" encoding="UTF-8"?>
@@ -2934,7 +2942,7 @@ export function buildCreateXml(
                      adtcore:type="PROG/P"
                      adtcore:masterLanguage="${masterLanguage}"
                      adtcore:masterSystem="H00"
-                     adtcore:responsible="DEVELOPER">
+                     adtcore:responsible="${escapeXml(responsibleUser)}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </program:abapProgram>`;
     case 'CLAS':
@@ -2946,7 +2954,7 @@ export function buildCreateXml(
                  adtcore:type="CLAS/OC"
                  adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
-                 adtcore:responsible="DEVELOPER">
+                 adtcore:responsible="${escapeXml(responsibleUser)}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </class:abapClass>`;
     case 'INTF':
@@ -2958,7 +2966,7 @@ export function buildCreateXml(
                     adtcore:type="INTF/OI"
                     adtcore:masterLanguage="${masterLanguage}"
                     adtcore:masterSystem="H00"
-                    adtcore:responsible="DEVELOPER">
+                    adtcore:responsible="${escapeXml(responsibleUser)}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </intf:abapInterface>`;
     case 'INCL':
@@ -2970,7 +2978,7 @@ export function buildCreateXml(
                      adtcore:type="PROG/I"
                      adtcore:masterLanguage="${masterLanguage}"
                      adtcore:masterSystem="H00"
-                     adtcore:responsible="DEVELOPER">
+                     adtcore:responsible="${escapeXml(responsibleUser)}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </include:abapInclude>`;
     case 'DDLS':
@@ -2982,7 +2990,7 @@ export function buildCreateXml(
                adtcore:type="DDLS/DF"
                adtcore:masterLanguage="${masterLanguage}"
                adtcore:masterSystem="H00"
-                 adtcore:responsible="DEVELOPER">
+                 adtcore:responsible="${escapeXml(responsibleUser)}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </ddl:ddlSource>`;
     case 'DCLS':
@@ -2994,7 +3002,7 @@ export function buildCreateXml(
                adtcore:type="DCLS/DL"
                adtcore:masterLanguage="${masterLanguage}"
                adtcore:masterSystem="H00"
-               adtcore:responsible="DEVELOPER">
+               adtcore:responsible="${escapeXml(responsibleUser)}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </dcl:dclSource>`;
     case 'TABL':
@@ -3012,7 +3020,7 @@ export function buildCreateXml(
                  adtcore:type="${adtType}"
                  adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
-                 adtcore:responsible="DEVELOPER">
+                 adtcore:responsible="${escapeXml(responsibleUser)}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </blue:blueSource>`;
     }
@@ -3027,7 +3035,7 @@ export function buildCreateXml(
                  adtcore:type="BDEF/BDO"
                  adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
-                 adtcore:responsible="DEVELOPER">
+                 adtcore:responsible="${escapeXml(responsibleUser)}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </blue:blueSource>`;
     case 'SRVD':
@@ -3039,7 +3047,7 @@ export function buildCreateXml(
                  adtcore:type="SRVD/SRV"
                  adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
-                 adtcore:responsible="DEVELOPER"
+                 adtcore:responsible="${escapeXml(responsibleUser)}"
                  srvd:srvdSourceType="S">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </srvd:srvdSource>`;
@@ -3061,6 +3069,7 @@ export function buildCreateXml(
         version: properties?.version ? String(properties.version) : undefined,
         odataVersion: properties?.odataVersion ? String(properties.odataVersion) : undefined,
         language: masterLanguage,
+        responsible: responsibleUser,
       };
       return buildServiceBindingXml(params);
     }
@@ -3073,7 +3082,7 @@ export function buildCreateXml(
                  adtcore:type="DDLX/EX"
                  adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
-                     adtcore:responsible="DEVELOPER">
+                     adtcore:responsible="${escapeXml(responsibleUser)}">
   <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
 </ddlx:ddlxSource>`;
     case 'DOMA': {
@@ -3100,6 +3109,7 @@ export function buildCreateXml(
         fixedValues,
         valueTable: properties?.valueTable ? String(properties.valueTable) : undefined,
         language: masterLanguage,
+        responsible: responsibleUser,
       };
       return buildDomainXml(params);
     }
@@ -3127,6 +3137,7 @@ export function buildCreateXml(
         defaultComponentName: properties?.defaultComponentName ? String(properties.defaultComponentName) : undefined,
         changeDocument: toBoolean(properties?.changeDocument),
         language: masterLanguage,
+        responsible: responsibleUser,
       };
       return buildDataElementXml(params);
     }
@@ -4008,7 +4019,7 @@ async function handleSAPWrite(
         const mergedProps = await mergeMetadataWriteProperties(client, type, name, metadataProps);
         const description = String(args.description ?? mergedProps._description ?? name);
         const pkg = String(args.package ?? existingPackage ?? mergedProps._package ?? '$TMP');
-        const body = buildCreateXml(type, name, pkg, description, mergedProps, config.language);
+        const body = buildCreateXml(type, name, pkg, description, mergedProps, config.language, config.username);
         await safeUpdateObject(
           client.http,
           client.safety,
@@ -4269,7 +4280,7 @@ async function handleSAPWrite(
       // SAP ADT requires the root element to match the object type —
       // a generic objectReferences body returns 400 "System expected the element ...".
       const metadataProperties = getMetadataWriteProperties(args);
-      const body = buildCreateXml(type, name, pkg, description, metadataProperties, config.language);
+      const body = buildCreateXml(type, name, pkg, description, metadataProperties, config.language, config.username);
 
       // Step 1: Create the object (metadata only)
       const createUrl = objectUrl.replace(/\/[^/]+$/, ''); // parent collection URL
@@ -5384,7 +5395,15 @@ async function handleSAPWrite(
           const objUrl = objectUrlForType(objType, objName);
           const createUrl = objUrl.replace(/\/[^/]+$/, '');
           const objMetadataProps = getMetadataWriteProperties(obj);
-          const body = buildCreateXml(objType, objName, objPackage, objDescription, objMetadataProps, config.language);
+          const body = buildCreateXml(
+            objType,
+            objName,
+            objPackage,
+            objDescription,
+            objMetadataProps,
+            config.language,
+            config.username,
+          );
           const contentType = createContentTypeForType(objType);
           const needsPackageParam =
             objType === 'BDEF' || objType === 'TABL' || objType === 'TABL/DT' || objType === 'TABL/DS';
@@ -7716,6 +7735,7 @@ async function handleSAPManage(
         transportLayer: transportLayer || undefined,
         recordChanges,
         packageType,
+        responsible: config.username,
       });
 
       await createObject(

--- a/tests/unit/adt/ddic-xml.test.ts
+++ b/tests/unit/adt/ddic-xml.test.ts
@@ -6,6 +6,7 @@ import {
   buildPackageXml,
   buildServiceBindingXml,
   decodeKtdText,
+  normalizeAdtResponsible,
   normalizeSrvbBindingType,
   rewriteKtdText,
 } from '../../../src/adt/ddic-xml.js';
@@ -89,6 +90,79 @@ describe('ddic-xml builders', () => {
         language: '   ',
       });
       expect(xml).toContain('adtcore:masterLanguage="EN"');
+    });
+  });
+
+  // Sibling of issue #343, for adtcore:responsible: the created object's "person
+  // responsible" must name a real user on the target system. The legacy hard-coded
+  // "DEVELOPER" only exists on SAP demo systems — on a real system the create fails
+  // with HTTP 400 [?/049] "Enter a valid user, not DEVELOPER, as the person
+  // responsible". ARC-1 threads the connection's logon user (config.username) instead.
+  describe('person responsible (adtcore:responsible)', () => {
+    it('buildPackageXml emits the configured responsible', () => {
+      const xml = buildPackageXml({ name: 'ZTEST', description: 'd', responsible: 'SRAHEMI' });
+      expect(xml).toContain('adtcore:responsible="SRAHEMI"');
+    });
+
+    it('buildPackageXml defaults responsible to DEVELOPER when unset', () => {
+      const xml = buildPackageXml({ name: 'ZTEST', description: 'd' });
+      expect(xml).toContain('adtcore:responsible="DEVELOPER"');
+    });
+
+    it('buildDomainXml emits the configured responsible', () => {
+      const xml = buildDomainXml({
+        name: 'ZD',
+        description: 'd',
+        package: '$TMP',
+        dataType: 'CHAR',
+        length: 1,
+        responsible: 'SRAHEMI',
+      });
+      expect(xml).toContain('adtcore:responsible="SRAHEMI"');
+    });
+
+    it('buildDataElementXml emits the configured responsible', () => {
+      const xml = buildDataElementXml({ name: 'ZE', description: 'd', package: '$TMP', responsible: 'SRAHEMI' });
+      expect(xml).toContain('adtcore:responsible="SRAHEMI"');
+    });
+
+    it('buildServiceBindingXml emits the configured responsible', () => {
+      const xml = buildServiceBindingXml({
+        name: 'ZSB',
+        description: 'd',
+        package: '$TMP',
+        serviceDefinition: 'ZSD',
+        responsible: 'SRAHEMI',
+      });
+      expect(xml).toContain('adtcore:responsible="SRAHEMI"');
+    });
+
+    it('defaults responsible to DEVELOPER across DDIC builders when unset', () => {
+      expect(buildDomainXml({ name: 'ZD', description: 'd', package: '$TMP', dataType: 'CHAR', length: 1 })).toContain(
+        'adtcore:responsible="DEVELOPER"',
+      );
+      expect(buildDataElementXml({ name: 'ZE', description: 'd', package: '$TMP' })).toContain(
+        'adtcore:responsible="DEVELOPER"',
+      );
+      expect(
+        buildServiceBindingXml({ name: 'ZSB', description: 'd', package: '$TMP', serviceDefinition: 'ZSD' }),
+      ).toContain('adtcore:responsible="DEVELOPER"');
+    });
+
+    it('upper-cases a lower-case responsible', () => {
+      const xml = buildPackageXml({ name: 'ZTEST', description: 'd', responsible: 'srahemi' });
+      expect(xml).toContain('adtcore:responsible="SRAHEMI"');
+    });
+
+    it('treats a blank responsible as the DEVELOPER default', () => {
+      const xml = buildPackageXml({ name: 'ZTEST', description: 'd', responsible: '   ' });
+      expect(xml).toContain('adtcore:responsible="DEVELOPER"');
+    });
+
+    it('normalizeAdtResponsible trims + upper-cases and defaults to DEVELOPER', () => {
+      expect(normalizeAdtResponsible('  srahemi ')).toBe('SRAHEMI');
+      expect(normalizeAdtResponsible()).toBe('DEVELOPER');
+      expect(normalizeAdtResponsible('   ')).toBe('DEVELOPER');
     });
   });
 

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -11946,6 +11946,65 @@ ENDCLASS.`;
     });
   });
 
+  // ─── create wiring: person responsible (adtcore:responsible) ─────────
+
+  describe('create — person responsible wiring (adtcore:responsible)', () => {
+    function dtelCreatePostBody(): string | undefined {
+      const call = mockFetch.mock.calls.find(
+        (c: any[]) => String(c[0]).includes('/sap/bc/adt/ddic/dataelements') && c[1]?.method === 'POST',
+      );
+      return call?.[1]?.body as string | undefined;
+    }
+
+    function packageCreatePostBody(): string | undefined {
+      const call = mockFetch.mock.calls.find(
+        (c: any[]) => String(c[0]).includes('/sap/bc/adt/packages') && c[1]?.method === 'POST',
+      );
+      return call?.[1]?.body as string | undefined;
+    }
+
+    it('threads config.username into the create_package POST body', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      const result = await handleToolCall(createClient(), { ...DEFAULT_CONFIG, username: 'SRAHEMI' }, 'SAPManage', {
+        action: 'create_package',
+        name: 'ZARC1_RESP',
+        description: 'Responsible wiring test',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(packageCreatePostBody()).toContain('adtcore:responsible="SRAHEMI"');
+    });
+
+    it('threads config.username into the DTEL create POST body', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(201, '<blue:wbobj/>', { 'x-csrf-token': 't' }));
+      const result = await handleToolCall(createClient(), { ...DEFAULT_CONFIG, username: 'SRAHEMI' }, 'SAPWrite', {
+        action: 'create',
+        type: 'DTEL',
+        name: 'ZARC1_RESP_UNIT',
+        description: 'Responsible test',
+        package: '$TMP',
+        typeKind: 'predefinedAbapType',
+        dataType: 'CHAR',
+        length: 10,
+      });
+      expect(result.isError).toBeFalsy();
+      expect(dtelCreatePostBody()).toContain('adtcore:responsible="SRAHEMI"');
+    });
+
+    it('falls back to DEVELOPER in the create_package POST body when username is unset', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+        action: 'create_package',
+        name: 'ZARC1_RESP_DEF',
+        description: 'Responsible default test',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(packageCreatePostBody()).toContain('adtcore:responsible="DEVELOPER"');
+    });
+  });
+
   // ─── buildCreateXml ─────────────────────────────────────────────────
 
   describe('buildCreateXml', () => {
@@ -11983,6 +12042,40 @@ ENDCLASS.`;
 
       it('normalizes a lower-case language to upper case', () => {
         expect(buildCreateXml('CLAS', 'ZCL', '$TMP', 'C', undefined, 'de')).toContain('adtcore:masterLanguage="DE"');
+      });
+    });
+
+    // Sibling of #343, for adtcore:responsible (7th arg = config.username). The legacy
+    // hard-coded "DEVELOPER" fails on real systems with 400 [?/049]; thread the logon user.
+    describe('person responsible (adtcore:responsible)', () => {
+      it('threads the configured responsible into source objects (7th arg)', () => {
+        const xml = buildCreateXml('PROG', 'ZHELLO', 'ZPACKAGE', 'Hello', undefined, 'EN', 'SRAHEMI');
+        expect(xml).toContain('adtcore:responsible="SRAHEMI"');
+      });
+
+      it('threads the configured responsible into DOMA/DTEL/SRVB create XML', () => {
+        expect(
+          buildCreateXml('DOMA', 'ZDOM', '$TMP', 'Dom', { dataType: 'CHAR', length: 1 }, 'EN', 'SRAHEMI'),
+        ).toContain('adtcore:responsible="SRAHEMI"');
+        expect(
+          buildCreateXml('DTEL', 'ZEL', '$TMP', 'El', { dataType: 'CHAR', length: 10 }, 'EN', 'SRAHEMI'),
+        ).toContain('adtcore:responsible="SRAHEMI"');
+        expect(buildCreateXml('SRVB', 'ZSB', '$TMP', 'SB', { serviceDefinition: 'ZSD' }, 'EN', 'SRAHEMI')).toContain(
+          'adtcore:responsible="SRAHEMI"',
+        );
+      });
+
+      it('defaults responsible to DEVELOPER when no responsible arg is passed', () => {
+        expect(buildCreateXml('PROG', 'ZHELLO', 'ZPACKAGE', 'Hello')).toContain('adtcore:responsible="DEVELOPER"');
+        expect(buildCreateXml('CLAS', 'ZCL', '$TMP', 'C', undefined, 'EN')).toContain(
+          'adtcore:responsible="DEVELOPER"',
+        );
+      });
+
+      it('normalizes a lower-case responsible to upper case', () => {
+        expect(buildCreateXml('CLAS', 'ZCL', '$TMP', 'C', undefined, 'EN', 'srahemi')).toContain(
+          'adtcore:responsible="SRAHEMI"',
+        );
       });
     });
 

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -11948,7 +11948,7 @@ ENDCLASS.`;
 
   // ─── create wiring: person responsible (adtcore:responsible) ─────────
 
-  describe('create — person responsible wiring (adtcore:responsible)', () => {
+  describe('create/update/batch — person responsible wiring (adtcore:responsible)', () => {
     function dtelCreatePostBody(): string | undefined {
       const call = mockFetch.mock.calls.find(
         (c: any[]) => String(c[0]).includes('/sap/bc/adt/ddic/dataelements') && c[1]?.method === 'POST',
@@ -12002,6 +12002,56 @@ ENDCLASS.`;
       });
       expect(result.isError).toBeUndefined();
       expect(packageCreatePostBody()).toContain('adtcore:responsible="DEVELOPER"');
+    });
+
+    // The metadata-UPDATE call site is full-XML-replace via buildCreateXml, so it
+    // threads config.username too (not just the create paths). ADT keeps the
+    // create-time owner on update, but the body must still name a real user — the
+    // legacy "DEVELOPER" would otherwise re-trip [?/049] on a no-DEVELOPER system.
+    it('threads config.username into the DTEL update PUT body', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>';
+      mockFetch.mockReset();
+      let putBody: string | undefined;
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string; body?: string }) => {
+        const method = opts?.method ?? 'GET';
+        if (method === 'POST' && String(url).includes('_action=LOCK')) {
+          return Promise.resolve(mockResponse(200, lockBody, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'PUT') putBody = String(opts?.body ?? '');
+        return Promise.resolve(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), { ...DEFAULT_CONFIG, username: 'SRAHEMI' }, 'SAPWrite', {
+        action: 'update',
+        type: 'DTEL',
+        name: 'ZSTATUS',
+        package: '$TMP',
+        typeKind: 'domain',
+        typeName: 'ZSTATUS',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(putBody).toContain('adtcore:responsible="SRAHEMI"');
+    });
+
+    it('threads config.username into the batch_create create POST body', async () => {
+      mockFetch.mockReset();
+      const posts: Array<{ url: string; body: string }> = [];
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string; body?: string }) => {
+        if (opts?.method === 'POST') posts.push({ url: String(url), body: String(opts?.body ?? '') });
+        return Promise.resolve(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), { ...DEFAULT_CONFIG, username: 'SRAHEMI' }, 'SAPWrite', {
+        action: 'batch_create',
+        package: '$TMP',
+        objects: [{ type: 'DTEL', name: 'ZSTATUS', typeKind: 'predefinedAbapType', dataType: 'CHAR', length: 10 }],
+      });
+
+      expect(result.isError).toBeUndefined();
+      const dtelPost = posts.find((p) => p.url.includes('/sap/bc/adt/ddic/dataelements'));
+      expect(dtelPost?.body).toContain('adtcore:responsible="SRAHEMI"');
     });
   });
 


### PR DESCRIPTION
Fixes #379.

## Problem
Object creation hard-codes `adtcore:responsible="DEVELOPER"` in 14 places (`buildPackageXml`/`buildDomainXml`/`buildDataElementXml`/`buildServiceBindingXml` in `src/adt/ddic-xml.ts`, plus the source-object literals in `buildCreateXml` in `src/handlers/intent.ts`). On a system without a `DEVELOPER` user, `create_package` (and the other creates) fail with `HTTP 400 [?/049] "Enter a valid user, not DEVELOPER, as the person responsible"`.

## Fix (mirrors the #343 `masterLanguage` pattern)
- Add `normalizeAdtResponsible()` (trim + upper-case, fallback `"DEVELOPER"`) in `ddic-xml.ts`.
- Add an optional `responsible` field to `PackageCreateParams`, `DomainCreateParams`, `DataElementCreateParams`, `ServiceBindingCreateParams`.
- Thread the connection logon user (`config.username`) through `buildCreateXml` (new 7th arg) and `buildPackageXml`, replacing every hard-coded literal. All three `buildCreateXml` callers and the `buildPackageXml` call site updated.
- `FUGR`/`FUNC`/`MSAG` never emitted `responsible` and are unchanged.

## Tests
- Builder- and handler-level unit tests in `tests/unit/adt/ddic-xml.test.ts` and `tests/unit/handlers/intent.test.ts` (configured user threaded into the create POST body; default `DEVELOPER` when unset; upper-casing).
- All unit tests pass; `tsc --noEmit` and `biome check` clean.

## Verified live (on-prem S/4HANA, SAP_BASIS 8.16)
- Before: `create_package` → `[?/049]`.
- After: a local `$…` package **and** a transportable package both created successfully with the logon user as `responsible` (confirmed by reading the object back). A `CLAS` and `DTEL` create were smoke-tested too.

## Notes
- #374 (`pak:recordChanges`) and #343 (`masterLanguage`) are already on HEAD; this is the remaining hard-coded master attribute.
- External precedent: `fr0ster/mcp-abap-adt` fixed the same class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)