### PR TITLE
fix: harden SAPRead grep regex handling

### DIFF
--- a/src/context/grep.ts
+++ b/src/context/grep.ts
@@ -37,13 +37,19 @@ export interface GrepResult {
   matchCount: number;
   /** Formatted, LLM-friendly match report (or a no-match / invalid-pattern message). */
   output: string;
-  /** True only when the pattern is not valid regex AND has no literal match either. */
+  /** True when the pattern cannot be used safely or has no valid regex/literal interpretation. */
   invalidPattern: boolean;
 }
 
 const DEFAULT_CONTEXT_LINES = 3;
 const DEFAULT_MAX_MATCHES = 100;
+export const MAX_GREP_PATTERN_LENGTH = 512;
+export const MAX_GREP_LINE_LENGTH = 1000;
 const REGEX_META = /[.*+?^${}()|[\]\\]/;
+const NESTED_QUANTIFIER_GROUP =
+  /\((?:\?:)?(?:[^()[\]\\]|\\.|\[[^\]]*])*[*+{](?:[^()[\]\\]|\\.|\[[^\]]*])*\)\s*(?:[+*?]|\{\d)/;
+const BACKREFERENCE = /\\[1-9]/;
+const LOOKAROUND = /\(\?(?:[=!]|<[=!])/;
 
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -58,12 +64,32 @@ function tryCompile(pattern: string): RegExp | null {
   }
 }
 
+function unsafePatternReason(pattern: string): string | null {
+  if (pattern.length > MAX_GREP_PATTERN_LENGTH) {
+    return `pattern is too long (${pattern.length} characters; maximum ${MAX_GREP_PATTERN_LENGTH})`;
+  }
+  if (LOOKAROUND.test(pattern)) {
+    return 'lookaround assertions are disabled for server-side grep';
+  }
+  if (BACKREFERENCE.test(pattern)) {
+    return 'backreferences are disabled for server-side grep';
+  }
+  if (NESTED_QUANTIFIER_GROUP.test(pattern)) {
+    return 'nested quantified groups are disabled for server-side grep';
+  }
+  return null;
+}
+
+function trimSearchLine(line: string): string {
+  return line.length <= MAX_GREP_LINE_LENGTH ? line : line.slice(0, MAX_GREP_LINE_LENGTH);
+}
+
 /** 0-based indexes of lines matching `regex` (resets lastIndex so the global flag never skips a line). */
 function matchingIndexes(lines: string[], regex: RegExp): number[] {
   const out: number[] = [];
   for (let i = 0; i < lines.length; i++) {
     regex.lastIndex = 0;
-    if (regex.test(lines[i]!)) out.push(i);
+    if (regex.test(trimSearchLine(lines[i]!))) out.push(i);
   }
   return out;
 }
@@ -125,6 +151,15 @@ export function grepSource(source: string, pattern: string, opts: GrepOptions = 
   const contextLines = opts.contextLines ?? DEFAULT_CONTEXT_LINES;
   const maxMatches = opts.maxMatches ?? DEFAULT_MAX_MATCHES;
   const lines = source.replace(/\r\n/g, '\n').split('\n');
+  const unsafeReason = unsafePatternReason(pattern);
+
+  if (unsafeReason) {
+    return {
+      matchCount: 0,
+      invalidPattern: true,
+      output: `Unsupported grep pattern: ${unsafeReason}. Use a shorter literal token or a simpler regex.`,
+    };
+  }
 
   const { indexes, effectivePattern, invalidPattern } = resolveMatches(lines, pattern);
 

--- a/src/context/grep.ts
+++ b/src/context/grep.ts
@@ -51,6 +51,10 @@ const NESTED_QUANTIFIER_GROUP =
 const BACKREFERENCE = /\\[1-9]/;
 const LOOKAROUND = /\(\?(?:[=!]|<[=!])/;
 
+interface RegexGroupFrame {
+  hasAlternation: boolean;
+}
+
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -62,6 +66,61 @@ function tryCompile(pattern: string): RegExp | null {
   } catch {
     return null;
   }
+}
+
+function isRegexQuantifierAt(pattern: string, index: number): boolean {
+  const char = pattern[index];
+  if (char === '{') return /^\{\d+(?:,\d*)?\}/.test(pattern.slice(index));
+  return char === '+' || char === '*' || char === '?';
+}
+
+function hasQuantifiedAlternationGroup(pattern: string): boolean {
+  const stack: RegexGroupFrame[] = [];
+  let inCharClass = false;
+
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i]!;
+
+    if (char === '\\') {
+      i++;
+      continue;
+    }
+
+    if (inCharClass) {
+      if (char === ']') inCharClass = false;
+      continue;
+    }
+
+    if (char === '[') {
+      inCharClass = true;
+      continue;
+    }
+
+    if (char === '(') {
+      stack.push({ hasAlternation: false });
+      continue;
+    }
+
+    if (char === '|') {
+      const top = stack[stack.length - 1];
+      if (top) top.hasAlternation = true;
+      continue;
+    }
+
+    if (char === ')') {
+      const frame = stack.pop();
+      if (!frame) continue;
+
+      if (frame.hasAlternation && isRegexQuantifierAt(pattern, i + 1)) {
+        return true;
+      }
+
+      const parent = stack[stack.length - 1];
+      if (parent && frame.hasAlternation) parent.hasAlternation = true;
+    }
+  }
+
+  return false;
 }
 
 function unsafePatternReason(pattern: string): string | null {
@@ -76,6 +135,9 @@ function unsafePatternReason(pattern: string): string | null {
   }
   if (NESTED_QUANTIFIER_GROUP.test(pattern)) {
     return 'nested quantified groups are disabled for server-side grep';
+  }
+  if (hasQuantifiedAlternationGroup(pattern)) {
+    return 'quantified alternation groups are disabled for server-side grep';
   }
   return null;
 }

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -11,6 +11,7 @@
  */
 
 import { z } from 'zod';
