### PR TITLE
docs: add /deep-issue and /deep-pr commands for external issue research & PR review

### DIFF
--- a/.claude/commands/deep-issue.md
+++ b/.claude/commands/deep-issue.md
@@ -1,0 +1,93 @@
+# Deep Issue — research & validate an external GitHub issue against real sources
+
+Deeply research a community-filed issue on **`marianfoo/arc-1`** before anyone touches code. The whole point: **decide whether the issue is real, and why, from verified evidence — not from the reporter's claim and not from memory.** ARC-1's worst bugs come from reasoning about ADT behavior instead of checking what the system actually does; the same trap turns a plausible-sounding issue into a wrong fix.
+
+Use this for any non-trivial external issue (bug report, feature request, "X doesn't work on release Y"). For an obvious typo-fix or a duplicate you can close in one line, just do that directly.
+
+The output is a **validated dossier + a paste-able GitHub reply + a recommendation** — not a code change. When the verdict is "fix it," hand the dossier to **`/deep-feature`** (which owns research→plan→implement→PR).
+
+---
+
+## Input
+
+An issue number or URL (e.g. `379` or `https://github.com/marianfoo/arc-1/issues/379`). If the user gives a vague description instead, ask for the number, then start.
+
+---
+
+## The prime directive
+
+**No verdict until you have the full picture.** "Full picture" means you can answer, with evidence: is the reported behavior real on a live system, what the ADT endpoint actually does, whether HEAD already fixes it, what the true root cause is, and which releases are affected. Until then you are still in Phase 1.
+
+A reporter saying "reproduced on SAP_BASIS 8.16" is a lead, not a fact — confirm it. A `200 OK` does **not** mean a filter/type/parameter was honored; ADT silently ignores unknown ones. Verify response *content*, not just status. The issue may be **already fixed on HEAD** (cf. #378: the fix existed, only a stale comment + doc hint remained) or a **duplicate** of a known dossier.
+
+---
+
+## Research Sources (concrete — same sources `/deep-feature` uses)
+
+All `~/DEV/*` repos are **read-only references** — never modify them. If a path is missing, note it and continue.
+
+| Source | Where | Use it for |
+|--------|-------|------------|
+| **The issue itself** | `gh issue view <n> --comments`; linked PRs via `gh issue view <n> --json` | The claim, the repro steps, prior maintainer replies, any linked fix attempt |
+| **ARC-1 project guide** | `CLAUDE.md`, `INFRASTRUCTURE.md` | Conventions, Key-Files map, code patterns; the **3 live systems** + how to reach them |
+| **Current HEAD code** | the cited `src/...` files (use `grep -a` — `intent.ts` contains raw NULs) | **Is it already fixed / never was as described?** Read the exact lines the issue cites before believing them |
+| **Prior issue dossiers** | `research/issues/` (e.g. `293-ecc-423-invalid-lock-handle.md`) | Duplicate? Same root cause as a solved one? Reuse the proven analysis |
+| **ARC-1 live research notes** | `docs/research/`, type-code evidence under `research/abap-types/` | Prior **live spikes & ground truth** — read first so you don't re-derive proven facts |
+| **Competitor / reference trackers** | `compare/` (esp. `compare/05-fr0ster-mcp-abap-adt.md`, `compare/01-vibing-steampunk.md`) | Did a sibling client hit the same SAP bug? Issues often cite `fr0ster`/`vibing-steampunk` precedent |
+| **Eclipse ADT — apidoc + contracts** | `~/DEV/arc-1-eclipse-adt/` (`com.sap.adt.core.apidoc-*`, `api/01..20-*.md`) | **Exact ADT endpoint URIs, media types, request/response contracts.** Ground truth for "what should this endpoint do" |
+| **SAP ADT language server** | `~/DEV/arc-1-lsp/` (`vendor/adt-ls`, `docs/adt-ls-*`) | How SAP's **own** server calls ADT — a second independent witness |
+| **Reference ADT-over-MCP impls** | `~/DEV/mcp-abap-adt/`, `~/DEV/mcp-abap-adt-fr0ster/` | How **others** implement the same op — and whether they fixed this exact bug |
+| **ABAP language reference** | `~/DEV/abap-docs/docs/` | ABAP keyword/syntax semantics when the issue touches language constructs |
+| **SAP docs / Notes (MCP)** | `sap-docs` MCP (`search`, `fetch`, `sap_community_search`, `sap_search_objects`, `abap_feature_matrix`) + `sap-notes` MCP (`search`, `fetch`) | Official docs, community threads, and SAP Notes/KBAs for known corrections — **cite the Note number** when a fix depends on it. For broad web research, `/deep-research` |
+| **Live SAP systems** | `arc1-cli call <Tool> ...`, `npm run probe -- --save-fixtures tests/fixtures/probe/<name>`. Systems: **NW 7.50** (`npl`), **S/4HANA 2023 / 758** (`a4h`), **ABAP Platform 2025 / 816** (`a4h-2025`) — creds + recipes in `INFRASTRUCTURE.md` | **Ground truth.** Reproduce the issue yourself, on the release(s) it names |
+
+---
+
+## Phase 1: Triage & frame
+
+1. **Fetch everything** — `gh issue view <n> --comments` plus `--json title,author,labels,body,closed,stateReason` and any linked PRs/issues. Note the **author** (external contributor?), the **claimed release**, and any prior maintainer reply (don't contradict yourself across the thread).
+2. **Restate the claim** in one paragraph: what the reporter did, what happened, what they expected. Identify the SAP objects/operations and the exact ARC-1 files/endpoints cited.
+3. **Classify** — `bug` / `feature-request` / `question-or-support` / `duplicate` / `already-fixed`. A quick `grep` of `research/issues/` and open+closed issues (`gh issue list --search`) catches duplicates before you spend an hour.
+
+## Phase 2: Verify the claim (this is the work)
+
+Work the sources above until the prime directive is satisfied:
+
+4. **Read HEAD first** — open the cited files (`grep -a` for `intent.ts`). Frequently the code already disagrees with the issue (fixed, or never behaved as described). State what HEAD actually does, with `file:line`.
+5. **ADT contract** — in `~/DEV/arc-1-eclipse-adt`, find the endpoint(s) the issue touches: exact URI, verb, Accept/Content-Type, request/response shape. Cross-check `~/DEV/arc-1-lsp` and the `mcp-abap-adt*` repos. Check `sap-notes`/`sap-docs` for a known SAP-side correction.
+6. **Reproduce live** — the deciding step. Run the reporter's scenario via `arc1-cli call ...` (or `npm run probe`) on the **release they named**, and on a second release if the area is release-sensitive (DDIC routing, locks, activation, lint, release detection). **Capture the real response body.** Distinguish the three outcomes: reproduces / doesn't reproduce / reproduces differently.
+7. **Root cause** — explain *why*, grounded in the captured evidence. If it's the same mechanism as an existing dossier, say so and link it. If the reporter's proposed cause is wrong (cf. #293, where Note 2727890 was the wrong fix), correct it explicitly.
+8. **Map impact** — using the Key-Files table in `CLAUDE.md`, list every file a fix would touch (source + tests + docs + the three-file schema trio when a tool surface changes), and the per-release behavior.
+
+### Phase 1–2 exit gate — do not write the verdict until all are YES:
+- [ ] I reproduced the issue live (or proved it does **not** reproduce), on the release(s) it names, with the response body captured
+- [ ] I read the cited HEAD code and stated what it actually does today
+- [ ] I checked the ADT contract (eclipse-adt) and ≥1 reference repo / SAP Note
+- [ ] I checked for a duplicate in `research/issues/` and open/closed issues
+- [ ] I know the true root cause and the per-release behavior
+
+## Phase 3: Write the dossier
+
+Capture findings in **`research/issues/<n>-<short-slug>.md`** (the existing convention — model it on `research/issues/293-ecc-423-invalid-lock-handle.md`):
+
+- **Status** + one-line verdict (e.g. "Confirmed bug, root cause validated live 2026-06-09" / "Not reproducible on 816, likely client-side" / "Already fixed on HEAD — docs gap only" / "Duplicate of #NNN").
+- **TL;DR**, **live validation** (the `arc1-cli` commands run + observed before/after, ideally a small table), **root cause**, **affected files**, **out of scope**.
+- This dossier is durable and is the input `/deep-feature` builds on — write it for a reader who wasn't here.
+
+## Phase 4: Reply & recommend
+
+1. **Draft the GitHub comment** — paste-able markdown in a fenced block in the dossier (as #293 does). Lead with the verdict, give the evidence, be precise and kind to the external reporter, cite Note numbers / `file:line` / releases. **Do not post it** — hand it back for the user to review and post (origin = `marianfoo`).
+2. **Recommend the next step**, explicitly:
+   - **Fix it** → "hand this dossier to `/deep-feature`" (point it at `research/issues/<n>-*.md`). For a one-file surgical fix, `/implement-feature` instead.
+   - **Close** as duplicate / already-fixed / works-as-designed → the drafted comment is the closing rationale.
+   - **Needs info** → the drafted comment asks the reporter for the specific missing piece (release SP, exact payload, response body).
+
+---
+
+## Guardrails & notes
+
+- **Verify-first is non-negotiable** — the value of this command is Phase 2. If you're about to write a verdict on an unverified ADT fact, stop and reproduce it.
+- **Never auto-post, label, or close** the issue, and never push anything — return paste-able markdown; the user acts on origin (`marianfoo`).
+- `~/DEV/arc-1-eclipse-adt`, `~/DEV/arc-1-lsp`, `~/DEV/mcp-abap-adt*`, `~/DEV/abap-docs` are **read-only**. Understand behavior; don't copy SAP code.
+- If a live system is unreachable, see `INFRASTRUCTURE.md` (Docker stop/start, start Cloud Connector manually) before concluding "can't reproduce."
+- **Related:** `/deep-pr` (review the fix PR), `/deep-feature` (own the fix), `/deep-research` (broad web research), `update-competitor-tracker` (if the issue mirrors a sibling-repo bug).

--- a/.claude/commands/deep-pr.md
+++ b/.claude/commands/deep-pr.md
@@ -1,0 +1,112 @@
+# Deep PR — review an external pull request against real sources & ARC-1's invariants
+
+Deeply review a community pull request on **`marianfoo/arc-1`** before it merges. The whole point: **verify the PR is correct, safe, and actually does what it claims — from your own evidence, not the PR description.** External PRs touch the most dangerous surfaces (write paths, schemas, the safety system); a PR body that says "verified live on 8.16" is a claim to check, not a fact to trust. ARC-1's worst regressions come from accepting ADT behavior on faith.
+
+Use this for any non-trivial external PR (bug fix, new ADT op, schema change, safety change). For a dependency bump or a one-line doc fix, a normal read is enough.
+
+The output is a **review verdict + paste-able review comments + a dossier** — not a commit. You **never push to the contributor's branch, never approve via `gh`, never post automatically** (per repo policy: hand back paste-able markdown; the user acts on origin = `marianfoo`).
+
+---
+
+## Input
+
+A PR number or URL (e.g. `380` or `https://github.com/marianfoo/arc-1/pull/380`).
+
+---
+
+## The prime directive
+
+**No verdict until you have verified the PR's correctness independently.** That means: the diff does what the title/body says; every SAP/ADT fact the PR asserts is confirmed against the contract and (for behavior changes) live; the security & architectural invariants below all still hold; and the tests actually cover the new paths. Until then you are still reviewing, not concluding.
+
+A `200 OK` in the PR author's transcript does **not** mean the parameter was honored — re-run it yourself. "All tests pass" is something you confirm by running them, not by reading it. **For any object-write change, a successful live `SAPActivate` is the definitive correctness check** (RAP CCDEF/CCIMP placement, DDIC table class, behavior-pool rules surface only there).
+
+---
+
+## Research Sources (same sources `/deep-feature` uses)
+
+All `~/DEV/*` repos are **read-only references** — never modify them.
+
+| Source | Where | Use it for |
+|--------|-------|------------|
+| **The PR itself** | `gh pr view <n> --json ...,isCrossRepository,headRepositoryOwner,files,reviews,comments`; `gh pr diff <n>` | The diff, the author, cross-repo fork?, the linked issue, the author's claims to verify |
+| **The linked issue** | `gh issue view <linked>` + its dossier in `research/issues/` (run `/deep-issue` first if none exists) | What problem the PR *should* solve — judge the diff against the real need, not the PR's framing |
+| **ARC-1 project guide** | `CLAUDE.md` (esp. **Security & Architectural Invariants**, **Authorization & Safety System**, **three-file schema sync**), `INFRASTRUCTURE.md` | The invariant checklist below; conventions; the 3 live systems |
+| **Current HEAD code** | the files the diff touches + their neighbors (`grep -a` for `intent.ts`) | Does the change fit existing patterns? Does it break an adjacent path (create/update/delete/activate, the `withSafety()` clone)? |
+| **ARC-1 live research notes** | `docs/research/`, `research/abap-types/` | Has the PR's SAP assumption already been proven/disproven here? |
+| **Eclipse ADT — apidoc + contracts** | `~/DEV/arc-1-eclipse-adt/` (`api/01..20-*.md`, apidoc) | **The real ADT contract** the PR must match — URIs, media types, request/response shapes. The deciding source when the PR's claim and the contract disagree |
+| **SAP ADT language server** | `~/DEV/arc-1-lsp/` (`vendor/adt-ls`, `docs/adt-ls-*`) | How SAP's own server calls it — second witness |
+| **Reference ADT-over-MCP impls** | `~/DEV/mcp-abap-adt/`, `~/DEV/mcp-abap-adt-fr0ster/` | How others implement the same op; whether the PR reinvents or contradicts a known-good approach |
+| **ABAP language reference** | `~/DEV/abap-docs/docs/` | ABAP semantics when the diff touches language constructs |
+| **SAP docs / Notes (MCP)** | `sap-docs` MCP (`search`, `fetch`, `sap_community_search`, `abap_feature_matrix`) + `sap-notes` MCP (`search`, `fetch`) | Confirm SAP-side facts / Note numbers the PR cites |
+| **Live SAP systems** | `arc1-cli call <Tool> ...`, `npm run probe`, `npm run test:integration`. Systems: **NW 7.50** (`npl`), **758** (`a4h`), **816** (`a4h-2025`) — `INFRASTRUCTURE.md` | **Ground truth.** Re-run the PR's own verification; confirm it on the releases it claims (and the oldest one if release-sensitive) |
+
+---
+
+## Phase 1: Frame & fetch
+
+1. **Read the PR** — `gh pr view <n>` for title/body/author/`isCrossRepository`/files/reviews/comments, `gh pr diff <n>` for the full diff. Note whether it's a **cross-repo fork** PR (most external ones are) and **what it claims** (the "verified live" table, "all tests pass", etc.) — these become your verification checklist.
+2. **Understand the goal** — read the linked issue and its `research/issues/` dossier (if none, run **`/deep-issue`** on it first; you can't judge a fix without knowing the real bug). Judge the diff against the actual need.
+3. **Scope the review** — code change vs. docs/skills-only (a large skills-only PR like #283 is reviewed for accuracy & sources, not for ADT correctness/tests). Set the depth accordingly.
+
+## Phase 2: Get the diff locally & run the gates
+
+4. **Check out in isolation.** The DEV tree accumulates other WIP — don't switch branches in place. Prefer a worktree:
+   ```bash
+   git worktree add ../arc-1-pr-<n> && cd ../arc-1-pr-<n> && gh pr checkout <n>
+   ```
+   (or just `gh pr diff <n>` for a read-only pass). Cross-repo PRs check out fine via `gh pr checkout`.
+5. **Run the gates yourself** — don't trust "all green":
+   ```bash
+   npm ci && npm run typecheck && npm run lint && npm test
+   ```
+   Record what actually passed/failed.
+
+## Phase 3: Correctness review (independent of the PR's claims)
+
+6. **Diff does what it says** — walk every hunk. Does it match the title/body? Any scope creep, dead code, leftover debug, `console.log` (forbidden — corrupts MCP stdout), `any` types, commented-out code?
+7. **Verify every SAP/ADT fact** the PR asserts against `~/DEV/arc-1-eclipse-adt` + a reference repo. If the PR changes an endpoint URI, media type, or payload, confirm the contract — the most common external-PR error is a plausible-but-wrong ADT assumption.
+8. **Re-run the PR's live verification.** Don't read the author's table — reproduce it via `arc1-cli call ...` on the release(s) it names. **For object-write changes, perform a real `SAPActivate` on a live system** and read the object back. Verify response *content*, not just `200`. Check the oldest release (7.50) too when the area is release-sensitive (DDIC routing, locks, activation, lint, release detection).
+9. **Adjacent paths** — does the change break a sibling op? Create/update/delete/activate, read/write, and especially the **`withSafety()` clone** (it bypasses the constructor — every new instance field must be re-attached, cf. #333).
+
+## Phase 4: Security & architectural invariants (the part external PRs get wrong)
+
+Check each — these are `CLAUDE.md` invariants, and the reason this server can be trusted:
+
+- [ ] **Every new ADT endpoint goes through `checkOperation(this.safety, OperationType.X, ...)`** — no unguarded `http.{get,post,put,delete}`. Mutations require `allowWrites`; transport/git writes their extra flag.
+- [ ] **Scope policy** — any new tool/action is in `ACTION_POLICY` (`src/authz/policy.ts`) with the right scope, and pruned from the tool list when the scope is absent.
+- [ ] **Package gating** — every mutating op resolves the object's **real** package and calls `enforceAllowedPackageForObjectUrl` (create/update/delete/surgery, activation, `change_package`), fail-closed.
+- [ ] **Three-file schema sync** — any tool surface change touches all of `tools.ts` (JSON Schema for LLMs), `schemas.ts` (Zod), `intent.ts` (handler); `batch_create` items updated separately. A field missing from `tools.ts` is invisible to LLMs.
+- [ ] **Per-user auth never inherits shared creds** — new Layer B fields respect the `perUser` strip in `buildAdtConfig`.
+- [ ] **stdout is sacred** (stderr-only logging), **no secrets committed** (`.env`/cookies), sensitive fields redacted.
+- [ ] **Typed errors** (`AdtApiError`/`AdtSafetyError`/`AdtNetworkError`) with **LLM-friendly hints**, not raw stack traces.
+
+Consider running **`/security-review`** on the checked-out diff for an independent pass, and **`/code-review`** for correctness/cleanup findings — then fold their results into your verdict.
+
+## Phase 5: Test adequacy
+
+10. **Every new path tested?** Unit tests mirror source structure and mock undici; integration/e2e added when SAP interaction changes. Skip policy honored (`tests/helpers/skip-policy.ts` — no bare `if (!x) return;` / empty catches). Tests assert the *right* thing (not written to match buggy code). For the `withSafety()` clone, a test asserts the new field is the same instance on the clone.
+
+### Phase 2–5 exit gate — do not write the verdict until all are YES:
+- [ ] I ran typecheck + lint + test myself and recorded the result
+- [ ] I verified the PR's SAP facts against the ADT contract, and re-ran its live verification (a real `SAPActivate` for write changes)
+- [ ] I walked every hunk for correctness, scope creep, and adjacent-path breakage
+- [ ] I checked every security/architectural invariant above
+- [ ] I confirmed the tests genuinely cover the new paths
+
+## Phase 6: Verdict, review comments & dossier
+
+1. **Write the dossier** — **`research/pull-requests/<n>-<short-slug>.md`** (mirrors `research/issues/`): the verdict, what you ran and observed (gate output + live `arc1-cli` results), invariant findings, and each issue with `file:line`.
+2. **Verdict** — one of **APPROVE** / **REQUEST CHANGES** / **COMMENT**, with a one-paragraph rationale grounded in the evidence above.
+3. **Paste-able review** — a fenced markdown block the user can paste into the GitHub review: a summary, then findings as `**file:line** — finding + suggested change`, ordered blocking-first. Be specific and kind to the external contributor; cite the contract / Note / release that backs each point.
+4. **Hand back, don't act** — present the verdict + the paste-able review. **Do not `gh pr review`/approve/merge, do not push to the fork branch, do not post comments.** If the fix is small and the user asks, you may prepare a diff suggestion in the block — but the user pushes it (to origin, `marianfoo`), not you. Clean up the worktree (`git worktree remove ../arc-1-pr-<n>`) when done.
+
+---
+
+## Guardrails & notes
+
+- **Verify-first is non-negotiable** — re-run the PR's claims; never accept "verified live" or "tests pass" on faith.
+- **Never push, approve, post, or merge** — return paste-able review markdown; the user acts on origin (`marianfoo`). No force-push, no commits onto a contributor's PR branch.
+- Work on a **worktree or `gh pr diff`**, never switch branches in the shared DEV tree; stage explicitly, never `git add -A`.
+- `~/DEV/arc-1-eclipse-adt`, `~/DEV/arc-1-lsp`, `~/DEV/mcp-abap-adt*`, `~/DEV/abap-docs` are **read-only**.
+- If a live system is unreachable, see `INFRASTRUCTURE.md` before concluding the PR's behavior is wrong.
+- **Related:** `/deep-issue` (validate the bug the PR targets), `/code-review` + `/security-review` (focused passes to fold in), `/verify` (drive the app to confirm a fix), `/deep-feature` (if the PR needs substantial rework you take over).

--- a/research/pull-requests/README.md
+++ b/research/pull-requests/README.md
@@ -1,0 +1,12 @@
+# PR review dossiers
+
+Durable review dossiers produced by the **`/deep-pr`** command, one file per reviewed
+pull request: `<pr-number>-<short-slug>.md`.
+
+Each dossier records the **verdict** (APPROVE / REQUEST CHANGES / COMMENT), what was actually
+run and observed (typecheck/lint/test output + live `arc1-cli` results), the security/architectural
+invariant findings, and each issue anchored to `file:line` — plus the paste-able review markdown.
+
+Mirrors `research/issues/` (which holds the `/deep-issue` dossiers). These notes are evidence,
+not the GitHub review itself — `/deep-pr` never posts, approves, or pushes; the maintainer acts on
+origin (`marianfoo`).


### PR DESCRIPTION
## Summary

Adds two slash commands for handling **external community contributions** on this repo, modeled on [`deep-feature.md`](https://github.com/marianfoo/arc-1/blob/main/.claude/commands/deep-feature.md)'s research-sources table, prime directive, and exit-gate style — and on the [`research/issues/293`](https://github.com/marianfoo/arc-1/blob/main/research/issues/293-ecc-423-invalid-lock-handle.md) dossier format. Follows the same `docs:` convention used to add `deep-feature` in #370.

The shared premise: ARC-1's worst bugs come from reasoning about ADT behavior instead of verifying it. Both commands force **claim-verification against real sources** (the `~/DEV/arc-1-eclipse-adt` / `arc-1-lsp` / `mcp-abap-adt*` / `abap-docs` repos, `sap-docs`/`sap-notes` MCP, and the `npl` 7.50 / `a4h` 758 / `a4h-2025` 816 live systems) before forming a verdict.

## `/deep-issue` — research & validate an external issue

Input: an issue number/URL. Reproduces the claim live on the release it names, reads HEAD first (issues are often already fixed or never behaved as described — cf. #378), and checks `research/issues/` for duplicates. Output: a durable dossier at `research/issues/<n>-slug.md` + a paste-able GitHub reply + a verdict (confirmed bug / not-reproducible / already-fixed / duplicate / needs-info). Hands the fix to `/deep-feature`.

## `/deep-pr` — review an external pull request

Input: a PR number/URL. Reviews independently of the PR's claims: checks out in a worktree, re-runs `typecheck`/`lint`/`test`, re-verifies the SAP facts against the ADT contract, re-runs the live verification (a real `SAPActivate` for write changes), and gates on the `CLAUDE.md` **security/architectural invariants** (`checkOperation` coverage, `ACTION_POLICY` scopes, package gating, three-file schema sync, the `withSafety()` clone trap from #333, stdout-sacred). Folds in `/security-review` and `/code-review`. Output: a verdict (APPROVE / REQUEST CHANGES / COMMENT) + paste-able review comments + a dossier at `research/pull-requests/<n>-slug.md`.

## Design boundaries

- Both **hand back paste-able markdown** and **never auto-post, approve, push, or merge** — the maintainer acts on origin (`marianfoo`).
- Implementation is delegated to `/deep-feature`; these commands stop at a validated dossier + recommendation/review.

## Files

- `.claude/commands/deep-issue.md`, `.claude/commands/deep-pr.md` — the two commands.
- `research/pull-requests/README.md` — documents the PR-dossier convention (mirrors `research/issues/`).

Docs/tooling only — no product code, tests, or dependencies touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
