### PR TITLE
fix(adt): make SRVB publish/unpublish content negotiation 758-proof

### DIFF
--- a/research/pull-requests/403-srvb-publish-content-negotiation.md
+++ b/research/pull-requests/403-srvb-publish-content-negotiation.md
@@ -128,13 +128,16 @@ right shape (mirrors the `crud.ts` lock Accept; ADR-0002-style narrow quirk).
 
 ## Residual notes (non-blocking)
 
-1. The unit suite's `DEFAULT_CONFIG`-based publish tests run with an *unrestricted* allowlist, so
-   the gate path was previously untested — that blind spot let #394 ship the 406. The new
-   regression test closes it for publish; an equivalent unpublish-gate test would be symmetric
-   polish.
-2. `resolveObjectPackage` could defensively strip media-type parameters from any caller-supplied
-   Accept at the choke point. Deliberately not done here (narrow fix per ADR-0002); worth
-   considering if a third parameter-bearing Accept ever appears.
+1. ~~An equivalent unpublish-gate test would be symmetric polish.~~ **Implemented** (review
+   follow-up commit): `intent.test.ts` now pins the gate GET's bare Accept for both
+   `publish_srvb` and `unpublish_srvb`. (Background: the `DEFAULT_CONFIG`-based publish tests
+   run with an *unrestricted* allowlist, so the gate path was previously untested — that blind
+   spot let #394 ship the 406.)
+2. ~~`resolveObjectPackage` could defensively strip media-type parameters at the choke point.~~
+   **Implemented** (review follow-up commit): `resolveObjectPackage` sends only the bare media
+   type from any caller-supplied Accept (`src/adt/client.ts`), with a unit test. Call sites keep
+   passing the bare `SERVICEBINDING_V2_ACCEPT` for clarity; the choke point now protects future
+   callers.
 3. The published-state readback after publish parses `getSrvb` JSON and only checks
    `published === false` — fine, but it means a readback parse failure silently passes. Existing
    behavior, unchanged by this PR.

--- a/research/pull-requests/403-srvb-publish-content-negotiation.md
+++ b/research/pull-requests/403-srvb-publish-content-negotiation.md
@@ -1,0 +1,140 @@
+# PR #403 — fix(adt): make SRVB publish/unpublish content negotiation 758-proof
+
+- **PR**: https://github.com/marianfoo/arc-1/pull/403 (branch `claude/wonderful-buck-c8e366`, same-repo, not a fork)
+- **Reviewed**: 2026-06-11, after rebasing onto `origin/main` @ `bc5cfc46` (post-#402 handler split) per maintainer request
+- **Verdict**: **APPROVE (after rebase + one added commit)** — see "What the rebase surfaced" below; the PR as originally pushed did *not* fix the reported bug on current main and was extended with the real root-cause fix during this review.
+
+## Scope
+
+Reported symptom: `SAPActivate action=publish_srvb` → HTTP 406 "The message content is not acceptable"
+against a4h (S/4HANA 2023, SAP_BASIS 758), publishing SRVB `ZSSI_UI_S_ORD_O4`.
+
+The PR (commit 1) hardens the `publishjobs`/`unpublishjobs` POST content negotiation in
+`src/adt/devtools.ts`. The review-added commit 2 fixes the package-gate metadata read in
+`src/handlers/{activate,write-helpers}.ts`, which turned out to be the actual production failure.
+
+## What the rebase surfaced (the real root cause)
+
+Re-running the live verification on the rebased branch immediately failed — but **not** on the
+publish POST. The failing request was the **package-gate metadata read** introduced by
+[#394 "fix: enforce SRVB package gate"](https://github.com/marianfoo/arc-1/pull/394) (shipped in
+**0.9.14**, merged after this PR's original live verification):
+
+```
+GET /sap/bc/adt/businessservices/bindings/ZARC1_UI_TRAVELDEMO_O4
+Accept: application/vnd.sap.adt.businessservices.servicebinding.v2+xml; charset=utf-8
+→ 406 SADT_RESOURCE 037 ("The message content is not acceptable", NO accepted-types list)
+```
+
+Isolated by header bisection (curl, both live systems):
+
+| Accept on `GET /businessservices/bindings/{name}` | 758 (a4h) | 816 (a4h-2025) |
+|---|---|---|
+| `…servicebinding.v2+xml; charset=utf-8` | **406** (T100 037) | **406** |
+| `…servicebinding.v2+xml` (bare) | 200 | 200 |
+
+- The backend rejects **any media-type parameter on the Accept** for this resource, on **both**
+  on-prem releases.
+- The 406 body names no accepted type (T100 037 has no V1 param), so the generic HTTP-layer
+  negotiation retry (`inferAcceptFromError`) cannot infer a fallback; its `application/xml`
+  fallback is also not renderable by this resource → double 406 → tool call fails.
+- The gate runs whenever `allowedPackages` is restricted — **the default is `['$TMP']`**, so on
+  0.9.14 `publish_srvb`/`unpublish_srvb` fail on virtually every real deployment **before the
+  publish POST is ever sent**. `SAPRead type=SRVB` still works (reads are never package-gated),
+  which makes the failure look publish-specific — matching the original report.
+- The original report's error text "The message content is not acceptable" is the T100 **037**
+  message from this gate read; the quoted "Accepted content types: application/vnd.sap.as+xml"
+  (T100 **044**) is the *publishjobs* 406 shape, reproducible only by sending the
+  `…odatav4.v1+xml` Accept to the POST (e.g. via manual repro experiments). Two distinct 406s,
+  conflated into one narrative — the PR's first commit fixed the second, rarer one.
+
+## Commits under review
+
+### Commit 1 — `fix(adt): make SRVB publish/unpublish content negotiation 758-proof` (`src/adt/devtools.ts`)
+
+Verified facts (curl matrix on a4h 758, publish/unpublish POST):
+
+| Content-Type | Accept | Result |
+|---|---|---|
+| `application/xml` | `application/*` | 200 |
+| `…odatav4.v1+xml` | `application/*` | 200 |
+| `application/xml` | `…odatav4.v1+xml` | **406** T100 044, names `application/vnd.sap.as+xml` |
+| anything | `application/vnd.sap.as+xml` (bare, composite, or with `dataname=` ) | 200 |
+
+- The POST 406 is **Accept-driven**; request Content-Type isn't validated on 758.
+- 758 renders the job status only as `application/vnd.sap.as+xml`. All four
+  `dataname=com.sap.adt.businessservices.{odatav2|odatav4}.{publishjob|unpublishjob}` types
+  verified live → 200.
+- Discovery is structurally unable to pick the right type here: 758 has no publishjobs entries
+  (shallow-match falls back to the parent collection's `…odatav4.v1+xml` — exactly the type that
+  406s); 816 lists publishjobs only as `templateLink`s without accepts.
+
+Change: primary Accept → `application/vnd.sap.as+xml, application/*;q=0.8`; self-scoping
+406/415→dataname-qualified-as+xml retry (`postPublishJob`). Correct, evidence-backed, and the
+right shape (mirrors the `crud.ts` lock Accept; ADR-0002-style narrow quirk).
+
+### Commit 2 (added during this review) — `fix(handlers): SRVB publish package-gate read must send a parameter-less Accept`
+
+- New `SERVICEBINDING_V2_ACCEPT` (bare type) in `src/handlers/write-helpers.ts:69`; both gate
+  calls in `src/handlers/activate.ts` (publish + unpublish) use it. The `; charset=utf-8` form
+  remains for PUT/POST **Content-Type** (where it is correct and long-verified).
+- Checked all other `enforceAllowedPackageForObjectUrl` call sites: only the two publish/unpublish
+  gates passed a parameter-carrying Accept. SDO gates pass the parameter-less blues type
+  (fine); update/delete/activate/change_package pass no Accept (discovery-negotiated bare type
+  — fine).
+
+## Gates (run on the rebased branch, `bc5cfc46` base)
+
+- `npm run typecheck` ✓ · `npm run lint` ✓ (485 files) · `npm run check:sizes` ✓ (file-size ratchet)
+- `npm test` ✓ **3719 passed** (3718 post-refactor + 1 new gate regression test)
+
+## Live verification (this review, rebased code, restricted allowlist `Z*,$TMP`)
+
+- **a4h 758**: V4 `ZARC1_UI_TRAVELDEMO_O4` unpublish→republish ✓; V2 `ZTEST_MCP_SB_FLIGHT`
+  (serviceType auto-detected) unpublish→republish ✓ — `published` readback confirmed each step.
+- **a4h-2025 816**: `ZSB_ARC1_SMOKE` unpublish→republish ✓.
+- **Deny path** (allowlist `$TMP`, binding in `Z_RAP_VB_BC26`): clean
+  `AdtSafetyError: Operations on package 'Z_RAP_VB_BC26' are blocked by safety configuration
+  (allowed: [$TMP])` — the gate now resolves the real package and denies properly instead of
+  surfacing the 406.
+- All test bindings restored to their original **published** state on both systems.
+
+## Invariant checklist
+
+- [x] Safety guard: publish/unpublish keep `checkOperation(…, OperationType.Activate, …)`;
+      gate read goes through `resolveObjectPackage` (`OperationType.Read`). No unguarded HTTP.
+- [x] Scope policy: no new tool/action — `ACTION_POLICY` untouched, nothing to add.
+- [x] Package gating: **strengthened** — the #394 gate now actually works on 758/816 instead of
+      failing closed with a misleading 406; fail-closed semantics preserved (no-packageRef →
+      `AdtSafetyError`).
+- [x] Three-file schema sync: no schema surface change (no new params) — N/A.
+- [x] Per-user auth: untouched.
+- [x] stdout sacred: only `logger.debug` (stderr) added.
+- [x] Typed errors: fallback rethrows original `AdtApiError` when not the as+xml complaint;
+      no error shapes changed.
+- [x] `withSafety()` clone: no new `AdtClient` instance fields — N/A.
+
+## Test adequacy
+
+- `tests/unit/adt/devtools.test.ts`: 6 new cases using the **verbatim a4h 406 body** — fallback
+  fires with the right dataname per serviceType×job; 406 without the as+xml mention not retried;
+  non-negotiation errors not retried; failing retry surfaces without looping. 2 existing header
+  assertions updated to the composite Accept.
+- `tests/unit/handlers/intent.test.ts`: new test runs `publish_srvb` with a **restricted**
+  allowlist (gate active) and pins the gate GET's wire Accept to the bare media type
+  (`expect(gateHeaders.Accept).not.toContain('charset')`).
+- Slow E2E `rap-write.slow.e2e.test.ts` (create→activate→publish→unpublish→delete) still covers
+  the full lifecycle path end-to-end.
+
+## Residual notes (non-blocking)
+
+1. The unit suite's `DEFAULT_CONFIG`-based publish tests run with an *unrestricted* allowlist, so
+   the gate path was previously untested — that blind spot let #394 ship the 406. The new
+   regression test closes it for publish; an equivalent unpublish-gate test would be symmetric
+   polish.
+2. `resolveObjectPackage` could defensively strip media-type parameters from any caller-supplied
+   Accept at the choke point. Deliberately not done here (narrow fix per ADR-0002); worth
+   considering if a third parameter-bearing Accept ever appears.
+3. The published-state readback after publish parses `getSrvb` JSON and only checks
+   `published === false` — fine, but it means a readback parse failure silently passes. Existing
+   behavior, unchanged by this PR.

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -1452,7 +1452,12 @@ export class AdtClient {
     // Server-driven objects (8.16+) only render their <blue:blueSource> metadata (with the
     // adtcore:packageRef) under the blues.vN+xml Accept — callers pass it so the allowedPackages
     // ceiling can resolve the real package. Other callers rely on discovery-driven negotiation.
-    const resp = await this.http.get(objectUrl, accept ? { Accept: accept } : undefined);
+    // Send the bare media type only: on-prem backends reject an Accept carrying parameters
+    // ("; charset=utf-8" → 406 SADT_RESOURCE 037, live-verified on 758 and 816 against the SRVB
+    // bindings resource), and that 406 body names no accepted type, so the generic negotiation
+    // retry cannot recover. Parameters select nothing on these metadata reads.
+    const bareAccept = accept?.split(';')[0]?.trim();
+    const resp = await this.http.get(objectUrl, bareAccept ? { Accept: bareAccept } : undefined);
     const packageRefMatch = resp.body.match(/adtcore:packageRef[^>]*adtcore:name="([^"]*)"/);
     if (packageRefMatch?.[1]) return packageRefMatch[1];
     const containerRefMatch = resp.body.match(/adtcore:containerRef[^>]*adtcore:packageName="([^"]*)"/);

--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -469,6 +469,53 @@ function publishBody(name: string): string {
   return `<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"><adtcore:objectReference adtcore:name="${escapeXmlAttr(name)}"/></adtcore:objectReferences>`;
 }
 
+// On-prem releases (live-verified on S/4HANA 2023, SAP_BASIS 758) render the publish/unpublish
+// job status ONLY as application/vnd.sap.as+xml: any Accept that does not cover it is rejected
+// with 406 SADT_RESOURCE 044 ("The message content is not acceptable. Accepted content types:
+// application/vnd.sap.as+xml") — e.g. the newer-release media type
+// application/vnd.sap.adt.businessservices.odatav4.v1+xml. Naming as+xml first keeps 758
+// deterministic; the wildcard keeps backends with other renderers working.
+const PUBLISH_JOB_ACCEPT = 'application/vnd.sap.as+xml, application/*;q=0.8';
+
+/**
+ * Fully-qualified AS-XML media type for a publish/unpublish job, as Eclipse ADT sends it.
+ * All four serviceType × job combinations live-verified against S/4HANA 2023 (SAP_BASIS 758).
+ */
+function publishJobAsXmlType(serviceType: 'odatav2' | 'odatav4', job: 'publishjob' | 'unpublishjob'): string {
+  return `application/vnd.sap.as+xml; charset=UTF-8; dataname=com.sap.adt.businessservices.${serviceType}.${job}`;
+}
+
+/**
+ * True when the backend rejected content negotiation and named application/vnd.sap.as+xml as
+ * the only type it supports. Self-scoping: only ever fires on backends that emit exactly this
+ * complaint, so the as+xml retry cannot affect systems that accept the primary headers.
+ */
+function isAsXmlOnlyNegotiationError(err: unknown): boolean {
+  if (!(err instanceof AdtApiError)) return false;
+  if (err.statusCode !== 406 && err.statusCode !== 415) return false;
+  return `${err.message} ${err.responseBody ?? ''}`.includes('application/vnd.sap.as+xml');
+}
+
+async function postPublishJob(
+  http: AdtHttpClient,
+  serviceType: 'odatav2' | 'odatav4',
+  job: 'publishjob' | 'unpublishjob',
+  name: string,
+  version: string,
+): Promise<PublishResult> {
+  const path = `/sap/bc/adt/businessservices/${serviceType}/${job}s?servicename=${encodeURIComponent(name)}&serviceversion=${encodeURIComponent(version)}`;
+  try {
+    const resp = await http.post(path, publishBody(name), 'application/xml', { Accept: PUBLISH_JOB_ACCEPT });
+    return parsePublishResponse(resp.body);
+  } catch (err) {
+    if (!isAsXmlOnlyNegotiationError(err)) throw err;
+    const asXmlType = publishJobAsXmlType(serviceType, job);
+    logger.debug(`Publish job content negotiation rejected — retrying with ${asXmlType}`, { path });
+    const resp = await http.post(path, publishBody(name), asXmlType, { Accept: asXmlType });
+    return parsePublishResponse(resp.body);
+  }
+}
+
 /** Publish an OData service binding (makes the service available for consumption) */
 export async function publishServiceBinding(
   http: AdtHttpClient,
@@ -478,15 +525,7 @@ export async function publishServiceBinding(
   serviceType: 'odatav2' | 'odatav4' = 'odatav2',
 ): Promise<PublishResult> {
   checkOperation(safety, OperationType.Activate, 'PublishServiceBinding');
-
-  const resp = await http.post(
-    `/sap/bc/adt/businessservices/${serviceType}/publishjobs?servicename=${encodeURIComponent(name)}&serviceversion=${encodeURIComponent(version)}`,
-    publishBody(name),
-    'application/xml',
-    { Accept: 'application/*' },
-  );
-
-  return parsePublishResponse(resp.body);
+  return postPublishJob(http, serviceType, 'publishjob', name, version);
 }
 
 /** Unpublish an OData service binding (removes the service from consumption) */
@@ -498,15 +537,7 @@ export async function unpublishServiceBinding(
   serviceType: 'odatav2' | 'odatav4' = 'odatav2',
 ): Promise<PublishResult> {
   checkOperation(safety, OperationType.Activate, 'UnpublishServiceBinding');
-
-  const resp = await http.post(
-    `/sap/bc/adt/businessservices/${serviceType}/unpublishjobs?servicename=${encodeURIComponent(name)}&serviceversion=${encodeURIComponent(version)}`,
-    publishBody(name),
-    'application/xml',
-    { Accept: 'application/*' },
-  );
-
-  return parsePublishResponse(resp.body);
+  return postPublishJob(http, serviceType, 'unpublishjob', name, version);
 }
 
 /** Run ABAP unit tests for an object */

--- a/src/handlers/activate.ts
+++ b/src/handlers/activate.ts
@@ -22,7 +22,7 @@ import { errorResult, type ToolResult, textResult } from './shared.js';
 import {
   enforceAllowedPackageForObjectUrl,
   inactiveSyntaxDiagnostic,
-  SERVICEBINDING_V2_CONTENT_TYPE,
+  SERVICEBINDING_V2_ACCEPT,
 } from './write-helpers.js';
 
 // ─── SAPActivate Handler ─────────────────────────────────────────────
@@ -61,7 +61,7 @@ export async function handleSAPActivate(
       client,
       objectUrlForType('SRVB', name),
       `Publish of service binding '${name}'`,
-      SERVICEBINDING_V2_CONTENT_TYPE,
+      SERVICEBINDING_V2_ACCEPT,
     );
     const serviceType = await resolveServiceType();
     const result = await publishServiceBinding(client.http, client.safety, name, version, serviceType);
@@ -111,7 +111,7 @@ export async function handleSAPActivate(
       client,
       objectUrlForType('SRVB', name),
       `Unpublish of service binding '${name}'`,
-      SERVICEBINDING_V2_CONTENT_TYPE,
+      SERVICEBINDING_V2_ACCEPT,
     );
     const serviceType = await resolveServiceType();
     const result = await unpublishServiceBinding(client.http, client.safety, name, version, serviceType);

--- a/src/handlers/write-helpers.ts
+++ b/src/handlers/write-helpers.ts
@@ -66,6 +66,13 @@ export const DOMAIN_V2_CONTENT_TYPE = 'application/vnd.sap.adt.domains.v2+xml; c
 export const DATAELEMENT_V2_CONTENT_TYPE = 'application/vnd.sap.adt.dataelements.v2+xml; charset=utf-8';
 export const SERVICEBINDING_V2_CONTENT_TYPE =
   'application/vnd.sap.adt.businessservices.servicebinding.v2+xml; charset=utf-8';
+// Accept variant WITHOUT media-type parameters. On-prem 758 rejects an Accept that carries
+// "; charset=utf-8" on the bindings resource with 406 SADT_RESOURCE 037 ("The message content
+// is not acceptable", no accepted-types list — so the generic negotiation retry cannot infer a
+// fallback either). Live-verified on S/4HANA 2023: bare type → 200, charset-suffixed → 406.
+// Use this for reads (the publish/unpublish package gate); keep the charset form for PUT/POST
+// Content-Type only.
+export const SERVICEBINDING_V2_ACCEPT = 'application/vnd.sap.adt.businessservices.servicebinding.v2+xml';
 const BDEF_CONTENT_TYPE = 'application/vnd.sap.adt.blues.v1+xml';
 const MESSAGECLASS_CONTENT_TYPE = 'application/vnd.sap.adt.mc.messageclass+xml';
 export const SKTD_V2_CONTENT_TYPE = 'application/vnd.sap.adt.sktdv2+xml';

--- a/tests/unit/adt/client.test.ts
+++ b/tests/unit/adt/client.test.ts
@@ -1932,6 +1932,28 @@ describe('AdtClient', () => {
       await client.resolveObjectPackage('/sap/bc/adt/oo/classes/ZCL_X');
       expect(fetchHeaders(0).Accept ?? '').not.toContain('blues');
     });
+
+    it('strips media-type parameters from a caller-supplied Accept', async () => {
+      // On-prem backends (758 + 816, live-verified on the SRVB bindings resource) reject an
+      // Accept carrying "; charset=utf-8" with 406 SADT_RESOURCE 037 — and that body names no
+      // accepted type, so the negotiation retry cannot recover. The choke point sends the bare
+      // media type regardless of what the caller passes.
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          '<srvb:serviceBinding xmlns:adtcore="http://www.sap.com/adt/core">' +
+            '<adtcore:packageRef adtcore:name="Z_GATED"/></srvb:serviceBinding>',
+        ),
+      );
+      const client = createClient();
+      const pkg = await client.resolveObjectPackage(
+        '/sap/bc/adt/businessservices/bindings/ZSB_X',
+        'application/vnd.sap.adt.businessservices.servicebinding.v2+xml; charset=utf-8',
+      );
+      expect(pkg).toBe('Z_GATED');
+      expect(fetchHeaders(0).Accept).toBe('application/vnd.sap.adt.businessservices.servicebinding.v2+xml');
+    });
   });
 
   describe('getInactiveObjects', () => {

--- a/tests/unit/adt/devtools.test.ts
+++ b/tests/unit/adt/devtools.test.ts
@@ -996,7 +996,7 @@ describe('DevTools', () => {
         '/sap/bc/adt/businessservices/odatav2/publishjobs?servicename=ZSB_BOOKING_V4&serviceversion=0001',
         expect.stringContaining('adtcore:objectReference adtcore:name="ZSB_BOOKING_V4"'),
         'application/xml',
-        expect.objectContaining({ Accept: 'application/*' }),
+        expect.objectContaining({ Accept: 'application/vnd.sap.as+xml, application/*;q=0.8' }),
       );
       expect(result.severity).toBe('OK');
       expect(result.shortText).toBe('published locally');
@@ -1054,7 +1054,7 @@ describe('DevTools', () => {
         '/sap/bc/adt/businessservices/odatav2/unpublishjobs?servicename=ZSB_BOOKING_V4&serviceversion=0001',
         expect.stringContaining('adtcore:objectReference adtcore:name="ZSB_BOOKING_V4"'),
         'application/xml',
-        expect.objectContaining({ Accept: 'application/*' }),
+        expect.objectContaining({ Accept: 'application/vnd.sap.as+xml, application/*;q=0.8' }),
       );
       expect(result.severity).toBe('OK');
       expect(result.shortText).toBe('un-published locally');
@@ -1075,6 +1075,126 @@ describe('DevTools', () => {
       const http = mockHttp();
       const safety = { ...unrestrictedSafetyConfig(), allowWrites: false };
       await expect(unpublishServiceBinding(http, safety, 'ZSB_TEST')).rejects.toThrow(AdtSafetyError);
+    });
+  });
+
+  // ─── publish/unpublish as+xml content negotiation fallback (issue: 406 on SAP_BASIS 758) ──
+
+  describe('publish/unpublish as+xml 406 fallback', () => {
+    const okResponse =
+      '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><SEVERITY>OK</SEVERITY><SHORT_TEXT>ZSSI_UI_S_ORD_O4 published locally</SHORT_TEXT><LONG_TEXT/></DATA></asx:values></asx:abap>';
+    // Verbatim 406 body from S/4HANA 2023 (SAP_BASIS 758) when Accept does not cover
+    // application/vnd.sap.as+xml (T100 SADT_RESOURCE 044).
+    const notAcceptableBody =
+      '<?xml version="1.0" encoding="utf-8"?><exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><namespace id="com.sap.adt"/><type id="ExceptionResourceNotAcceptable"/><message lang="EN">The message content is not acceptable. Accepted content types: application/vnd.sap.as+xml</message><localizedMessage lang="EN">The message content is not acceptable. Accepted content types: application/vnd.sap.as+xml</localizedMessage><properties><entry key="T100KEY-ID">SADT_RESOURCE</entry><entry key="T100KEY-NO">044</entry><entry key="T100KEY-V1">application/vnd.sap.as+xml</entry></properties></exc:exception>';
+
+    function http406ThenOk(path: string): AdtHttpClient {
+      const post = vi
+        .fn()
+        .mockRejectedValueOnce(new AdtApiError(notAcceptableBody, 406, path, notAcceptableBody))
+        .mockResolvedValueOnce({ statusCode: 200, headers: {}, body: okResponse });
+      return {
+        get: vi.fn(),
+        post,
+        put: vi.fn(),
+        delete: vi.fn(),
+        fetchCsrfToken: vi.fn(),
+        withStatefulSession: vi.fn(),
+      } as unknown as AdtHttpClient;
+    }
+
+    it('publish retries a 406 naming application/vnd.sap.as+xml with the dataname-qualified as+xml type (odatav4)', async () => {
+      const path = '/sap/bc/adt/businessservices/odatav4/publishjobs?servicename=ZSSI_UI_S_ORD_O4&serviceversion=0001';
+      const http = http406ThenOk(path);
+      const result = await publishServiceBinding(
+        http,
+        unrestrictedSafetyConfig(),
+        'ZSSI_UI_S_ORD_O4',
+        '0001',
+        'odatav4',
+      );
+
+      expect(http.post).toHaveBeenCalledTimes(2);
+      expect(http.post).toHaveBeenNthCalledWith(
+        1,
+        path,
+        expect.stringContaining('adtcore:objectReference adtcore:name="ZSSI_UI_S_ORD_O4"'),
+        'application/xml',
+        { Accept: 'application/vnd.sap.as+xml, application/*;q=0.8' },
+      );
+      const asXmlType =
+        'application/vnd.sap.as+xml; charset=UTF-8; dataname=com.sap.adt.businessservices.odatav4.publishjob';
+      expect(http.post).toHaveBeenNthCalledWith(
+        2,
+        path,
+        expect.stringContaining('adtcore:objectReference adtcore:name="ZSSI_UI_S_ORD_O4"'),
+        asXmlType,
+        { Accept: asXmlType },
+      );
+      expect(result.severity).toBe('OK');
+      expect(result.shortText).toBe('ZSSI_UI_S_ORD_O4 published locally');
+    });
+
+    it('unpublish retries with the unpublishjob dataname (odatav4)', async () => {
+      const path =
+        '/sap/bc/adt/businessservices/odatav4/unpublishjobs?servicename=ZSSI_UI_S_ORD_O4&serviceversion=0001';
+      const http = http406ThenOk(path);
+      const result = await unpublishServiceBinding(
+        http,
+        unrestrictedSafetyConfig(),
+        'ZSSI_UI_S_ORD_O4',
+        '0001',
+        'odatav4',
+      );
+
+      const asXmlType =
+        'application/vnd.sap.as+xml; charset=UTF-8; dataname=com.sap.adt.businessservices.odatav4.unpublishjob';
+      expect(http.post).toHaveBeenCalledTimes(2);
+      expect(http.post).toHaveBeenNthCalledWith(2, path, expect.any(String), asXmlType, { Accept: asXmlType });
+      expect(result.severity).toBe('OK');
+    });
+
+    it('publish retry uses the odatav2 dataname for odatav2 bindings', async () => {
+      const path = '/sap/bc/adt/businessservices/odatav2/publishjobs?servicename=ZSB_FLIGHT&serviceversion=0001';
+      const http = http406ThenOk(path);
+      await publishServiceBinding(http, unrestrictedSafetyConfig(), 'ZSB_FLIGHT');
+
+      const asXmlType =
+        'application/vnd.sap.as+xml; charset=UTF-8; dataname=com.sap.adt.businessservices.odatav2.publishjob';
+      expect(http.post).toHaveBeenNthCalledWith(2, path, expect.any(String), asXmlType, { Accept: asXmlType });
+    });
+
+    it('does not retry a 406 that does not name application/vnd.sap.as+xml', async () => {
+      const err = new AdtApiError('Not acceptable', 406, '/sap/bc/adt/businessservices/odatav4/publishjobs');
+      const post = vi.fn().mockRejectedValue(err);
+      const http = { post } as unknown as AdtHttpClient;
+
+      await expect(
+        publishServiceBinding(http, unrestrictedSafetyConfig(), 'ZSB_TEST', '0001', 'odatav4'),
+      ).rejects.toThrow(AdtApiError);
+      expect(post).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry non-negotiation errors', async () => {
+      const err = new AdtApiError('Internal server error', 500, '/sap/bc/adt/businessservices/odatav4/publishjobs');
+      const post = vi.fn().mockRejectedValue(err);
+      const http = { post } as unknown as AdtHttpClient;
+
+      await expect(
+        publishServiceBinding(http, unrestrictedSafetyConfig(), 'ZSB_TEST', '0001', 'odatav4'),
+      ).rejects.toThrow('Internal server error');
+      expect(post).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces the error when the as+xml retry also fails (no retry loop)', async () => {
+      const err = new AdtApiError(notAcceptableBody, 406, '/x', notAcceptableBody);
+      const post = vi.fn().mockRejectedValue(err);
+      const http = { post } as unknown as AdtHttpClient;
+
+      await expect(
+        publishServiceBinding(http, unrestrictedSafetyConfig(), 'ZSB_TEST', '0001', 'odatav4'),
+      ).rejects.toThrow(AdtApiError);
+      expect(post).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -6062,6 +6062,54 @@ ENDCLASS.`;
       expect(String(publishOpts.body)).toContain('adtcore:name="ZSB_TRAVEL_O4"');
     });
 
+    it('package-gate metadata read for publish_srvb sends the parameter-less servicebinding Accept', async () => {
+      // Regression (SAP_BASIS 758): the bindings resource rejects an Accept carrying
+      // "; charset=utf-8" with 406 SADT_RESOURCE 037, which broke publish_srvb/unpublish_srvb
+      // whenever allowedPackages is restricted (the gate's resolveObjectPackage GET ran with
+      // the charset-suffixed content type). The gate must send the bare media type.
+      const bindingXml =
+        '<srvb:serviceBinding xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:name="ZSB_TRAVEL_O4"><adtcore:packageRef adtcore:name="Z_TEST_PKG"/><binding version="V2" type="ODATA" category="0"/></srvb:serviceBinding>';
+      mockFetch
+        // 1) package-gate resolveObjectPackage GET (also delivers CSRF token)
+        .mockResolvedValueOnce(mockResponse(200, bindingXml, { 'x-csrf-token': 'T' }))
+        // 2) getSrvb for service type detection
+        .mockResolvedValueOnce(mockResponse(200, bindingXml, { 'x-csrf-token': 'T' }))
+        // 3) publish POST
+        .mockResolvedValueOnce(
+          mockResponse(
+            200,
+            '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><SEVERITY>OK</SEVERITY><SHORT_TEXT>Published</SHORT_TEXT><LONG_TEXT></LONG_TEXT></DATA></asx:values></asx:abap>',
+            { 'x-csrf-token': 'T' },
+          ),
+        )
+        // 4) getSrvb readback
+        .mockResolvedValueOnce(
+          mockResponse(
+            200,
+            '<serviceBinding xmlns="http://www.sap.com/adt/ddic/ServiceBindings" name="ZSB_TRAVEL_O4" published="true"></serviceBinding>',
+            { 'x-csrf-token': 'T' },
+          ),
+        );
+      const client = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'admin',
+        password: 'secret',
+        safety: { ...unrestrictedSafetyConfig(), allowedPackages: ['Z*'] },
+      });
+      const result = await handleToolCall(client, DEFAULT_CONFIG, 'SAPActivate', {
+        action: 'publish_srvb',
+        name: 'ZSB_TRAVEL_O4',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('Successfully published service binding ZSB_TRAVEL_O4');
+
+      const gateCall = mockFetch.mock.calls[0];
+      expect(String(gateCall[0])).toContain('/sap/bc/adt/businessservices/bindings/ZSB_TRAVEL_O4');
+      const gateHeaders = ((gateCall[1] as Record<string, unknown>)?.headers ?? {}) as Record<string, string>;
+      expect(gateHeaders.Accept).toBe('application/vnd.sap.adt.businessservices.servicebinding.v2+xml');
+      expect(gateHeaders.Accept).not.toContain('charset');
+    });
+
     it('returns error when publish_srvb fails', async () => {
       mockFetch
         // getSrvb for service type detection (also delivers CSRF token)

--- a/tests/unit/handlers/intent.test.ts
+++ b/tests/unit/handlers/intent.test.ts
@@ -6250,6 +6250,53 @@ ENDCLASS.`;
       expect(unpublishUrl).toContain('servicename=ZSB_TRAVEL_O4');
     });
 
+    it('package-gate metadata read for unpublish_srvb sends the parameter-less servicebinding Accept', async () => {
+      // Symmetric to the publish_srvb gate regression test: the unpublish gate runs the same
+      // resolveObjectPackage GET and must send the bare media type (758/816 reject parameters
+      // with 406 SADT_RESOURCE 037).
+      const bindingXml =
+        '<srvb:serviceBinding xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:name="ZSB_TRAVEL_O4"><adtcore:packageRef adtcore:name="Z_TEST_PKG"/><binding version="V2" type="ODATA" category="0"/></srvb:serviceBinding>';
+      mockFetch
+        // 1) package-gate resolveObjectPackage GET (also delivers CSRF token)
+        .mockResolvedValueOnce(mockResponse(200, bindingXml, { 'x-csrf-token': 'T' }))
+        // 2) getSrvb for service type detection
+        .mockResolvedValueOnce(mockResponse(200, bindingXml, { 'x-csrf-token': 'T' }))
+        // 3) unpublish POST
+        .mockResolvedValueOnce(
+          mockResponse(
+            200,
+            '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><SEVERITY>OK</SEVERITY><SHORT_TEXT>Unpublished</SHORT_TEXT><LONG_TEXT></LONG_TEXT></DATA></asx:values></asx:abap>',
+            { 'x-csrf-token': 'T' },
+          ),
+        )
+        // 4) getSrvb readback
+        .mockResolvedValueOnce(
+          mockResponse(
+            200,
+            '<serviceBinding xmlns="http://www.sap.com/adt/ddic/ServiceBindings" name="ZSB_TRAVEL_O4" published="false"></serviceBinding>',
+            { 'x-csrf-token': 'T' },
+          ),
+        );
+      const client = new AdtClient({
+        baseUrl: 'http://sap:8000',
+        username: 'admin',
+        password: 'secret',
+        safety: { ...unrestrictedSafetyConfig(), allowedPackages: ['Z*'] },
+      });
+      const result = await handleToolCall(client, DEFAULT_CONFIG, 'SAPActivate', {
+        action: 'unpublish_srvb',
+        name: 'ZSB_TRAVEL_O4',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('Successfully unpublished service binding ZSB_TRAVEL_O4');
+
+      const gateCall = mockFetch.mock.calls[0];
+      expect(String(gateCall[0])).toContain('/sap/bc/adt/businessservices/bindings/ZSB_TRAVEL_O4');
+      const gateHeaders = ((gateCall[1] as Record<string, unknown>)?.headers ?? {}) as Record<string, string>;
+      expect(gateHeaders.Accept).toBe('application/vnd.sap.adt.businessservices.servicebinding.v2+xml');
+      expect(gateHeaders.Accept).not.toContain('charset');
+    });
+
     it('activates a DDIC structure via TABL with structure URL in XML body', async () => {
       // Model B: structures use type='TABL'. The activate handler resolves the
       // URL via client.resolveTablObjectUrlForWrite which asks SAP for the


### PR DESCRIPTION
## What

`SAPActivate action=publish_srvb`/`unpublish_srvb` failed with **HTTP 406 "The message content is not acceptable"** against on-prem systems. Two distinct 406s were involved; this PR fixes both:

### Commit 2 — the actual production failure (0.9.14 regression): package-gate read
The package gate added in #394 (`enforceAllowedPackageForObjectUrl` on publish/unpublish) passed `SERVICEBINDING_V2_CONTENT_TYPE` — which carries `; charset=utf-8` — as the **Accept** for the binding metadata GET. Live-verified on **both** S/4HANA 2023 (758) and ABAP Platform 2025 (816):

| Accept on `GET /businessservices/bindings/{name}` | 758 | 816 |
|---|---|---|
| `…servicebinding.v2+xml; charset=utf-8` | **406** (T100 SADT_RESOURCE 037) | **406** |
| `…servicebinding.v2+xml` (bare) | 200 | 200 |

The 037 body names no accepted type, so the generic negotiation retry can't infer a fallback → publish/unpublish failed **before the publish POST was even sent**, whenever `allowedPackages` is restricted — which is the default (`$TMP`). Fix: new parameter-less `SERVICEBINDING_V2_ACCEPT` used by both gate calls; the charset form remains for PUT/POST Content-Type only.

### Commit 1 — publishjobs POST hardening
The publish/unpublish job POST is rejected with 406 (T100 SADT_RESOURCE 044, "Accepted content types: application/vnd.sap.as+xml") when the Accept names only newer-release types (e.g. `…odatav4.v1+xml` — what discovery shallow-matching produces for that path). The 406 is **purely Accept-driven**; request Content-Type isn't validated on 758. Fixes in `postPublishJob`:
1. Primary Accept → `application/vnd.sap.as+xml, application/*;q=0.8` (mirrors the lock Accept in `crud.ts`).
2. Self-scoping fallback: a 406/415 naming `application/vnd.sap.as+xml` is retried once with the Eclipse-style `application/vnd.sap.as+xml; charset=UTF-8; dataname=com.sap.adt.businessservices.<serviceType>.<publishjob|unpublishjob>` as Content-Type + Accept (all four combos live-verified → 200).

Discovery-driven type selection was evaluated and ruled out: 758 has no publishjobs discovery entries (shallow-match falls back to the parent collection's v1+xml — exactly the type that 406s); 816 lists publishjobs only as `templateLink`s without accepts.

## Tests

- `tests/unit/adt/devtools.test.ts`: 6 new regression tests using the verbatim a4h 406 body (fallback datanames per serviceType×job; no retry on other errors; no retry loop) + 2 updated header assertions.
- `tests/unit/handlers/intent.test.ts`: new test runs `publish_srvb` with a **restricted allowlist** (gate active) and pins the gate GET's wire Accept to the bare media type.
- Full suite on the rebased branch (post-#402 handler split): **3719 pass**; typecheck, lint, `check:sizes` clean.

## Live verification (2026-06-11, rebased branch, restricted allowlist `Z*,$TMP`)

- **a4h (758)**: V4 `ZARC1_UI_TRAVELDEMO_O4` and V2 `ZTEST_MCP_SB_FLIGHT` (auto-detected serviceType) unpublish→republish cycles ✓ with `published` readback confirmed; original repro binding `ZSSI_UI_S_ORD_O4` publishes ✓.
- **a4h-2025 (816)**: `ZSB_ARC1_SMOKE` unpublish→republish ✓.
- **Deny path** (allowlist `$TMP`, binding in `Z_RAP_VB_BC26`): clean `AdtSafetyError` naming the real package — instead of the misleading 406.
- All test bindings restored to their original published state on both systems.

## Reviewer notes

- Review dossier: `research/pull-requests/403-srvb-publish-content-negotiation.md` (full curl matrices, gate call-site audit, invariant checklist).
- The two 406s explain the original report: the gate read produces the bare "message content is not acceptable" (T100 037); the as+xml "accepted content types" quote (T100 044) comes from the publishjobs POST when probed with the v1+xml type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)