### PR TITLE
test(handlers): Zod↔JSON-Schema type-parity guard (PR-5 spike → NO-GO on generation)

### DIFF
--- a/docs/plans/post-consolidation-hygiene-plan.md
+++ b/docs/plans/post-consolidation-hygiene-plan.md
@@ -146,37 +146,32 @@ The local helper is appropriately specialized; no real divergence risk (they moc
 **Acceptance met:** 3,723 tests green (count unchanged); zero `as ResolvedFeatures` in
 tests/unit/handlers; no fixture diff; full gate. **Risk:** none.
 
-## PR 5 — Zod → JSON Schema generation (spike first, GO/NO-GO)
+## PR 5 — Zod → JSON Schema generation (spike → **NO-GO** → sync-test fallback)
 
-**Status: planned; checkpoint after PR 4 merge. The only LLM-surface-touching PR — highest rigor.**
+**Status: DONE (branch pr5-zod-jsonschema-spike).** The spike ran via `/deep-feature`; full evidence
+in [docs/research/zod-to-jsonschema-spike.md](../research/zod-to-jsonschema-spike.md).
 
-Today `schemas.ts` (Zod, 919 lines) and `tools.ts` (hand-written JSON Schema, 1,587 lines,
-263 `description:` strings) define the same 12 tool surfaces twice — the root of the "three-file
-sync" invariant. Codex's complication list is real and verified: ~50 `z.preprocess`/
-`looseOptionalBoolean` usages + 4 `superRefine` blocks in schemas.ts (superRefine is
-runtime-only — fine; `z.preprocess` is where `z.toJSONSchema()` needs explicit input types or
-overrides), feature-gated enums, BTP/on-prem variants, OpenAI-compat nullable handling, and rich
-LLM-facing prose that must survive byte-for-byte.
+**Spike result — NO-GO on full generation.** The premise (descriptions live in `.describe()` and
+come along for free) is empirically false: across all of `schemas.ts` there are **2** `.describe()`
+calls vs **263** hand-written `description:` strings in `tools.ts`, so `z.toJSONSchema()` produces a
+schema with **0/53** descriptions on SAPWrite. Generation would mean hand-migrating 263 LLM-facing
+strings into Zod — the exact high-risk surface the spike was meant to de-risk — for a benefit
+already captured by existing guards. Also found: `.transform()` fields make `z.toJSONSchema` *throw*
+(`siblingMaxCandidates`), and the SAPWrite-only `makeOptionalPropertiesNullable` quirk isn't
+reproduced. Net: a lot of LLM-surface risk for a drift class that's already ~covered.
 
-**Phase A — spike (no behavior change, throwaway branch):** generate JSON Schema for ONE complex
-tool (SAPWrite) via `z.toJSONSchema()`; write a semantic differ (deep-equal modulo key order +
-formatting) against the hand-written schema; inventory every divergence class:
-`looseOptionalBoolean` → must emit plain `{type:'boolean'}` (what LLMs should send, not what Zod
-accepts), enum pruning parity for all 9 fixture variants, `items`/array shapes, nullability,
-description placement. Output: a divergence table + **GO/NO-GO**.
-**Phase B(GO):** generate `inputSchema` for all tools from the Zod schemas (per-field overrides
-where preprocess obscures the wire type); tool-level prose stays as constants; regenerate the 9
-snapshot fixtures **intentionally** (the one legitimate `vitest -u`), with a committed semantic
-proof: a test asserting old-vs-new schema deep-equality modulo formatting, plus a reviewed fixture
-diff. Three-file sync becomes two-file (registry + Zod). AGENTS.md invariant row updated.
-**Phase B(NO-GO fallback):** keep hand-written tools.ts but add a **semantic sync test**
-(Zod-derived schema ≅ hand-written, modulo the inventoried acceptable divergences) — the drift
-class dies either way; generation can be revisited later.
-**Acceptance (Codex's criteria, adopted):** preserve every description, preserve
-nullable/optional-field semantics, preserve array `items`, regenerate snapshots intentionally with
-semantic-comparison tests, MCP client smoke (e2e suite) green. Commit: `refactor(handlers):` if
-output is semantically identical; anything user-visible beyond formatting → stop and re-plan.
-**Risk:** the LLM-visible surface — bounded by the spike's GO/NO-GO and the semantic differ.
+**Shipped — the NO-GO fallback** (`test(handlers):`, no LLM-surface change, no fixture regen):
+`zod-jsonschema-parity.test.ts` derives each tool's JSON Schema from Zod via `z.toJSONSchema()` and
+asserts per-property base-type + enum-membership parity vs the hand-written `tools.ts` (modulo
+descriptions + the nullable wrap + `.transform()` fields). This closes the ONE drift sliver the
+existing guards miss — a field's base type changed in Zod but not tools.ts (boolean→string) passes
+key-sync, the snapshot, AND registry-sync, yet silently makes Zod reject what the LLM is told is
+valid. Mutation-proven (flip `depth` number→string → 2 failures). The stale `schemas.ts` header
+("generation planned for a future PR") now records the decision + the four guards.
+
+**Sync coverage after this PR:** key set (schema-key-sync) ∧ type enums (registry-sync) ∧
+per-property base type (zod-jsonschema-parity) ∧ exact bytes (tool-definitions-snapshot).
+**Revisit generation only if** descriptions are ever migrated into Zod for an independent reason.
 
 ## Parked (explicit non-goals until triggered)
 

--- a/docs/research/zod-to-jsonschema-spike.md
+++ b/docs/research/zod-to-jsonschema-spike.md
@@ -1,0 +1,57 @@
+# Spike: generate tools.ts JSON Schema from the Zod schemas (z.toJSONSchema)
+
+**Date:** 2026-06-12
+**Status:** Spike complete — **NO-GO on full generation**; ship the sync-test fallback instead.
+**Context:** PR 5 of [post-consolidation-hygiene-plan.md](../plans/post-consolidation-hygiene-plan.md).
+The idea (from the merged-main survey + an external review): collapse the "three-file sync"
+invariant by generating the hand-written JSON Schema in `src/handlers/tools.ts` from the Zod schemas
+in `src/handlers/schemas.ts` via `z.toJSONSchema()`. This is the ONLY LLM-surface-touching item, so
+it was gated behind a spike + GO/NO-GO before any fixture regeneration.
+
+## Method (empirical, zod 4.4.3)
+
+Ran `z.toJSONSchema(SAPWriteSchema)` (the most complex tool — `superRefine` + ~17
+`looseOptionalBoolean` preprocessors + 3 batch variants) and structurally diffed the output against
+the frozen fixture `tests/fixtures/tool-definitions/onprem-full-textsearch-on.json` (the byte-exact
+LLM surface). Scratch scripts, not committed.
+
+## Findings — divergence inventory
+
+| # | Divergence | Severity | Notes |
+|---|---|---|---|
+| **D1** | **Descriptions have no Zod home.** Generated schema: **0/53** props carry a `description`. Hand-written: **53/53**. Across all of `schemas.ts` there are only **2** `.describe()` calls (and 0 `.meta()`), vs **263** hand-written `description:` strings in `tools.ts`. | **Decisive / blocking** | The premise that descriptions live in `.describe()` and "come along for free" is **false**. The LLM-facing prose lives exclusively in tools.ts. |
+| D2 | **SAPWrite-only nullable transform not reproduced.** Hand-written has 52 nullable optional props (`type: [..., "null"]`) via `makeOptionalPropertiesNullable` (applied to SAPWrite *only*, tools.ts:594). Generated: 0. | Replicable | A post-generation step could re-apply it, but it's a per-tool quirk the generator must special-case. |
+| D3 | Generated adds top-level `$schema` + `additionalProperties`; hand-written has neither. | Strippable | Trivial post-processing. |
+| **D4** | **`.transform()` makes `z.toJSONSchema` THROW** (`"Transforms cannot be represented in JSON Schema"`). SAPContext's `siblingMaxCandidates` (`z.coerce.number().int().transform(clamp)`) can't be generated without `{ unrepresentable: 'any' }` (→ emits `any`, losing the type). | **Blocking per-tool** | Found while building the parity test. Generation would need per-field special-casing or input/output-schema split. Reinforces NO-GO. |
+| obs | **`maxResults` int-vs-number looseness.** SAPRead/SAPContext use `z.coerce.number().int()` (→ `integer`) but the hand-written schema (and the other three tools' `maxResults`, which omit `.int()`) say `number`. | Pre-existing, benign | A real minor inconsistency surfaced by the parity test; not worth an LLM-surface change to fix. The test normalizes `integer`→`number` (guards type *category*, not numeric precision). |
+| — | `superRefine` (cross-field rules) silently dropped by `z.toJSONSchema`. | **Not a divergence** | Correct — those rules aren't JSON-Schema-expressible and the hand-written schema doesn't encode them either. Runtime-only, stays in Zod. |
+| — | `looseOptionalBoolean` (a `z.preprocess`) → `{"type":"boolean"}`. | **Handled** | Matches the hand-written boolean type (modulo D2's nullable wrap). |
+| — | Property **set** parity: 53 generated = 53 hand-written, no extras either side. | **Already perfect** | And already guarded — see below. |
+
+## Why NO-GO on full generation
+
+1. **D1 makes it a 263-string migration on the most sensitive surface.** "Generate from Zod" first
+   requires hand-migrating all 263 LLM-facing description strings into `.describe()` calls in
+   schemas.ts, byte-perfectly. That is exactly the high-risk, LLM-instruction-facing edit the spike
+   was meant to de-risk — and the spike found no mechanical shortcut. Even then, tool-level prose
+   (the big `SAPREAD_DESC_*` blocks) stays as constants, so the win is partial.
+2. **The drift class the invariant guards is already ~covered:**
+   - `schema-key-sync.test.ts` — Zod field-key set ≡ JSON-Schema field-key set (all 12 tools).
+   - `registry-sync.test.ts` — JSON-Schema type enums ≡ Zod enums ≡ registry.
+   - `tool-definitions-snapshot.test.ts` — the exact JSON bytes are frozen (9 variants).
+   Generation wouldn't kill a *live* drift risk; it would just relocate where the schema is authored
+   (and add D2/D3 quirks to replicate).
+3. The one **uncovered** sliver: per-property **base-type** parity (a field flipped boolean→string in
+   Zod would pass key-sync, pass the snapshot, and pass registry-sync, yet silently make Zod reject
+   what the LLM is told is valid). That sliver is closeable with a ~40-line test — no generation, no
+   fixture regen, no LLM-surface risk.
+
+## Decision → ship the fallback
+
+- Add `zod-jsonschema-parity.test.ts`: for every tool, `z.toJSONSchema(getToolSchema(...))`'s
+  per-property base type ≅ the hand-written `getToolDefinitions(...)` type (modulo descriptions +
+  D2 nullable + D3 extras). Closes the last drift sliver; the spike proves it currently holds.
+- Update the stale `schemas.ts` header ("JSON Schema generation … is planned for a future PR") to
+  record that generation was evaluated and rejected, pointing here + at the guard tests.
+- Leave `tools.ts` hand-written. Revisit generation only if descriptions are ever migrated into Zod
+  for an independent reason (then D1 dissolves and this dossier's math changes).

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -2,8 +2,11 @@
  * Zod v4 input schemas for all 12 MCP tools.
  *
  * These schemas provide runtime validation via safeParse() in handleToolCall().
- * JSON Schema generation via z.toJSONSchema() is planned for a future PR
- * (currently, JSON Schema is still hand-written in tools.ts).
+ * The JSON Schema the LLM sees is hand-written in tools.ts (NOT generated from these). Generating
+ * it via z.toJSONSchema() was evaluated and rejected — the 263 LLM-facing descriptions live only in
+ * tools.ts (these schemas carry ~zero .describe()), and `.transform()` fields can't be represented;
+ * see docs/research/zod-to-jsonschema-spike.md. The two are kept in sync by schema-key-sync,
+ * registry-sync, zod-jsonschema-parity, and tool-definitions-snapshot tests, not by generation.
  *
  * BTP variants exclude types not available on BTP ABAP Environment.
  * Numeric fields use z.coerce.number() for MCP client compatibility

--- a/tests/unit/handlers/zod-jsonschema-parity.test.ts
+++ b/tests/unit/handlers/zod-jsonschema-parity.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Zod ↔ JSON-Schema per-property TYPE parity (the sync-test fallback from the PR-5 spike).
+ *
+ * tools.ts (the JSON Schema the LLM sees) is hand-written; schemas.ts (the Zod runtime validation)
+ * is independent. Three guards already keep them in sync:
+ *   - schema-key-sync.test.ts        — the property KEY set matches
+ *   - registry-sync.test.ts          — the `type` field's enum matches the registry
+ *   - tool-definitions-snapshot.test — the exact JSON bytes are frozen
+ * The one drift class none of them catch: a field whose BASE TYPE is changed in Zod but not in
+ * tools.ts (e.g. boolean→string). It would pass key-sync (key present), pass the snapshot (tools.ts
+ * unchanged), and pass registry-sync (not the type enum) — yet silently make Zod reject what the LLM
+ * is told is valid. This test closes that sliver by deriving each tool's JSON Schema from Zod via
+ * z.toJSONSchema() and asserting the per-property base type + enum membership match the hand-written
+ * schema, modulo the two documented, mechanical differences:
+ *   - descriptions          — live only in tools.ts, never in Zod (see docs/research/zod-to-jsonschema-spike.md)
+ *   - nullable optional props — tools.ts wraps SAPWrite optionals as `type: [..., "null"]` for OpenAI
+ *
+ * Background + the GO/NO-GO that rejected full schema generation: docs/research/zod-to-jsonschema-spike.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { getToolSchema } from '../../../src/handlers/schemas.js';
+import { getToolDefinitions } from '../../../src/handlers/tools.js';
+import { features, fullConfig } from './handler-test-config.js';
+
+const TOOLS = [
+  'SAPRead',
+  'SAPSearch',
+  'SAPWrite',
+  'SAPActivate',
+  'SAPNavigate',
+  'SAPQuery',
+  'SAPTransport',
+  'SAPGit',
+  'SAPContext',
+  'SAPLint',
+  'SAPDiagnose',
+  'SAPManage',
+] as const;
+
+type JsonNode = Record<string, unknown>;
+
+/**
+ * Reduce a JSON-Schema property node to its wire-contract essentials, normalized so the two
+ * documented, mechanical differences (description text; the OpenAI `null` union on optionals) don't
+ * register as drift. Compares base type, enum membership (order-independent — the LLM-facing order
+ * is frozen by the snapshot), and array item type.
+ */
+// `integer` is a refinement-subtype of `number`, not a different category. zod emits `integer` for
+// `.int()` while several hand-written maxResults fields say `number` (a real but benign pre-existing
+// looseness — see docs/research/zod-to-jsonschema-spike.md). This test guards base-type CATEGORY
+// drift (boolean→string, array→object), so both collapse to `number`.
+const normPrim = (t: string): string => (t === 'integer' ? 'number' : t);
+
+function wireType(node: unknown): string {
+  if (!node || typeof node !== 'object' || Array.isArray(node)) return JSON.stringify(node ?? null);
+  const p = node as JsonNode;
+  let type = p.type as string | string[] | undefined;
+  if (typeof type === 'string') {
+    type = normPrim(type);
+  } else if (Array.isArray(type)) {
+    const stripped = type.filter((t) => t !== 'null').map(normPrim); // drop makeOptionalPropertiesNullable's union
+    type = stripped.length === 1 ? stripped[0] : stripped.sort();
+  }
+  const enumSet = Array.isArray(p.enum) ? [...(p.enum as unknown[])].map(String).sort() : undefined;
+  const items = p.items !== undefined ? wireType(p.items) : undefined;
+  const anyOf = Array.isArray(p.anyOf) ? (p.anyOf as unknown[]).map(wireType).sort() : undefined;
+  return JSON.stringify({ type, enum: enumSet, items, anyOf });
+}
+
+// zod's empty/any node (e.g. a field whose Zod type is a `.transform()` — genuinely not
+// representable in JSON Schema). `wireType` reduces such a node to "{}"; the comparison skips it.
+const ANY_NODE = '{}';
+
+/**
+ * Derive a tool's JSON Schema from its Zod schema. `unrepresentable: 'any'` keeps generation from
+ * throwing on `.transform()` fields (e.g. SAPContext.siblingMaxCandidates) — those emit `any` and
+ * are skipped below, since a transform has no JSON-Schema type to compare against.
+ */
+function generatedProps(tool: string, btp: boolean): Record<string, unknown> {
+  const schema = getToolSchema(tool, btp, true);
+  if (!schema) throw new Error(`getToolSchema returned undefined for ${tool} (${btp ? 'btp' : 'onprem'})`);
+  const json = z.toJSONSchema(schema, { unrepresentable: 'any' }) as JsonNode;
+  return (json.properties as Record<string, unknown>) ?? {};
+}
+
+function handWrittenProps(tool: string, btp: boolean): Record<string, unknown> | null {
+  // features() = all backends available, so feature-gated tools (SAPGit) are registered.
+  const def = getToolDefinitions(fullConfig(btp), true, features()).find((d) => d.name === tool);
+  return def ? (((def.inputSchema as JsonNode).properties as Record<string, unknown>) ?? {}) : null;
+}
+
+describe('Zod ↔ JSON-Schema per-property type parity', () => {
+  for (const tool of TOOLS) {
+    for (const btp of [false, true]) {
+      it(`${tool} (${btp ? 'btp' : 'onprem'}) property types are reproducible from Zod`, () => {
+        const hand = handWrittenProps(tool, btp);
+        expect(hand, `${tool} (${btp ? 'btp' : 'onprem'}) not registered under the full config`).not.toBeNull();
+        const gen = generatedProps(tool, btp);
+
+        // Only compare keys present on BOTH sides — the key SET is schema-key-sync.test.ts's job.
+        // Skip keys zod can't represent (ANY_NODE, i.e. `.transform()` fields): nothing to compare.
+        const shared = Object.keys(hand as object).filter((k) => k in gen && wireType(gen[k]) !== ANY_NODE);
+        const mismatches = shared
+          .filter((k) => wireType((hand as JsonNode)[k]) !== wireType(gen[k]))
+          .map((k) => `${k}: hand=${wireType((hand as JsonNode)[k])} gen=${wireType(gen[k])}`);
+
+        expect(mismatches, `${tool} (${btp ? 'btp' : 'onprem'}) Zod-derived types diverge from tools.ts`).toEqual([]);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## What

PR 5 (final rung of the [post-consolidation hygiene ladder](docs/plans/post-consolidation-hygiene-plan.md)) evaluated **generating `tools.ts`'s JSON Schema from the Zod schemas** via `z.toJSONSchema()` to collapse the three-file-sync invariant. Run as a spike → GO/NO-GO via `/deep-feature`.

**Result: NO-GO on full generation. Shipped the sync-test fallback** — no LLM-surface change, no fixture regen. Full evidence: [docs/research/zod-to-jsonschema-spike.md](docs/research/zod-to-jsonschema-spike.md).

## Why NO-GO (empirical, zod 4.4.3)

| Finding | Detail |
|---|---|
| **Descriptions have no Zod home** | `schemas.ts` has **2** `.describe()` calls; `tools.ts` has **263** hand-written `description:` strings. `z.toJSONSchema(SAPWriteSchema)` → **0/53** descriptions. Generation = hand-migrating 263 LLM-facing strings into Zod — the exact surface the spike was meant to de-risk. |
| **`.transform()` throws** | `z.toJSONSchema` errors `"Transforms cannot be represented in JSON Schema"` on `SAPContext.siblingMaxCandidates`. |
| **SAPWrite-only nullable quirk** | `makeOptionalPropertiesNullable` (52 props) isn't reproduced by generation. |
| **Benefit already captured** | the drift the invariant guards is covered by `schema-key-sync` (keys) + `registry-sync` (type enums) + `tool-definitions-snapshot` (bytes). Generation would relocate authoring, not kill a live risk. |

## What shipped — `zod-jsonschema-parity.test.ts`

Derives each tool's JSON Schema from Zod via `z.toJSONSchema()` and asserts **per-property base-type + enum-membership parity** vs the hand-written `tools.ts`, modulo the documented mechanical differences (descriptions; the OpenAI nullable wrap; `.transform()` fields, which are skipped). This closes the **one drift sliver** the three existing guards all miss: a field's base type changed in Zod but not `tools.ts` (e.g. `boolean→string`) passes key-sync (key present), the snapshot (`tools.ts` unchanged), AND registry-sync (not the type enum) — yet silently makes Zod **reject what the LLM is told is valid**. Mutation-proven (flip `depth` number→string → 2 failures; revert → 24 green).

Also: the stale `schemas.ts` header ("JSON Schema generation … planned for a future PR") now records the decision + the four guards, so this isn't re-attempted blind.

**Sync coverage after this PR:** key set ∧ type enums ∧ **per-property base type** ∧ exact bytes.

## Observation (not fixed here)

The parity test surfaced a pre-existing minor inconsistency: `maxResults` is `z.coerce.number().int()` (→ `integer`) in SAPRead/SAPContext but plain `number` in three other tools and in all hand-written schemas. Benign (integer ⊆ number); fixing it "properly" would touch the LLM surface. Recorded in the dossier; the test normalizes `integer`→`number` (guards type *category*, not numeric precision).

## Verification

Full gate green: `typecheck` / `lint` / `validate:policy` / `build` / `check:sizes`, **3,754 tests** (+24 new), tool-definition fixtures **byte-identical**. `test(handlers):` + `docs:` → no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
