### PR TITLE
fix(write): emit adtcore:language + masterLanguage on MSAG payloads (blank T100 SPRSL)

### DIFF
--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -262,9 +262,19 @@ export interface MessageClassCreateParams {
   description: string;
   package: string;
   messages?: MessageClassMessage[];
+  /** Maintenance + master language (e.g. "EN", "DE"), emitted as BOTH
+   *  adtcore:language and adtcore:masterLanguage — matching the server's own
+   *  GET serialization. Live-verified on a4h (S/4HANA 2023, 7.58): the MSAG
+   *  handler keys the T100 text rows by the BODY adtcore:language; without it
+   *  every message is stored under a BLANK language key (SPRSL = space), so
+   *  MESSAGE ... INTO never resolves the text at runtime and ATC/SLIN flags
+   *  every message number as missing. The sap-language URL param and
+   *  adtcore:masterLanguage alone do NOT prevent this. Defaults to "EN". */
+  language?: string;
 }
 
 export function buildMessageClassXml(params: MessageClassCreateParams): string {
+  const masterLanguage = normalizeAdtLanguage(params.language);
   const messages = params.messages ?? [];
   const messagesXml =
     messages.length === 0
@@ -281,7 +291,9 @@ export function buildMessageClassXml(params: MessageClassCreateParams): string {
 <mc:messageClass xmlns:mc="http://www.sap.com/adt/MessageClass"
                  xmlns:adtcore="http://www.sap.com/adt/core"
                  adtcore:description="${escapeXml(params.description)}"
-                 adtcore:name="${escapeXml(params.name)}">
+                 adtcore:name="${escapeXml(params.name)}"
+                 adtcore:language="${masterLanguage}"
+                 adtcore:masterLanguage="${masterLanguage}">
   <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>${messagesXml}
 </mc:messageClass>`;
 }

--- a/src/handlers/intent.ts
+++ b/src/handlers/intent.ts
@@ -3154,6 +3154,13 @@ export function buildCreateXml(
         description,
         package: pkg,
         messages: messages.length > 0 ? messages : undefined,
+        // Thread the configured language into the body (same spirit as #343).
+        // Live-verified on a4h 7.58: the MSAG handler keys T100.SPRSL by the
+        // BODY adtcore:language — without it the messages are stored under a
+        // BLANK language key (texts never resolve at runtime; ATC/SLIN flags
+        // every number as missing). The sap-language URL param alone does NOT
+        // prevent this.
+        language: masterLanguage,
       };
       return buildMessageClassXml(params);
     }

--- a/tests/unit/adt/ddic-xml.test.ts
+++ b/tests/unit/adt/ddic-xml.test.ts
@@ -75,6 +75,30 @@ describe('ddic-xml builders', () => {
       expect(xml).toContain('adtcore:masterLanguage="EN"');
     });
 
+    it('buildMessageClassXml emits the configured language as BOTH language and masterLanguage', () => {
+      // The MSAG handler keys the T100 text rows by the BODY adtcore:language
+      // (live-verified on a4h 7.58); masterLanguage matches the server's own
+      // serialization and drives the object master language.
+      const xml = buildMessageClassXml({
+        name: 'ZM',
+        description: 'd',
+        package: '$TMP',
+        language: 'DE',
+        messages: [{ number: '001', shortText: 'Probe &1' }],
+      });
+      expect(xml).toContain('adtcore:language="DE"');
+      expect(xml).toContain('adtcore:masterLanguage="DE"');
+    });
+
+    it('buildMessageClassXml defaults to EN when no language given (blank-SPRSL bug)', () => {
+      // Without adtcore:language the handler stores the T100 rows with
+      // SPRSL = space: MESSAGE ... INTO never resolves the texts and ATC/SLIN
+      // reports every message number as missing. Verified on a4h 7.58.
+      const xml = buildMessageClassXml({ name: 'ZM', description: 'd', package: '$TMP' });
+      expect(xml).toContain('adtcore:language="EN"');
+      expect(xml).toContain('adtcore:masterLanguage="EN"');
+    });
+
     it('normalizes a lower-case 2-char language to upper case', () => {
       const xml = buildDataElementXml({ name: 'ZE', description: 'd', package: '$TMP', language: 'de' });
       expect(xml).toContain('adtcore:masterLanguage="DE"');

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -12075,6 +12075,23 @@ ENDCLASS.`;
         expect(xml).toContain('adtcore:masterLanguage="DE"');
       });
 
