### PR TITLE
fix(oauth): match redirect-uri allowlist against parsed URL components

### DIFF
--- a/src/server/stateless-client-store.ts
+++ b/src/server/stateless-client-store.ts
@@ -162,11 +162,12 @@ const XSUAA_REDIRECT_URI_REGEXPS = XSUAA_REDIRECT_URI_PATTERNS.map(redirectPatte
  * would otherwise let a URL-userinfo segment ride inside the same-segment
  * wildcard — `http://localhost:x@evil.com/cb` matches the `localhost:[^slash]`
  * port glob yet `new URL(...).host === 'evil.com'`, steering a victim's code to an
- * attacker host. So we reject anything that doesn't parse, and reject any
- * userinfo (`user[:pass]@`) — that `@` is the only construct that can relocate
- * the authority past a same-segment wildcard, and no legitimate OAuth
- * redirect_uri carries credentials. After this guard, a glob match implies the
- * parsed host is the literal host in the pattern.
+ * attacker host. So we reject anything that doesn't parse, reject any userinfo
+ * (`user[:pass]@`, which no legitimate redirect_uri carries), and — for http/https —
+ * match the glob against a subject rebuilt from the PARSED components rather than the
+ * raw string, so `\`, `#` and `?` (authority terminators the WHATWG parser folds) cannot
+ * relocate the host past a same-segment wildcard. After these guards, a glob match
+ * implies the parsed host is the literal host in the pattern.
  */
 export function matchesXsuaaRedirectPattern(uri: string): boolean {
   let parsed: URL;
@@ -176,7 +177,17 @@ export function matchesXsuaaRedirectPattern(uri: string): boolean {
     return false;
   }
   if (parsed.username !== '' || parsed.password !== '') return false;
-  return XSUAA_REDIRECT_URI_REGEXPS.some((re) => re.test(uri));
+  // SECURITY: match the glob against a subject rebuilt from the PARSED components, not the
+  // raw string. For http/https, `\`, `#` and `?` are authority terminators the parser folds,
+  // so a raw value like `https://evil.com\@x.hana.ondemand.com/cb` matches a `*.hana.ondemand.com`
+  // glob yet parses to host `evil.com` — and `evil.com` is the host the `code`-bearing 302 reaches.
+  // Rebuilding `${protocol}//${host}${pathname}${search}` makes the regex see that same host.
+  // Custom schemes (cursor:, vscode:) carry no authority component, so match their raw value.
+  const subject =
+    parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? `${parsed.protocol}//${parsed.host}${parsed.pathname}${parsed.search}`
+      : uri;
+  return XSUAA_REDIRECT_URI_REGEXPS.some((re) => re.test(subject));
 }
 
 // ─── Payload Schema ───────────────────────────────────────────────────

--- a/tests/unit/server/stateless-client-store.test.ts
+++ b/tests/unit/server/stateless-client-store.test.ts
@@ -293,6 +293,26 @@ describe('matchesXsuaaRedirectPattern (redirect-uri allowlist for the shared XSU
     expect(matchesXsuaaRedirectPattern('http://localhost:6274/oauth/callback')).toBe(true);
   });
 
+  it('rejects host/string divergence via backslash, fragment, or query (string matches glob, parses to a foreign host)', () => {
+    // SECURITY regression: the glob is matched against a subject rebuilt from the PARSED URL, not
+    // the raw string. `\`, `#` and `?` are authority terminators the WHATWG parser folds, so each
+    // raw string below matches `https://*.hana.ondemand.com/**` yet `new URL(...).host` is
+    // `evil.com` — the host the `code`-bearing 302 would actually reach. (Deep security review, R8.)
+    const divergent = [
+      'https://evil.com\\@x.hana.ondemand.com/cb',
+      'https://evil.com#@x.hana.ondemand.com/cb',
+      'https://evil.com?@x.hana.ondemand.com/cb',
+      'https://evil.com\\.hana.ondemand.com/cb',
+    ];
+    for (const uri of divergent) {
+      expect(new URL(uri).host, uri).toBe('evil.com'); // documents the parse
+      expect(matchesXsuaaRedirectPattern(uri), uri).toBe(false);
+    }
+    // legitimate SAP hosts and custom-scheme app callbacks still pass
+    expect(matchesXsuaaRedirectPattern('https://app.hana.ondemand.com/oauth/callback')).toBe(true);
+    expect(matchesXsuaaRedirectPattern('cursor://anysphere.cursor-mcp/cb')).toBe(true);
+  });
+
   it('rejects values that are not parseable URLs', () => {
     expect(matchesXsuaaRedirectPattern('not a url')).toBe(false);
     expect(matchesXsuaaRedirectPattern('http://')).toBe(false);


### PR DESCRIPTION
## Summary

Hardens the XSUAA redirect-URI allowlist (`matchesXsuaaRedirectPattern`).

The matcher tested the glob against the **raw** URI string and guarded only `@`-userinfo. For `http`/`https`, `\`, `#` and `?` are authority terminators the WHATWG URL parser folds, so the raw string and the **parsed host** can diverge — and the `/oauth/callback` 302 (which carries the OAuth `code`) follows the parsed host.

This rebuilds the match subject from the parsed components (`${protocol}//${host}${pathname}${search}`) for `http`/`https` so the regex sees the same host the parser resolves. Authority-less custom schemes (`cursor:`, `vscode:`) keep raw matching. The userinfo guard is retained.

## Test

Adds a regression test asserting that backslash/fragment/query host relocation (string matches the glob, `new URL().host` is the attacker host) is rejected, while legitimate SAP hosts and custom-scheme callbacks still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)