### PR TITLE
fix: isolate PP cache state

### DIFF
--- a/src/cache/inactive-list-cache.ts
+++ b/src/cache/inactive-list-cache.ts
@@ -2,49 +2,53 @@ import type { AdtClient } from '../adt/client.js';
 import type { InactiveObject } from '../adt/types.js';
 
 interface CachedInactiveList {
-  username: string;
+  userKey: string;
   objects: InactiveObject[];
   fetchedAt: number;
 }
 
 export class InactiveListCache {
-  private byUsername = new Map<string, CachedInactiveList>();
+  private byUserKey = new Map<string, CachedInactiveList>();
   private ttlMs = 60_000;
 
-  async getOrFetch(client: AdtClient): Promise<InactiveObject[]> {
-    const cached = this.byUsername.get(client.username);
+  async getOrFetch(client: AdtClient, userKey = client.username): Promise<InactiveObject[]> {
+    const key = userKey.trim();
+    if (!key) return client.getInactiveObjects();
+
+    const cached = this.byUserKey.get(key);
     if (cached && Date.now() - cached.fetchedAt < this.ttlMs) {
       return cached.objects;
     }
 
     const objects = await client.getInactiveObjects();
-    this.byUsername.set(client.username, {
-      username: client.username,
+    this.byUserKey.set(key, {
+      userKey: key,
       objects,
       fetchedAt: Date.now(),
     });
     return objects;
   }
 
-  getCached(username: string): InactiveObject[] | null {
-    return this.byUsername.get(username)?.objects ?? null;
+  getCached(userKey: string): InactiveObject[] | null {
+    return this.byUserKey.get(userKey)?.objects ?? null;
   }
 
-  invalidate(username: string): void {
-    this.byUsername.delete(username);
+  invalidate(userKey: string | undefined): void {
+    if (!userKey) return;
+    this.byUserKey.delete(userKey);
   }
 
   clear(): void {
-    this.byUsername.clear();
+    this.byUserKey.clear();
   }
 
   stats(): { userCount: number; totalEntries: number } {
     let totalEntries = 0;
-    for (const cached of this.byUsername.values()) {
+    for (const cached of this.byUserKey.values()) {
       totalEntries += cached.objects.length;
     }
     return {
-      userCount: this.byUsername.size,
+      userCount: this.byUserKey.size,
       totalEntries,
     };
   }

--- a/src/cache/inactive-list-cache.ts
+++ b/src/cache/inactive-list-cache.ts
@@ -11,8 +11,9 @@ export class InactiveListCache {
   private byUserKey = new Map<string, CachedInactiveList>();
   private ttlMs = 60_000;
 
-  async getOrFetch(client: AdtClient, userKey = client.username): Promise<InactiveObject[]> {
-    const key = userKey.trim();
+  async getOrFetch(client: AdtClient, ...userKeyArg: [] | [string | undefined]): Promise<InactiveObject[]> {
+    const keySource = userKeyArg.length > 0 ? userKeyArg[0] : client.username;
+    const key = typeof keySource === 'string' ? keySource.trim() : '';
     if (!key) return client.getInactiveObjects();
 
     const cached = this.byUserKey.get(key);
@@ -30,12 +31,13 @@ export class InactiveListCache {
   }
 
   getCached(userKey: string): InactiveObject[] | null {
-    return this.byUserKey.get(userKey)?.objects ?? null;
+    return this.byUserKey.get(userKey.trim())?.objects ?? null;
   }
 
   invalidate(userKey: string | undefined): void {
-    if (!userKey) return;
-    this.byUserKey.delete(userKey);
+    const key = userKey?.trim();
+    if (!key) return;
+    this.byUserKey.delete(key);
   }
 
   clear(): void {

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -1441,12 +1441,42 @@ function inactiveTypeMatches(readType: string, inactiveType: string): boolean {
   return (inactiveType.split('/')[0] ?? inactiveType).toUpperCase() === readType.toUpperCase();
 }
 
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function resolveCacheUserKey(authInfo: AuthInfo | undefined): string | undefined {
+  if (!authInfo) return undefined;
+  const extra = (authInfo.extra ?? {}) as {
+    userName?: unknown;
+    email?: unknown;
+    sub?: unknown;
+    preferred_username?: unknown;
+    iss?: unknown;
+  };
+  const issuerOrClient = nonEmptyString(extra.iss) ?? nonEmptyString(authInfo.clientId) ?? 'unknown-auth-source';
+  const namespace = issuerOrClient.toLowerCase();
+
+  const userName = nonEmptyString(extra.userName);
+  if (userName) return `${namespace}:userName:${userName.toUpperCase()}`;
+
+  const email = nonEmptyString(extra.email);
+  if (email) return `${namespace}:email:${email.toLowerCase()}`;
+
+  const sub = nonEmptyString(extra.sub);
+  if (sub) return `${namespace}:sub:${sub}`;
+
+  const preferredUsername = nonEmptyString(extra.preferred_username);
+  if (preferredUsername) return `${namespace}:preferred_username:${preferredUsername.toLowerCase()}`;
+
+  return undefined;
+}
+
 function buildCacheSecurityContext(authInfo: AuthInfo | undefined, isPerUserClient?: boolean): CacheSecurityContext {
   if (!isPerUserClient) return { isPerUserClient: false };
-  const userKey = authInfo ? resolveRateLimitUserKey(authInfo) : undefined;
   return {
     isPerUserClient: true,
-    userKey: userKey && userKey !== '__anon__' ? userKey : undefined,
+    userKey: resolveCacheUserKey(authInfo),
   };
 }
 

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -1261,10 +1261,11 @@ export async function handleToolCall(
   return requestContext.run({ requestId: reqId, user, tool: toolName }, async () => {
     try {
       let result: ToolResult;
+      const cacheSecurity = buildCacheSecurityContext(authInfo, isPerUserClient);
 
       switch (toolName) {
         case 'SAPRead':
-          result = await handleSAPRead(client, args, cachingLayer);
+          result = await handleSAPRead(client, args, cachingLayer, cacheSecurity);
           break;
         case 'SAPSearch':
           result = await handleSAPSearch(client, args);
@@ -1273,10 +1274,10 @@ export async function handleToolCall(
           result = await handleSAPQuery(client, args);
           break;
         case 'SAPWrite':
-          result = await handleSAPWrite(client, args, config, cachingLayer);
+          result = await handleSAPWrite(client, args, config, cachingLayer, cacheSecurity);
           break;
         case 'SAPActivate':
-          result = await handleSAPActivate(client, args, cachingLayer);
+          result = await handleSAPActivate(client, args, cachingLayer, cacheSecurity);
           break;
         case 'SAPNavigate':
           result = await handleSAPNavigate(client, args);
@@ -1294,7 +1295,7 @@ export async function handleToolCall(
           result = await handleSAPGit(client, args, authInfo);
           break;
         case 'SAPContext':
-          result = await handleSAPContext(client, args, cachingLayer);
+          result = await handleSAPContext(client, args, cachingLayer, cacheSecurity);
           break;
         case 'SAPManage':
           result = await handleSAPManage(client, config, args, cachingLayer, isPerUserClient);
@@ -1414,6 +1415,10 @@ const BTP_HINTS: Record<string, string> = {
 
 type SourceVersion = 'active' | 'inactive';
 type RequestedSourceVersion = SourceVersion | 'auto';
+interface CacheSecurityContext {
+  isPerUserClient: boolean;
+  userKey?: string;
+}
 
 const VERSIONED_SOURCE_READ_TYPES = new Set([
   'PROG',
@@ -1436,12 +1441,41 @@ function inactiveTypeMatches(readType: string, inactiveType: string): boolean {
   return (inactiveType.split('/')[0] ?? inactiveType).toUpperCase() === readType.toUpperCase();
 }
 
+function buildCacheSecurityContext(authInfo: AuthInfo | undefined, isPerUserClient?: boolean): CacheSecurityContext {
+  if (!isPerUserClient) return { isPerUserClient: false };
+  const userKey = authInfo ? resolveRateLimitUserKey(authInfo) : undefined;
+  return {
+    isPerUserClient: true,
+    userKey: userKey && userKey !== '__anon__' ? userKey : undefined,
+  };
+}
+
+function inactiveListUserKey(client: AdtClient, cacheSecurity?: CacheSecurityContext): string | undefined {
+  return cacheSecurity?.isPerUserClient ? cacheSecurity.userKey : client.username;
+}
+
+function invalidateInactiveList(
+  cachingLayer: CachingLayer | undefined,
+  client: AdtClient,
+  cacheSecurity?: CacheSecurityContext,
+): void {
+  cachingLayer?.inactiveLists.invalidate(inactiveListUserKey(client, cacheSecurity));
+}
+
+function contextCacheForDependencyPayloads(
+  cachingLayer: CachingLayer | undefined,
+  cacheSecurity?: CacheSecurityContext,
+): CachingLayer | undefined {
+  return cacheSecurity?.isPerUserClient ? undefined : cachingLayer;
+}
+
 async function resolveVersionAndDraftInfo(
   client: AdtClient,
   cachingLayer: CachingLayer | undefined,
   type: string,
   name: string,
   requestedVersion: RequestedSourceVersion,
+  cacheSecurity?: CacheSecurityContext,
 ): Promise<{ effectiveVersion: SourceVersion; draft?: InactiveObject }> {
   if (!VERSIONED_SOURCE_READ_TYPES.has(type)) {
     return { effectiveVersion: requestedVersion === 'auto' ? 'active' : requestedVersion };
@@ -1451,7 +1485,7 @@ async function resolveVersionAndDraftInfo(
   if (cachingLayer || requestedVersion !== 'active') {
     try {
       const inactiveObjects = cachingLayer
-        ? await cachingLayer.inactiveLists.getOrFetch(client)
+        ? await cachingLayer.inactiveLists.getOrFetch(client, inactiveListUserKey(client, cacheSecurity))
         : await client.getInactiveObjects();
       const upperName = name.toUpperCase();
       draft = inactiveObjects.find(
@@ -1489,6 +1523,7 @@ async function handleSAPRead(
   client: AdtClient,
   args: Record<string, unknown>,
   cachingLayer?: CachingLayer,
+  cacheSecurity?: CacheSecurityContext,
 ): Promise<ToolResult> {
   const type = normalizeObjectType(String(args.type ?? ''));
   const name = String(args.name ?? '');
@@ -1516,7 +1551,7 @@ async function handleSAPRead(
   }
 
   if (args.force_refresh === true && cachingLayer && VERSIONED_SOURCE_READ_TYPES.has(type)) {
-    cachingLayer.inactiveLists.invalidate(client.username);
+    invalidateInactiveList(cachingLayer, client, cacheSecurity);
     cachingLayer.invalidate(type, name, 'all');
   }
 
@@ -1526,6 +1561,7 @@ async function handleSAPRead(
     type,
     name,
     requestedVersion,
+    cacheSecurity,
   );
   const versionWarning = sourceVersionWarning(effectiveVersion, draft);
 
@@ -3773,6 +3809,7 @@ async function handleServerDrivenObjectWrite(
   name: string,
   args: Record<string, unknown>,
   cachingLayer?: CachingLayer,
+  cacheSecurity?: CacheSecurityContext,
 ): Promise<ToolResult> {
   // Discovery gate — mirror handleSAPRead's server-driven branch.
   if (supportsServerDrivenObject(client.http, type) === false) {
@@ -3788,7 +3825,7 @@ async function handleServerDrivenObjectWrite(
 
   const invalidate = (): void => {
     cachingLayer?.invalidate(type, name, 'all');
-    cachingLayer?.inactiveLists.invalidate(client.username);
+    invalidateInactiveList(cachingLayer, client, cacheSecurity);
   };
 
   // SDO source is AFF JSON (not ABAP) — validate it parses before any PUT.
@@ -3863,6 +3900,7 @@ async function handleSAPWrite(
   args: Record<string, unknown>,
   config: ServerConfig,
   cachingLayer?: CachingLayer,
+  cacheSecurity?: CacheSecurityContext,
 ): Promise<ToolResult> {
   const action = String(args.action ?? '');
   const type = normalizeWriteObjectType(String(args.type ?? ''));
@@ -3908,7 +3946,7 @@ async function handleSAPWrite(
   // objectBasePath(<sdo>) throws, so this MUST come before the objectUrl computation. Mirrors the
   // server-driven branch in handleSAPRead.
   if (isServerDrivenObjectType(type)) {
-    return handleServerDrivenObjectWrite(client, action, type, name, args, cachingLayer);
+    return handleServerDrivenObjectWrite(client, action, type, name, args, cachingLayer, cacheSecurity);
   }
 
   // For TABL update/delete/edit_method, the existing object may live at /tables/
@@ -3984,7 +4022,7 @@ async function handleSAPWrite(
   const invalidateWrittenObject = (objType = type, objName = name): void => {
     // Source cache is keyed by canonical type (SAPRead collapses TABL/DT, TABL/DS).
     cachingLayer?.invalidate(canonicalTablType(objType), objName, 'all');
-    cachingLayer?.inactiveLists.invalidate(client.username);
+    invalidateInactiveList(cachingLayer, client, cacheSecurity);
   };
 
   // Helper: enforce allowedPackages for existing objects (update/delete/edit_method/scaffold_rap_handlers).
@@ -4006,7 +4044,14 @@ async function handleSAPWrite(
   async function fetchClassStructureAndMain(
     clsName: string,
   ): Promise<{ structure: ClassStructure; main: string; effectiveVersion: SourceVersion }> {
-    const { effectiveVersion } = await resolveVersionAndDraftInfo(client, cachingLayer, 'CLAS', clsName, 'auto');
+    const { effectiveVersion } = await resolveVersionAndDraftInfo(
+      client,
+      cachingLayer,
+      'CLAS',
+      clsName,
+      'auto',
+      cacheSecurity,
+    );
     const structure = await client.getClassStructure(clsName, effectiveVersion);
     const main = cachingLayer
       ? (
@@ -4529,7 +4574,14 @@ async function handleSAPWrite(
         // splice against stale content (and frequently "method not found").
         // Use the standard inactive-list lookup to pick the right version —
         // same auto-resolution semantics SAPRead exposes via `version='auto'`.
-        const { effectiveVersion } = await resolveVersionAndDraftInfo(client, cachingLayer, 'CLAS', name, 'auto');
+        const { effectiveVersion } = await resolveVersionAndDraftInfo(
+          client,
+          cachingLayer,
+          'CLAS',
+          name,
+          'auto',
+          cacheSecurity,
+        );
         const fetched = await client.getClass(name, resolvedInclude, { version: effectiveVersion });
         currentSource = stripIncludeHeader(fetched.source);
         // If the include itself has no draft (only MAIN does), SAP returns the
@@ -5615,7 +5667,7 @@ async function handleSAPWrite(
           for (const o of writtenObjects) {
             cachingLayer?.invalidate(o.type, o.name, 'all');
           }
-          cachingLayer?.inactiveLists.invalidate(client.username);
+          invalidateInactiveList(cachingLayer, client, cacheSecurity);
         } else {
           // Flip every written-but-not-yet-activated entry to 'failed', preserving the
           // "create + source-write succeeded" context. Reuse the existing per-object
@@ -5908,6 +5960,7 @@ async function handleSAPActivate(
   client: AdtClient,
   args: Record<string, unknown>,
   cachingLayer?: CachingLayer,
+  cacheSecurity?: CacheSecurityContext,
 ): Promise<ToolResult> {
   const action = String(args.action ?? 'activate');
   const name = String(args.name ?? '');
@@ -6074,7 +6127,7 @@ async function handleSAPActivate(
       for (const object of objects) {
         cachingLayer?.invalidate(object.type, object.name, 'all');
       }
-      cachingLayer?.inactiveLists.invalidate(client.username);
+      invalidateInactiveList(cachingLayer, client, cacheSecurity);
       return textResult(`Successfully activated ${objects.length} objects: ${names}.${statusDetails}`);
     }
     // On batch failure enrich with per-object inactive-version syntax errors —
@@ -6149,7 +6202,7 @@ async function handleSAPActivate(
 
   if (result.success) {
     cachingLayer?.invalidate(type, name, 'all');
-    cachingLayer?.inactiveLists.invalidate(client.username);
+    invalidateInactiveList(cachingLayer, client, cacheSecurity);
     return textResult(`Successfully activated ${type} ${name}.${formatActivationMessages(result)}`);
   }
   // On failure, try to enrich with the actual compiler errors from the inactive version —
@@ -7350,6 +7403,7 @@ async function handleSAPContext(
   client: AdtClient,
   args: Record<string, unknown>,
   cachingLayer?: CachingLayer,
+  cacheSecurity?: CacheSecurityContext,
 ): Promise<ToolResult> {
   const action = String(args.action ?? '');
   // action="impact" is DDLS-only on the server side — default the type so LLMs
@@ -7367,6 +7421,12 @@ async function handleSAPContext(
   // ─── Reverse dep lookup (pre-warmer only) ─────────────────────────
   if (action === 'usages') {
     if (!name) return errorResult('"name" is required for usages action.');
+    if (cacheSecurity?.isPerUserClient) {
+      return errorResult(
+        'SAPContext(action="usages") is disabled under principal propagation because it reads the shared warmup index. ' +
+          `Use SAPNavigate(action="references", type="${type || 'CLAS'}", name="${name}") for a live SAP-authorized lookup.`,
+      );
+    }
     if (!cachingLayer) {
       return errorResult(
         'Reverse dependency lookup requires object caching. Cache is disabled (ARC1_CACHE=none). ' +
@@ -7643,7 +7703,14 @@ async function handleSAPContext(
       }
       case 'DDLS': {
         const ddlSource = await cachedGet('DDLS', name, (ifNoneMatch) => client.getDdls(name, { ifNoneMatch }));
-        const cdsResult = await compressCdsContext(client, ddlSource, name, maxDeps, depth, cachingLayer);
+        const cdsResult = await compressCdsContext(
+          client,
+          ddlSource,
+          name,
+          maxDeps,
+          depth,
+          contextCacheForDependencyPayloads(cachingLayer, cacheSecurity),
+        );
         return textResult(cdsResult.output);
       }
       default:
@@ -7652,8 +7719,9 @@ async function handleSAPContext(
   }
 
   // Check dep graph cache — if source hash matches, return cached contracts
-  if (cachingLayer) {
-    const cachedGraph = cachingLayer.getCachedDepGraph(source);
+  const dependencyPayloadCache = contextCacheForDependencyPayloads(cachingLayer, cacheSecurity);
+  if (dependencyPayloadCache) {
+    const cachedGraph = dependencyPayloadCache.getCachedDepGraph(source);
     if (cachedGraph) {
       const successful = cachedGraph.contracts.filter((c) => c.success);
       const failed = cachedGraph.contracts.filter((c) => !c.success);
@@ -7689,7 +7757,16 @@ async function handleSAPContext(
     ? mapSapReleaseToAbaplintVersion(cachedFeatures.abapRelease)
     : undefined;
 
-  const result = await compressContext(client, source, name, type, maxDeps, depth, abaplintVersion, cachingLayer);
+  const result = await compressContext(
+    client,
+    source,
+    name,
+    type,
+    maxDeps,
+    depth,
+    abaplintVersion,
+    dependencyPayloadCache,
+  );
   return textResult(result.output);
 }
 

--- a/tests/unit/cache/inactive-list-cache.test.ts
+++ b/tests/unit/cache/inactive-list-cache.test.ts
@@ -26,6 +26,30 @@ describe('InactiveListCache', () => {
     expect(client.getInactiveObjects).toHaveBeenCalledTimes(1);
   });
 
+  it('uses an explicit user key instead of client.username', async () => {
+    const alice = makeClient('', [{ name: 'ZCL_ALICE', type: 'CLAS/OC', uri: '/alice' }]);
+    const bob = makeClient('', [{ name: 'ZCL_BOB', type: 'CLAS/OC', uri: '/bob' }]);
+
+    expect(await cache.getOrFetch(alice, 'sub-alice')).toEqual([{ name: 'ZCL_ALICE', type: 'CLAS/OC', uri: '/alice' }]);
+    expect(await cache.getOrFetch(bob, 'sub-bob')).toEqual([{ name: 'ZCL_BOB', type: 'CLAS/OC', uri: '/bob' }]);
+    expect(await cache.getOrFetch(alice, 'sub-alice')).toEqual([{ name: 'ZCL_ALICE', type: 'CLAS/OC', uri: '/alice' }]);
+
+    expect(alice.getInactiveObjects).toHaveBeenCalledTimes(1);
+    expect(bob.getInactiveObjects).toHaveBeenCalledTimes(1);
+    expect(cache.getCached('sub-alice')?.[0]?.name).toBe('ZCL_ALICE');
+    expect(cache.getCached('sub-bob')?.[0]?.name).toBe('ZCL_BOB');
+  });
+
+  it('bypasses the cache when no non-empty key is available', async () => {
+    const client = makeClient('', [{ name: 'ZCL_A', type: 'CLAS/OC', uri: '/a' }]);
+
+    await cache.getOrFetch(client, '');
+    await cache.getOrFetch(client, '  ');
+
+    expect(client.getInactiveObjects).toHaveBeenCalledTimes(2);
+    expect(cache.stats()).toEqual({ userCount: 0, totalEntries: 0 });
+  });
+
   it('getOrFetch refetches after TTL expiry', async () => {
     vi.useFakeTimers();
     const client = makeClient('MARIAN', [{ name: 'ZCL_A', type: 'CLAS/OC', uri: '/a' }]);

--- a/tests/unit/cache/inactive-list-cache.test.ts
+++ b/tests/unit/cache/inactive-list-cache.test.ts
@@ -50,6 +50,16 @@ describe('InactiveListCache', () => {
     expect(cache.stats()).toEqual({ userCount: 0, totalEntries: 0 });
   });
 
+  it('bypasses the cache for an explicit undefined key even when client.username is set', async () => {
+    const client = makeClient('SHARED_DISPLAY', [{ name: 'ZCL_A', type: 'CLAS/OC', uri: '/a' }]);
+
+    await cache.getOrFetch(client, undefined);
+    await cache.getOrFetch(client, undefined);
+
+    expect(client.getInactiveObjects).toHaveBeenCalledTimes(2);
+    expect(cache.stats()).toEqual({ userCount: 0, totalEntries: 0 });
+  });
+
   it('getOrFetch refetches after TTL expiry', async () => {
     vi.useFakeTimers();
     const client = makeClient('MARIAN', [{ name: 'ZCL_A', type: 'CLAS/OC', uri: '/a' }]);

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -5248,6 +5248,63 @@ ENDCLASS.`;
       expect(layer.inactiveLists.stats()).toEqual({ userCount: 2, totalEntries: 0 });
     });
 
+    it('bypasses inactive-list caching under principal propagation when auth has no user-specific key', async () => {
+      const layer = new CachingLayer(new MemoryCache());
+      const client = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'DISPLAY_USER',
+        password: 'secret',
+        safety: unrestrictedSafetyConfig(),
+      });
+      let inactiveCalls = 0;
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL) => {
+        const urlStr = String(url);
+        if (urlStr.includes('/sap/bc/adt/activation/inactiveobjects')) {
+          inactiveCalls += 1;
+          return Promise.resolve(
+            mockResponse(
+              200,
+              '<?xml version="1.0" encoding="utf-8"?><ioc:inactiveObjects xmlns:ioc="http://www.sap.com/adt/inactiveObjects"/>',
+              { 'x-csrf-token': 'T' },
+            ),
+          );
+        }
+        return Promise.resolve(mockResponse(200, "REPORT zfoo.\nWRITE 'x'.", { 'x-csrf-token': 'T' }));
+      });
+      const auth: AuthInfo = {
+        token: 'jwt',
+        clientId: 'shared-oidc-client',
+        scopes: ['read'],
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        extra: {},
+      };
+
+      await handleToolCall(
+        client,
+        DEFAULT_CONFIG,
+        'SAPRead',
+        { type: 'PROG', name: 'ZFOO', version: 'auto' },
+        auth,
+        undefined,
+        layer,
+        true,
+      );
+      await handleToolCall(
+        client,
+        DEFAULT_CONFIG,
+        'SAPRead',
+        { type: 'PROG', name: 'ZFOO', version: 'auto' },
+        auth,
+        undefined,
+        layer,
+        true,
+      );
+
+      expect(inactiveCalls).toBe(2);
+      expect(layer.inactiveLists.stats()).toEqual({ userCount: 0, totalEntries: 0 });
+    });
+
     it('returns CDS impact with upstream and downstream buckets', async () => {
       mockFetch.mockReset();
       const whereUsedXml = `<?xml version="1.0" encoding="utf-8"?>

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -5115,6 +5115,139 @@ ENDCLASS.`;
       expect(result.content[0]?.text).toContain('CDS dependency context for ZI_ORDER');
     });
 
+    it('does not serve cached dependency contracts under principal propagation', async () => {
+      const layer = new CachingLayer(new MemoryCache());
+      const source = 'CLASS zcl_root DEFINITION PUBLIC. ENDCLASS.';
+      layer.putDepGraph(source, 'ZCL_ROOT', 'CLAS', [
+        { name: 'ZCL_SECRET', type: 'CLAS', methodCount: 0, source: 'SECRET SOURCE', success: true },
+      ]);
+      const auth: AuthInfo = {
+        token: 'jwt',
+        clientId: 'oidc-client',
+        scopes: ['read'],
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        extra: { sub: 'user-a' },
+      };
+
+      const result = await handleToolCall(
+        createClient(),
+        DEFAULT_CONFIG,
+        'SAPContext',
+        { type: 'CLAS', name: 'ZCL_ROOT', source },
+        auth,
+        undefined,
+        layer,
+        true,
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).not.toContain('SECRET SOURCE');
+      expect(result.content[0]?.text).not.toContain('[cached]');
+      expect(result.content[0]?.text).toContain('0 deps resolved');
+    });
+
+    it('disables shared warmup usages under principal propagation', async () => {
+      const layer = new CachingLayer(new MemoryCache());
+      layer.setWarmupDone(true);
+      layer.cache.putEdge({
+        fromId: 'ZCL_SECRET',
+        toId: 'ZCL_TARGET',
+        edgeType: 'USES',
+        discoveredAt: new Date().toISOString(),
+        valid: true,
+      });
+      const auth: AuthInfo = {
+        token: 'jwt',
+        clientId: 'oidc-client',
+        scopes: ['read'],
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        extra: { sub: 'user-a' },
+      };
+
+      const result = await handleToolCall(
+        createClient(),
+        DEFAULT_CONFIG,
+        'SAPContext',
+        { action: 'usages', type: 'CLAS', name: 'ZCL_TARGET' },
+        auth,
+        undefined,
+        layer,
+        true,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('shared warmup index');
+      expect(result.content[0]?.text).toContain('SAPNavigate');
+      expect(result.content[0]?.text).not.toContain('ZCL_SECRET');
+    });
+
+    it('keys inactive-list caching by authenticated user under principal propagation', async () => {
+      const layer = new CachingLayer(new MemoryCache());
+      const client = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: '',
+        password: 'secret',
+        safety: unrestrictedSafetyConfig(),
+      });
+      let inactiveCalls = 0;
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL) => {
+        const urlStr = String(url);
+        if (urlStr.includes('/sap/bc/adt/activation/inactiveobjects')) {
+          inactiveCalls += 1;
+          return Promise.resolve(
+            mockResponse(
+              200,
+              '<?xml version="1.0" encoding="utf-8"?><ioc:inactiveObjects xmlns:ioc="http://www.sap.com/adt/inactiveObjects"/>',
+              { 'x-csrf-token': 'T' },
+            ),
+          );
+        }
+        return Promise.resolve(mockResponse(200, "REPORT zfoo.\nWRITE 'x'.", { 'x-csrf-token': 'T' }));
+      });
+      const auth = (sub: string): AuthInfo => ({
+        token: 'jwt',
+        clientId: 'oidc-client',
+        scopes: ['read'],
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        extra: { sub },
+      });
+
+      await handleToolCall(
+        client,
+        DEFAULT_CONFIG,
+        'SAPRead',
+        { type: 'PROG', name: 'ZFOO', version: 'auto' },
+        auth('alice'),
+        undefined,
+        layer,
+        true,
+      );
+      await handleToolCall(
+        client,
+        DEFAULT_CONFIG,
+        'SAPRead',
+        { type: 'PROG', name: 'ZFOO', version: 'auto' },
+        auth('bob'),
+        undefined,
+        layer,
+        true,
+      );
+      await handleToolCall(
+        client,
+        DEFAULT_CONFIG,
+        'SAPRead',
+        { type: 'PROG', name: 'ZFOO', version: 'auto' },
+        auth('alice'),
+        undefined,
+        layer,
+        true,
+      );
+
+      expect(inactiveCalls).toBe(2);
+      expect(layer.inactiveLists.stats()).toEqual({ userCount: 2, totalEntries: 0 });
+    });
+
     it('returns CDS impact with upstream and downstream buckets', async () => {
       mockFetch.mockReset();
       const whereUsedXml = `<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## Goal

Close security register items R1, R3, and R12 by preventing shared cache state from crossing user authorization boundaries under principal propagation.

## Changes

- Keys inactive-object list caching by the authenticated user key when PP is active.
- Bypasses inactive-list caching when no non-empty user key is available.
- Routes inactive-list invalidation through the same effective key helper.
- Disables dependency payload cache read/write for `SAPContext` under PP.
- Disables `SAPContext(action="usages")` under PP because it reads the shared warmup reverse-dependency index, and points callers to live `SAPNavigate(action="references")` instead.

## Review

Re-reviewed the scoped diff before publishing. The branch contains only cache-isolation changes and tests; the overlapping SRVB publish/unpublish package-gate hunks were intentionally removed from this PR.

## Validation

- `npm test -- tests/unit/cache/inactive-list-cache.test.ts tests/unit/cache/caching-layer.test.ts tests/unit/handlers/intent.test.ts` passed, 742 tests
- `npm run typecheck` passed
- `npm run lint` passed, 456 files checked

Live SAP validation was not run because the worktree has no `INFRASTRUCTURE.md` credentials/recipes.