+      it('threads the configured language into MSAG language + masterLanguage (blank-SPRSL fix)', () => {
+        // Guards the intent.ts → buildMessageClassXml wiring, not just the builder in
+        // isolation: the MSAG handler keys T100 text rows by the BODY adtcore:language
+        // (live-verified on a4h 7.58), so messages created without it land under a blank
+        // SPRSL and never resolve at runtime.
+        const xml = buildCreateXml(
+          'MSAG',
+          'ZMSG',
+          '$TMP',
+          'Msg',
+          { messages: [{ number: '001', shortText: 'Probe &1' }] },
+          'DE',
+        );
+        expect(xml).toContain('adtcore:language="DE"');
+        expect(xml).toContain('adtcore:masterLanguage="DE"');
+      });
+
       it('threads the configured language into DOMA create XML', () => {
         const xml = buildCreateXml('DOMA', 'ZDOM', '$TMP', 'Dom', { dataType: 'CHAR', length: 1 }, 'DE');
         expect(xml).toContain('adtcore:masterLanguage="DE"');


### PR DESCRIPTION
## Problem

`SAPWrite` MSAG create/update stores every message text with a **blank language key** (`T100.SPRSL = space`). Consequences on the affected system:

1. `MESSAGE eNNN(zmsgclass) … INTO` never resolves the text at runtime — it silently falls back to raw-parameter text.
2. ATC/SLIN reports *"The message NNN in the message class … does not exist"* for **every** number.
3. `SAPRead type=MSAG` still shows the messages (it reads language-independently), which masks the problem. The per-message sub-resource `GET /messageclass/{name}/messages/{no}` returns an **empty** message for blank-key rows — reads are language-keyed too.

Observed with `ZSSI_IMPORTER` on A4H (S/4HANA 2023, SAP_BASIS 7.58); a standard class like `ARBGB '00'` shows proper `E`/`D` keys.

## Root cause (live-verified mechanism)

`buildMessageClassXml` emitted **neither** `adtcore:language` **nor** `adtcore:masterLanguage` on the root. Experiment matrix on A4H 7.58 (fresh $TMP classes, T100 read back directly):

| body `adtcore:language` | body `adtcore:masterLanguage` | URL `sap-language` | resulting `T100.SPRSL` |
|---|---|---|---|
| — | — | `EN` | **space** (today's arc-1) |
| — | `EN` | `EN` | **space** (masterLanguage alone is NOT enough) |
| `EN` | `EN` | `EN` | **`E`** ✓ (create AND update paths) |

So the MSAG handler keys the T100 rows by the **body `adtcore:language`**; the `sap-language` URL param does not cover it. The server's own GET serialization carries both attributes. MSAG belongs with the **both-attribute** group the `SRVB`/`FUGR` builders already emit — **not** the `masterLanguage`-only treatment #343 gave `DOMA`/`DTEL` (sufficient there because `DD04T`/`DD01T` key off the master language). As the matrix shows, `masterLanguage` alone leaves `SPRSL` blank, so MSAG must also emit `adtcore:language`.

## Fix

- `buildMessageClassXml`: emit `adtcore:language` + `adtcore:masterLanguage` (via `normalizeAdtLanguage`, default `EN`), documented with the verified mechanism.
- `intent.ts` MSAG case: thread the configured language into `MessageClassCreateParams` — create, update, and `batch_create` all share `buildCreateXml`, so every write path is fixed.

## Verification

- **Unit:** three tests in the issue-#343 blocks — two on `buildMessageClassXml` directly (explicit `DE`, default `EN`) plus one on the `buildCreateXml('MSAG', …)` wiring (guards the `intent.ts` threading, not just the builder) — all asserting BOTH attributes. Full suite 3569/3569 green; `tsc` and biome clean.
- **Live (A4H 7.58, compiled `dist/cli.js call SAPWrite`):** fresh $TMP message class via **create** → single T100 row with `SPRSL='E'`; **update** path → `'E'` rows; probe classes deleted afterwards (delete cascades all rows, including blank-key orphans). A/B confirmed: the same call on the pre-fix build stores `SPRSL = space`.
- **Cross-release:** `T100.SPRSL='E'` confirmed on **816** (ABAP Platform 2025) as well as **7.58** (S/4HANA 2023). On **NW 7.50** create+activate still succeed with the new attribute (no regression), but the older v1 handler may ignore the body language (see #343), so the blank-key condition can persist there — 7.50 is out of scope for this fix.

## Note for existing systems

Message classes written by earlier arc-1 versions keep their orphaned `SPRSL = space` rows (the texts "work" only as fallback). One-time cleanup: re-key the rows to the master language (SE91 re-save or direct re-key). This fix prevents new occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
