### PR TITLE
ci: decouple npm publish from the Docker CVE gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,12 @@ jobs:
         # which sets bump-minor-pre-major: true so breaking changes only bump
         # the minor version while the package is pre-1.0.0.
 
-  # Gate the npm publish on the Docker CVE scan (publish-docker) so a release is
-  # atomic: if the image fails the gating Trivy scan, npm does NOT publish either.
-  # Previously publish-npm and publish-docker ran in parallel (both only needed
-  # release-please), so a HIGH/CRITICAL CVE failed Docker AFTER npm had already
-  # shipped — a split release that a re-run can't fix (the tagged commit predates
-  # the patch). Serializing costs ~1.5 min per release; consistency is worth it.
+  # npm publishes independently of the Docker CVE gate — a HIGH/CRITICAL finding
+  # blocks the Docker image but not the npm package. (The scheduled security-scan.yml
+  # gate-preview is what keeps base-image CVEs from reaching a release in the first
+  # place, so the two artifacts rarely diverge.)
   publish-npm:
-    needs: [release-please, publish-docker]
+    needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why

[#400](https://github.com/marianfoo/arc-1/pull/400) landed `publish-npm` gated on `publish-docker` (atomic release). The follow-up that reverted that coupling didn't make it into the squash merge, so `main` still has:

```yaml
publish-npm:
  needs: [release-please, publish-docker]
```

A HIGH/CRITICAL Trivy finding should block the **Docker image only** — not hold back the **npm package**. This restores the independent publish.

## Change

`release.yml` only — one line:

```diff
 publish-npm:
-  needs: [release-please, publish-docker]
+  needs: release-please
```

(+ comment updated to match.)

## Trade-off (intended)

npm can now publish even if the Docker CVE gate fails. That divergence stays rare because the other two layers from #400 are still in place:
- **`security-scan.yml`** (Mon/Wed/Fri) runs the exact release gate against the current `Dockerfile`, so base-image CVEs surface *before* a release.
- **`apk upgrade`** in the `Dockerfile` heals base-image OS CVEs at build time.

## Validation

- `release.yml` passes `actionlint` (the lone SC2046 warning is pre-existing in the unrelated `publish-docker-merge` digest command).
- Branched fresh off `origin/main` (`909f2534`), which already includes #400, #402, #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)