### PR TITLE
fix(git): enforce package allowlist on abapGit pull/push

### DIFF
--- a/src/adt/abapgit.ts
+++ b/src/adt/abapgit.ts
@@ -4,7 +4,7 @@
  * Bridge endpoints live under /sap/bc/adt/abapgit/* and use XML payloads.
  */
 
-import { AdtApiError, classifyAbapgitError } from './errors.js';
+import { AdtApiError, AdtSafetyError, classifyAbapgitError } from './errors.js';
 import type { AdtHttpClient } from './http.js';
 import type { PackageHierarchyResolver } from './package-hierarchy.js';
 import { checkGit, checkOperation, checkPackage, OperationType, type SafetyConfig } from './safety.js';
@@ -308,6 +308,32 @@ export async function createRepo(
   );
 
   return parseAbapGitRepos(resp.body);
+}
+
+/**
+ * Enforce the package allowlist against a repository's server-bound package (R9).
+ *
+ * `clone` chooses (and gates) the target package up-front, but `pull`/`push` operate on an
+ * existing repo whose binding ARC-1 did not choose — abapGit deserializes the remote content
+ * into that bound package regardless of any caller-supplied `package` value (which it ignores
+ * for an existing repo). Re-validate the real binding here. Fail-closed when an allowlist is
+ * configured and the package can't be resolved; no-op when unrestricted.
+ */
+export async function enforceRepoPackageAllowed(
+  safety: SafetyConfig,
+  repoPackage: string | undefined,
+  resolver: PackageHierarchyResolver | null | undefined,
+  label = 'AbapGitRepo',
+): Promise<void> {
+  if (safety.allowedPackages.length === 0) return;
+  if (!repoPackage) {
+    throw new AdtSafetyError(
+      `${label}: cannot resolve the repository's package to check it against allowedPackages (${JSON.stringify(
+        safety.allowedPackages,
+      )}); refusing.`,
+    );
+  }
+  await checkPackage(safety, repoPackage, resolver);
 }
 
 export async function pullRepo(

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -16,6 +16,7 @@ import {
   checkRepo as abapGitCheckRepo,
   createBranch as abapGitCreateBranch,
   createRepo as abapGitCreateRepo,
+  enforceRepoPackageAllowed as abapGitEnforceRepoPackage,
   getExternalInfo as abapGitGetExternalInfo,
   listRepos as abapGitListRepos,
   pullRepo as abapGitPullRepo,
@@ -6938,6 +6939,16 @@ async function handleSAPGit(
       if (backend === 'gcts') {
         result = await gctsPullRepo(client.http, client.safety, repoId, String(args.commit ?? '').trim() || undefined);
       } else {
+        // R9: a pull deserializes remote content into the repo's server-bound package, which is
+        // NOT the caller-supplied `package` (abapGit ignores that for an existing repo). Gate the
+        // real binding against the allowlist before writing.
+        const repo = await loadAbapGitRepo(client, repoId);
+        await abapGitEnforceRepoPackage(
+          client.safety,
+          repo.package,
+          client.getPackageHierarchyResolver(),
+          'SAPGit(action="pull")',
+        );
         result = await abapGitPullRepo(client.http, client.safety, repoId, {
           ...(packageName ? { package: packageName } : {}),
           ...(url ? { url } : {}),
@@ -6951,6 +6962,14 @@ async function handleSAPGit(
     case 'push': {
       if (!repoId) return errorResult('SAPGit(action="push") requires repoId.');
       const repo = await loadAbapGitRepo(client, repoId);
+      // R9: push exports the repo's bound-package source to a remote git; gate that package
+      // against the allowlist (the read-side mirror of the pull gate above).
+      await abapGitEnforceRepoPackage(
+        client.safety,
+        repo.package,
+        client.getPackageHierarchyResolver(),
+        'SAPGit(action="push")',
+      );
       const staging =
         Array.isArray(args.objects) && args.objects.length > 0
           ? { repoKey: repo.key, branchName: repo.branchName, objects: args.objects as Array<Record<string, unknown>> }

--- a/tests/unit/adt/abapgit.test.ts
+++ b/tests/unit/adt/abapgit.test.ts
@@ -5,6 +5,7 @@ import {
   checkRepo,
   createBranch,
   createRepo,
+  enforceRepoPackageAllowed,
   getExternalInfo,
   listRepos,
   parseAbapGitExternalInfo,
@@ -103,6 +104,35 @@ describe('abapGit client helpers', () => {
     await expect(
       createRepo(http, safety, { package: 'ZBLOCKED', url: 'https://github.com/example/repo.git' }),
     ).rejects.toThrow(AdtSafetyError);
+  });
+
+  describe('enforceRepoPackageAllowed (R9 — pull/push gate the repo binding)', () => {
+    it('is a no-op when no allowlist is configured', async () => {
+      await expect(enforceRepoPackageAllowed(gitSafety, '$TUTORIALS', null, 'pull')).resolves.toBeUndefined();
+    });
+
+    it('allows a repo whose bound package is within the allowlist', async () => {
+      const safety = { ...gitSafety, allowedPackages: ['$TUTORIALS'] };
+      await expect(enforceRepoPackageAllowed(safety, '$TUTORIALS', null, 'pull')).resolves.toBeUndefined();
+    });
+
+    it('refuses a repo whose bound package is outside the allowlist', async () => {
+      // $TUTORIALS is the binding of repos-v2 repo[0]; a pull would deserialize remote content into it.
+      const safety = { ...gitSafety, allowedPackages: ['$TMP'] };
+      await expect(enforceRepoPackageAllowed(safety, '$TUTORIALS', null, 'SAPGit(action="pull")')).rejects.toThrow(
+        AdtSafetyError,
+      );
+    });
+
+    it('fails closed when the allowlist is set but the bound package cannot be resolved', async () => {
+      const safety = { ...gitSafety, allowedPackages: ['$TMP'] };
+      await expect(enforceRepoPackageAllowed(safety, undefined, null, 'SAPGit(action="pull")')).rejects.toThrow(
+        AdtSafetyError,
+      );
+      await expect(enforceRepoPackageAllowed(safety, '', null, 'SAPGit(action="pull")')).rejects.toThrow(
+        AdtSafetyError,
+      );
+    });
   });
 
   it('createRepo sends Username + base64 Password headers and remote credentials in XML body', async () => {


### PR DESCRIPTION
## Summary

`clone` gates its target package up-front, but `pull`/`push` operated on an existing repo with only the `allowGitWrites` flag checked — no per-package gate. A repo bound (out-of-band) to a package outside `allowedPackages` could therefore be **pulled** (deserializing remote content into that package) or **pushed** (exfiltrating its source), with the caller-supplied `package` acting as a decoy abapGit ignores for an existing repo.

Resolves the repo's real binding (`loadAbapGitRepo`) and re-validates it via a new `abapgit.enforceRepoPackageAllowed()` before pull and push — fail-closed when an allowlist is set and the package can't be resolved; no-op when unrestricted.

Scoped to **abapGit** (1:1 repo→package). gCTS `pull`/`commit` gating is a tracked follow-up (gCTS repos can span packages; resolution needs the per-repo object list).

## Test

Adds unit tests for `enforceRepoPackageAllowed`: no-op unrestricted, allow on match, refuse out-of-allowlist binding, and fail-closed on an unresolvable package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)