### PR TITLE
docs: recover stuck MCP clients (invalid_client / invalid_token) + safe-update guidance

### DIFF
--- a/docs_page/updating.md
+++ b/docs_page/updating.md
@@ -202,6 +202,25 @@ cf rollback arc1-mcp-server
   ```
 - **Scaled > 1 instance (`cf scale -i 2`):** rolling update handles each instance sequentially.
 
+### Keeping MCP clients signed in across updates
+
+Updating the image is invisible to connected MCP clients **as long as the OAuth DCR signing key doesn't change** — they keep their cached `client_id` and reconnect on their own. How you deploy decides that:
+
+- **`cf push` with a new image tag (recommended):** reuses the existing XSUAA binding, so the `clientsecret` — and the DCR signing key derived from it — is unchanged. Cached `client_id`s stay valid; clients reconnect with no re-auth.
+- **MTA `cf deploy`, or `cf unbind`/`cf bind` of XSUAA:** recreates the binding and **rotates the `clientsecret`**, which by default rotates the DCR signing key and invalidates every cached `client_id`. Clients then hit `invalid_client` — most re-register automatically, but Eclipse Copilot and Cursor need a one-time manual reset (see [Recovering a stuck client](xsuaa-setup.md#recovering-a-stuck-client-invalid_client)).
+
+**To make even MTA redeploys seamless, set a stable DCR signing key once** (via `cf set-env`, which survives deploys):
+
+```bash
+cf set-env arc1-mcp-server ARC1_DCR_SIGNING_SECRET "$(openssl rand -base64 48)"
+cf set-env arc1-mcp-server ARC1_OAUTH_DCR_TTL_SECONDS 0
+cf restage arc1-mcp-server
+```
+
+After this the signing key no longer tracks the rotating `clientsecret`, so no deploy invalidates client registrations. See [Stable DCR signing key](xsuaa-setup.md#stable-dcr-signing-key-recommended).
+
+Other restart side effects are benign: in-flight requests during the instance swap are retried by the client (a `--strategy rolling` push avoids even that), and the on-disk SQLite source cache is preserved and ETag-revalidated — no cold-cache penalty.
+
 ---
 
 ## git clone (development)

--- a/docs_page/updating.md
+++ b/docs_page/updating.md
@@ -207,7 +207,7 @@ cf rollback arc1-mcp-server
 Updating the image is invisible to connected MCP clients **as long as the OAuth DCR signing key doesn't change** — they keep their cached `client_id` and reconnect on their own. How you deploy decides that:
 
 - **`cf push` with a new image tag (recommended):** reuses the existing XSUAA binding, so the `clientsecret` — and the DCR signing key derived from it — is unchanged. Cached `client_id`s stay valid; clients reconnect with no re-auth.
-- **MTA `cf deploy`, or `cf unbind`/`cf bind` of XSUAA:** recreates the binding and **rotates the `clientsecret`**, which by default rotates the DCR signing key and invalidates every cached `client_id`. Clients then hit `invalid_client` — most re-register automatically, but Eclipse Copilot and Cursor need a one-time manual reset (see [Recovering a stuck client](xsuaa-setup.md#recovering-a-stuck-client-invalid_client)).
+- **MTA `cf deploy`, or `cf unbind`/`cf bind` of XSUAA:** recreates the binding and **rotates the `clientsecret`**, which by default rotates the DCR signing key and invalidates every cached `client_id`. Clients then hit `invalid_client` — most re-register automatically, but Eclipse Copilot and Cursor need a one-time manual reset (see [Recovering a stuck client](xsuaa-setup.md#recovering-a-stuck-client)).
 
 **To make even MTA redeploys seamless, set a stable DCR signing key once** (via `cf set-env`, which survives deploys):
 

--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -237,34 +237,25 @@ This is the only operation that invalidates DCR state. Routine restarts (`cf res
 
 ### Recovering a stuck client (`invalid_client` / `invalid_token`)
 
