### PR TITLE
fix(context): avoid SAPContext dependency convoy

### DIFF
--- a/docs/plans/completed/ralphex-context-worker-pool.md
+++ b/docs/plans/completed/ralphex-context-worker-pool.md
@@ -1,0 +1,95 @@
+# Ralphex Plan: SAPContext Dependency Worker Pool
+
+## Overview
+
+This plan fixes the convoy effect in `SAPContext` dependency resolution. The existing implementation resolves dependencies in fixed five-request waves; the next wave cannot start until the slowest request in the current wave completes. The target behavior is a bounded worker pool that keeps up to five dependency fetches in flight and starts the next dependency as soon as any slot frees up.
+
+The change is intentionally local to context compression. It does not add an ADT endpoint, alter safety policy, change response schemas, or change dependency ordering in the final result.
+
+## Context
+
+### Current State
+
+`fetchContractsParallel()` in `src/context/compressor.ts` slices dependencies into `MAX_CONCURRENT` batches and awaits `Promise.all()` for each batch. `resolveCdsDepthLevel()` uses the same fixed-wave pattern for CDS dependency reads. Heterogeneous SAP request latency means four worker slots can sit idle behind one slow dependency.
+
+The repository already has a FIFO semaphore in `src/adt/semaphore.ts`, but this call site only needs bounded ordered mapping inside `compressor.ts`; pulling in the ADT semaphore would not remove much complexity because the result array must remain dependency-order stable.
+
+### Target State
+
+`SAPContext` dependency resolution uses a small local `mapWithConcurrency()` helper. It preserves result order, caps concurrency at `MAX_CONCURRENT`, and starts the next dependency immediately after any current dependency settles.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/context/compressor.ts` | Fetches and compresses ABAP/CDS dependency contracts for `SAPContext` |
+| `tests/unit/context/compressor.test.ts` | Unit coverage for context compression, dependency limits, failure tolerance, and new worker-pool scheduling |
+
+### Verified Live Evidence
+
+2026-06-12, local `.env` target: `SAPRead(type="COMPONENTS")` succeeded against S/4HANA 2023 with `SAP_BASIS` release `758` and `S4FND` release `108`.
+
+2026-06-12, same target: built `dist/`, then `SAPRead(type="SYSTEM")` succeeded through the CLI dispatcher. This verifies the branch still builds and reaches a live ADT backend on the available 2023 system.
+
+Local direct 7.50 and 2025 execution could not be completed in this workspace because no `NPL_*` / A4H 2025 environment variables were present. The repository workflow labels `TEST_SAP_*` live CI as `A4H 2025`, so PR CI is the available 2025 verification path for this branch. The change is release-invariant because it only schedules existing client calls and does not alter ADT URLs, headers, XML parsing, or object payloads.
+
+### Design Principles
+
+1. Preserve observable output order even when dependency fetches complete out of order.
+2. Keep the existing `MAX_CONCURRENT = 5` ceiling.
+3. Do not change failure semantics: per-dependency failures still produce empty contracts via existing fetch helpers.
+4. Keep the helper local until another module needs the same ordered bounded mapping behavior.
+5. Treat live SAP release behavior as unchanged because the same ADT calls are issued; only their scheduling changes.
+
+## Development Approach
+
+Implement the helper first, then switch both ABAP contract resolution and CDS dependency resolution to use it. Add deterministic unit tests with controlled promises so the test can prove the sixth dependency starts immediately after one of the first five resolves, instead of waiting for all five to settle.
+
+No user-facing docs are required because this is a performance and scheduling fix behind the existing `SAPContext` behavior.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Replace Fixed Dependency Waves With Ordered Worker Pool
+
+**Files:**
+- Modify: `src/context/compressor.ts`
+
+Introduce a bounded ordered mapper and use it in both dependency-resolution paths.
+
+- [x] Add a local `mapWithConcurrency<T, R>()` helper that preserves input order.
+- [x] Use the helper in `fetchContractsParallel()` for ABAP contract dependencies.
+- [x] Use the helper in `resolveCdsDepthLevel()` for CDS dependency reads.
+- [x] Keep `MAX_CONCURRENT` unchanged at five.
+- [x] Leave all existing fetch/error handling helpers intact.
+
+### Task 2: Add Scheduling Regression Coverage
+
+**Files:**
+- Modify: `tests/unit/context/compressor.test.ts`
+
+Add tests that would fail under the previous fixed-wave implementation.
+
+- [x] Add an ABAP dependency test with six mocked class reads and controlled promise release.
+- [x] Assert only five reads start initially.
+- [x] Resolve one early dependency and assert the sixth read starts immediately.
+- [x] Add the same scheduling assertion for CDS dependency reads.
+- [x] Assert final dependency counts remain correct.
+
+### Task 3: Final Verification and PR Handoff
+
+**Files:**
+- Modify: `docs/plans/completed/ralphex-context-worker-pool.md`
+
+Run fast gates and record live-system limits for the PR.
+
+- [x] Run targeted unit tests: `npm test -- tests/unit/context/compressor.test.ts`.
+- [x] Run full unit suite: `npm test`.
+- [x] Run typecheck: `npm run typecheck`.
+- [x] Run lint: `npm run lint`.
+- [x] Run build: `npm run build`.
+- [x] Run read-only live CLI smoke on the available S/4HANA 2023 / SAP_BASIS 758 system.
+- [x] Confirm local 7.50 and 2025 credentials are unavailable in this workspace and document that PR CI is the available A4H 2025 verification path.

--- a/src/context/compressor.ts
+++ b/src/context/compressor.ts
@@ -27,6 +27,29 @@ const DEFAULT_DEPTH = 1;
 const MAX_DEPTH = 3;
 const MAX_CONCURRENT = 5;
 
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  const worker = async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= items.length) return;
+      results[index] = await mapper(items[index]!, index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
 function readResultSource(result: SourceReadResult | string): string {
   return typeof result === 'string' ? result : result.source;
 }
@@ -155,15 +178,9 @@ async function fetchContractsParallel(
   abaplintVersion?: Version,
   cachingLayer?: CachingLayer,
 ): Promise<Contract[]> {
-  const results: Contract[] = [];
-  for (let i = 0; i < deps.length; i += MAX_CONCURRENT) {
-    const batch = deps.slice(i, i + MAX_CONCURRENT);
-    const batchResults = await Promise.all(
-      batch.map((dep) => fetchSingleContract(client, dep, abaplintVersion, cachingLayer)),
-    );
-    results.push(...batchResults);
-  }
-  return results;
+  return mapWithConcurrency(deps, MAX_CONCURRENT, (dep) =>
+    fetchSingleContract(client, dep, abaplintVersion, cachingLayer),
+  );
 }
 
 /**
@@ -398,12 +415,12 @@ async function resolveCdsDepthLevel(
   }
   const limited = newDeps.slice(0, maxDeps);
 
-  // Fetch in bounded parallel batches
-  for (let i = 0; i < limited.length; i += MAX_CONCURRENT) {
-    const batch = limited.slice(i, i + MAX_CONCURRENT);
-    const results = await Promise.all(batch.map((dep) => fetchCdsDependency(client, dep, cachingLayer)));
-    resolved.push(...results);
-  }
+  // Fetch with a bounded worker pool. This keeps MAX_CONCURRENT requests in
+  // flight instead of waiting for the slowest request in fixed-size waves.
+  const results = await mapWithConcurrency(limited, MAX_CONCURRENT, (dep) =>
+    fetchCdsDependency(client, dep, cachingLayer),
+  );
+  resolved.push(...results);
 
   // Recurse into resolved DDLS sources if depth > 1
   if (depth > 1) {

--- a/tests/unit/context/compressor.test.ts
+++ b/tests/unit/context/compressor.test.ts
@@ -35,6 +35,25 @@ function mockClient(sources: Record<string, string>): AdtClient {
   } as unknown as AdtClient;
 }
 
+async function waitUntil(assertion: () => boolean, timeoutMs = 250): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (assertion()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
+function dependencyClassSource(name: string): string {
+  return `CLASS ${name} DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    METHODS run.
+ENDCLASS.
+CLASS ${name} IMPLEMENTATION.
+  METHOD run. ENDMETHOD.
+ENDCLASS.`;
+}
+
 describe('compressContext', () => {
   it('compresses class with dependencies', async () => {
     const mainSource = `CLASS zcl_order DEFINITION PUBLIC.
