### PR TITLE
fix: ignore BTP service key files

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -13,6 +13,7 @@ compare/
 # Dev config
 .env
 .env.*
+*service-key*.json
 .github/
 .husky/
 .cursor/

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 .env.local
 .env.*
 !.env.example
+*service-key*.json
 cookies.txt
 cookie.txt
 cookies

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@
 .env.*
 !.env.example
 *service-key*.json
+**/*service-key*.json
 cookies.txt
 cookie.txt
 cookies

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cookie
 # Infrastructure credentials (NEVER commit)
 INFRASTRUCTURE.md
 .env.infrastructure
+*service-key*.json
 
 # Session context files
 MEMORY.md

--- a/tests/unit/security-ignore-patterns.test.ts
+++ b/tests/unit/security-ignore-patterns.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+function ignoredPatterns(fileName: string): string[] {
+  return readFileSync(resolve(repoRoot, fileName), 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+}
+
+describe('security ignore patterns', () => {
+  it('excludes service-key JSON files from git, docker, and Cloud Foundry packages', () => {
+    for (const fileName of ['.gitignore', '.dockerignore', '.cfignore']) {
+      expect(ignoredPatterns(fileName)).toContain('*service-key*.json');
+    }
+  });
+});

--- a/tests/unit/security-ignore-patterns.test.ts
+++ b/tests/unit/security-ignore-patterns.test.ts
@@ -17,5 +17,7 @@ describe('security ignore patterns', () => {
     for (const fileName of ['.gitignore', '.dockerignore', '.cfignore']) {
       expect(ignoredPatterns(fileName)).toContain('*service-key*.json');
     }
+
+    expect(ignoredPatterns('.dockerignore')).toContain('**/*service-key*.json');
   });
 });


### PR DESCRIPTION
## Goal

Close security register item R16 by ensuring BTP service-key JSON files are not committed, baked into Docker images, or included in Cloud Foundry staging packages.

## Changes

- Adds `*service-key*.json` to `.gitignore`.
- Adds `*service-key*.json` to `.dockerignore`.
- Adds `*service-key*.json` to `.cfignore`.
- Adds a unit guard that checks all three ignore surfaces keep the pattern.

## Review

Re-reviewed the scoped diff before publishing. The change is intentionally limited to ignore/package configuration and the direct guard test.

## Validation

- `npm test -- tests/unit/security-ignore-patterns.test.ts` passed, 1 test
- `npm run typecheck` passed
- `npm run lint` passed, 457 files checked

Live SAP validation is not applicable for this packaging/ignore-list hardening.