+import { MAX_GREP_PATTERN_LENGTH } from '../context/grep.js';
 
 /**
  * Optional boolean that accepts real JSON booleans AND string-serialized booleans from
@@ -228,7 +229,7 @@ export const SAPReadSchema = z
     include: z.string().optional(),
     group: z.string().optional(),
     method: z.string().optional(),
-    grep: z.string().optional(),
+    grep: z.string().max(MAX_GREP_PATTERN_LENGTH).optional(),
     expand_includes: looseOptionalBoolean,
     format: z.enum(['text', 'structured']).optional(),
     version: z.enum(['active', 'inactive', 'auto']).optional().default('active'),
@@ -255,7 +256,7 @@ export const SAPReadSchemaBtp = z
     include: z.string().optional(),
     group: z.string().optional(),
     method: z.string().optional(),
-    grep: z.string().optional(),
+    grep: z.string().max(MAX_GREP_PATTERN_LENGTH).optional(),
     format: z.enum(['text', 'structured']).optional(),
     version: z.enum(['active', 'inactive', 'auto']).optional().default('active'),
     force_refresh: looseOptionalBoolean,

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -18,6 +18,7 @@
  */
 
 import type { ResolvedFeatures } from '../adt/types.js';
+import { MAX_GREP_PATTERN_LENGTH } from '../context/grep.js';
 import type { ServerConfig } from '../server/types.js';
 import { getHyperfocusedToolDefinition } from './hyperfocused.js';
 
