### PR TITLE
refactor(adt): consolidate XML escaping onto the shared escapeXmlAttr

### DIFF
--- a/docs/plans/joule-extensibility-assistant.md
+++ b/docs/plans/joule-extensibility-assistant.md
@@ -122,7 +122,7 @@ Mirror the existing `buildDataElementXml()` / `buildDomainXml()` exports in `src
   </blue:appendStructure>
   ```
   Verify root element + namespace against the existing DDIC builders. The exact root name TBD against live a4h on first integration run — use `R3TR APPS` semantics.
-- [ ] Use the existing `escapeXml()` helper for all attribute values
+- [ ] Use the existing `escapeXmlAttr()` helper (`src/adt/xml-parser.ts`) for all attribute values
 - [ ] Add unit tests (~4 tests): happy path, empty fields list rejected, name validation (starts with Z/Y), special characters escaped correctly
 - [ ] Run `npm test -- ddic-xml` — all tests pass
 

--- a/docs/plans/post-consolidation-hygiene-plan.md
+++ b/docs/plans/post-consolidation-hygiene-plan.md
@@ -1,0 +1,161 @@
+# Post-Consolidation Hygiene & Schema-Generation Plan
+
+**Status: Proposed — PR 1 awaiting go.** Successor to
+[completed/test-split-and-typecheck-plan.md](completed/test-split-and-typecheck-plan.md) (PR #405)
+and the architecture consolidation (PR #402). Sources: a 4-angle survey of merged main
+@ `7a032820` (src structure / legacy remnants / test architecture / knowledge architecture) plus an
+external Codex review of the candidate list — its ordering (risk-ascending: XML escaping first,
+schema generation last, alias removal deferred) is adopted here.
+
+## Process
+
+- **One PR per point**, merged before the next starts. After each merge: a short **plan-review
+  checkpoint** — re-read the next PR's section against the then-current main (rebases, new
+  findings), adjust, then implement. Update this file's status lines as part of each PR.
+- Every PR runs the full gate: `npm test` + `npm run typecheck` + `lint` + `validate:policy` +
+  `build` + `check:sizes`, and the tool-definition fixtures stay **byte-identical** — except PR 5,
+  whose entire point is an *intentional, semantically-proven* fixture regeneration.
+- Release impact (release-please, `bump-minor-pre-major` + `bump-patch-for-minor-pre-major` both
+  true): `refactor:`/`test:`/`docs:`/`chore:` → no release; `fix:`/`feat:` → patch (0.9.x);
+  `feat!:` → minor (0.10.0).
+
+## Baseline (main @ 7a032820, 2026-06-12)
+
+41,262 src lines / 70,074 test lines; largest file tools.ts 1,587 (budget 1,700); zero TODO/FIXME;
+suite 3,721 tests / 118 files green. The survey's *rejected* candidates (with reasons, so they are
+not re-triaged): write-helpers.ts / xml-parser.ts / types.ts splits (cohesive; churn > clarity),
+dispatch.ts error-tree restructure (well-factored), tools.test.ts + adt.integration.test.ts splits
+(structured / sequential-by-design), AGENTS.md↔dev-guide sync guard (verified zero drift; anchors
+premature), test `as any` sweep (303 instances are partial-mock plumbing, not type holes).
+
+---
+
+## PR 1 — `refactor(adt)`: one XML escaper (escapeXmlAttr)
+
+**Status: DONE (branch pr1-xml-escaping).** Two commits.
+
+Survey said 3 duplicates; it was **4** (the survey missed `escapeXmlText`). All folded onto the
+shared `escapeXmlAttr`:
+
+| Site | Form | Coverage | Output change |
+|---|---|---|---|
+| `xml-parser.ts:45` `escapeXmlAttr` | exported keeper, 4 importers | `& < > " '` | — (keeper) |
+| `ddic-xml.ts` `escapeXml` (45 calls) | private | `& " ' < >` (order-equivalent) | none |
+| `write-helpers.ts` `escapeXml` (45 calls; ALSO imported by `write/create.ts`) | exported | `& " ' < >` | none |
+| `devtools.ts` `escapeXmlText` (3 calls) | private | byte-identical to keeper | none |
+| `refactoring.ts` `escapeXml` (10 calls) | private | **omitted `'`** | now emits `&apos;` |
+
+**Correction to the survey/Codex framing:** the missing apostrophe in refactoring.ts is **not an
+active bug** — every call site interpolates into double-quoted attributes or element text, where a
+literal `'` is valid XML, so today's output is well-formed. So this shipped as `refactor:` (no
+release), not `fix:`. The apostrophe escaping becomes uniform as defensive hardening.
+**Commit 1** `refactor(adt): consolidate the DDIC/devtools/write XML escapers …` — the three
+byte-identical folds (ddic-xml, write-helpers, devtools, + consumer write/create.ts); zero output
+change. escapeXmlAttr gains a "this is THE XML escaper" doc comment (notes the separate HTML
+escapers in oauth.ts/http.ts that emit `&#39;`).
+**Commit 2** `refactor(adt): route change-package XML through the shared escapeXmlAttr` —
+refactoring.ts + a test pinning all five entities incl. `'`.
+**Gate verification:** the tests-typecheck gate caught the multi-line `escapeXml` import in
+write/create.ts that a one-line grep missed — exactly the Stage-T safety net working.
+**Result:** one XML escaper in src; 502 affected-suite tests green; no fixture diff.
+
+## PR 2 — `refactor(adt)`: `withSafety()` clone safe by construction
+
+**Status: planned; checkpoint after PR 1 merge.**
+
+`src/adt/client.ts:329` clones via `Object.create(AdtClient.prototype)` + 6 hand-attached fields;
+a forgotten field is the proven #333 crash class (runtime `undefined`), guarded today only by a
+comment. **Design constraint (Codex + #333 history): the clone must SHARE the live `http` client
+(cookie jar / CSRF / sessions) and the cache holders — a naive `new AdtClient(config)` would build
+a fresh `AdtHttpClient` and break authenticated sessions.** Shape: a private constructor path
+(e.g. an internal options overload or static `AdtClient.cloneWithSafety(source, safety)`) that
+receives the existing `http` + caches explicitly, so a NEW instance field is a missing-argument
+**compile error** instead of a silent `undefined`.
+**Acceptance:** existing `describe('withSafety')` identity assertions stay green (same `http`,
+same cache instances, only `safety` differs); the hand-attach invariant comment is deleted because
+the invariant is structural; AGENTS.md row for `withSafety()` updated; no fixture diff; full gate.
+**Risk:** low-medium — touches the auth-critical client path; mitigated by the existing
+clone-identity tests + integration suite. Commit: `refactor(adt):` (no release).
+
+## PR 3 — `docs:` truth pass (bounded)
+
+**Status: planned; checkpoint after PR 2 merge.**
+
+Scope is **current-guidance accuracy, not history rewriting** (Codex's bound, adopted):
+
+1. Move the three known-executed plans to `docs/plans/completed/`:
+   `architecture-consolidation-plan.md`, `architecture-consolidation-progress.md`,
+   `test-split-and-typecheck-plan.md` — and fix the AGENTS.md "History" link that points at the
+   progress file. Mark the first one's stale "Proposed — v2 for owner review" header as executed
+   (PR #402).
+2. Quick status triage of the other ~27 top-level plans: move ONLY those whose own header already
+   says done/shipped; touch nothing ambiguous.
+3. Fix references that present the deleted `src/handlers/intent.ts` as CURRENT:
+   `docs_page/roadmap.md` (8 line refs — public site) and
+   `docs/research/joule-2026-roadmap-feature-assessment.md` (describes the consolidation as future
+   work). Frame as "implemented in the former intent.ts, split into per-tool modules in #402" —
+   do not rewrite historical changelog entries.
+
+**Acceptance:** `grep -rn "handlers/intent.ts" docs_page/ docs/research/ README.md` returns only
+clearly-historical phrasing; AGENTS.md links resolve; no source changes.
+**Risk:** broken links only — grep-verify all moved-file references.
+
+## PR 4 — `test:`/`chore:` small hygiene batch
+
+**Status: planned; checkpoint after PR 3 merge.**
+
+One commit each:
+1. `chore(tests):` rename `tests/unit/handlers/intent-rate-limit.test.ts` →
+   `dispatch-rate-limit.test.ts` (it tests dispatch.ts; the name is the last "intent" in tests).
+2. `test(handlers):` convert the 5 remaining `as ResolvedFeatures` casts in
+   `action-policy-integration.test.ts` (lines ~218/234/249/306/434) to the
+   `features()`/`featuresOff()` factory — finishing the #405 sweep (file was out of scope then).
+3. `test(server):` `xsuaa.test.ts:280` hand-built Response mock → `mockResponse()` from
+   `tests/helpers/mock-fetch.ts`.
+4. `chore(handlers):` strip the "extracted from intent.ts (Stage B …)" provenance lines from the
+   ~15 handler module headers — per the playbook, comments must not record where code came from.
+
+**Acceptance:** suite count unchanged (rename is discovery-neutral); zero `as ResolvedFeatures` in
+tests/unit/handlers; no fixture diff; full gate. **Risk:** none.
+
+## PR 5 — Zod → JSON Schema generation (spike first, GO/NO-GO)
+
+**Status: planned; checkpoint after PR 4 merge. The only LLM-surface-touching PR — highest rigor.**
+
+Today `schemas.ts` (Zod, 919 lines) and `tools.ts` (hand-written JSON Schema, 1,587 lines,
+263 `description:` strings) define the same 12 tool surfaces twice — the root of the "three-file
+sync" invariant. Codex's complication list is real and verified: ~50 `z.preprocess`/
+`looseOptionalBoolean` usages + 4 `superRefine` blocks in schemas.ts (superRefine is
+runtime-only — fine; `z.preprocess` is where `z.toJSONSchema()` needs explicit input types or
+overrides), feature-gated enums, BTP/on-prem variants, OpenAI-compat nullable handling, and rich
+LLM-facing prose that must survive byte-for-byte.
+
+**Phase A — spike (no behavior change, throwaway branch):** generate JSON Schema for ONE complex
+tool (SAPWrite) via `z.toJSONSchema()`; write a semantic differ (deep-equal modulo key order +
+formatting) against the hand-written schema; inventory every divergence class:
+`looseOptionalBoolean` → must emit plain `{type:'boolean'}` (what LLMs should send, not what Zod
+accepts), enum pruning parity for all 9 fixture variants, `items`/array shapes, nullability,
+description placement. Output: a divergence table + **GO/NO-GO**.
+**Phase B(GO):** generate `inputSchema` for all tools from the Zod schemas (per-field overrides
+where preprocess obscures the wire type); tool-level prose stays as constants; regenerate the 9
+snapshot fixtures **intentionally** (the one legitimate `vitest -u`), with a committed semantic
+proof: a test asserting old-vs-new schema deep-equality modulo formatting, plus a reviewed fixture
+diff. Three-file sync becomes two-file (registry + Zod). AGENTS.md invariant row updated.
+**Phase B(NO-GO fallback):** keep hand-written tools.ts but add a **semantic sync test**
+(Zod-derived schema ≅ hand-written, modulo the inventoried acceptable divergences) — the drift
+class dies either way; generation can be revisited later.
+**Acceptance (Codex's criteria, adopted):** preserve every description, preserve
+nullable/optional-field semantics, preserve array `items`, regenerate snapshots intentionally with
+semantic-comparison tests, MCP client smoke (e2e suite) green. Commit: `refactor(handlers):` if
+output is semantically identical; anything user-visible beyond formatting → stop and re-plan.
+**Risk:** the LLM-visible surface — bounded by the spike's GO/NO-GO and the semantic differ.
+
+## Parked (explicit non-goals until triggered)
+
+- **Remove deprecated `MESSAGES`/`FTG2` SAPRead aliases** — 14 minors past the "one minor release"
+  promise (deprecated v0.9.0, now 0.9.14), but it is a breaking LLM-surface change → `feat!:` →
+  0.10.0. **Trigger: the owner schedules a deliberate 0.10.0.** Scope when triggered: registry
+  rows, two read.ts dispatch cases + warnings, tools.ts description mentions, fixtures, docs.
+- **`checkJs` for `scripts/ci/*.mjs`** — the tests gate already type-checks their *exports* via
+  `allowJs` inference; full checkJs needs JSDoc-typing the scripts. Revisit if a script bug slips
+  through the inference gate.

--- a/docs/plans/post-consolidation-hygiene-plan.md
+++ b/docs/plans/post-consolidation-hygiene-plan.md
@@ -39,7 +39,7 @@ shared `escapeXmlAttr`:
 
 | Site | Form | Coverage | Output change |
 |---|---|---|---|
-| `xml-parser.ts:45` `escapeXmlAttr` | exported keeper, 4 importers | `& < > " '` | — (keeper) |
+| `xml-parser.ts:45` `escapeXmlAttr` | exported keeper, 5 importers (abapgit, codeintel, devtools, server-driven, transport) | `& < > " '` | — (keeper) |
 | `ddic-xml.ts` `escapeXml` (45 calls) | private | `& " ' < >` (order-equivalent) | none |
 | `write-helpers.ts` `escapeXml` (45 calls; ALSO imported by `write/create.ts`) | exported | `& " ' < >` | none |
 | `devtools.ts` `escapeXmlText` (3 calls) | private | byte-identical to keeper | none |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -148,7 +148,7 @@ Fails when: a pattern/loop derived from args has no cap (R2).
 Every argument interpolated into a URL, SQL statement, XML payload, or HTTP header is
 encoded/escaped/allowlisted **at the sink** *and* constrained at the schema (defense in depth) —
 `encodeURIComponent` for path segments, `sanitizeIdentifier`/`quoteSqlLiteral` for SQL,
-`escapeXml` for XML, enum/charset for headers.
+`escapeXmlAttr` (`src/adt/xml-parser.ts`) for XML, enum/charset for headers.
 
 Where: URL building in [`src/adt/client.ts`](../src/adt/client.ts) and
 [`src/handlers/intent.ts`](../src/handlers/), SQL helpers in
@@ -231,7 +231,7 @@ Run the invariant(s) for whatever the change touches. This is the operational co
 | **Auth, PP, or scope resolution** | **I3**: every error path denies; no fall-through to success, to the shared client, or to a broader scope. Distinguish "token isn't mine" from "validator threw". |
 | **Logging, audit, a new event field, or a new sink** | **I4**: the field is redacted in *all* sinks (prefer centralizing in `Logger.emitAudit`); secret-bearing values never logged; redaction recurses into nested objects. |
 | **Any loop/regex/list built from tool args** | **I5**: bounded length + count + (for regex) time/complexity. Never compile a raw LLM regex without a length cap and timeout/RE2. |
-| **A new URL path, SQL, XML payload, or HTTP header from args** | **I6**: `encodeURIComponent` per path segment; `sanitizeIdentifier`/`quoteSqlLiteral`/charset-allowlist for SQL; `escapeXml` for XML; enum/charset for headers. Add a defense-in-depth schema constraint too. |
+| **A new URL path, SQL, XML payload, or HTTP header from args** | **I6**: `encodeURIComponent` per path segment; `sanitizeIdentifier`/`quoteSqlLiteral`/charset-allowlist for SQL; `escapeXmlAttr` for XML; enum/charset for headers. Add a defense-in-depth schema constraint too. |
 | **A new capability or a default value** | **I7**: it is read-only unless an explicit admin opt-in is set; no default loosens; user scopes can only restrict. Update the safety ceiling + `ACTION_POLICY` together. |
 | **`withSafety()` / a new `AdtClient` field** | The clone re-attaches the field (it bypasses the constructor); per-user data is not shared across users via a shared holder. (Regression class: #333.) |
 | **GPT/OpenAI arg hardening** | Stripping/coercion can only make a field *absent* (→ safe default) or error — never flip a deny to allow. Never `z.coerce.boolean()`. |
@@ -269,7 +269,7 @@ if the change is *in* one of them.
   `ARC1_PUBLIC_URL`/CF route, never from `Host`/`X-Forwarded-*`.
 - **SQL injection** — structured SQL is allowlisted (`sanitizeIdentifier`, `quoteSqlLiteral`,
   operator allowlist); ad-hoc SQL charset-whitelists before interpolation.
-- **XML injection** — DDIC/FUGR/FUNC builders `escapeXml` every free string.
+- **XML injection** — DDIC/FUGR/FUNC builders escape every free string via the shared `escapeXmlAttr` (`src/adt/xml-parser.ts`).
 - **`withSafety()` clone** — re-attaches all instance fields; the restricted safety is applied;
   shared holders carry no per-user data. [`src/adt/client.ts`](../src/adt/client.ts).
 - **CORS** — off by default; exact `Set.has` origin match with `credentials:true`; no wildcard.

--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -5,6 +5,8 @@
  * structured XML payloads on create/update.
  */
 
+import { escapeXmlAttr } from './xml-parser.js';
+
 export interface DomainFixedValue {
   low: string;
   high?: string;
@@ -165,15 +167,6 @@ export function normalizeAdtResponsible(responsible?: string): string {
   return (responsible ?? '').trim().toUpperCase() || 'DEVELOPER';
 }
 
-function escapeXml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
 function formatLength(value: number | string | undefined, width: number): string {
   if (value === undefined || value === null || String(value).trim() === '') {
     return ''.padStart(width, '0');
@@ -211,9 +204,9 @@ export function buildDomainXml(params: DomainCreateParams): string {
           ...fixedValues.map(
             (value, index) => `        <doma:fixValue>
           <doma:position>${String(index + 1).padStart(4, '0')}</doma:position>
-          <doma:low>${escapeXml(value.low)}</doma:low>
-          <doma:high>${escapeXml(value.high ?? '')}</doma:high>
-          <doma:text>${escapeXml(value.description ?? '')}</doma:text>
+          <doma:low>${escapeXmlAttr(value.low)}</doma:low>
+          <doma:high>${escapeXmlAttr(value.high ?? '')}</doma:high>
+          <doma:text>${escapeXmlAttr(value.description ?? '')}</doma:text>
         </doma:fixValue>`,
           ),
           '      </doma:fixValues>',
@@ -222,29 +215,29 @@ export function buildDomainXml(params: DomainCreateParams): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <doma:domain xmlns:doma="http://www.sap.com/dictionary/domain"
              xmlns:adtcore="http://www.sap.com/adt/core"
-             adtcore:description="${escapeXml(params.description)}"
-             adtcore:name="${escapeXml(params.name)}"
+             adtcore:description="${escapeXmlAttr(params.description)}"
+             adtcore:name="${escapeXmlAttr(params.name)}"
              adtcore:type="DOMA/DD"
              adtcore:masterLanguage="${masterLanguage}"
              adtcore:masterSystem="H00"
-             adtcore:responsible="${escapeXml(responsible)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>
+             adtcore:responsible="${escapeXmlAttr(responsible)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(params.package)}"/>
   <doma:content>
     <doma:typeInformation>
-      <doma:datatype>${escapeXml(params.dataType)}</doma:datatype>
+      <doma:datatype>${escapeXmlAttr(params.dataType)}</doma:datatype>
       <doma:length>${formatLength(params.length, 6)}</doma:length>
       <doma:decimals>${formatLength(params.decimals, 6)}</doma:decimals>
     </doma:typeInformation>
     <doma:outputInformation>
       <doma:length>${formatLength(params.outputLength ?? params.length, 6)}</doma:length>
       <doma:style>00</doma:style>
-      <doma:conversionExit>${escapeXml(params.conversionExit ?? '')}</doma:conversionExit>
+      <doma:conversionExit>${escapeXmlAttr(params.conversionExit ?? '')}</doma:conversionExit>
       <doma:signExists>${boolToXml(params.signExists)}</doma:signExists>
       <doma:lowercase>${boolToXml(params.lowercase)}</doma:lowercase>
       <doma:ampmFormat>false</doma:ampmFormat>
     </doma:outputInformation>
     <doma:valueInformation>
-${valueTable ? `      <doma:valueTableRef adtcore:type="TABL/DT" adtcore:name="${escapeXml(valueTable)}"/>` : ''}
+${valueTable ? `      <doma:valueTableRef adtcore:type="TABL/DT" adtcore:name="${escapeXmlAttr(valueTable)}"/>` : ''}
       <doma:appendExists>false</doma:appendExists>
 ${fixValuesXml}
     </doma:valueInformation>
@@ -283,18 +276,18 @@ export function buildMessageClassXml(params: MessageClassCreateParams): string {
         messages
           .map(
             (m) =>
-              `  <mc:messages mc:msgno="${escapeXml(m.number)}" mc:msgtext="${escapeXml(m.shortText)}" mc:selfexplainatory="true" mc:documented="false"/>`,
+              `  <mc:messages mc:msgno="${escapeXmlAttr(m.number)}" mc:msgtext="${escapeXmlAttr(m.shortText)}" mc:selfexplainatory="true" mc:documented="false"/>`,
           )
           .join('\n');
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <mc:messageClass xmlns:mc="http://www.sap.com/adt/MessageClass"
                  xmlns:adtcore="http://www.sap.com/adt/core"
-                 adtcore:description="${escapeXml(params.description)}"
-                 adtcore:name="${escapeXml(params.name)}"
+                 adtcore:description="${escapeXmlAttr(params.description)}"
+                 adtcore:name="${escapeXmlAttr(params.name)}"
                  adtcore:language="${masterLanguage}"
                  adtcore:masterLanguage="${masterLanguage}">
-  <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>${messagesXml}
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(params.package)}"/>${messagesXml}
 </mc:messageClass>`;
 }
 
@@ -311,35 +304,35 @@ export function buildDataElementXml(params: DataElementCreateParams): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <blue:wbobj xmlns:blue="http://www.sap.com/wbobj/dictionary/dtel"
             xmlns:adtcore="http://www.sap.com/adt/core"
-            adtcore:description="${escapeXml(params.description)}"
-            adtcore:name="${escapeXml(params.name)}"
+            adtcore:description="${escapeXmlAttr(params.description)}"
+            adtcore:name="${escapeXmlAttr(params.name)}"
             adtcore:type="DTEL/DE"
             adtcore:masterLanguage="${masterLanguage}"
             adtcore:masterSystem="H00"
-            adtcore:responsible="${escapeXml(responsible)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>
+            adtcore:responsible="${escapeXmlAttr(responsible)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(params.package)}"/>
   <dtel:dataElement xmlns:dtel="http://www.sap.com/adt/dictionary/dataelements">
-    <dtel:typeKind>${escapeXml(typeKind)}</dtel:typeKind>
-    <dtel:typeName>${escapeXml(typeName)}</dtel:typeName>
-    <dtel:dataType>${escapeXml(params.dataType ?? '')}</dtel:dataType>
+    <dtel:typeKind>${escapeXmlAttr(typeKind)}</dtel:typeKind>
+    <dtel:typeName>${escapeXmlAttr(typeName)}</dtel:typeName>
+    <dtel:dataType>${escapeXmlAttr(params.dataType ?? '')}</dtel:dataType>
     <dtel:dataTypeLength>${formatLength(params.length, 6)}</dtel:dataTypeLength>
     <dtel:dataTypeDecimals>${formatLength(params.decimals, 6)}</dtel:dataTypeDecimals>
-    <dtel:shortFieldLabel>${escapeXml(shortLabel)}</dtel:shortFieldLabel>
+    <dtel:shortFieldLabel>${escapeXmlAttr(shortLabel)}</dtel:shortFieldLabel>
     <dtel:shortFieldLength>${formatLabelLength(shortLabel, DTEL_MAX_LABEL_LENGTHS.short)}</dtel:shortFieldLength>
     <dtel:shortFieldMaxLength>${String(DTEL_MAX_LABEL_LENGTHS.short).padStart(2, '0')}</dtel:shortFieldMaxLength>
-    <dtel:mediumFieldLabel>${escapeXml(mediumLabel)}</dtel:mediumFieldLabel>
+    <dtel:mediumFieldLabel>${escapeXmlAttr(mediumLabel)}</dtel:mediumFieldLabel>
     <dtel:mediumFieldLength>${formatLabelLength(mediumLabel, DTEL_MAX_LABEL_LENGTHS.medium)}</dtel:mediumFieldLength>
     <dtel:mediumFieldMaxLength>${DTEL_MAX_LABEL_LENGTHS.medium}</dtel:mediumFieldMaxLength>
-    <dtel:longFieldLabel>${escapeXml(longLabel)}</dtel:longFieldLabel>
+    <dtel:longFieldLabel>${escapeXmlAttr(longLabel)}</dtel:longFieldLabel>
     <dtel:longFieldLength>${formatLabelLength(longLabel, DTEL_MAX_LABEL_LENGTHS.long)}</dtel:longFieldLength>
     <dtel:longFieldMaxLength>${DTEL_MAX_LABEL_LENGTHS.long}</dtel:longFieldMaxLength>
-    <dtel:headingFieldLabel>${escapeXml(headingLabel)}</dtel:headingFieldLabel>
+    <dtel:headingFieldLabel>${escapeXmlAttr(headingLabel)}</dtel:headingFieldLabel>
     <dtel:headingFieldLength>${formatLabelLength(headingLabel, DTEL_MAX_LABEL_LENGTHS.heading)}</dtel:headingFieldLength>
     <dtel:headingFieldMaxLength>${DTEL_MAX_LABEL_LENGTHS.heading}</dtel:headingFieldMaxLength>
-    <dtel:searchHelp>${escapeXml(params.searchHelp ?? '')}</dtel:searchHelp>
-    <dtel:searchHelpParameter>${escapeXml(params.searchHelpParameter ?? '')}</dtel:searchHelpParameter>
-    <dtel:setGetParameter>${escapeXml(params.setGetParameter ?? '')}</dtel:setGetParameter>
-    <dtel:defaultComponentName>${escapeXml(params.defaultComponentName ?? '')}</dtel:defaultComponentName>
+    <dtel:searchHelp>${escapeXmlAttr(params.searchHelp ?? '')}</dtel:searchHelp>
+    <dtel:searchHelpParameter>${escapeXmlAttr(params.searchHelpParameter ?? '')}</dtel:searchHelpParameter>
+    <dtel:setGetParameter>${escapeXmlAttr(params.setGetParameter ?? '')}</dtel:setGetParameter>
+    <dtel:defaultComponentName>${escapeXmlAttr(params.defaultComponentName ?? '')}</dtel:defaultComponentName>
     <dtel:deactivateInputHistory>false</dtel:deactivateInputHistory>
     <dtel:changeDocument>${boolToXml(params.changeDocument)}</dtel:changeDocument>
     <dtel:leftToRightDirection>false</dtel:leftToRightDirection>
@@ -361,18 +354,18 @@ export function buildPackageXml(params: PackageCreateParams): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <pak:package xmlns:pak="http://www.sap.com/adt/packages"
              xmlns:adtcore="http://www.sap.com/adt/core"
-             adtcore:description="${escapeXml(params.description)}"
-             adtcore:name="${escapeXml(params.name)}"
+             adtcore:description="${escapeXmlAttr(params.description)}"
+             adtcore:name="${escapeXmlAttr(params.name)}"
              adtcore:type="DEVC/K"
              adtcore:version="active"
-             adtcore:responsible="${escapeXml(responsible)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(params.name)}"/>
-  <pak:attributes pak:packageType="${escapeXml(packageType)}" pak:recordChanges="${boolToXml(recordChanges)}"/>
-  <pak:superPackage adtcore:name="${escapeXml(superPackage)}"/>
+             adtcore:responsible="${escapeXmlAttr(responsible)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(params.name)}"/>
+  <pak:attributes pak:packageType="${escapeXmlAttr(packageType)}" pak:recordChanges="${boolToXml(recordChanges)}"/>
+  <pak:superPackage adtcore:name="${escapeXmlAttr(superPackage)}"/>
   <pak:applicationComponent/>
   <pak:transport>
-    <pak:softwareComponent pak:name="${escapeXml(softwareComponent)}"/>
-    <pak:transportLayer pak:name="${escapeXml(transportLayer)}"/>
+    <pak:softwareComponent pak:name="${escapeXmlAttr(softwareComponent)}"/>
+    <pak:transportLayer pak:name="${escapeXmlAttr(transportLayer)}"/>
   </pak:transport>
   <pak:translation/>
   <pak:useAccesses/>
@@ -394,19 +387,19 @@ export function buildServiceBindingXml(params: ServiceBindingCreateParams): stri
   return `<?xml version="1.0" encoding="UTF-8"?>
 <srvb:serviceBinding xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings"
                      xmlns:adtcore="http://www.sap.com/adt/core"
-                     adtcore:description="${escapeXml(params.description)}"
-                     adtcore:name="${escapeXml(params.name)}"
+                     adtcore:description="${escapeXmlAttr(params.description)}"
+                     adtcore:name="${escapeXmlAttr(params.name)}"
                      adtcore:type="SRVB/SVB"
                      adtcore:language="${masterLanguage}"
                      adtcore:masterLanguage="${masterLanguage}"
-                     adtcore:responsible="${escapeXml(responsible)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(params.package)}"/>
-  <srvb:services srvb:name="${escapeXml(params.name)}">
-    <srvb:content srvb:version="${escapeXml(serviceVersion)}">
-      <srvb:serviceDefinition adtcore:name="${escapeXml(params.serviceDefinition)}"/>
+                     adtcore:responsible="${escapeXmlAttr(responsible)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(params.package)}"/>
+  <srvb:services srvb:name="${escapeXmlAttr(params.name)}">
+    <srvb:content srvb:version="${escapeXmlAttr(serviceVersion)}">
+      <srvb:serviceDefinition adtcore:name="${escapeXmlAttr(params.serviceDefinition)}"/>
     </srvb:content>
   </srvb:services>
-  <srvb:binding srvb:category="${category}" srvb:type="${escapeXml(normalized.type)}" srvb:version="${escapeXml(odataVersion)}">
+  <srvb:binding srvb:category="${category}" srvb:type="${escapeXmlAttr(normalized.type)}" srvb:version="${escapeXmlAttr(odataVersion)}">
     <srvb:implementation adtcore:name=""/>
   </srvb:binding>
 </srvb:serviceBinding>`;

--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -714,14 +714,14 @@ export async function applyFixProposal(
     proposal.userContent === undefined
       ? ''
       : `
-  <userContent>${escapeXmlText(proposal.userContent)}</userContent>`;
+  <userContent>${escapeXmlAttr(proposal.userContent)}</userContent>`;
   const affectedObjects = serializeAffectedObjects(proposal.affectedObjects);
   // quickfixes.xsd uses elementFormDefault="unqualified"; only the root and imported adtcore
   // elements are prefixed.
   const body = `<?xml version="1.0" encoding="UTF-8"?>
 <quickfixes:proposalRequest xmlns:quickfixes="http://www.sap.com/adt/quickfixes" xmlns:adtcore="http://www.sap.com/adt/core">
   <input>
-    <content>${escapeXmlText(source)}</content>
+    <content>${escapeXmlAttr(source)}</content>
     <adtcore:objectReference adtcore:uri="${escapeXmlAttr(uriWithStart)}"/>
   </input>${affectedObjects}${userContent}
 </quickfixes:proposalRequest>`;
@@ -976,15 +976,6 @@ function parseUnitTestResults(xml: string): UnitTestResult[] {
   return results;
 }
 
-function escapeXmlText(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
-}
-
 function toNodeRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value) return undefined;
   if (Array.isArray(value)) {
@@ -1063,7 +1054,7 @@ function serializeAffectedObjects(affectedObjects: FixAffectedObject[] | undefin
     .filter((affected) => affected.uri && affected.content !== undefined)
     .map(
       (affected) => `    <unit>
-      <content>${escapeXmlText(affected.content ?? '')}</content>
+      <content>${escapeXmlAttr(affected.content ?? '')}</content>
       <adtcore:objectReference ${serializeObjectReferenceAttrs(affected)}/>
     </unit>`,
     );

--- a/src/adt/refactoring.ts
+++ b/src/adt/refactoring.ts
@@ -14,6 +14,7 @@
 
 import type { AdtHttpClient } from './http.js';
 import { checkOperation, OperationType, type SafetyConfig } from './safety.js';
+import { escapeXmlAttr } from './xml-parser.js';
 
 /** Parameters for a change-package refactoring operation */
 export interface ChangePackageParams {
@@ -43,32 +44,27 @@ const NS_CHANGEPACKAGE = 'http://www.sap.com/adt/refactoring/changepackagerefact
 const NS_GENERIC = 'http://www.sap.com/adt/refactoring/genericrefactoring';
 const NS_ADTCORE = 'http://www.sap.com/adt/core';
 
-/** Escape XML special characters */
-function escapeXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-
 /** Build the inner genericRefactoring XML fragment (shared by preview and execute) */
 function buildGenericRefactoringInner(params: ChangePackageParams): string {
-  const desc = escapeXml(params.description ?? 'ABAP Object');
+  const desc = escapeXmlAttr(params.description ?? 'ABAP Object');
   const transport = params.transport ?? '';
   return [
     `<generic:title>Change Package</generic:title>`,
-    `<generic:adtObjectUri>${escapeXml(params.objectUri)}</generic:adtObjectUri>`,
+    `<generic:adtObjectUri>${escapeXmlAttr(params.objectUri)}</generic:adtObjectUri>`,
     `<generic:affectedObjects>`,
     `<generic:affectedObject`,
     ` adtcore:description="${desc}"`,
-    ` adtcore:name="${escapeXml(params.objectName)}"`,
-    ` adtcore:packageName="${escapeXml(params.oldPackage)}"`,
-    ` adtcore:type="${escapeXml(params.objectType)}"`,
-    ` adtcore:uri="${escapeXml(params.objectUri)}">`,
+    ` adtcore:name="${escapeXmlAttr(params.objectName)}"`,
+    ` adtcore:packageName="${escapeXmlAttr(params.oldPackage)}"`,
+    ` adtcore:type="${escapeXmlAttr(params.objectType)}"`,
+    ` adtcore:uri="${escapeXmlAttr(params.objectUri)}">`,
     `<generic:userContent/>`,
     `<generic:changePackageDelta>`,
-    `<generic:newPackage>${escapeXml(params.newPackage)}</generic:newPackage>`,
+    `<generic:newPackage>${escapeXmlAttr(params.newPackage)}</generic:newPackage>`,
     `</generic:changePackageDelta>`,
     `</generic:affectedObject>`,
     `</generic:affectedObjects>`,
-    `<generic:transport>${escapeXml(transport)}</generic:transport>`,
+    `<generic:transport>${escapeXmlAttr(transport)}</generic:transport>`,
     `<generic:ignoreSyntaxErrorsAllowed>false</generic:ignoreSyntaxErrorsAllowed>`,
     `<generic:ignoreSyntaxErrors>false</generic:ignoreSyntaxErrors>`,
     `<generic:userContent/>`,
@@ -86,8 +82,8 @@ export function buildPreviewXml(params: ChangePackageParams): string {
     ` xmlns:adtcore="${NS_ADTCORE}"`,
     ` xmlns:generic="${NS_GENERIC}"`,
     ` xmlns:changepackage="${NS_CHANGEPACKAGE}">`,
-    `<changepackage:oldPackage>${escapeXml(params.oldPackage)}</changepackage:oldPackage>`,
-    `<changepackage:newPackage>${escapeXml(params.newPackage)}</changepackage:newPackage>`,
+    `<changepackage:oldPackage>${escapeXmlAttr(params.oldPackage)}</changepackage:oldPackage>`,
+    `<changepackage:newPackage>${escapeXmlAttr(params.newPackage)}</changepackage:newPackage>`,
     `<generic:genericRefactoring>`,
     buildGenericRefactoringInner(params),
     `</generic:genericRefactoring>`,

--- a/src/adt/xml-parser.ts
+++ b/src/adt/xml-parser.ts
@@ -41,7 +41,14 @@ import type {
   TransactionInfo,
 } from './types.js';
 
-/** Escape XML special characters for safe interpolation into XML attributes */
+/**
+ * Escape the five predefined XML entities (`& < > " '`) for safe interpolation into XML.
+ *
+ * This is the ONE XML escaper for the codebase — safe for both attribute values and element text
+ * (escaping `"`/`'` in text content is valid and harmless). Do NOT add a local copy in another
+ * module; import this. (HTML/XSS contexts are different — `escapeHtml` in oauth.ts/http.ts emits
+ * `&#39;`, not the XML `&apos;`, and must stay separate.)
+ */
 export function escapeXmlAttr(s: string): string {
   return s
     .replace(/&/g, '&amp;')

--- a/src/handlers/write-helpers.ts
+++ b/src/handlers/write-helpers.ts
@@ -32,6 +32,7 @@ import {
   updateServerDrivenObjectSource,
 } from '../adt/server-driven.js';
 import type { ResolvedFeatures } from '../adt/types.js';
+import { escapeXmlAttr } from '../adt/xml-parser.js';
 import type { CachingLayer } from '../cache/caching-layer.js';
 import type { LintConfigOptions, RuleOverrides } from '../lint/config-builder.js';
 import { detectFilename, validateBeforeWrite } from '../lint/lint.js';
@@ -318,73 +319,73 @@ export function buildCreateXml(
       return `<?xml version="1.0" encoding="UTF-8"?>
 <program:abapProgram xmlns:program="http://www.sap.com/adt/programs/programs"
                      xmlns:adtcore="http://www.sap.com/adt/core"
-                     adtcore:description="${escapeXml(description)}"
-                     adtcore:name="${escapeXml(name)}"
+                     adtcore:description="${escapeXmlAttr(description)}"
+                     adtcore:name="${escapeXmlAttr(name)}"
                      adtcore:type="PROG/P"
                      adtcore:masterLanguage="${masterLanguage}"
                      adtcore:masterSystem="H00"
-                     adtcore:responsible="${escapeXml(responsibleUser)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+                     adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </program:abapProgram>`;
     case 'CLAS':
       return `<?xml version="1.0" encoding="UTF-8"?>
 <class:abapClass xmlns:class="http://www.sap.com/adt/oo/classes"
                  xmlns:adtcore="http://www.sap.com/adt/core"
-                 adtcore:description="${escapeXml(description)}"
-                 adtcore:name="${escapeXml(name)}"
+                 adtcore:description="${escapeXmlAttr(description)}"
+                 adtcore:name="${escapeXmlAttr(name)}"
                  adtcore:type="CLAS/OC"
                  adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
-                 adtcore:responsible="${escapeXml(responsibleUser)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+                 adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </class:abapClass>`;
     case 'INTF':
       return `<?xml version="1.0" encoding="UTF-8"?>
 <intf:abapInterface xmlns:intf="http://www.sap.com/adt/oo/interfaces"
                     xmlns:adtcore="http://www.sap.com/adt/core"
-                    adtcore:description="${escapeXml(description)}"
-                    adtcore:name="${escapeXml(name)}"
+                    adtcore:description="${escapeXmlAttr(description)}"
+                    adtcore:name="${escapeXmlAttr(name)}"
                     adtcore:type="INTF/OI"
                     adtcore:masterLanguage="${masterLanguage}"
                     adtcore:masterSystem="H00"
-                    adtcore:responsible="${escapeXml(responsibleUser)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+                    adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </intf:abapInterface>`;
     case 'INCL':
       return `<?xml version="1.0" encoding="UTF-8"?>
 <include:abapInclude xmlns:include="http://www.sap.com/adt/programs/includes"
                      xmlns:adtcore="http://www.sap.com/adt/core"
-                     adtcore:description="${escapeXml(description)}"
-                     adtcore:name="${escapeXml(name)}"
+                     adtcore:description="${escapeXmlAttr(description)}"
+                     adtcore:name="${escapeXmlAttr(name)}"
                      adtcore:type="PROG/I"
                      adtcore:masterLanguage="${masterLanguage}"
                      adtcore:masterSystem="H00"
-                     adtcore:responsible="${escapeXml(responsibleUser)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+                     adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </include:abapInclude>`;
     case 'DDLS':
       return `<?xml version="1.0" encoding="UTF-8"?>
 <ddl:ddlSource xmlns:ddl="http://www.sap.com/adt/ddic/ddlsources"
                xmlns:adtcore="http://www.sap.com/adt/core"
-               adtcore:description="${escapeXml(description)}"
-               adtcore:name="${escapeXml(name)}"
+               adtcore:description="${escapeXmlAttr(description)}"
+               adtcore:name="${escapeXmlAttr(name)}"
                adtcore:type="DDLS/DF"
                adtcore:masterLanguage="${masterLanguage}"
                adtcore:masterSystem="H00"
-                 adtcore:responsible="${escapeXml(responsibleUser)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+                 adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </ddl:ddlSource>`;
     case 'DCLS':
       return `<?xml version="1.0" encoding="UTF-8"?>
 <dcl:dclSource xmlns:dcl="http://www.sap.com/adt/acm/dclsources"
                xmlns:adtcore="http://www.sap.com/adt/core"
-               adtcore:description="${escapeXml(description)}"
-               adtcore:name="${escapeXml(name)}"
+               adtcore:description="${escapeXmlAttr(description)}"
+               adtcore:name="${escapeXmlAttr(name)}"
                adtcore:type="DCLS/DL"
                adtcore:masterLanguage="${masterLanguage}"
                adtcore:masterSystem="H00"
-               adtcore:responsible="${escapeXml(responsibleUser)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+               adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </dcl:dclSource>`;
     case 'TABL':
     case 'TABL/DT':
@@ -396,13 +397,13 @@ export function buildCreateXml(
       return `<?xml version="1.0" encoding="UTF-8"?>
 <blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue"
                  xmlns:adtcore="http://www.sap.com/adt/core"
-                 adtcore:description="${escapeXml(description)}"
-                 adtcore:name="${escapeXml(name)}"
+                 adtcore:description="${escapeXmlAttr(description)}"
+                 adtcore:name="${escapeXmlAttr(name)}"
                  adtcore:type="${adtType}"
                  adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
-                 adtcore:responsible="${escapeXml(responsibleUser)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+                 adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </blue:blueSource>`;
     }
     case 'BDEF':
@@ -411,26 +412,26 @@ export function buildCreateXml(
       return `<?xml version="1.0" encoding="UTF-8"?>
 <blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue"
                  xmlns:adtcore="http://www.sap.com/adt/core"
-                 adtcore:description="${escapeXml(description)}"
-                 adtcore:name="${escapeXml(name)}"
+                 adtcore:description="${escapeXmlAttr(description)}"
+                 adtcore:name="${escapeXmlAttr(name)}"
                  adtcore:type="BDEF/BDO"
                  adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
-                 adtcore:responsible="${escapeXml(responsibleUser)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+                 adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </blue:blueSource>`;
     case 'SRVD':
       return `<?xml version="1.0" encoding="UTF-8"?>
 <srvd:srvdSource xmlns:srvd="http://www.sap.com/adt/ddic/srvdsources"
                  xmlns:adtcore="http://www.sap.com/adt/core"
-                 adtcore:description="${escapeXml(description)}"
-                 adtcore:name="${escapeXml(name)}"
+                 adtcore:description="${escapeXmlAttr(description)}"
+                 adtcore:name="${escapeXmlAttr(name)}"
                  adtcore:type="SRVD/SRV"
                  adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
-                 adtcore:responsible="${escapeXml(responsibleUser)}"
+                 adtcore:responsible="${escapeXmlAttr(responsibleUser)}"
                  srvd:srvdSourceType="S">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </srvd:srvdSource>`;
     case 'SRVB': {
       const serviceDefinition = String(properties?.serviceDefinition ?? '').trim();
@@ -458,13 +459,13 @@ export function buildCreateXml(
       return `<?xml version="1.0" encoding="UTF-8"?>
 <ddlx:ddlxSource xmlns:ddlx="http://www.sap.com/adt/ddic/ddlxsources"
                  xmlns:adtcore="http://www.sap.com/adt/core"
-                 adtcore:description="${escapeXml(description)}"
-                 adtcore:name="${escapeXml(name)}"
+                 adtcore:description="${escapeXmlAttr(description)}"
+                 adtcore:name="${escapeXmlAttr(name)}"
                  adtcore:type="DDLX/EX"
                  adtcore:masterLanguage="${masterLanguage}"
                  adtcore:masterSystem="H00"
-                     adtcore:responsible="${escapeXml(responsibleUser)}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+                     adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </ddlx:ddlxSource>`;
     case 'DOMA': {
       const fixedValuesRaw = Array.isArray(properties?.fixedValues) ? properties.fixedValues : [];
@@ -550,8 +551,8 @@ export function buildCreateXml(
       // with Content-Type: application/vnd.sap.adt.functions.groups.v3+xml.
       // Verified live on a4h S/4HANA 2023 (issue #250).
       return `<?xml version="1.0" encoding="UTF-8"?>
-<group:abapFunctionGroup xmlns:group="http://www.sap.com/adt/functions/groups" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${escapeXml(description)}" adtcore:language="${masterLanguage}" adtcore:name="${escapeXml(name)}" adtcore:type="FUGR/F" adtcore:masterLanguage="${masterLanguage}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
+<group:abapFunctionGroup xmlns:group="http://www.sap.com/adt/functions/groups" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${escapeXmlAttr(description)}" adtcore:language="${masterLanguage}" adtcore:name="${escapeXmlAttr(name)}" adtcore:type="FUGR/F" adtcore:masterLanguage="${masterLanguage}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </group:abapFunctionGroup>`;
     case 'FUNC': {
       // Function module create envelope. POSTed to
@@ -567,15 +568,15 @@ export function buildCreateXml(
       }
       const groupLc = encodeURIComponent(group.toLowerCase());
       return `<?xml version="1.0" encoding="UTF-8"?>
-<fmodule:abapFunctionModule xmlns:fmodule="http://www.sap.com/adt/functions/fmodules" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${escapeXml(description)}" adtcore:name="${escapeXml(name)}" adtcore:type="FUGR/FF">
-  <adtcore:containerRef adtcore:name="${escapeXml(group)}" adtcore:type="FUGR/F" adtcore:uri="/sap/bc/adt/functions/groups/${groupLc}"/>
+<fmodule:abapFunctionModule xmlns:fmodule="http://www.sap.com/adt/functions/fmodules" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${escapeXmlAttr(description)}" adtcore:name="${escapeXmlAttr(name)}" adtcore:type="FUGR/FF">
+  <adtcore:containerRef adtcore:name="${escapeXmlAttr(group)}" adtcore:type="FUGR/F" adtcore:uri="/sap/bc/adt/functions/groups/${groupLc}"/>
 </fmodule:abapFunctionModule>`;
     }
     default:
       // Fallback — generic objectReferences using the correct URL for the type
       return `<?xml version="1.0" encoding="UTF-8"?>
 <adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
-  <adtcore:objectReference adtcore:uri="${escapeXml(objectUrlForType(type, name))}" adtcore:type="${escapeXml(type)}" adtcore:name="${escapeXml(name)}" adtcore:packageName="${escapeXml(pkg)}"/>
+  <adtcore:objectReference adtcore:uri="${escapeXmlAttr(objectUrlForType(type, name))}" adtcore:type="${escapeXmlAttr(type)}" adtcore:name="${escapeXmlAttr(name)}" adtcore:packageName="${escapeXmlAttr(pkg)}"/>
 </adtcore:objectReferences>`;
   }
 }
@@ -600,16 +601,6 @@ export function stripFmParamCommentBlock(source: string): { source: string; wasS
   const lines = source.split('\n');
   const kept = lines.filter((line) => !/^\s*\*"/.test(line));
   return { source: kept.join('\n'), wasStripped: kept.length !== lines.length };
-}
-
-/** Escape special characters for XML attribute values */
-export function escapeXml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
 }
 
 // ─── SAPWrite Handler ────────────────────────────────────────────────

--- a/src/handlers/write/create.ts
+++ b/src/handlers/write/create.ts
@@ -16,6 +16,7 @@ import { AdtApiError } from '../../adt/errors.js';
 import { type FmParameter, spliceFmSignature } from '../../adt/fm-signature.js';
 import { checkPackage } from '../../adt/safety.js';
 import { getTransport, getTransportInfo } from '../../adt/transport.js';
+import { escapeXmlAttr } from '../../adt/xml-parser.js';
 import { validateAffHeader } from '../../aff/validator.js';
 import { logger } from '../../server/logger.js';
 import {
@@ -38,7 +39,6 @@ import {
   buildCreateXml,
   createContentTypeForType,
   dtelNeedsPostCreateUpdate,
-  escapeXml,
   getMetadataWriteProperties,
   isMetadataWriteType,
   mergePreWriteWarnings,
@@ -188,9 +188,9 @@ export async function writeActionCreate(ctx: SapWriteContext): Promise<ToolResul
 
     const ktdLang = normalizeAdtLanguage(config.language);
     const ktdBody = `<?xml version="1.0" encoding="UTF-8"?>
-<sktd:docu xmlns:sktd="http://www.sap.com/wbobj/texts/sktd" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:language="${ktdLang}" adtcore:name="${escapeXml(name)}" adtcore:type="SKTD/TYP" adtcore:masterLanguage="${ktdLang}">
-  <adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>
-  <sktd:refObject adtcore:description="${escapeXml(refDescription)}" adtcore:name="${escapeXml(refName)}" adtcore:type="${escapeXml(refType)}" adtcore:uri="${escapeXml(refUri)}"/>
+<sktd:docu xmlns:sktd="http://www.sap.com/wbobj/texts/sktd" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:language="${ktdLang}" adtcore:name="${escapeXmlAttr(name)}" adtcore:type="SKTD/TYP" adtcore:masterLanguage="${ktdLang}">
+  <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
+  <sktd:refObject adtcore:description="${escapeXmlAttr(refDescription)}" adtcore:name="${escapeXmlAttr(refName)}" adtcore:type="${escapeXmlAttr(refType)}" adtcore:uri="${escapeXmlAttr(refUri)}"/>
 </sktd:docu>`;
 
     const ktdCreateUrl = '/sap/bc/adt/documentation/ktd/documents';

--- a/tests/unit/adt/refactoring.test.ts
+++ b/tests/unit/adt/refactoring.test.ts
@@ -67,6 +67,13 @@ describe('refactoring — change package', () => {
       expect(xml).toContain('<generic:title>Change Package</generic:title>');
       expect(xml).toContain('</generic:genericRefactoring>');
     });
+
+    it('escapes all five XML entities incl. apostrophes in the description (shared escapeXmlAttr)', () => {
+      const xml = buildPreviewXml({ ...BASE_PARAMS, description: `O'Brien & <Co> "x"` });
+      expect(xml).toContain('adtcore:description="O&apos;Brien &amp; &lt;Co&gt; &quot;x&quot;"');
+      // No raw apostrophe survives in the description attribute (the former local escaper omitted it).
+      expect(xml).not.toContain("O'Brien");
+    });
   });
 
   describe('buildExecuteXml', () => {


### PR DESCRIPTION
## What

Consolidate the codebase's **four** XML escapers onto the single shared `escapeXmlAttr`
(`src/adt/xml-parser.ts`). First of the post-consolidation hygiene ladder
([plan](docs/plans/post-consolidation-hygiene-plan.md)).

The survey found 3 duplicates; it was actually **4** — it missed `escapeXmlText` in `devtools.ts`.
All now import the one helper:

| Site | Calls | Output change |
|---|---|---|
| `xml-parser.ts` `escapeXmlAttr` | keeper (5 importers before, 9 after) | — |
| `ddic-xml.ts` `escapeXml` | 45 | none (byte-identical) |
| `write-helpers.ts` `escapeXml` (+ consumer `write/create.ts`) | 45 + 3 | none |
| `devtools.ts` `escapeXmlText` | 3 | none |
| `refactoring.ts` `escapeXml` | 10 | now also escapes `'` |

## Why `refactor:`, not `fix:`

The survey and an external review called the missing apostrophe in `refactoring.ts` "a real bug."
On inspection it is **not** an active bug: every call site interpolates into double-quoted
attributes or element text, where a literal `'` is valid XML — today's output is well-formed for
all inputs. So this ships as `refactor:` (no release). The apostrophe escaping becomes uniform as
**defensive hardening** (and `&apos;` round-trips through any conformant parser, so it's output-only).

## Commits

1. `refactor(adt): consolidate the DDIC/devtools/write XML escapers onto escapeXmlAttr` — the three
   byte-identical folds; zero output change. `escapeXmlAttr` gains a "this is THE XML escaper" doc
   comment (noting the deliberately-separate HTML/XSS escapers in `oauth.ts`/`http.ts`, which emit
   `&#39;`).
2. `refactor(adt): route change-package XML through the shared escapeXmlAttr` — `refactoring.ts` +
   a test pinning all five entities incl. `'`.
3. `docs:` the hygiene plan.

## Verification

Full gate green: `typecheck` (src+scripts+tests) / `lint` / `validate:policy` / `build` /
`check:sizes`, **3,722 tests**, tool-definition fixtures **byte-identical** (no LLM-surface change).
The tests-typecheck gate (Stage T, #405) caught a multi-line `escapeXml` import in `write/create.ts`
that a one-line grep missed — the safety net working as designed.

> Note: one unrelated re-run flake in `auth-rate-limit.test.ts` (passes in isolation + on clean
> re-run; touches no code in this PR) — a pre-existing test-isolation issue, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review round (4 finder angles)

Correctness came back clean — the order-equivalence proof holds at every site (replace-order
commutes once `&` runs first), no straggler escapers repo-wide, no import cycles, fixtures
untouched. Two documentation findings, implemented in the `docs:` follow-up commit:
`docs/security-model.md` (I6 narrative + checklist + XML-injection register) and the
joule-extensibility plan still named the deleted `escapeXml` as the canonical defense — a dev
following the security checklist would have hand-rolled a new local escaper, recreating the exact
drift this PR removes. Both now name `escapeXmlAttr`; the hygiene plan's keeper importer count was
also corrected (5, not 4).
