### PR TITLE
feat(xsuaa): raise default refresh-token-validity to 30 days

### DIFF
--- a/xs-security.json
+++ b/xs-security.json
@@ -85,6 +85,6 @@
     ],
     "grant-types": ["authorization_code", "refresh_token"],
     "token-validity": 3600,
-    "refresh-token-validity": 43200
+    "refresh-token-validity": 2592000
   }
 }


### PR DESCRIPTION
## What

`xs-security.json` → `oauth2-configuration.refresh-token-validity`: **`43200` (12h) → `2592000` (30 days)**. Access token (`token-validity`) stays `3600` (1h).

## Why

A 12h refresh window means an MCP client's session dies overnight. Clients that don't aggressively re-authenticate — notably **Eclipse GitHub Copilot** — then resend a now-dead access token, so the next day's first call fails with `invalid_token` / "not a valid XSUAA, OIDC, or API key token". Verified by decoding a real cached Copilot session: access token expired, refresh token also expired (12h), no re-auth → stale token sent.

30 days lets clients silently refresh for weeks. The **access token stays short-lived (1h)** — that's the right security posture; the refresh token is the session-continuity mechanism and is the one that was too short. Admins can still override per deployment.

## Rollout

New deployments get 30d automatically. Existing ones pick it up by re-applying the descriptor:

```bash
cf update-service <xsuaa-instance> -c xs-security.json
cf restage <app>
```

Docs (the `invalid_token` vs `invalid_client` troubleshooting, and "restart your client" as the universal recovery) are in #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