@@ -617,6 +618,7 @@ export function getToolDefinitions(
           },
           grep: {
             type: 'string',
+            maxLength: MAX_GREP_PATTERN_LENGTH,
             description:
               'Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. ' +
               'For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section, but do NOT combine with method= (use grep to find, then method= to read). ' +

--- a/tests/unit/context/grep.test.ts
+++ b/tests/unit/context/grep.test.ts
@@ -3,7 +3,12 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { grepSource, type MethodRange } from '../../../src/context/grep.js';
+import {
+  grepSource,
+  MAX_GREP_LINE_LENGTH,
+  MAX_GREP_PATTERN_LENGTH,
+  type MethodRange,
+} from '../../../src/context/grep.js';
 
 // ─── Fixtures ───────────────────────────────────────────────────────
 
@@ -92,11 +97,38 @@ describe('grepSource', () => {
     expect(r.output).toContain('read_entities(');
   });
 
-  it('flags invalidPattern only when a malformed regex also has no literal match', () => {
+  it('flags invalidPattern when a malformed regex also has no literal match', () => {
     const r = grepSource(SOURCE, 'nope(');
     expect(r.invalidPattern).toBe(true);
     expect(r.matchCount).toBe(0);
     expect(r.output).toContain('Invalid regex pattern');
+  });
+
+  it('rejects oversized patterns before compiling regex', () => {
+    const r = grepSource(SOURCE, 'x'.repeat(MAX_GREP_PATTERN_LENGTH + 1));
+    expect(r.invalidPattern).toBe(true);
+    expect(r.output).toContain('pattern is too long');
+  });
+
+  it('rejects nested quantified groups that can cause catastrophic backtracking', () => {
+    const repeatedChar = String.fromCharCode(97);
+    const source = `${repeatedChar.repeat(30)}!`;
+    const unsafePattern = `(${repeatedChar}+)+$`;
+    const started = Date.now();
+    const r = grepSource(source, unsafePattern);
+    expect(Date.now() - started).toBeLessThan(50);
+    expect(r.invalidPattern).toBe(true);
+    expect(r.output).toContain('nested quantified groups');
+  });
+
+  it('searches only the bounded line prefix while rendering the original source line', () => {
+    const longLine = `${'x'.repeat(MAX_GREP_LINE_LENGTH)}TAIL`;
+    expect(grepSource(longLine, 'TAIL').matchCount).toBe(0);
+
+    const visiblePrefix = `HEAD${'x'.repeat(MAX_GREP_LINE_LENGTH)}`;
+    const r = grepSource(visiblePrefix, 'HEAD');
+    expect(r.matchCount).toBe(1);
+    expect(r.output).toContain(visiblePrefix);
   });
 
   it('does not mutate the caller pattern argument', () => {

--- a/tests/unit/context/grep.test.ts
+++ b/tests/unit/context/grep.test.ts
@@ -121,6 +121,23 @@ describe('grepSource', () => {
     expect(r.output).toContain('nested quantified groups');
   });
 
+  it('rejects quantified alternation groups that can cause catastrophic backtracking', () => {
+    const repeatedChar = String.fromCharCode(97);
+    const source = `${repeatedChar.repeat(40)}!`;
+    const unsafePattern = `^(${repeatedChar}|${repeatedChar}${repeatedChar})+$`;
+    const started = Date.now();
+    const r = grepSource(source, unsafePattern);
+    expect(Date.now() - started).toBeLessThan(50);
+    expect(r.invalidPattern).toBe(true);
+    expect(r.output).toContain('quantified alternation groups');
+  });
+
+  it('still allows simple non-quantified alternation searches', () => {
+    const r = grepSource(SOURCE, '\\b(?:SELECT|WRITE)\\b');
+    expect(r.invalidPattern).toBe(false);
+    expect(r.matchCount).toBe(4);
+  });
+
   it('searches only the bounded line prefix while rendering the original source line', () => {
     const longLine = `${'x'.repeat(MAX_GREP_LINE_LENGTH)}TAIL`;
     expect(grepSource(longLine, 'TAIL').matchCount).toBe(0);

--- a/tests/unit/handlers/schemas.test.ts
+++ b/tests/unit/handlers/schemas.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { MAX_GREP_PATTERN_LENGTH } from '../../../src/context/grep.js';
 import {
   getToolSchema,
   SAPActivateSchema,
@@ -210,6 +211,12 @@ describe('SAPReadSchema', () => {
   it('rejects a non-string grep', () => {
     expect(SAPReadSchema.safeParse({ type: 'CLAS', name: 'ZCL_X', grep: 123 }).success).toBe(false);
     expect(SAPReadSchemaBtp.safeParse({ type: 'CLAS', name: 'ZCL_X', grep: ['a'] }).success).toBe(false);
+  });
+
+  it('rejects grep patterns beyond the server-side length cap', () => {
+    const grep = 'x'.repeat(MAX_GREP_PATTERN_LENGTH + 1);
+    expect(SAPReadSchema.safeParse({ type: 'CLAS', name: 'ZCL_X', grep }).success).toBe(false);
+    expect(SAPReadSchemaBtp.safeParse({ type: 'CLAS', name: 'ZCL_X', grep }).success).toBe(false);
   });
 
   it('accepts on-prem AUTH/FEATURE_TOGGLE/ENHO types', () => {

--- a/tests/unit/handlers/tools.test.ts
+++ b/tests/unit/handlers/tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { MAX_GREP_PATTERN_LENGTH } from '../../../src/context/grep.js';
 import { getToolDefinitions } from '../../../src/handlers/tools.js';
 import { DEFAULT_CONFIG } from '../../../src/server/types.js';
 
@@ -21,6 +22,7 @@ describe('Tool Definitions', () => {
       const props = (sapRead!.inputSchema as Record<string, any>).properties;
       expect(props.grep).toBeDefined();
       expect(props.grep.type).toBe('string');
+      expect(props.grep.maxLength).toBe(MAX_GREP_PATTERN_LENGTH);
     }
   });
 


### PR DESCRIPTION
## Goal

Close security register item R2 by reducing ReDoS risk in the optional `SAPRead.grep` server-side source filter.

## Changes

- Adds shared grep limits for pattern length and per-line search input.
- Rejects high-risk regex constructs before compiling: lookaround assertions, backreferences, and nested quantified groups.
- Exposes the same max length in the Zod schemas and MCP tool JSON schema.
- Keeps rendered grep output based on original source lines while matching only bounded line prefixes.

## Review

Re-reviewed the scoped diff before publishing. The change is limited to grep runtime/schema/tool surfaces and focused unit coverage. It does not change any ADT endpoint behavior.

## Validation

- `npm test -- tests/unit/context/grep.test.ts tests/unit/handlers/schemas.test.ts tests/unit/handlers/tools.test.ts` passed, 274 tests
- `npm run typecheck` passed
- `npm run lint` passed, 456 files checked

Live SAP validation was not run; this is a local post-fetch formatter hardening and the worktree has no `INFRASTRUCTURE.md` credentials/recipes.