### PR TITLE
fix(limits): clamp unbounded result limits to prevent resource exhaustion

### DIFF
--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -207,6 +207,17 @@ export function clampPreviewRows(requested: number | undefined, fallback = 100):
   return Math.min(Math.floor(requested), MAX_TABLE_QUERY_ROWS);
 }
 
+const MAX_SEARCH_RESULTS = 1_000;
+
+/** Coerce a caller-supplied search-result limit into a safe positive integer in
+ *  [1, MAX_SEARCH_RESULTS]. NaN / non-finite / non-positive / undefined fall back to the
+ *  caller's default — prevents an unbounded `maxResults` from buffering a huge result set
+ *  on the shared event loop. */
+export function clampSearchResults(requested: number | undefined, fallback: number): number {
+  if (requested === undefined || !Number.isFinite(requested) || requested < 1) return fallback;
+  return Math.min(Math.floor(requested), MAX_SEARCH_RESULTS);
+}
+
 /** Sanitize a SQL identifier (table / column / field): uppercase, then strip everything but
  *  word characters and the namespace slash. Throws when nothing survives — a structurally
  *  invalid identifier must fail closed rather than emit malformed SQL (e.g. `SELECT , X FROM`).
@@ -1006,8 +1017,9 @@ export class AdtClient {
   /** Search for ABAP objects by name pattern */
   async searchObject(query: string, maxResults = 100): Promise<AdtSearchResult[]> {
     checkOperation(this.safety, OperationType.Search, 'SearchObject');
+    const limit = clampSearchResults(maxResults, 100);
     const resp = await this.http.get(
-      `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=${encodeURIComponent(query)}&maxResults=${maxResults}`,
+      `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=${encodeURIComponent(query)}&maxResults=${limit}`,
     );
     return parseSearchResults(resp.body);
   }
