### PR TITLE
perf(lint): memoize abaplint default configs

### DIFF
--- a/docs/plans/completed/ralphex-abaplint-config-memo.md
+++ b/docs/plans/completed/ralphex-abaplint-config-memo.md
@@ -1,0 +1,111 @@
+# Ralphex Plan: Memoize abaplint Default Config
+
+## Overview
+
+This plan addresses external feedback point 3: several hot paths call `Config.getDefault(version)` during every parse or lint-config build. The `Registry` must stay fresh because it holds file/parse state, but the default abaplint config is version-constant and can be memoized.
+
+The implementation adds a small cache module under `src/lint/` and routes all production `Config.getDefault()` call sites through it. Parser users still construct a new `Registry(config)` per parse. Config-builder users receive an isolated JSON clone before applying presets or user overrides, so no mutable caller can corrupt the cached default.
+
+## Context
+
+### Current State
+
+`Config.getDefault()` is called in dependency extraction, contract extraction, method surgery, lint config building, pre-write config building, and the legacy lint fallback. On workflows like `SAPContext`, a single request can parse the root source plus many dependencies, rebuilding the same default config repeatedly.
+
+### Target State
+
+Default configs are memoized by abaplint `Version`. Registry instances remain per-call. Config-builder code gets fresh clones derived from a cached serialized default config, preserving caller isolation while avoiding repeated default-rule construction.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/lint/abaplint-config-cache.ts` | Central cache for abaplint default configs and cloneable default JSON |
+| `src/context/deps.ts` | AST dependency extraction for `SAPContext` |
+| `src/context/contract.ts` | Public contract extraction for classes/interfaces |
+| `src/context/method-surgery.ts` | Method list/extract/splice AST parsing |
+| `src/lint/config-builder.ts` | Builds customized lint and pre-write configs from defaults |
+| `src/lint/lint.ts` | Offline lint wrapper and legacy default config fallback |
+| `tests/unit/lint/abaplint-config-cache.test.ts` | Cache identity and clone-isolation tests |
+
+### Verified Live Evidence
+
+2026-06-12, local `.env` target: built `dist/`, then `SAPRead(type="COMPONENTS")` succeeded against S/4HANA 2023 with `SAP_BASIS` release `758` and `S4FND` release `108`.
+
+Local direct 7.50 and 2025 execution could not be completed in this workspace because no `NPL_*` / A4H 2025 environment variables were present. The repository workflow labels `TEST_SAP_*` live CI as `A4H 2025`, so PR CI is the available 2025 verification path for this branch. The change is release-invariant because it affects local abaplint config construction only; it does not change ADT calls, release detection, SAP payloads, or server safety behavior.
+
+### Design Principles
+
+1. Cache default `Config` per abaplint `Version`.
+2. Never cache or reuse `Registry` instances.
+3. Give mutable config-builder callers isolated clones.
+4. Keep the cache module small and explicit, with a test-only clear helper.
+5. Preserve all version mapping, parser-ceiling, preset, and user override behavior.
+
+## Development Approach
+
+Create the cache module first, then update each production `Config.getDefault()` call site. Add focused unit tests for same-version reuse, different-version separation, and clone isolation. Run targeted lint/context tests before the full suite because this change crosses both `src/lint` and `src/context`.
+
+No user-facing documentation is required because this is an internal performance fix with no tool-schema, CLI, configuration, or SAP behavior change.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add Default Config Cache
+
+**Files:**
+- Create: `src/lint/abaplint-config-cache.ts`
+
+Centralize default abaplint config creation.
+
+- [x] Add `getDefaultAbaplintConfig(version)` backed by a `Map`.
+- [x] Add `cloneDefaultAbaplintConfig(version)` that caches serialized default JSON and returns a fresh parsed object.
+- [x] Add `clearAbaplintConfigCacheForTests()` for deterministic unit tests.
+- [x] Key the cache by abaplint `Version`.
+
+### Task 2: Route Production Call Sites Through the Cache
+
+**Files:**
+- Modify: `src/context/deps.ts`
+- Modify: `src/context/contract.ts`
+- Modify: `src/context/method-surgery.ts`
+- Modify: `src/lint/config-builder.ts`
+- Modify: `src/lint/lint.ts`
+
+Replace repeated default-config construction while keeping parse state fresh.
+
+- [x] Replace context parser `Config.getDefault()` calls with `getDefaultAbaplintConfig()`.
+- [x] Keep `new Registry(config)` per parse.
+- [x] Replace config-builder deep-copy logic with `cloneDefaultAbaplintConfig()`.
+- [x] Replace the legacy fallback default in `lint.ts` with the cache helper.
+- [x] Confirm `src/` has no direct `Config.getDefault()` calls outside the cache module.
+
+### Task 3: Add Cache Regression Tests
+
+**Files:**
+- Create: `tests/unit/lint/abaplint-config-cache.test.ts`
+
+Prove the cache behavior without coupling tests to abaplint internals.
+
+- [x] Assert same-version calls reuse the same `Config` object.
+- [x] Assert different versions return distinct cached configs.
+- [x] Assert cloned default configs are isolated from caller mutation.
+- [x] Run targeted lint/context tests covering cache consumers.
+
+### Task 4: Final Verification and PR Handoff
+
+**Files:**
+- Modify: `docs/plans/completed/ralphex-abaplint-config-memo.md`
+
+Run validation and capture release notes for the PR.
+
+- [x] Run targeted unit tests for cache, config builder, lint, dependency extraction, contract extraction, and method surgery.
+- [x] Run full unit suite: `npm test`.
+- [x] Run typecheck: `npm run typecheck`.
+- [x] Run lint: `npm run lint`.
+- [x] Run build: `npm run build`.
+- [x] Run read-only live CLI smoke on the available S/4HANA 2023 / SAP_BASIS 758 system.
+- [x] Confirm local 7.50 and 2025 credentials are unavailable in this workspace and document that PR CI is the available A4H 2025 verification path.

--- a/src/context/contract.ts
+++ b/src/context/contract.ts
@@ -9,7 +9,8 @@
  * This achieves 7-30x token compression vs full source code.
  */
 
-import { Config, MemoryFile, Registry, Statements, Structures, Version } from '@abaplint/core';
+import { MemoryFile, Registry, Statements, Structures, Version } from '@abaplint/core';
+import { getDefaultAbaplintConfig } from '../lint/abaplint-config-cache.js';
 import type { Contract } from './types.js';
 
 // Cast helpers for abaplint AST nodes
@@ -65,7 +66,7 @@ export function extractContract(
  * Strips PROTECTED, PRIVATE sections and entire CLASS IMPLEMENTATION.
  */
 function extractClassContract(source: string, name: string, ver: Version): Contract {
-  const config = Config.getDefault(ver);
+  const config = getDefaultAbaplintConfig(ver);
   const reg = new Registry(config);
   reg.addFile(new MemoryFile(`${name.toLowerCase()}.clas.abap`, source));
   reg.parse();
@@ -172,7 +173,7 @@ function extractClassContractRegex(source: string, name: string): Contract {
  * Count methods for stats.
  */
 function extractInterfaceContract(source: string, name: string, ver: Version): Contract {
-  const config = Config.getDefault(ver);
+  const config = getDefaultAbaplintConfig(ver);
   const reg = new Registry(config);
   reg.addFile(new MemoryFile(`${name.toLowerCase()}.intf.abap`, source));
   reg.parse();

--- a/src/context/deps.ts
+++ b/src/context/deps.ts
@@ -15,7 +15,8 @@
  * - exception:      RAISING <name>, CATCH <name>
  */
 
-import { Config, Expressions, MemoryFile, Registry, Statements, Version } from '@abaplint/core';
+import { Expressions, MemoryFile, Registry, Statements, Version } from '@abaplint/core';
+import { getDefaultAbaplintConfig } from '../lint/abaplint-config-cache.js';
 import { detectFilename } from '../lint/lint.js';
 import type { Dependency, DependencyKind } from './types.js';
 
@@ -111,7 +112,7 @@ export function extractDependencies(
 ): Dependency[] {
   // Normalize CRLF → LF (SAP ADT returns CRLF which can break abaplint parsing)
   const normalizedSource = source.replace(/\r\n/g, '\n');
-  const config = Config.getDefault(abaplintVersion ?? ABAPLINT_VERSION);
+  const config = getDefaultAbaplintConfig(abaplintVersion ?? ABAPLINT_VERSION);
   const filename = detectFilename(normalizedSource, objectName);
   const reg = new Registry(config);
   reg.addFile(new MemoryFile(filename, normalizedSource));

--- a/src/context/method-surgery.ts
+++ b/src/context/method-surgery.ts
@@ -10,7 +10,8 @@
  * Uses @abaplint/core AST for accurate parsing with regex fallback for unparseable source.
  */
 
-import { Config, MemoryFile, Registry, Statements, Structures, Version } from '@abaplint/core';
+import { MemoryFile, Registry, Statements, Structures, Version } from '@abaplint/core';
+import { getDefaultAbaplintConfig } from '../lint/abaplint-config-cache.js';
 
 const DEFAULT_VERSION = Version.Cloud;
 
@@ -115,7 +116,7 @@ export function listMethods(source: string, className: string, abaplintVersion?:
 }
 
 function listMethodsAST(source: string, className: string, ver: Version): MethodListResult {
-  const config = Config.getDefault(ver);
+  const config = getDefaultAbaplintConfig(ver);
   const reg = new Registry(config);
   reg.addFile(new MemoryFile(`${className.toLowerCase().replace(/\//g, '#')}.clas.abap`, source));
   reg.parse();

--- a/src/lint/abaplint-config-cache.ts
+++ b/src/lint/abaplint-config-cache.ts
@@ -1,0 +1,33 @@
+import { Config, type Version } from '@abaplint/core';
+
+const defaultConfigCache = new Map<string, Config>();
+const defaultConfigJsonCache = new Map<string, string>();
+
+function cacheKey(version: Version): string {
+  return String(version);
+}
+
+export function getDefaultAbaplintConfig(version: Version): Config {
+  const key = cacheKey(version);
+  let cached = defaultConfigCache.get(key);
+  if (!cached) {
+    cached = Config.getDefault(version);
+    defaultConfigCache.set(key, cached);
+  }
+  return cached;
+}
+
+export function cloneDefaultAbaplintConfig(version: Version): Record<string, unknown> {
+  const key = cacheKey(version);
+  let json = defaultConfigJsonCache.get(key);
+  if (!json) {
+    json = JSON.stringify(getDefaultAbaplintConfig(version).get());
+    defaultConfigJsonCache.set(key, json);
+  }
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+export function clearAbaplintConfigCacheForTests(): void {
+  defaultConfigCache.clear();
+  defaultConfigJsonCache.clear();
+}

--- a/src/lint/config-builder.ts
+++ b/src/lint/config-builder.ts
@@ -25,6 +25,7 @@ import { readFileSync } from 'node:fs';
 import { Config, Version } from '@abaplint/core';
 import { isBeyondAbaplintCeiling, mapSapReleaseToAbaplintVersion } from '../adt/features.js';
 import type { SystemType } from '../adt/types.js';
+import { cloneDefaultAbaplintConfig } from './abaplint-config-cache.js';
 import { CLOUD_DISABLED_RULES, CLOUD_ERROR_RULES, CLOUD_WARNING_RULES } from './presets/cloud.js';
 import { ONPREM_DISABLED_RULES, ONPREM_ERROR_RULES, ONPREM_WARNING_RULES } from './presets/onprem.js';
 
@@ -54,8 +55,7 @@ export interface LintConfigOptions {
  */
 export function buildLintConfig(options: LintConfigOptions = {}): Config {
   const version = resolveVersion(options);
-  const base = Config.getDefault(version);
-  const raw = JSON.parse(JSON.stringify(base.get())) as Record<string, unknown>;
+  const raw = cloneDefaultAbaplintConfig(version);
 
   // Apply system preset
   const preset = options.systemType === 'btp' ? 'cloud' : 'onprem';
@@ -92,8 +92,7 @@ export function buildLintConfig(options: LintConfigOptions = {}): Config {
  */
 export function buildPreWriteConfig(options: LintConfigOptions = {}): Config {
   const version = resolveVersion(options);
-  const base = Config.getDefault(version);
-  const raw = JSON.parse(JSON.stringify(base.get())) as Record<string, unknown>;
+  const raw = cloneDefaultAbaplintConfig(version);
   const rules = raw.rules as Record<string, unknown>;
 
   // Disable ALL rules first

--- a/src/lint/lint.ts
+++ b/src/lint/lint.ts
@@ -14,7 +14,8 @@
  * - Pre-write validation (blocks writes on hard errors)
  */
 
-import { Config, Edits, MemoryFile, Registry, Version } from '@abaplint/core';
+import { type Config, Edits, MemoryFile, Registry, Version } from '@abaplint/core';
+import { getDefaultAbaplintConfig } from './abaplint-config-cache.js';
 import { buildPreWriteConfig, type LintConfigOptions } from './config-builder.js';
 import { inspectTablSource } from './pre-write-hints.js';
 
@@ -52,7 +53,7 @@ export interface PreWriteResult {
 }
 
 /** Default abaplint configuration for ARC-1 (legacy, used as fallback) */
-const DEFAULT_CONFIG = Config.getDefault(Version.v702);
+const DEFAULT_CONFIG = getDefaultAbaplintConfig(Version.v702);
 
 /**
  * Lint ABAP source code using @abaplint/core.

--- a/tests/unit/lint/abaplint-config-cache.test.ts
+++ b/tests/unit/lint/abaplint-config-cache.test.ts
@@ -1,0 +1,38 @@
+import { Version } from '@abaplint/core';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  clearAbaplintConfigCacheForTests,
+  cloneDefaultAbaplintConfig,
+  getDefaultAbaplintConfig,
+} from '../../../src/lint/abaplint-config-cache.js';
+
+describe('abaplint config cache', () => {
+  afterEach(() => {
+    clearAbaplintConfigCacheForTests();
+  });
+
+  it('reuses the same default Config for the same version', () => {
+    const first = getDefaultAbaplintConfig(Version.Cloud);
+    const second = getDefaultAbaplintConfig(Version.Cloud);
+
+    expect(second).toBe(first);
+  });
+
+  it('keeps different versions in separate cache entries', () => {
+    const cloud = getDefaultAbaplintConfig(Version.Cloud);
+    const v702 = getDefaultAbaplintConfig(Version.v702);
+
+    expect(v702).not.toBe(cloud);
+  });
+
+  it('returns isolated clones for mutable config builder callers', () => {
+    const first = cloneDefaultAbaplintConfig(Version.Cloud);
+    const firstRules = first.rules as Record<string, unknown>;
+    firstRules.__arc1_test_marker = false;
+
+    const second = cloneDefaultAbaplintConfig(Version.Cloud);
+    const secondRules = second.rules as Record<string, unknown>;
+
+    expect(secondRules.__arc1_test_marker).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes external feedback point 3: repeated `Config.getDefault(version)` construction is now memoized while keeping `Registry` instances fresh per parse.

## Changes

- Add `src/lint/abaplint-config-cache.ts` with:
  - `getDefaultAbaplintConfig(version)` for shared default configs
  - `cloneDefaultAbaplintConfig(version)` for mutable config-builder callers
  - test-only cache clear helper
- Route context parser and lint call sites through the cache.
- Keep `new Registry(config)` per parse so file/parse state is never shared.
- Add cache identity and clone-isolation tests.
- Add completed ralphex plan: `docs/plans/completed/ralphex-abaplint-config-memo.md`.

## Validation

- `npm test -- tests/unit/lint/abaplint-config-cache.test.ts tests/unit/lint/config-builder.test.ts tests/unit/lint/lint.test.ts tests/unit/context/deps.test.ts tests/unit/context/contract.test.ts tests/unit/context/method-surgery.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Live read-only smoke against available S/4HANA 2023 / SAP_BASIS 758 target:
  - `SAPRead(type="COMPONENTS")` succeeded and confirmed `SAP_BASIS=758`, `S4FND=108`

## Live SAP Notes

Local credentials for NW 7.50 and A4H 2025 were not present in this workspace (`NPL_*` and A4H 2025 env vars unset). This change is release-invariant: it affects local abaplint config construction only and does not alter ADT calls, headers, payloads, parsing of SAP responses, or safety behavior. Repository PR CI is labeled `A4H 2025` and is the available 2025 live verification path.