-After a client has been connected for a while it can fail with one of two errors. They have different causes but the **same one-step fix — restart the client**, which re-runs the OAuth handshake.
+After a client has been connected for a while it can fail with one of two errors. They look alike but invalidate **different things, so they have different fixes**:
 
-| Error | What's stale | Why it happens | Prevent it |
-|-------|--------------|----------------|------------|
-| `invalid_client` / `Invalid client_id` | the cached **DCR registration** | the signing key changed — an MTA `cf deploy` rotates the XSUAA `clientsecret` (the default signing key), or the DCR TTL expired | stable [`ARC1_DCR_SIGNING_SECRET`](#stable-dcr-signing-key-recommended) + `ARC1_OAUTH_DCR_TTL_SECONDS=0` |
-| `invalid_token` / "not a valid XSUAA, OIDC, or API key token" | the cached **access token** | it expired and the client didn't refresh in time (e.g. a session left idle overnight) | a longer `refresh-token-validity` in `xs-security.json` — **30 days** by default |
+| Error | What's stale | Cached token still works? | Fix |
+|-------|--------------|---------------------------|-----|
+| `invalid_token` / "not a valid XSUAA, OIDC, or API key token" | the **access token** | no — it expired | **restart the client** — a cold start re-runs auth |
+| `invalid_client` / `Invalid client_id` | the **DCR registration** | usually yes — so tool calls keep working | **clear the cached registration** — a restart alone won't, because the client keeps using its still-valid token and never re-registers |
 
-**The fix: restart your MCP client.** A cold start re-runs authentication, which mints a fresh registration *and* a fresh token — so it clears **both** errors. Most clients (Claude Desktop, VS Code's MCP client, MCP Inspector) refresh and re-register automatically and rarely surface either one.
+**Prevent both:** for `invalid_client`, set a stable [`ARC1_DCR_SIGNING_SECRET`](#stable-dcr-signing-key-recommended) + `ARC1_OAUTH_DCR_TTL_SECONDS=0` so a redeploy can't rotate the signing key. For `invalid_token`, the default `refresh-token-validity` in `xs-security.json` is **30 days**, so idle sessions survive far longer.
 
-**Eclipse GitHub Copilot** is the exception worth calling out: it doesn't refresh or re-register on its own mid-session, so when it gets stuck, **quit and reopen Eclipse**. On restart the Copilot agent re-runs the sign-in — you'll see its *"… wants to authenticate"* dialog — and the session is restored. (There's no per-server "restart MCP" action yet: [copilot-for-eclipse#237](https://github.com/microsoft/copilot-for-eclipse/issues/237).)
+**Most clients self-heal** — Claude Desktop, VS Code's MCP client, and MCP Inspector refresh and re-register on their own and rarely surface either error. The two that need a manual nudge are **Eclipse GitHub Copilot** and **Cursor** (Eclipse has no per-server "restart MCP" / re-auth action yet — [copilot-for-eclipse#237](https://github.com/microsoft/copilot-for-eclipse/issues/237)).
 
-#### If a restart doesn't clear it
+#### Eclipse GitHub Copilot
 
-This only happens with a genuinely stale **registration** (`invalid_client`) that the client keeps reloading — not with `invalid_token`, which a restart always re-auths. Clear Eclipse Copilot's cached registration:
+**For `invalid_token`** (an expired or long-idle session — you're effectively logged out): **quit and reopen Eclipse**. On the cold start it re-runs the sign-in — its *"… wants to authenticate"* dialog appears — and you're back.
 
-| OS | File |
-|----|------|
-| macOS / Linux | `~/.config/github-copilot/copilot-eclipse.db` |
-| Windows | `%LOCALAPPDATA%\github-copilot\copilot-eclipse.db` |
-
-**Quit Eclipse first** (it rewrites the file on exit), delete that one file, then reopen Eclipse — it recreates the file and prompts you to sign in again. Deleting it sounds drastic but is low-impact:
-
-- ✅ The only cost: you re-authorize your MCP server(s) once (a browser sign-in each).
-- ❌ It does **not** sign you out of GitHub Copilot itself — that lives in a separate `auth.db`.
-- ❌ It does **not** touch your code, workspaces, Eclipse preferences, or your configured MCP server list — only cached MCP auth tokens.
+**For `invalid_client`** (the server's signing key rotated, e.g. an MTA `cf deploy`): **a restart usually won't help** — Copilot keeps using its still-valid access token and never re-registers, so the stale `client_id` only resurfaces on the next forced sign-in. You have to clear its cached registration so it calls `/register` again. **Quit Eclipse**, then delete its one cache file:
 
 ```bash
-# macOS / Linux
+# macOS / Linux — clears cached MCP logins; you re-authorize each server once
 rm ~/.config/github-copilot/copilot-eclipse.db
 ```
 ```powershell
@@ -272,7 +263,13 @@ rm ~/.config/github-copilot/copilot-eclipse.db
 Remove-Item "$env:LOCALAPPDATA\github-copilot\copilot-eclipse.db"
 ```
 
-> Want to keep your *other* MCP servers signed in? With the `sqlite3` CLI, delete only ARC-1's rows instead of the whole file (the cache is keyed by server URL):
+Reopen Eclipse → use the server → it registers fresh and prompts you to sign in. Deleting the file is low-impact:
+
+- ✅ The only cost: re-authorize your MCP server(s) once (a browser sign-in each).
+- ❌ It does **not** sign you out of GitHub Copilot itself — that's a separate `auth.db`.
+- ❌ It does **not** touch your code, workspaces, Eclipse preferences, or your MCP server list — only cached MCP auth.
+
+> Want to keep your *other* MCP servers signed in? With the `sqlite3` CLI, delete only this server's rows (the cache is keyed by server URL):
 > ```bash
 > sqlite3 ~/.config/github-copilot/copilot-eclipse.db \
 >   "DELETE FROM state WHERE key LIKE 'dynamicAuthProvider:%your-app.cfapps%';"
@@ -283,6 +280,8 @@ Remove-Item "$env:LOCALAPPDATA\github-copilot\copilot-eclipse.db"
 #### Cursor
 
 Cursor also caches its registration and may not re-register on `invalid_client`. Reset it by **removing the MCP server entry, restarting Cursor, then re-adding it**. With the stable signing key set (above), you only ever do this once.
+
+> **Found an easier way to recover an Eclipse or Cursor MCP login?** MCP-client behavior is still evolving — please [open an issue or PR](https://github.com/marianfoo/arc-1/issues/new) so these docs can capture the simplest known fix.
 
 ### Browser-based DCR clients (rare)
 

--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -235,6 +235,59 @@ After this sequence:
 
 This is the only operation that invalidates DCR state. Routine restarts (`cf restart`, `cf push` without rebind, cell moves) no longer disrupt clients.
 
+### Recovering a stuck client (`invalid_client`)
+
+When a cached `client_id` stops validating — after a redeploy that rotated the signing key (above), after the DCR TTL expires, or after a forced key rotation — the MCP client fails on connect with `invalid_client` / `Invalid client_id` / "invalid Client ID". Fixing it has two halves: **stop it happening** (server side, above) and **clear the stale registration the client already cached** (client side, here).
+
+**Most clients self-heal.** Claude Desktop, VS Code's MCP client, and MCP Inspector detect `invalid_client` and silently re-register via `/register` on the next connect — no action needed. **Some clients cache the `client_id` and do *not* re-register automatically** — notably **Eclipse GitHub Copilot** and **Cursor** — and need a one-time manual reset.
+
+#### Eclipse GitHub Copilot
+
+Eclipse's Copilot language server caches each server's DCR registration in a small SQLite database, keyed by the MCP server **URL** (so renaming the server in your config does *not* clear it). It does not re-register on `invalid_client`, so it stays stuck until you clear the cache.
+
+1. **Quit Eclipse completely first** — it writes its in-memory state back on exit, so editing the file while it runs won't stick.
+2. **Locate the cache:**
+
+   | OS | Path |
+   |----|------|
+   | macOS / Linux | `~/.config/github-copilot/copilot-eclipse.db` |
+   | Windows | `%LOCALAPPDATA%\github-copilot\copilot-eclipse.db` (i.e. `C:\Users\<you>\AppData\Local\github-copilot\copilot-eclipse.db`) |
+
+3. **Clear the cached registration** — either approach works:
+
+   - **Surgical** (keeps your other MCP servers signed in) — needs the `sqlite3` CLI (preinstalled on macOS and most Linux; on Windows install it or use [DB Browser for SQLite](https://sqlitebrowser.org/)):
+
+     ```bash
+     # clear every cached MCP/DCR registration:
+     sqlite3 ~/.config/github-copilot/copilot-eclipse.db \
+       "DELETE FROM state WHERE key LIKE 'dynamicAuthProvider:%';"
+
+     # …or only your server (use a substring of its host):
+     sqlite3 ~/.config/github-copilot/copilot-eclipse.db \
+       "DELETE FROM state WHERE key LIKE 'dynamicAuthProvider:%your-app.cfapps%';"
+     ```
+
+   - **Simplest** (no tools) — delete the whole file; Eclipse recreates it on next launch. You stay signed into Copilot itself (that lives in a separate `auth.db`); you just re-authorize the MCP server:
+
+     ```bash
+     # macOS / Linux
+     rm ~/.config/github-copilot/copilot-eclipse.db
+     ```
+     ```powershell
+     # Windows (PowerShell)
+     Remove-Item "$env:LOCALAPPDATA\github-copilot\copilot-eclipse.db"
+     ```
+
+4. **Reopen Eclipse** → it re-runs `/register`, mints a fresh `client_id`, and prompts you to authorize again.
+
+> A healthy ARC-1 `client_id` looks like `arc1-eyJ2Ijox…` (~280+ chars — a base64 payload plus a `.signature`). A short `arc1-<8 hex>` id predates the stateless store and is always rejected; clear it the same way.
+
+#### Cursor
+
+Cursor also caches the registration and may not re-register on `invalid_client`. The reliable reset is to **remove the MCP server entry, restart Cursor, then re-add it** (it re-runs DCR for the fresh entry).
+
+> **Prevention beats cure:** set `ARC1_DCR_SIGNING_SECRET` and `ARC1_OAUTH_DCR_TTL_SECONDS=0` ([above](#stable-dcr-signing-key-recommended)). With a stable signing key and no expiry, cached `client_id`s stay valid across redeploys, so these manual resets become a one-time event instead of a recurring chore after every deploy.
+
 ### Browser-based DCR clients (rare)
 
 The four MCP clients in the section above (Claude Desktop, Cursor, MCP Inspector, Copilot Studio) all run as native processes — they call `/register` and `/authorize` over native HTTP, not the browser `fetch` API, and never trigger CORS. If a browser-based MCP client (custom playground, embedded widget) calls these OAuth endpoints from a different origin, you must add that origin to `ARC1_ALLOWED_ORIGINS`. See [Security headers & CORS](security-guide.md#cors-for-browser-based-mcp-clients-opt-in) for the full configuration.

--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -235,53 +235,54 @@ After this sequence:
 
 This is the only operation that invalidates DCR state. Routine restarts (`cf restart`, `cf push` without rebind, cell moves) no longer disrupt clients.
 
-### Recovering a stuck client (`invalid_client`)
+### Recovering a stuck client (`invalid_client` / `invalid_token`)
 
-**Why this happens.** An MCP client registers once via DCR and then *caches* the `client_id` it received. That `client_id` is an HMAC token signed by ARC-1's signing key, so it stops validating — and the client fails to connect with `invalid_client` / `Invalid client_id` / "invalid Client ID" — whenever that signing key changes underneath it. The usual cause is an **MTA `cf deploy` that rotated the XSUAA `clientsecret`** (the default signing key is derived from it), or the **DCR TTL expiring**. A plain `cf push` does not cause this.
+After a client has been connected for a while it can fail with one of two errors. They have different causes but the **same one-step fix — restart the client**, which re-runs the OAuth handshake.
 
-**The real fix is to prevent it — do this first.** Set [`ARC1_DCR_SIGNING_SECRET`](#stable-dcr-signing-key-recommended) plus `ARC1_OAUTH_DCR_TTL_SECONDS=0` on the server. With a stable signing key and no expiry, cached `client_id`s keep working across deploys and the problem disappears for every client. Everything below is only for a client that is *already* stuck.
+| Error | What's stale | Why it happens | Prevent it |
+|-------|--------------|----------------|------------|
+| `invalid_client` / `Invalid client_id` | the cached **DCR registration** | the signing key changed — an MTA `cf deploy` rotates the XSUAA `clientsecret` (the default signing key), or the DCR TTL expired | stable [`ARC1_DCR_SIGNING_SECRET`](#stable-dcr-signing-key-recommended) + `ARC1_OAUTH_DCR_TTL_SECONDS=0` |
+| `invalid_token` / "not a valid XSUAA, OIDC, or API key token" | the cached **access token** | it expired and the client didn't refresh in time (e.g. a session left idle overnight) | a longer `refresh-token-validity` in `xs-security.json` — **30 days** by default |
 
-**Most clients recover on their own** — Claude Desktop, VS Code's MCP client, and MCP Inspector detect `invalid_client` and silently re-register on the next connect, nothing to do. A couple cache the `client_id` and don't re-register automatically — **Eclipse GitHub Copilot** and **Cursor**.
+**The fix: restart your MCP client.** A cold start re-runs authentication, which mints a fresh registration *and* a fresh token — so it clears **both** errors. Most clients (Claude Desktop, VS Code's MCP client, MCP Inspector) refresh and re-register automatically and rarely surface either one.
 
-#### Eclipse GitHub Copilot
+**Eclipse GitHub Copilot** is the exception worth calling out: it doesn't refresh or re-register on its own mid-session, so when it gets stuck, **quit and reopen Eclipse**. On restart the Copilot agent re-runs the sign-in — you'll see its *"… wants to authenticate"* dialog — and the session is restored. (There's no per-server "restart MCP" action yet: [copilot-for-eclipse#237](https://github.com/microsoft/copilot-for-eclipse/issues/237).)
 
-Eclipse Copilot has no built-in "restart MCP server" or "re-authenticate" action yet ([copilot-for-eclipse#237](https://github.com/microsoft/copilot-for-eclipse/issues/237)), and it won't re-register a stale `client_id` by itself. In order, **easiest first**:
+#### If a restart doesn't clear it
 
-1. **Restart Eclipse.** Usually enough — on a cold start the Copilot agent re-runs registration and prompts you to sign in again. Nothing is deleted and nothing is lost. Try this before anything else.
+This only happens with a genuinely stale **registration** (`invalid_client`) that the client keeps reloading — not with `invalid_token`, which a restart always re-auths. Clear Eclipse Copilot's cached registration:
 
-2. **If a restart doesn't clear it, reset the cached login.** Eclipse Copilot stores its MCP sign-in state in one file, `copilot-eclipse.db`:
+| OS | File |
+|----|------|
+| macOS / Linux | `~/.config/github-copilot/copilot-eclipse.db` |
+| Windows | `%LOCALAPPDATA%\github-copilot\copilot-eclipse.db` |
 
-   | OS | File |
-   |----|------|
-   | macOS / Linux | `~/.config/github-copilot/copilot-eclipse.db` |
-   | Windows | `%LOCALAPPDATA%\github-copilot\copilot-eclipse.db` |
+**Quit Eclipse first** (it rewrites the file on exit), delete that one file, then reopen Eclipse — it recreates the file and prompts you to sign in again. Deleting it sounds drastic but is low-impact:
 
-   **Quit Eclipse first** (it rewrites the file on exit), delete that one file, then reopen Eclipse — it recreates the file and prompts you to sign in again. Deleting it sounds drastic but is low-impact:
+- ✅ The only cost: you re-authorize your MCP server(s) once (a browser sign-in each).
+- ❌ It does **not** sign you out of GitHub Copilot itself — that lives in a separate `auth.db`.
+- ❌ It does **not** touch your code, workspaces, Eclipse preferences, or your configured MCP server list — only cached MCP auth tokens.
 
-   - ✅ The only cost: you re-authorize your MCP server(s) once (a browser sign-in each).
-   - ❌ It does **not** sign you out of GitHub Copilot itself — that lives in a separate `auth.db`.
-   - ❌ It does **not** touch your code, workspaces, Eclipse preferences, or your configured MCP server list — only cached MCP auth tokens.
+```bash
+# macOS / Linux
+rm ~/.config/github-copilot/copilot-eclipse.db
+```
+```powershell
+# Windows (PowerShell)
+Remove-Item "$env:LOCALAPPDATA\github-copilot\copilot-eclipse.db"
+```
 
-   ```bash
-   # macOS / Linux
-   rm ~/.config/github-copilot/copilot-eclipse.db
-   ```
-   ```powershell
-   # Windows (PowerShell)
-   Remove-Item "$env:LOCALAPPDATA\github-copilot\copilot-eclipse.db"
-   ```
-
-   > Want to keep your *other* MCP servers signed in? If you have the `sqlite3` CLI, delete only ARC-1's rows instead of the whole file (the cache is keyed by server URL):
-   > ```bash
-   > sqlite3 ~/.config/github-copilot/copilot-eclipse.db \
-   >   "DELETE FROM state WHERE key LIKE 'dynamicAuthProvider:%your-app.cfapps%';"
-   > ```
+> Want to keep your *other* MCP servers signed in? With the `sqlite3` CLI, delete only ARC-1's rows instead of the whole file (the cache is keyed by server URL):
+> ```bash
+> sqlite3 ~/.config/github-copilot/copilot-eclipse.db \
+>   "DELETE FROM state WHERE key LIKE 'dynamicAuthProvider:%your-app.cfapps%';"
+> ```
 
 > Sanity check: a healthy ARC-1 `client_id` looks like `arc1-eyJ2Ijox…` (~280+ chars). A short `arc1-<8 hex>` id predates the stateless store and is always rejected — clear it the same way.
 
 #### Cursor
 
-Cursor also caches the registration and may not re-register on `invalid_client`. Reset it by **removing the MCP server entry, restarting Cursor, then re-adding it**. With the stable signing key set (above), you only ever do this once.
+Cursor also caches its registration and may not re-register on `invalid_client`. Reset it by **removing the MCP server entry, restarting Cursor, then re-adding it**. With the stable signing key set (above), you only ever do this once.
 
 ### Browser-based DCR clients (rare)
 

--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -237,56 +237,51 @@ This is the only operation that invalidates DCR state. Routine restarts (`cf res
 
 ### Recovering a stuck client (`invalid_client`)
 
-When a cached `client_id` stops validating — after a redeploy that rotated the signing key (above), after the DCR TTL expires, or after a forced key rotation — the MCP client fails on connect with `invalid_client` / `Invalid client_id` / "invalid Client ID". Fixing it has two halves: **stop it happening** (server side, above) and **clear the stale registration the client already cached** (client side, here).
+**Why this happens.** An MCP client registers once via DCR and then *caches* the `client_id` it received. That `client_id` is an HMAC token signed by ARC-1's signing key, so it stops validating — and the client fails to connect with `invalid_client` / `Invalid client_id` / "invalid Client ID" — whenever that signing key changes underneath it. The usual cause is an **MTA `cf deploy` that rotated the XSUAA `clientsecret`** (the default signing key is derived from it), or the **DCR TTL expiring**. A plain `cf push` does not cause this.
 
-**Most clients self-heal.** Claude Desktop, VS Code's MCP client, and MCP Inspector detect `invalid_client` and silently re-register via `/register` on the next connect — no action needed. **Some clients cache the `client_id` and do *not* re-register automatically** — notably **Eclipse GitHub Copilot** and **Cursor** — and need a one-time manual reset.
+**The real fix is to prevent it — do this first.** Set [`ARC1_DCR_SIGNING_SECRET`](#stable-dcr-signing-key-recommended) plus `ARC1_OAUTH_DCR_TTL_SECONDS=0` on the server. With a stable signing key and no expiry, cached `client_id`s keep working across deploys and the problem disappears for every client. Everything below is only for a client that is *already* stuck.
+
+**Most clients recover on their own** — Claude Desktop, VS Code's MCP client, and MCP Inspector detect `invalid_client` and silently re-register on the next connect, nothing to do. A couple cache the `client_id` and don't re-register automatically — **Eclipse GitHub Copilot** and **Cursor**.
 
 #### Eclipse GitHub Copilot
 
-Eclipse's Copilot language server caches each server's DCR registration in a small SQLite database, keyed by the MCP server **URL** (so renaming the server in your config does *not* clear it). It does not re-register on `invalid_client`, so it stays stuck until you clear the cache.
+Eclipse Copilot has no built-in "restart MCP server" or "re-authenticate" action yet ([copilot-for-eclipse#237](https://github.com/microsoft/copilot-for-eclipse/issues/237)), and it won't re-register a stale `client_id` by itself. In order, **easiest first**:
 
-1. **Quit Eclipse completely first** — it writes its in-memory state back on exit, so editing the file while it runs won't stick.
-2. **Locate the cache:**
+1. **Restart Eclipse.** Usually enough — on a cold start the Copilot agent re-runs registration and prompts you to sign in again. Nothing is deleted and nothing is lost. Try this before anything else.
 
-   | OS | Path |
+2. **If a restart doesn't clear it, reset the cached login.** Eclipse Copilot stores its MCP sign-in state in one file, `copilot-eclipse.db`:
+
+   | OS | File |
    |----|------|
    | macOS / Linux | `~/.config/github-copilot/copilot-eclipse.db` |
-   | Windows | `%LOCALAPPDATA%\github-copilot\copilot-eclipse.db` (i.e. `C:\Users\<you>\AppData\Local\github-copilot\copilot-eclipse.db`) |
+   | Windows | `%LOCALAPPDATA%\github-copilot\copilot-eclipse.db` |
 
-3. **Clear the cached registration** — either approach works:
+   **Quit Eclipse first** (it rewrites the file on exit), delete that one file, then reopen Eclipse — it recreates the file and prompts you to sign in again. Deleting it sounds drastic but is low-impact:
 
-   - **Surgical** (keeps your other MCP servers signed in) — needs the `sqlite3` CLI (preinstalled on macOS and most Linux; on Windows install it or use [DB Browser for SQLite](https://sqlitebrowser.org/)):
+   - ✅ The only cost: you re-authorize your MCP server(s) once (a browser sign-in each).
+   - ❌ It does **not** sign you out of GitHub Copilot itself — that lives in a separate `auth.db`.
+   - ❌ It does **not** touch your code, workspaces, Eclipse preferences, or your configured MCP server list — only cached MCP auth tokens.
 
-     ```bash
-     # clear every cached MCP/DCR registration:
-     sqlite3 ~/.config/github-copilot/copilot-eclipse.db \
-       "DELETE FROM state WHERE key LIKE 'dynamicAuthProvider:%';"
+   ```bash
+   # macOS / Linux
+   rm ~/.config/github-copilot/copilot-eclipse.db
+   ```
+   ```powershell
+   # Windows (PowerShell)
+   Remove-Item "$env:LOCALAPPDATA\github-copilot\copilot-eclipse.db"
+   ```
 
-     # …or only your server (use a substring of its host):
-     sqlite3 ~/.config/github-copilot/copilot-eclipse.db \
-       "DELETE FROM state WHERE key LIKE 'dynamicAuthProvider:%your-app.cfapps%';"
-     ```
+   > Want to keep your *other* MCP servers signed in? If you have the `sqlite3` CLI, delete only ARC-1's rows instead of the whole file (the cache is keyed by server URL):
+   > ```bash
+   > sqlite3 ~/.config/github-copilot/copilot-eclipse.db \
+   >   "DELETE FROM state WHERE key LIKE 'dynamicAuthProvider:%your-app.cfapps%';"
+   > ```
 
-   - **Simplest** (no tools) — delete the whole file; Eclipse recreates it on next launch. You stay signed into Copilot itself (that lives in a separate `auth.db`); you just re-authorize the MCP server:
-
-     ```bash
-     # macOS / Linux
-     rm ~/.config/github-copilot/copilot-eclipse.db
-     ```
-     ```powershell
-     # Windows (PowerShell)
-     Remove-Item "$env:LOCALAPPDATA\github-copilot\copilot-eclipse.db"
-     ```
-
-4. **Reopen Eclipse** → it re-runs `/register`, mints a fresh `client_id`, and prompts you to authorize again.
-
-> A healthy ARC-1 `client_id` looks like `arc1-eyJ2Ijox…` (~280+ chars — a base64 payload plus a `.signature`). A short `arc1-<8 hex>` id predates the stateless store and is always rejected; clear it the same way.
+> Sanity check: a healthy ARC-1 `client_id` looks like `arc1-eyJ2Ijox…` (~280+ chars). A short `arc1-<8 hex>` id predates the stateless store and is always rejected — clear it the same way.
 
 #### Cursor
 
-Cursor also caches the registration and may not re-register on `invalid_client`. The reliable reset is to **remove the MCP server entry, restart Cursor, then re-add it** (it re-runs DCR for the fresh entry).
-
-> **Prevention beats cure:** set `ARC1_DCR_SIGNING_SECRET` and `ARC1_OAUTH_DCR_TTL_SECONDS=0` ([above](#stable-dcr-signing-key-recommended)). With a stable signing key and no expiry, cached `client_id`s stay valid across redeploys, so these manual resets become a one-time event instead of a recurring chore after every deploy.
+Cursor also caches the registration and may not re-register on `invalid_client`. Reset it by **removing the MCP server entry, restarting Cursor, then re-adding it**. With the stable signing key set (above), you only ever do this once.
 
 ### Browser-based DCR clients (rare)
 

--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -235,7 +235,7 @@ After this sequence:
 
 This is the only operation that invalidates DCR state. Routine restarts (`cf restart`, `cf push` without rebind, cell moves) no longer disrupt clients.
 
-### Recovering a stuck client (`invalid_client` / `invalid_token`)
+### Recovering a stuck client
 
 After a client has been connected for a while it can fail with one of two errors. They look alike but invalidate **different things, so they have different fixes**:
 


### PR DESCRIPTION
Docs for the two ways a long-lived MCP client gets stuck on ARC-1's XSUAA OAuth, plus safe-update guidance. Came out of #301 (Eclipse Copilot hitting first `invalid Client ID`, then `invalid_token` the next day). Pairs with #383 (30-day refresh-token default).

## 1. Recover a stuck client — `xsuaa-setup.md`

Covers **both** failure modes with a cause/prevention table and one universal fix:

| Error | Stale thing | Cause | Prevent |
|---|---|---|---|
| `invalid_client` | DCR registration | signing key rotated (`cf deploy`) / DCR TTL | `ARC1_DCR_SIGNING_SECRET` + `ARC1_OAUTH_DCR_TTL_SECONDS=0` |
| `invalid_token` | access token | expired, client didn't refresh (idle overnight) | longer `refresh-token-validity` (30d default, #383) |

- **The one-step fix is to restart the client** — a cold start re-runs OAuth and mints a fresh registration *and* token, clearing both. Verified on Eclipse Copilot (its sign-in dialog re-appears on restart).
- Most clients (Claude Desktop, VS Code, Inspector) auto-recover. Eclipse Copilot / Cursor are the exceptions.
- The cache-file delete is now explicitly the **rare fallback** for a stubborn `invalid_client` only — restart-first, with side effects + what's *not* touched spelled out, cross-platform paths, and the `sqlite3` one-liner demoted to an optional tip.

## 2. Safely updating ARC-1 — `updating.md`

`cf push` (binding unchanged → clients reconnect silently) vs MTA `cf deploy` (rotates `clientsecret` → invalidates `client_id`s), how to make redeploys seamless with a stable signing key, and the benign restart side effects.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