@@ -1172,7 +1184,8 @@ export class AdtClient {
     packageName?: string,
   ): Promise<SourceSearchResult[]> {
     checkOperation(this.safety, OperationType.Search, 'SearchSource');
-    let url = `/sap/bc/adt/repository/informationsystem/textSearch?searchString=${encodeURIComponent(pattern)}&maxResults=${maxResults}`;
+    const limit = clampSearchResults(maxResults, 50);
+    let url = `/sap/bc/adt/repository/informationsystem/textSearch?searchString=${encodeURIComponent(pattern)}&maxResults=${limit}`;
     if (objectType) url += `&objectType=${encodeURIComponent(objectType)}`;
     if (packageName) url += `&packageName=${encodeURIComponent(packageName)}`;
     const resp = await this.http.get(url);
@@ -1295,8 +1308,9 @@ export class AdtClient {
     sqlFilter?: string,
   ): Promise<{ columns: string[]; rows: Record<string, string>[] }> {
     checkOperation(this.safety, OperationType.Query, 'GetTableContents');
+    const rowLimit = clampPreviewRows(maxRows);
     const resp = await this.http.post(
-      `/sap/bc/adt/datapreview/ddic?rowNumber=${maxRows}&ddicEntityName=${encodeURIComponent(tableName)}`,
+      `/sap/bc/adt/datapreview/ddic?rowNumber=${rowLimit}&ddicEntityName=${encodeURIComponent(tableName)}`,
       sqlFilter,
       'text/plain',
     );

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -7322,7 +7322,10 @@ async function handleSAPContext(
   const rawType = String(args.type ?? '');
   const type = normalizeObjectType(rawType || (action === 'impact' ? 'DDLS' : ''));
   const name = String(args.name ?? '');
-  const maxDeps = Number(args.maxDeps ?? 20);
+  // Bound dependency fan-out: a huge maxDeps would fan out unbounded SAP fetches per level
+  // (depth is already capped at 3). Clamp to [1, 100]; non-finite/<1 falls back to the default 20.
+  const rawMaxDeps = Number(args.maxDeps ?? 20);
+  const maxDeps = Number.isFinite(rawMaxDeps) && rawMaxDeps >= 1 ? Math.min(Math.floor(rawMaxDeps), 100) : 20;
   const depth = Math.min(Math.max(Number(args.depth ?? 1), 1), 3);
 
   // ─── Reverse dep lookup (pre-warmer only) ─────────────────────────

--- a/tests/unit/adt/client.test.ts
+++ b/tests/unit/adt/client.test.ts
@@ -12,7 +12,7 @@ vi.mock('undici', async (importOriginal) => {
   return { ...actual, fetch: mockFetch };
 });
 
-const { AdtClient } = await import('../../../src/adt/client.js');
+const { AdtClient, clampSearchResults } = await import('../../../src/adt/client.js');
 
 const fixturesDir = join(import.meta.dirname, '../../fixtures/xml');
 const loadFixture = (name: string) => readFileSync(join(fixturesDir, name), 'utf-8');
@@ -1530,6 +1530,49 @@ describe('AdtClient', () => {
       await client.runTableQuery('T000', { maxRows: Number.NaN });
       const postCall = mockFetch.mock.calls.find((c) => String(c[0]).includes('/datapreview/freestyle'));
       expect(String(postCall?.[0])).toContain('rowNumber=100');
+    });
+  });
+
+  describe('result-limit clamping (unbounded count DoS guard)', () => {
+    it('clampSearchResults bounds to [1, 1000] and falls back on invalid input', () => {
+      expect(clampSearchResults(50, 100)).toBe(50);
+      expect(clampSearchResults(5000, 100)).toBe(1000); // capped
+      expect(clampSearchResults(12.9, 100)).toBe(12); // floored
+      expect(clampSearchResults(0, 100)).toBe(100); // <1 -> fallback
+      expect(clampSearchResults(-1, 50)).toBe(50);
+      expect(clampSearchResults(Number.NaN, 100)).toBe(100);
+      expect(clampSearchResults(undefined, 50)).toBe(50);
+    });
+
+    it('searchObject clamps an oversized maxResults in the query string', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<empty/>'));
+      const client = createClient();
+      await client.searchObject('Z*', 999_999);
+      expect(String(mockFetch.mock.calls[0]?.[0] ?? '')).toContain('maxResults=1000');
+    });
+
+    it('searchSource clamps an oversized maxResults in the query string', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<empty/>'));
+      const client = createClient();
+      await client.searchSource('foo', 999_999);
+      expect(String(mockFetch.mock.calls[0]?.[0] ?? '')).toContain('maxResults=1000');
+    });
+
+    it('getTableContents (TABLE_CONTENTS) clamps rowNumber to <= 10000 and NaN to the default', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, loadFixture('table-contents.xml'), { 'x-csrf-token': 'T' }));
+      const client = createClient();
+      await client.getTableContents('MARA', 999_999);
+      const big = mockFetch.mock.calls.find((c) => String(c[0]).includes('/datapreview/ddic'));
+      expect(String(big?.[0])).toContain('rowNumber=10000');
+
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, loadFixture('table-contents.xml'), { 'x-csrf-token': 'T' }));
+      await client.getTableContents('MARA', Number.NaN);
+      const nan = mockFetch.mock.calls.find((c) => String(c[0]).includes('/datapreview/ddic'));
+      expect(String(nan?.[0])).toContain('rowNumber=100');
     });
   });
 


### PR DESCRIPTION
## Summary

`maxRows` (TABLE_CONTENTS), `maxResults` (object/source search) and `maxDeps` (dependency context) were interpolated/sliced without an upper bound, so a single tool call (e.g. `SAPRead(type=TABLE_CONTENTS, maxRows=99999999)`) could buffer a huge result set on the shared event loop and amplify SAP load — the existing clamp only covered `TABLE_QUERY`/`getPackageContents`.

Clamps at the sinks (graceful — over-cap silently clamps, never errors):
- `getTableContents` → existing `clampPreviewRows` (`[1, 10000]`)
- `searchObject` / `searchSource` → new `clampSearchResults` (`[1, 1000]`, NaN/<1 → caller default)
- `maxDeps` → bounded to `[1, 100]` in the handler (depth already capped at 3)

## Test

Adds a unit test for `clampSearchResults` plus URL-level assertions that each sink clamps an oversized value (and falls back to the default on NaN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)