@@ -106,6 +125,48 @@ ENDCLASS.`;
 
     // Should resolve at most 2
     expect(result.depsResolved).toBeLessThanOrEqual(2);
+  });
+
+  it('starts the next dependency as soon as a worker slot frees up', async () => {
+    const mainSource = `CLASS zcl_test DEFINITION PUBLIC.
+  PUBLIC SECTION.
+    DATA m1 TYPE REF TO zcl_dep1.
+    DATA m2 TYPE REF TO zcl_dep2.
+    DATA m3 TYPE REF TO zcl_dep3.
+    DATA m4 TYPE REF TO zcl_dep4.
+    DATA m5 TYPE REF TO zcl_dep5.
+    DATA m6 TYPE REF TO zcl_dep6.
+ENDCLASS.
+CLASS zcl_test IMPLEMENTATION.
+ENDCLASS.`;
+
+    const started: string[] = [];
+    const resolvers = new Map<string, () => void>();
+    const client = {
+      getClass: vi.fn(async (name: string) => {
+        const upper = name.toUpperCase();
+        started.push(upper);
+        await new Promise<void>((resolve) => resolvers.set(upper, resolve));
+        return dependencyClassSource(name);
+      }),
+      getInterface: vi.fn(),
+      getFunction: vi.fn(),
+      searchObject: vi.fn(),
+      http: {},
+      safety: {},
+    } as unknown as AdtClient;
+
+    const resultPromise = compressContext(client, mainSource, 'zcl_test', 'CLAS', 6);
+    await waitUntil(() => started.length === 5);
+
+    resolvers.get('ZCL_DEP1')?.();
+    await waitUntil(() => started.includes('ZCL_DEP6'));
+
+    expect(started).toEqual(['ZCL_DEP1', 'ZCL_DEP2', 'ZCL_DEP3', 'ZCL_DEP4', 'ZCL_DEP5', 'ZCL_DEP6']);
+
+    for (const resolve of resolvers.values()) resolve();
+    const result = await resultPromise;
+    expect(result.depsResolved).toBe(6);
   });
 
   it('handles fetch failures gracefully', async () => {
@@ -357,6 +418,43 @@ define view entity ZC_ORDER as projection on ZI_ORDER { key OrderId }`;
     expect(result.depsResolved).toBe(1);
     expect(result.output).toContain('ZI_ORDER');
     expect(result.output).toContain('ddls');
