### PR TITLE
chore(ci): guard MCP tool schema budget

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Validate action policy
         run: npm run validate:policy
 
-      - name: Check file-size ratchet
+      - name: Check size and schema budgets
         run: npm run check:sizes
 
       - name: npx package smoke test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Distributed as npm package (`arc-1`) and Docker image (`ghcr.io/marianfoo/arc-1`
 
 1. **Centralized admin control** — managed service; server-wide safety ceiling (`allowWrites`, package allowlists, SQL/data/transport/Git gates, deny actions); every call audited; per-user scopes restrict, never expand.
 2. **Per-user SAP identity** — principal propagation maps each MCP user to their own SAP user (BTP Destination Service + Cloud Connector); SAP auth applies per user.
-3. **Token-efficient tools** — 12 intent tools (~5K schema tokens) vs 200+ endpoints; hyperfocused mode = 1 tool (~200 tokens); method-level surgery + context compression keep mid-tier LLMs viable.
+3. **Token-efficient tools** — 12 intent tools vs 200+ endpoints, with schema payload guarded by CI budgets; hyperfocused mode = 1 tool (~200 tokens); method-level surgery + context compression keep mid-tier LLMs viable.
 4. **BTP-native deployment** — Destination Service, Cloud Connector, XSUAA OAuth, BTP Audit Log; also Docker/npm/stdio.
 5. **Multi-client, vendor-neutral** — XSUAA OAuth + Entra ID OIDC + API key coexist; one instance serves Claude, Copilot Studio, VS Code, Gemini CLI, Cursor.
 6. **Safe defaults, opt-in power** — read-only by default; free SQL blocked; package allowlist defaults to `$TMP`; everything forbidden until the admin allows it.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Deploy ARC-1 as a Cloud Foundry app on SAP BTP with full platform integration:
 
 ### Token Efficiency
 
-- **12 intent-based tools** (~5K schema tokens) instead of 200+ individual tools — keeps the LLM's context window small
+- **12 intent-based tools** instead of 200+ individual tools — keeps tool selection simple, with the schema payload guarded by CI budgets and a hyperfocused 1-tool mode for tight context windows
 - **Method-level read/edit** — read or update a single class method, not the whole source (up to 20x fewer tokens)
 - **Context compression** — `SAPContext` returns public API contracts of all dependencies in one call (7-30x compression)
 

--- a/docs/plans/completed/ralphex-tool-schema-budget-guard.md
+++ b/docs/plans/completed/ralphex-tool-schema-budget-guard.md
@@ -1,0 +1,111 @@
+# Ralphex Tool Schema Budget Guard
+
+## Overview
+
+This plan addresses external feedback point 5: ARC-1's MCP tool schema payload can grow silently because `src/handlers/tools.ts` contains long tool and property descriptions. The existing `check:sizes` guard only tracked source file line counts; it did not measure the actual JSON schema payload sent to MCP clients.
+
+The implementation adds a CI budget guard for representative tool-definition scenarios. It measures the serialized MCP schema payload and all string-valued `description` fields with a deterministic byte/4 token estimate. It also removes stale documentation claims that the standard 12-tool surface is `~5K schema tokens`; the current implementation now reports the measured budget in CI instead of advertising an inaccurate fixed number.
+
+## Context
+
+### Current State
+
+`scripts/ci/check-file-sizes.mjs` enforces line budgets and is already wired into `npm run check:sizes` and `.github/workflows/test.yml`. `src/handlers/tools.ts` has a line budget, but descriptions and nested JSON schema fields can still grow inside that budget. `README.md`, `docs_page/tools.md`, and `AGENTS.md` still claimed `~5K schema tokens`, which no longer matches the measured standard-mode payload.
+
+Measured current schema payloads on 2026-06-12 with text search and Git features enabled:
+
+- `standard-default`: 9 tools, ~11,182 schema tokens, 145 description strings / ~8,815 description tokens.
+- `standard-full-git`: 12 tools, ~18,985 schema tokens, 258 description strings / ~14,505 description tokens.
+- `btp-full-git`: 12 tools, ~17,222 schema tokens, 256 description strings / ~12,848 description tokens.
+- `hyperfocused-default`: 1 tool, ~222 schema tokens, 6 description strings / ~102 description tokens.
+
+### Target State
+
+`npm run check:sizes` fails when the MCP schema payload grows past reviewed budgets. CI prints the measured payload per scenario so reviewers can see whether a PR expands prompt surface. Public docs avoid the stale `~5K` standard-mode claim and instead state that schema size is guarded by CI, with hyperfocused mode available for tight context windows.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `scripts/ci/check-tool-schema-budget.ts` | New MCP schema payload measurement and budget guard |
+| `scripts/ci/check-file-sizes.mjs` | Existing file-size ratchet invoked by `check:sizes` |
+| `package.json` | Wires the new guard into `npm run check:sizes` |
+| `.github/workflows/test.yml` | CI step label for the combined size/schema budget check |
+| `tests/unit/scripts/check-tool-schema-budget.test.ts` | Unit coverage for budget measurement and failure reporting |
+| `README.md` | Removes stale `~5K schema tokens` claim |
+| `docs_page/tools.md` | Removes stale `~5K schema tokens` claim from published tool docs |
+| `AGENTS.md` | Removes stale `~5K schema tokens` claim from agent guidance |
+
+### Verified Live Evidence
+
+2026-06-12 live read smoke after implementation, using `node ./dist/cli.js call SAPRead --json '{"type":"COMPONENTS"}' --output json` with credentials parsed from `/Users/marianzeis/DEV/arc-1/.env.infrastructure`:
+
+- NW 7.50 NPL: HTTPS endpoint returned `SAP_BASIS=750`.
+- S/4HANA 2023: HTTP endpoint returned `SAP_BASIS=758`, `S4FND=108`.
+- ABAP Platform 2025: HTTP endpoint returned `SAP_BASIS=816`, `S4FND=109`.
+
+The code change is release-invariant because it changes CI scripts and documentation only. The live smoke verifies that the built CLI still performs read-only ADT round trips on all three configured SAP releases.
+
+### Design Principles
+
+1. Use a deterministic byte/4 token estimate as a CI ratchet, not as billing telemetry.
+2. Measure both whole serialized tool definitions and the accumulated `description` strings, because descriptions are the drift vector called out in the feedback.
+3. Include worst-case standard surfaces: default read-oriented tools, full on-prem tools with Git features, full BTP tools with Git features, and hyperfocused mode.
+4. Keep budgets close to the current measured values so growth requires a deliberate diff.
+5. Avoid new tokenizer/runtime dependencies for a CI-only guard.
+
+## Development Approach
+
+Add a TypeScript CI script under `scripts/ci/` because it can import `getToolDefinitions()` directly without requiring a prebuilt `dist/`. Export small measurement helpers so unit tests can cover recursion, token estimation, offender reporting, and current ARC-1 scenario budgets. Wire the script into `check:sizes` so the existing GitHub Actions step runs it automatically.
+
+Update docs in the same PR because the research uncovered a concrete false claim. Do not attempt a broad prompt-copy reduction in this plan; the guard makes any future expansion visible, and prompt-surface trimming can happen in separate focused work.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add MCP schema budget measurement
+
+**Files:**
+- Create: `scripts/ci/check-tool-schema-budget.ts`
+- Create: `tests/unit/scripts/check-tool-schema-budget.test.ts`
+
+Add a CI script that measures serialized tool definitions and nested `description` strings for the current standard and hyperfocused surfaces.
+
+- [x] Add a deterministic `estimateTokens(bytes)` helper using the byte/4 heuristic.
+- [x] Add recursive `collectDescriptionStats()` that counts only string-valued `description` fields.
+- [x] Define scenarios for default standard mode, full on-prem/Git mode, full BTP/Git mode, and hyperfocused mode.
+- [x] Set reviewed budgets just above current measured values.
+- [x] Add failure reporting that identifies the scenario and metric that exceeded budget.
+- [x] Add unit tests for token estimation, description recursion, current budgets, and failure reporting.
+- [x] Run `npm test -- tests/unit/scripts/check-tool-schema-budget.test.ts`.
+
+### Task 2: Wire the guard into CI and correct stale docs
+
+**Files:**
+- Modify: `package.json`
+- Modify: `.github/workflows/test.yml`
+- Modify: `README.md`
+- Modify: `docs_page/tools.md`
+- Modify: `AGENTS.md`
+
+Run the new schema-budget guard as part of the existing size check and remove the inaccurate `~5K schema tokens` wording from docs.
+
+- [x] Extend `npm run check:sizes` to run `tsx scripts/ci/check-tool-schema-budget.ts` after the file-size ratchet.
+- [x] Rename the GitHub Actions step to "Check size and schema budgets".
+- [x] Update README token-efficiency copy to mention CI-guarded schema payload and hyperfocused mode.
+- [x] Update the published tool reference intro with the same wording.
+- [x] Update agent guidance so future autonomous work does not repeat the stale `~5K` claim.
+- [x] Run `npm run check:sizes`.
+
+### Task 3: Final verification
+
+- [x] Run full test suite: `npm test` - all tests pass.
+- [x] Run typecheck: `npm run typecheck` - no errors.
+- [x] Run lint: `npm run lint` - no errors.
+- [x] Run build: `npm run build` - no errors.
+- [x] Live SAP read-only smoke on 7.50 via HTTPS: `SAPRead COMPONENTS` returned `SAP_BASIS=750`.
+- [x] Live SAP read-only smoke on 2023 via HTTP: `SAPRead COMPONENTS` returned `SAP_BASIS=758`.
+- [x] Live SAP read-only smoke on 2025 via HTTP: `SAPRead COMPONENTS` returned `SAP_BASIS=816`.

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -307,7 +307,7 @@ Optional pre-write validation layers and tool-set selection.
 | `--lint-before-write` | `SAP_LINT_BEFORE_WRITE` | `true` | Runs `@abaplint/core` against the source body before every `SAPWrite`. Syntax errors block the write; warnings are appended to the response (non-blocking). When `false`, lint is skipped — the write goes straight to the activation/save round-trip. Some object types (e.g. `FUNC` source with structured signatures) are exempt from lint regardless of this flag. |
 | `--abaplint-config` | `SAP_ABAPLINT_CONFIG` | — (uses built-in preset) | Path to a custom `abaplint.jsonc`. When unset, ARC-1 builds a preset config based on the detected system type (cloud-strict for BTP, relaxed for on-prem). Custom config takes full precedence. |
 | `--check-before-write` | `SAP_CHECK_BEFORE_WRITE` | `false` | See [Authorization and safety](#authorization-and-safety) — adds a server-side ADT syntax check round-trip before save. Different layer from `lint-before-write` (this hits SAP, lint runs locally). |
-| `--tool-mode` | `ARC1_TOOL_MODE` | `standard` | `standard` exposes the 12 intent-based tools (~5K schema tokens). `hyperfocused` exposes a single universal `sap` tool (~200 tokens) that dispatches everything internally. Use `hyperfocused` for severely token-constrained LLM clients (e.g. GPT-4o-mini, Copilot Studio). |
+| `--tool-mode` | `ARC1_TOOL_MODE` | `standard` | `standard` exposes the 12 intent-based tools (schema payload guarded by CI budgets). `hyperfocused` exposes a single universal `sap` tool (~200 tokens) that dispatches everything internally. Use `hyperfocused` for severely token-constrained LLM clients (e.g. GPT-4o-mini, Copilot Studio). |
 
 ---
 

--- a/docs_page/tools.md
+++ b/docs_page/tools.md
@@ -2,7 +2,7 @@
 
 Complete documentation for all MCP tools available in ARC-1.
 
-ARC-1 exposes **12 intent-based tools** designed for AI agents. Instead of 200+ individual tools (one per object type per operation), ARC-1 groups by *intent* with a `type` parameter for routing. This keeps the LLM's tool selection simple and the context window small (~5K schema tokens).
+ARC-1 exposes **12 intent-based tools** designed for AI agents. Instead of 200+ individual tools (one per object type per operation), ARC-1 groups by *intent* with a `type` parameter for routing. This keeps the LLM's tool selection simple, with the schema payload guarded by CI budgets and a hyperfocused 1-tool mode for tight context windows.
 
 **Error intelligence:** ARC-1 enriches many SAP ADT failures with concise, actionable hints (for example lock conflicts, enqueue issues, missing authorizations, and transport/corrNr problems). Hints can include SAP transaction references like `SM12` (locks), `SU53` (authorization), and `SE09` (transport checks) to speed up troubleshooting.
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json && tsc --noEmit -p tsconfig.tests.json",
     "validate:policy": "tsx scripts/validate-action-policy.ts",
-    "check:sizes": "node scripts/ci/check-file-sizes.mjs",
+    "check:sizes": "node scripts/ci/check-file-sizes.mjs && tsx scripts/ci/check-tool-schema-budget.ts",
     "cli": "tsx src/cli.ts",
     "extract-sap-cookies": "tsx src/extract-sap-cookies.ts",
     "probe": "tsx scripts/probe-adt-types.ts",

--- a/scripts/ci/check-tool-schema-budget.ts
+++ b/scripts/ci/check-tool-schema-budget.ts
@@ -1,0 +1,238 @@
+#!/usr/bin/env tsx
+/**
+ * MCP tool schema budget guard.
+ *
+ * This intentionally uses a deterministic byte/4 token estimate instead of a
+ * tokenizer dependency. The number is a CI ratchet, not billing telemetry: if
+ * tool descriptions or JSON schemas grow, this fails and forces a reviewed
+ * budget bump or a prompt-surface reduction.
+ */
+
+import { pathToFileURL } from 'node:url';
+import type { FeatureStatus, ResolvedFeatures } from '../../src/adt/types.js';
+import { getToolDefinitions, type ToolDefinition } from '../../src/handlers/tools.js';
+import { DEFAULT_CONFIG, type ServerConfig } from '../../src/server/types.js';
+
+const TOKEN_ESTIMATE_BYTES = 4;
+
+export interface DescriptionStats {
+  count: number;
+  bytes: number;
+  tokenEstimate: number;
+}
+
+export interface ToolSchemaMeasurement {
+  scenario: string;
+  tools: number;
+  schemaBytes: number;
+  schemaTokenEstimate: number;
+  descriptionCount: number;
+  descriptionBytes: number;
+  descriptionTokenEstimate: number;
+}
+
+export interface ToolSchemaBudget {
+  schemaTokenEstimate: number;
+  descriptionTokenEstimate: number;
+  descriptionCount: number;
+}
+
+export interface ToolSchemaScenario {
+  name: string;
+  config: ServerConfig;
+  textSearchAvailable: boolean;
+  resolvedFeatures?: ResolvedFeatures;
+  budget: ToolSchemaBudget;
+}
+
+export interface BudgetOffender {
+  scenario: string;
+  metric: keyof ToolSchemaBudget;
+  actual: number;
+  budget: number;
+}
+
+const availableFeature = (id: string): FeatureStatus => ({ id, available: true, mode: 'on' });
+
+const ALL_FEATURES_AVAILABLE: ResolvedFeatures = {
+  hana: availableFeature('hana'),
+  abapGit: availableFeature('abapGit'),
+  gcts: availableFeature('gcts'),
+  rap: availableFeature('rap'),
+  amdp: availableFeature('amdp'),
+  ui5: availableFeature('ui5'),
+  transport: availableFeature('transport'),
+  ui5repo: availableFeature('ui5repo'),
+  flp: availableFeature('flp'),
+  textSearch: { available: true },
+};
+
+const FULL_ACCESS_CONFIG: ServerConfig = {
+  ...DEFAULT_CONFIG,
+  allowWrites: true,
+  allowDataPreview: true,
+  allowFreeSQL: true,
+  allowTransportWrites: true,
+  allowGitWrites: true,
+};
+
+export const TOOL_SCHEMA_SCENARIOS: ToolSchemaScenario[] = [
+  {
+    name: 'standard-default',
+    config: DEFAULT_CONFIG,
+    textSearchAvailable: true,
+    resolvedFeatures: ALL_FEATURES_AVAILABLE,
+    budget: {
+      schemaTokenEstimate: 11_500,
+      descriptionTokenEstimate: 9_000,
+      descriptionCount: 150,
+    },
+  },
+  {
+    name: 'standard-full-git',
+    config: FULL_ACCESS_CONFIG,
+    textSearchAvailable: true,
+    resolvedFeatures: ALL_FEATURES_AVAILABLE,
+    budget: {
+      schemaTokenEstimate: 19_500,
+      descriptionTokenEstimate: 15_000,
+      descriptionCount: 265,
+    },
+  },
+  {
+    name: 'btp-full-git',
+    config: { ...FULL_ACCESS_CONFIG, systemType: 'btp' },
+    textSearchAvailable: true,
+    resolvedFeatures: { ...ALL_FEATURES_AVAILABLE, systemType: 'btp' },
+    budget: {
+      schemaTokenEstimate: 17_500,
+      descriptionTokenEstimate: 13_200,
+      descriptionCount: 265,
+    },
+  },
+  {
+    name: 'hyperfocused-default',
+    config: { ...DEFAULT_CONFIG, toolMode: 'hyperfocused' },
+    textSearchAvailable: true,
+    resolvedFeatures: ALL_FEATURES_AVAILABLE,
+    budget: {
+      schemaTokenEstimate: 250,
+      descriptionTokenEstimate: 120,
+      descriptionCount: 8,
+    },
+  },
+];
+
+export function estimateTokens(bytes: number): number {
+  return Math.ceil(bytes / TOKEN_ESTIMATE_BYTES);
+}
+
+export function collectDescriptionStats(value: unknown): DescriptionStats {
+  let count = 0;
+  let bytes = 0;
+
+  function visit(node: unknown): void {
+    if (Array.isArray(node)) {
+      for (const item of node) visit(item);
+      return;
+    }
+    if (node === null || typeof node !== 'object') return;
+
+    for (const [key, child] of Object.entries(node)) {
+      if (key === 'description' && typeof child === 'string') {
+        count += 1;
+        bytes += Buffer.byteLength(child, 'utf8');
+      }
+      visit(child);
+    }
+  }
+
+  visit(value);
+  return { count, bytes, tokenEstimate: estimateTokens(bytes) };
+}
+
+export function measureToolDefinitions(scenario: ToolSchemaScenario): ToolSchemaMeasurement {
+  const definitions = getToolDefinitions(
+    scenario.config,
+    scenario.textSearchAvailable,
+    scenario.resolvedFeatures,
+  ) as ToolDefinition[];
+  const serialized = JSON.stringify(definitions);
+  const schemaBytes = Buffer.byteLength(serialized, 'utf8');
+  const descriptions = collectDescriptionStats(definitions);
+
+  return {
+    scenario: scenario.name,
+    tools: definitions.length,
+    schemaBytes,
+    schemaTokenEstimate: estimateTokens(schemaBytes),
+    descriptionCount: descriptions.count,
+    descriptionBytes: descriptions.bytes,
+    descriptionTokenEstimate: descriptions.tokenEstimate,
+  };
+}
+
+export function checkToolSchemaBudgets(
+  scenarios: ToolSchemaScenario[] = TOOL_SCHEMA_SCENARIOS,
+): { measurements: ToolSchemaMeasurement[]; offenders: BudgetOffender[] } {
+  const measurements = scenarios.map(measureToolDefinitions);
+  const offenders: BudgetOffender[] = [];
+
+  for (const measurement of measurements) {
+    const budget = scenarios.find((scenario) => scenario.name === measurement.scenario)?.budget;
+    if (!budget) continue;
+    for (const metric of ['schemaTokenEstimate', 'descriptionTokenEstimate', 'descriptionCount'] as const) {
+      if (measurement[metric] > budget[metric]) {
+        offenders.push({
+          scenario: measurement.scenario,
+          metric,
+          actual: measurement[metric],
+          budget: budget[metric],
+        });
+      }
+    }
+  }
+
+  return { measurements, offenders };
+}
+
+export function formatToolSchemaBudgetReport(
+  measurements: ToolSchemaMeasurement[],
+  offenders: BudgetOffender[],
+): string {
+  const lines = [
+    'MCP tool schema budget:',
+    ...measurements.map(
+      (measurement) =>
+        `  ${measurement.scenario}: tools=${measurement.tools}, schema~${measurement.schemaTokenEstimate} tokens ` +
+        `(${measurement.schemaBytes} bytes), descriptions=${measurement.descriptionCount}/~${measurement.descriptionTokenEstimate} tokens`,
+    ),
+  ];
+
+  if (offenders.length === 0) {
+    lines.push('✓ tool schema budget: all scenarios within budget.');
+    return lines.join('\n');
+  }
+
+  lines.push('', '✗ tool schema budget failed:');
+  for (const offender of offenders) {
+    lines.push(`  ${offender.scenario}.${offender.metric}: ${offender.actual} (budget ${offender.budget})`);
+  }
+  lines.push(
+    '',
+    'Trim tool descriptions/schema payload, move long examples into docs/help surfaces, or raise the budget deliberately.',
+  );
+  return lines.join('\n');
+}
+
+function main(): void {
+  const { measurements, offenders } = checkToolSchemaBudgets();
+  const report = formatToolSchemaBudgetReport(measurements, offenders);
+  const stream = offenders.length > 0 ? process.stderr : process.stdout;
+  stream.write(`${report}\n`);
+  if (offenders.length > 0) process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tests/unit/scripts/check-tool-schema-budget.test.ts
+++ b/tests/unit/scripts/check-tool-schema-budget.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkToolSchemaBudgets,
+  collectDescriptionStats,
+  estimateTokens,
+  formatToolSchemaBudgetReport,
+  TOOL_SCHEMA_SCENARIOS,
+  type ToolSchemaScenario,
+} from '../../../scripts/ci/check-tool-schema-budget.js';
+import { DEFAULT_CONFIG } from '../../../src/server/types.js';
+
+describe('check-tool-schema-budget', () => {
+  it('estimates tokens with the CI byte/4 heuristic', () => {
+    expect(estimateTokens(0)).toBe(0);
+    expect(estimateTokens(1)).toBe(1);
+    expect(estimateTokens(8)).toBe(2);
+    expect(estimateTokens(9)).toBe(3);
+  });
+
+  it('counts only string-valued description fields recursively', () => {
+    const stats = collectDescriptionStats({
+      description: 'top',
+      properties: {
+        description: {
+          type: 'string',
+          description: 'schema field named description',
+        },
+        nested: [{ description: 'nested' }, { description: 42 }],
+      },
+    });
+
+    expect(stats).toEqual({
+      count: 3,
+      bytes: Buffer.byteLength('topschema field named descriptionnested', 'utf8'),
+      tokenEstimate: 10,
+    });
+  });
+
+  it('passes the current ARC-1 tool schema scenarios under their ratchet budgets', () => {
+    const { measurements, offenders } = checkToolSchemaBudgets();
+
+    expect(offenders).toEqual([]);
+    expect(measurements.map((measurement) => measurement.scenario)).toEqual(
+      TOOL_SCHEMA_SCENARIOS.map((scenario) => scenario.name),
+    );
+    expect(measurements.find((measurement) => measurement.scenario === 'hyperfocused-default')).toMatchObject({
+      tools: 1,
+      schemaTokenEstimate: expect.any(Number),
+    });
+  });
+
+  it('reports every metric that exceeds a scenario budget', () => {
+    const scenario: ToolSchemaScenario = {
+      name: 'tiny-budget',
+      config: DEFAULT_CONFIG,
+      textSearchAvailable: true,
+      budget: {
+        schemaTokenEstimate: 1,
+        descriptionTokenEstimate: 1,
+        descriptionCount: 1,
+      },
+    };
+
+    const { measurements, offenders } = checkToolSchemaBudgets([scenario]);
+    const report = formatToolSchemaBudgetReport(measurements, offenders);
+
+    expect(offenders.map((offender) => offender.metric)).toEqual([
+      'schemaTokenEstimate',
+      'descriptionTokenEstimate',
+      'descriptionCount',
+    ]);
+    expect(report).toContain('tiny-budget.schemaTokenEstimate');
+    expect(report).toContain('Trim tool descriptions/schema payload');
+  });
+});


### PR DESCRIPTION
## Summary
- add `scripts/ci/check-tool-schema-budget.ts` to ratchet MCP tool schema size and description-string growth
- wire it into `npm run check:sizes` and the GitHub Actions size-budget step
- remove stale `~5K schema tokens` wording from README, published tool docs, and agent guidance
- add the completed ralphex plan with measured budget evidence

## Current measured budgets
`npm run check:sizes` now reports:
- `standard-default`: 9 tools, schema ~11,182 tokens, descriptions 145 / ~8,815 tokens
- `standard-full-git`: 12 tools, schema ~18,985 tokens, descriptions 258 / ~14,505 tokens
- `btp-full-git`: 12 tools, schema ~17,222 tokens, descriptions 256 / ~12,848 tokens
- `hyperfocused-default`: 1 tool, schema ~222 tokens, descriptions 6 / ~102 tokens

## Validation
- `npm test -- tests/unit/scripts/check-tool-schema-budget.test.ts`
- `npm run check:sizes`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

## Live SAP smoke
Read-only `SAPRead COMPONENTS` against the built CLI:
- NW 7.50 NPL over HTTPS: `SAP_BASIS=750`
- S/4HANA 2023 over HTTP: `SAP_BASIS=758`, `S4FND=108`
- ABAP Platform 2025 over HTTP: `SAP_BASIS=816`, `S4FND=109`
