### PR TITLE
fix(transport): delete requests holding locked objects via removeLockedObjects

### DIFF
--- a/src/adt/transport.ts
+++ b/src/adt/transport.ts
@@ -353,20 +353,61 @@ export async function releaseTransportRecursive(
   return { released };
 }
 
-/** Delete a transport request */
+/**
+ * Remove a single object from a transport task.
+ *
+ * SAP ADT exposes this as the `removeobject` action on the task URI (atom rel
+ * `http://www.sap.com/cts/relations/removeobject`, "Remove Locked Object"). It MUST be a
+ * PUT — a POST with the same body is accepted (HTTP 200) but silently no-ops. Mirrors the
+ * `changeowner` PUT in `reassignSingle`. Verified live on S/4HANA (SAP_BASIS 8.16): clears
+ * the lock so a request holding a deleted object's lingering record (lock_status="X") can
+ * then be deleted.
+ */
+async function removeTransportObject(http: AdtHttpClient, taskId: string, obj: TransportObject): Promise<void> {
+  const body = `<?xml version="1.0" encoding="ASCII"?>
+<tm:root xmlns:tm="${CTS_NAMESPACE_TM}"
+ tm:number="${escapeXmlAttr(taskId)}"
+ tm:useraction="removeobject">
+  <tm:request>
+    <tm:abap_object tm:pgmid="${escapeXmlAttr(obj.pgmid)}" tm:type="${escapeXmlAttr(obj.type)}" tm:name="${escapeXmlAttr(obj.name)}" tm:position="${escapeXmlAttr(obj.position)}" tm:obj_desc="${escapeXmlAttr(obj.description)}"/>
+  </tm:request>
+</tm:root>`;
+
+  await http.put(`/sap/bc/adt/cts/transportrequests/${encodeURIComponent(taskId)}`, body, CTS_CONTENT_TYPE_ORGANIZER, {
+    Accept: CTS_CONTENT_TYPE_ORGANIZER,
+  });
+}
+
+/**
+ * Delete a transport request.
+ *
+ * @param recursive            delete child tasks first, then the parent request.
+ * @param removeLockedObjects  strip locked objects from each task before deleting. ADT refuses to
+ *   delete a request/task that still holds locked objects (HTTP 400 "...contains locked objects") —
+ *   e.g. when a deleted object's record lingers in the task. With this flag ARC-1 removes those
+ *   objects first (the ADT "Remove Locked Object" operation) so the request can be discarded.
+ */
 export async function deleteTransport(
   http: AdtHttpClient,
   safety: SafetyConfig,
   transportId: string,
   recursive = false,
+  removeLockedObjects = false,
 ): Promise<void> {
   checkTransport(safety, transportId, 'DeleteTransport', true);
 
-  if (recursive) {
+  if (recursive || removeLockedObjects) {
     const transport = await getTransport(http, safety, transportId);
     if (transport) {
       for (const task of transport.tasks) {
-        if (task.status !== 'R') {
+        if (task.status === 'R') continue;
+        if (removeLockedObjects) {
+          for (const obj of task.objects.filter((o) => o.locked)) {
+            checkTransport(safety, task.id, 'RemoveTransportObject', true);
+            await removeTransportObject(http, task.id, obj);
+          }
+        }
+        if (recursive) {
           checkTransport(safety, task.id, 'DeleteTransport', true);
           await http.delete(`/sap/bc/adt/cts/transportrequests/${encodeURIComponent(task.id)}`);
         }

--- a/src/adt/transport.ts
+++ b/src/adt/transport.ts
@@ -359,9 +359,18 @@ export async function releaseTransportRecursive(
  * SAP ADT exposes this as the `removeobject` action on the task URI (atom rel
  * `http://www.sap.com/cts/relations/removeobject`, "Remove Locked Object"). It MUST be a
  * PUT — a POST with the same body is accepted (HTTP 200) but silently no-ops. Mirrors the
- * `changeowner` PUT in `reassignSingle`. Verified live on S/4HANA (SAP_BASIS 8.16): clears
- * the lock so a request holding a deleted object's lingering record (lock_status="X") can
- * then be deleted.
+ * `changeowner` PUT in `reassignSingle`. Verified live on S/4HANA SAP_BASIS 758 and 816:
+ * clears the lock so a request holding a deleted object's lingering record (lock_status="X")
+ * can then be deleted.
+ *
+ * Release-sensitive — NOT functional on NW 7.5x (verified on 7.50): (1) the 7.50
+ * `CL_ADT_TM_RESOURCE` does not honor `tm:useraction="removeobject"` (the PUT returns
+ * HTTP 400 "User does not exist in the system" — the same `tm:useraction` mishandling
+ * documented for `newrequest` in `createTransport`), and (2) the 7.50 transportorganizer
+ * XML omits `tm:lock_status` entirely, so `parseTransportList` reports `locked:false` and
+ * the `deleteTransport` filter never reaches this call. Net effect on 7.5x: the
+ * `removeLockedObjects` flag is inert and `delete` still fails with the original
+ * "...contains locked objects" (clean such requests in SE09/SE10). No data loss either way.
  */
 async function removeTransportObject(http: AdtHttpClient, taskId: string, obj: TransportObject): Promise<void> {
   const body = `<?xml version="1.0" encoding="ASCII"?>
@@ -663,6 +672,10 @@ function parseTransportList(xml: string): TransportRequest[] {
 
   return requests.map((req) => {
     const tasks: TransportTask[] = findDeepNodes(req, 'task').map((t) => {
+      // Objects are collected per <task>. The ADT transportorganizer XML nests <abap_object>
+      // under <task>, not directly under <request>, so request-level entries (rare, e.g. some
+      // non-workbench request shapes) are not represented here — which is why `removeLockedObjects`
+      // in deleteTransport iterates tasks. `tm:lock_status` is "X" when locked; absent on NW 7.5x.
       const objects: TransportObject[] = findDeepNodes(t, 'abap_object').map((o) => ({
         pgmid: String(o['@_pgmid'] ?? ''),
         type: String(o['@_type'] ?? ''),

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -7107,8 +7107,25 @@ async function handleSAPTransport(client: AdtClient, args: Record<string, unknow
       const id = String(args.id ?? '');
       if (!id) return errorResult('Transport ID is required for "delete" action.');
       const recursive = Boolean(args.recursive ?? false);
-      await deleteTransport(client.http, client.safety, id, recursive);
-      return textResult(`Deleted transport request: ${id}${recursive ? ' (recursive)' : ''}`);
+      const removeLockedObjects = Boolean(args.removeLockedObjects ?? false);
+      try {
+        await deleteTransport(client.http, client.safety, id, recursive, removeLockedObjects);
+      } catch (e) {
+        // ADT refuses to delete a request/task that still holds locked objects (e.g. a deleted
+        // object's lingering record). Point the caller at removeLockedObjects instead of a raw [?/009].
+        if (!removeLockedObjects && e instanceof Error && /locked objects/i.test(e.message)) {
+          return errorResult(
+            `${e.message}\n\nThe request still holds locked object(s). ` +
+              `Retry with removeLockedObjects=true to strip them first:\n` +
+              `  SAPTransport(action="delete", id="${id}", removeLockedObjects=true)`,
+          );
+        }
+        throw e;
+      }
+      const extras = [recursive ? 'recursive' : '', removeLockedObjects ? 'removed locked objects' : '']
+        .filter(Boolean)
+        .join(', ');
+      return textResult(`Deleted transport request: ${id}${extras ? ` (${extras})` : ''}`);
     }
     case 'reassign': {
       const id = String(args.id ?? '');

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -851,8 +851,10 @@ export const SAPTransportSchema = z.object({
   status: z.string().optional(),
   type: z.string().optional(),
   owner: z.string().optional(),
-  recursive: z.boolean().optional(),
-  removeLockedObjects: z.boolean().optional(),
+  // looseOptionalBoolean (not z.boolean()) so GPT/OpenAI clients sending stringified
+  // "true"/"false" coerce instead of erroring at validation (CLAUDE.md boolean guidance).
+  recursive: looseOptionalBoolean,
+  removeLockedObjects: looseOptionalBoolean,
 });
 
 // ─── SAPGit ─────────────────────────────────────────────────────────

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -852,6 +852,7 @@ export const SAPTransportSchema = z.object({
   type: z.string().optional(),
   owner: z.string().optional(),
   recursive: z.boolean().optional(),
+  removeLockedObjects: z.boolean().optional(),
 });
 
 // ─── SAPGit ─────────────────────────────────────────────────────────

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1493,7 +1493,7 @@ export function getToolDefinitions(
               'get: fetch transport details including tasks and objects. ' +
               'create: create a new transport request (description required). To target another system, pass target=<system | system.client | /group/> (the Transportziel / TR_TARGET, e.g. "/TRG/" or "C11"; the group and system.client forms require extended transport control to be active). Otherwise omit target and pass an optional package to let SAP infer the route (defaults to $TMP). The response reports the resolved transport target; an empty target means a LOCAL request (cannot be transported onward). ' +
               'release: release a single transport or task. ' +
-              'delete: delete a transport (use recursive=true to delete tasks first). ' +
+              'delete: delete a transport (use recursive=true to delete tasks first; removeLockedObjects=true to strip locked objects that otherwise block deletion with "...contains locked objects"). ' +
               'reassign: change transport owner (use recursive=true for tasks too). ' +
               'release_recursive: release all unreleased tasks first, then the transport itself. ' +
               'check: check if a transport is needed for a package/object (requires type, name, package). ' +
@@ -1541,6 +1541,11 @@ export function getToolDefinitions(
           recursive: {
             type: 'boolean',
             description: 'Apply recursively to child tasks (for delete/reassign). release_recursive always recurses.',
+          },
+          removeLockedObjects: {
+            type: 'boolean',
+            description:
+              'For delete only. Strip locked objects from each task before deleting, so a request that still holds a locked object (e.g. a deleted object\'s lingering record → HTTP 400 "...contains locked objects") can be removed.',
           },
         },
         required: ['action'],

--- a/tests/unit/adt/transport.test.ts
+++ b/tests/unit/adt/transport.test.ts
@@ -606,6 +606,30 @@ describe('Transport Management', () => {
       expect(putCalls[0]?.[1]).toContain('tm:name="ZGHOST"');
       expect(putCalls[0]?.[1]).not.toContain('ZCL_OK');
     });
+
+    it('removeLockedObjects + recursive strips the lock, then deletes the task, then the request', async () => {
+      const xml = `<tm:root xmlns:tm="http://www.sap.com/cts/transports">
+        <tm:request tm:number="DEVK900001" tm:owner="DEV" tm:desc="Test" tm:status="D" tm:type="K">
+          <tm:task tm:number="DEVK900001T1" tm:owner="DEV1" tm:desc="Task 1" tm:status="D">
+            <tm:abap_object tm:pgmid="R3TR" tm:type="DEVC" tm:name="ZGHOST" tm:lock_status="X" tm:position="000001"/>
+          </tm:task>
+        </tm:request>
+      </tm:root>`;
+      const http = mockHttp(xml);
+      await deleteTransport(http, enabledSafety, 'DEVK900001', true, true);
+
+      // The locked object must be stripped (PUT removeobject) BEFORE the task is deleted,
+      // otherwise ADT refuses to delete the task ("...contains locked objects").
+      const putCalls = (http.put as ReturnType<typeof vi.fn>).mock.calls;
+      expect(putCalls).toHaveLength(1);
+      expect(putCalls[0]?.[0]).toBe('/sap/bc/adt/cts/transportrequests/DEVK900001T1');
+      expect(putCalls[0]?.[1]).toContain('tm:useraction="removeobject"');
+
+      const deleteCalls = (http.delete as ReturnType<typeof vi.fn>).mock.calls;
+      expect(deleteCalls).toHaveLength(2);
+      expect(deleteCalls[0]?.[0]).toBe('/sap/bc/adt/cts/transportrequests/DEVK900001T1');
+      expect(deleteCalls[1]?.[0]).toBe('/sap/bc/adt/cts/transportrequests/DEVK900001');
+    });
   });
 
   // ─── reassignTransport ────────────────────────────────────────────

--- a/tests/unit/adt/transport.test.ts
+++ b/tests/unit/adt/transport.test.ts
@@ -551,6 +551,61 @@ describe('Transport Management', () => {
       expect(deleteCalls[0]?.[0]).toContain('DEVK900001T2');
       expect(deleteCalls[1]?.[0]).toContain('DEVK900001');
     });
+
+    it('does not fetch or PUT when removeLockedObjects is false (backward compatible)', async () => {
+      const http = mockHttp();
+      await deleteTransport(http, enabledSafety, 'DEVK900001');
+      expect((http.get as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+      expect((http.put as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+
+    it('removeLockedObjects strips locked objects via a removeobject PUT, then deletes the request', async () => {
+      const xml = `<tm:root xmlns:tm="http://www.sap.com/cts/transports">
+        <tm:request tm:number="DEVK900001" tm:owner="DEV" tm:desc="Test" tm:status="D" tm:type="K">
+          <tm:task tm:number="DEVK900001T1" tm:owner="DEV1" tm:desc="Task 1" tm:status="D">
+            <tm:abap_object tm:pgmid="R3TR" tm:type="DEVC" tm:name="ZGHOST" tm:wbtype="DEVC/K" tm:obj_desc="Package" tm:lock_status="X" tm:position="000001"/>
+          </tm:task>
+        </tm:request>
+      </tm:root>`;
+      const http = mockHttp(xml);
+      await deleteTransport(http, enabledSafety, 'DEVK900001', false, true);
+
+      const putCalls = (http.put as ReturnType<typeof vi.fn>).mock.calls;
+      expect(putCalls).toHaveLength(1);
+      // PUT (not POST) to the TASK URI — POST silently no-ops on the SAP side.
+      expect(putCalls[0]?.[0]).toBe('/sap/bc/adt/cts/transportrequests/DEVK900001T1');
+      const body = putCalls[0]?.[1] as string;
+      expect(body).toContain('tm:useraction="removeobject"');
+      expect(body).toContain('tm:number="DEVK900001T1"');
+      expect(body).toContain('tm:pgmid="R3TR"');
+      expect(body).toContain('tm:type="DEVC"');
+      expect(body).toContain('tm:name="ZGHOST"');
+      expect(body).toContain('tm:position="000001"');
+      expect(putCalls[0]?.[2]).toBe(CTS_CONTENT_TYPE_ORGANIZER);
+
+      const deleteCalls = (http.delete as ReturnType<typeof vi.fn>).mock.calls;
+      // recursive=false → only the request itself is deleted, after the lock is cleared.
+      expect(deleteCalls).toHaveLength(1);
+      expect(deleteCalls[0]?.[0]).toBe('/sap/bc/adt/cts/transportrequests/DEVK900001');
+    });
+
+    it('removeLockedObjects only touches locked objects, not unlocked ones', async () => {
+      const xml = `<tm:root xmlns:tm="http://www.sap.com/cts/transports">
+        <tm:request tm:number="DEVK900001" tm:owner="DEV" tm:desc="Test" tm:status="D" tm:type="K">
+          <tm:task tm:number="DEVK900001T1" tm:owner="DEV1" tm:desc="Task 1" tm:status="D">
+            <tm:abap_object tm:pgmid="R3TR" tm:type="DEVC" tm:name="ZGHOST" tm:lock_status="X" tm:position="000001"/>
+            <tm:abap_object tm:pgmid="R3TR" tm:type="CLAS" tm:name="ZCL_OK" tm:lock_status="" tm:position="000002"/>
+          </tm:task>
+        </tm:request>
+      </tm:root>`;
+      const http = mockHttp(xml);
+      await deleteTransport(http, enabledSafety, 'DEVK900001', false, true);
+
+      const putCalls = (http.put as ReturnType<typeof vi.fn>).mock.calls;
+      expect(putCalls).toHaveLength(1);
+      expect(putCalls[0]?.[1]).toContain('tm:name="ZGHOST"');
+      expect(putCalls[0]?.[1]).not.toContain('ZCL_OK');
+    });
   });
 
   // ─── reassignTransport ────────────────────────────────────────────

--- a/tests/unit/handlers/schemas.test.ts
+++ b/tests/unit/handlers/schemas.test.ts
@@ -1429,6 +1429,22 @@ describe('SAPTransportSchema', () => {
     const result = SAPTransportSchema.safeParse({ action: 'history' });
     expect(result.success).toBe(true);
   });
+
+  it('coerces stringified booleans for delete flags (GPT/OpenAI client robustness)', () => {
+    const result = SAPTransportSchema.safeParse({
+      action: 'delete',
+      id: 'DEVK900001',
+      recursive: 'false',
+      removeLockedObjects: 'true',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Stringified booleans coerce (looseOptionalBoolean) instead of erroring — a real GPT
+      // pollution case; plain z.boolean() would reject "true"/"false" here.
+      expect(result.data.recursive).toBe(false);
+      expect(result.data.removeLockedObjects).toBe(true);
+    }
+  });
 });
 
 describe('SAPGitSchema', () => {


### PR DESCRIPTION
Fixes #385.

## Problem
`SAPTransport delete` returns `HTTP 400 [?/009] "...contains locked objects"` when a task still holds a locked object (e.g. a deleted object''s lingering record). There was no way past it.

## Fix
Add `removeLockedObjects` (default `false`) to `SAPTransport delete`. When set, ARC-1 GETs the request and, for each locked object in each task, issues the ADT **"Remove Locked Object"** operation, then deletes. New `removeTransportObject` helper mirrors `reassignSingle`.

**Implementation note:** the operation must be a `PUT` to `/cts/transportrequests/{task}` with `tm:useraction="removeobject"` — a `POST` with the same body is accepted (HTTP 200) but silently no-ops. The delete handler also hints at the flag when it hits the locked-objects error.

## Tests
Unit tests for the removeobject PUT (method/URL/body), locked-only filtering, and backward-compatible no-op. All unit tests pass; `tsc --noEmit` and `biome check` clean.

## Verified live (on-prem S/4HANA, SAP_BASIS 8.16)
Reproduced the `[?/009]` failure, then confirmed a request whose task holds locked objects (tested with 1 and with 2) deletes cleanly with `removeLockedObjects=true`. The removeobject contract is verified on 8.16; not yet verified on NW 7.5x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)