+  });
+
+  it('starts the next CDS dependency as soon as a worker slot frees up', async () => {
+    const ddlSource = `define view entity ZC_ORDER as projection on ZI_DEP1 {
+  key order_id,
+  association to ZI_DEP2 as _D2 on _D2.ID = order_id,
+  association to ZI_DEP3 as _D3 on _D3.ID = order_id,
+  association to ZI_DEP4 as _D4 on _D4.ID = order_id,
+  association to ZI_DEP5 as _D5 on _D5.ID = order_id,
+  association to ZI_DEP6 as _D6 on _D6.ID = order_id
+}`;
+
+    const started: string[] = [];
+    const resolvers = new Map<string, () => void>();
+    const client = {
+      getDdls: vi.fn(async (name: string) => {
+        const upper = name.toUpperCase();
+        started.push(upper);
+        await new Promise<void>((resolve) => resolvers.set(upper, resolve));
+        return `define view entity ${name} as select from zbase { key id }`;
+      }),
+      getTabl: vi.fn(),
+      http: {},
+      safety: {},
+    } as unknown as AdtClient;
+
+    const resultPromise = compressCdsContext(client, ddlSource, 'ZC_ORDER', 6);
+    await waitUntil(() => started.length === 5);
+
+    resolvers.get('ZI_DEP1')?.();
+    await waitUntil(() => started.includes('ZI_DEP6'));
+
+    expect(started).toEqual(['ZI_DEP1', 'ZI_DEP2', 'ZI_DEP3', 'ZI_DEP4', 'ZI_DEP5', 'ZI_DEP6']);
+
+    for (const resolve of resolvers.values()) resolve();
+    const result = await resultPromise;
+    expect(result.depsResolved).toBe(6);
   });
 
   it('handles failed dependencies gracefully', async () => {


### PR DESCRIPTION
## Summary

Fixes external feedback point 2: `SAPContext` dependency resolution no longer waits on fixed five-request waves. It now uses a bounded worker pool that keeps up to five dependency fetches in flight and starts the next dependency as soon as a slot frees up.

## Changes

- Add ordered `mapWithConcurrency()` helper in `src/context/compressor.ts`.
- Use it for ABAP contract dependency fetches and CDS dependency fetches.
- Add deterministic unit tests proving the sixth dependency starts after the first worker slot frees, not after the full first batch completes.
- Add completed ralphex plan: `docs/plans/completed/ralphex-context-worker-pool.md`.

## Validation

- `npm test -- tests/unit/context/compressor.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Live read-only smoke against available S/4HANA 2023 / SAP_BASIS 758 target:
  - `SAPRead(type="SYSTEM")` succeeded through built CLI
  - `SAPRead(type="COMPONENTS")` confirmed `SAP_BASIS=758`, `S4FND=108`

## Live SAP Notes

Local credentials for NW 7.50 and A4H 2025 were not present in this workspace (`NPL_*` and A4H 2025 env vars unset). This change is release-invariant: it schedules the same existing ADT calls without changing URLs, headers, payloads, parsing, or safety behavior. Repository PR CI is labeled `A4H 2025` and is the available 2025 live verification path.
