### PR TITLE
perf(cache): batch warmup writes in transactions

### DIFF
--- a/docs/plans/completed/ralphex-sqlite-warmup-transactions.md
+++ b/docs/plans/completed/ralphex-sqlite-warmup-transactions.md
@@ -1,0 +1,109 @@
+# Ralphex SQLite Warmup Transactions
+
+## Overview
+
+This plan addresses external feedback point 6: ARC-1 uses `better-sqlite3`, which is appropriate for the single-process stdio/server model, but synchronous writes can block the event loop when many warmup entries are written one statement at a time. The highest-leverage fix is to batch pre-warmer writes in SQLite transactions so the startup TADIR scan does not pay per-statement commit overhead.
+
+The implementation adds a small transaction primitive to the cache interface. `SqliteCache` maps it to `better-sqlite3` transactions, while `MemoryCache` runs the callback inline. Warmup now fetches SAP objects outside any transaction, builds synchronous cache-write closures, and commits each parallel fetch batch in one transaction.
+
+## Context
+
+### Current State
+
+`src/cache/sqlite.ts` performs each `putSource`, `putNode`, `putEdge`, and `putFuncGroup` as an individual `better-sqlite3` statement. `src/cache/warmup.ts` fetches objects in batches of five, but writes source, node metadata, function-group mappings, and dependency edges inside each object indexing flow. That means a warmup batch can still issue many independent SQLite writes.
+
+The cache docs already state that warmup writes are batched, but the code did not enforce that. Warmup also received ETags from `getClass`, `getInterface`, and `getFunction`, but discarded them when storing source entries.
+
+### Target State
+
+Warmup performs all SAP/network work before opening a cache transaction. For each parallel fetch batch, successful indexing results contribute synchronous write closures. The batch then executes those writes through `Cache.transaction()`, so SQLite commits the batch atomically while memory cache behavior stays unchanged.
+
+Warmup source entries also preserve ETags returned by ADT, matching the published caching documentation and enabling conditional GETs after pre-warm.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/cache/cache.ts` | Cache interface; adds `transaction<T>()` |
+| `src/cache/sqlite.ts` | SQLite cache implementation; maps `transaction()` to `better-sqlite3` |
+| `src/cache/memory.ts` | Memory cache implementation; runs transaction callbacks inline |
+| `src/cache/warmup.ts` | TADIR warmup pipeline; batches cache writes per parallel fetch batch |
+| `tests/unit/cache/sqlite.test.ts` | SQLite transaction rollback coverage |
+| `tests/unit/cache/memory.test.ts` | Memory transaction behavior coverage |
+| `tests/unit/cache/warmup.test.ts` | Warmup batch transaction coverage |
+| `docs_page/caching.md` | Published caching behavior documentation |
+
+### Verified Live Evidence
+
+2026-06-12 live read smoke after implementation, using `node ./dist/cli.js call SAPRead --json '{"type":"COMPONENTS"}' --output json` with credentials parsed from `/Users/marianzeis/DEV/arc-1/.env.infrastructure`:
+
+- NW 7.50 NPL: HTTPS endpoint returned `SAP_BASIS=750`.
+- S/4HANA 2023: HTTP endpoint returned `SAP_BASIS=758`, `S4FND=108`.
+- ABAP Platform 2025: HTTP endpoint returned `SAP_BASIS=816`, `S4FND=109`.
+
+The transaction change is release-invariant because it only changes local cache write grouping after SAP responses have already been fetched and parsed. The smoke verifies the built CLI still performs read-only ADT round trips on all configured SAP releases.
+
+### Design Principles
+
+1. Never keep a SQLite transaction open across SAP HTTP calls or dependency extraction.
+2. Batch only synchronous cache writes, preserving the existing warmup concurrency of five SAP requests.
+3. Keep the cache abstraction simple: one generic `transaction<T>()` primitive instead of special warmup-only batch methods.
+4. Preserve memory-cache semantics and existing cache keys.
+5. Preserve ADT ETags during warmup because the source read result already exposes them and the docs claim warmup stores them.
+
+## Development Approach
+
+Add the cache transaction primitive first, then update warmup to return write closures instead of writing inline during object indexing. This keeps failure handling straightforward: fetch/index failures still return per-object status, while a batch storage failure is logged and counted as failed for that batch.
+
+Tests cover the new abstraction and the warmup behavior. SQLite gets a rollback test to prove `better-sqlite3` transactions are active. Memory gets an inline callback test. Warmup gets a fake ADT client that returns two TADIR entries in one batch and a tracking cache that asserts only one cache transaction is used.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Add cache transaction primitive
+
+**Files:**
+- Modify: `src/cache/cache.ts`
+- Modify: `src/cache/sqlite.ts`
+- Modify: `src/cache/memory.ts`
+- Modify: `tests/unit/cache/sqlite.test.ts`
+- Modify: `tests/unit/cache/memory.test.ts`
+
+Expose one transaction primitive that both cache implementations support.
+
+- [x] Add `transaction<T>(fn: () => T): T` to the `Cache` interface.
+- [x] Implement `SqliteCache.transaction()` with `this.db.transaction(fn)()`.
+- [x] Implement `MemoryCache.transaction()` by running the callback inline.
+- [x] Add SQLite rollback coverage for a throwing transaction callback.
+- [x] Add memory-cache coverage that the callback result is returned and writes persist.
+
+### Task 2: Batch warmup writes per parallel fetch batch
+
+**Files:**
+- Modify: `src/cache/warmup.ts`
+- Create: `tests/unit/cache/warmup.test.ts`
+- Modify: `docs_page/caching.md`
+
+Refactor warmup so SAP I/O remains outside transactions and cache writes are committed per batch.
+
+- [x] Introduce `WarmupIndexResult` with optional write closure.
+- [x] Change CLAS/INTF indexing to compute source hash, node metadata, dependency edges, and an eventual cache write closure.
+- [x] Change function-group indexing to collect mapping/source/node/edge writes for each function module.
+- [x] Add `applyWarmupWrites()` to execute all result write closures inside one `cache.transaction()` call per warmup batch.
+- [x] Preserve ADT ETags when warmup stores CLAS, INTF, and FUNC source entries.
+- [x] Add a warmup unit test proving two fetched objects in one batch are stored in one cache transaction.
+- [x] Update caching docs to state that writes from each parallel fetch batch are committed in one cache transaction.
+- [x] Run focused cache tests: `npm test -- tests/unit/cache/sqlite.test.ts tests/unit/cache/memory.test.ts tests/unit/cache/warmup.test.ts`.
+
+### Task 3: Final verification
+
+- [x] Run full test suite: `npm test` - all tests pass.
+- [x] Run typecheck: `npm run typecheck` - no errors.
+- [x] Run lint: `npm run lint` - no errors.
+- [x] Run build: `npm run build` - no errors.
+- [x] Live SAP read-only smoke on 7.50 via HTTPS: `SAPRead COMPONENTS` returned `SAP_BASIS=750`.
+- [x] Live SAP read-only smoke on 2023 via HTTP: `SAPRead COMPONENTS` returned `SAP_BASIS=758`.
+- [x] Live SAP read-only smoke on 2025 via HTTP: `SAPRead COMPONENTS` returned `SAP_BASIS=816`.

--- a/docs_page/caching.md
+++ b/docs_page/caching.md
@@ -243,7 +243,7 @@ The pre-warmer runs at startup when `ARC1_CACHE_WARMUP=true`. It populates the c
 2. **Fetch** — retrieves source code for each object in parallel batches of 5 concurrent requests. Stores body + ETag.
 3. **Delta check** — compares the SHA-256 hash of fetched source against the cached hash. If unchanged, the object is skipped (no re-parsing).
 4. **Extract** — runs the local AST parser (`@abaplint/core`) on each changed source to extract dependencies. No additional ADT calls are needed for this step.
-5. **Index** — stores source, node metadata, and dependency edges in the cache. For function groups, individual function modules are enumerated and indexed separately.
+5. **Index** — stores source, node metadata, and dependency edges in the cache. Writes from each parallel fetch batch are committed in one cache transaction, so SQLite warmup avoids per-statement commits on the request path. For function groups, individual function modules are enumerated and indexed separately.
 6. **Enable reverse lookup** — sets the `warmupDone` flag, which enables `SAPContext(action="usages")`.
 
 After warmup completes, subsequent reads of warmed objects use conditional GET — so a re-read against a server with the same content costs ~50 bytes per object.

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -133,6 +133,7 @@ export interface Cache {
   // Management
   clear(): void;
   stats(): CacheStats;
+  transaction<T>(fn: () => T): T;
   close(): void;
 }
 

--- a/src/cache/memory.ts
+++ b/src/cache/memory.ts
@@ -170,6 +170,10 @@ export class MemoryCache implements Cache {
     };
   }
 
+  transaction<T>(fn: () => T): T {
+    return fn();
+  }
+
   close(): void {
     this.clear();
   }

--- a/src/cache/sqlite.ts
+++ b/src/cache/sqlite.ts
@@ -283,6 +283,10 @@ export class SqliteCache implements Cache {
     return { nodeCount, edgeCount, apiCount, sourceCount, contractCount };
   }
 
+  transaction<T>(fn: () => T): T {
+    return this.db.transaction(fn)();
+  }
+
   close(): void {
     this.db.close();
   }

--- a/src/cache/warmup.ts
+++ b/src/cache/warmup.ts
@@ -45,6 +45,14 @@ interface TadirEntry {
   packageName: string;
 }
 
+type WarmupIndexStatus = 'fetched' | 'skipped' | 'failed';
+
+interface WarmupIndexResult {
+  status: WarmupIndexStatus;
+  edges: number;
+  write?: () => void;
+}
+
 /**
  * Run cache warmup: enumerate + fetch + index all custom objects.
  *
@@ -86,6 +94,16 @@ export async function runWarmup(
       }),
     );
 
+    try {
+      applyWarmupWrites(cachingLayer, results);
+    } catch (err) {
+      logger.warn('Cache warmup: failed to store indexed batch', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      failed += results.length;
+      continue;
+    }
+
     for (const r of results) {
       if (r.status === 'fetched') {
         fetched++;
@@ -118,6 +136,15 @@ export async function runWarmup(
   });
 
   return { totalObjects: entries.length, fetched, skipped, failed, edgesCreated, durationMs };
+}
+
+function applyWarmupWrites(cachingLayer: CachingLayer, results: WarmupIndexResult[]): void {
+  const writers = results.flatMap((result) => (result.write ? [result.write] : []));
+  if (writers.length === 0) return;
+
+  cachingLayer.cache.transaction(() => {
+    for (const write of writers) write();
+  });
 }
 
 /**
@@ -210,7 +237,7 @@ async function indexObject(
   client: AdtClient,
   cachingLayer: CachingLayer,
   entry: TadirEntry,
-): Promise<{ status: 'fetched' | 'skipped' | 'failed'; edges: number }> {
+): Promise<WarmupIndexResult> {
   const { objectType, objectName, packageName } = entry;
 
   // For FUGR: we enumerate the function modules within the group
@@ -220,14 +247,17 @@ async function indexObject(
 
   // Fetch source
   let source: string;
+  let etag: string | undefined;
   try {
     const cached = cachingLayer.getCachedSourceWithEtag(objectType, objectName);
     if (objectType === 'CLAS') {
       const result = await client.getClass(objectName, undefined, { ifNoneMatch: cached?.etag });
       source = result.notModified && cached ? cached.source : result.source;
+      etag = result.notModified && cached ? cached.etag : result.etag;
     } else if (objectType === 'INTF') {
       const result = await client.getInterface(objectName, { ifNoneMatch: cached?.etag });
       source = result.notModified && cached ? cached.source : result.source;
+      etag = result.notModified && cached ? cached.etag : result.etag;
     } else {
       return { status: 'failed', edges: 0 };
     }
@@ -242,37 +272,38 @@ async function indexObject(
     return { status: 'skipped', edges: 0 };
   }
 
-  // Store source
-  cachingLayer.cache.putSource(objectType, objectName, source);
-
-  // Store node metadata
-  cachingLayer.cache.putNode({
+  const cachedAt = new Date().toISOString();
+  const node = {
     id: `${objectType}:${objectName}`.toUpperCase(),
     objectType,
     objectName: objectName.toUpperCase(),
     packageName: packageName.toUpperCase(),
     sourceHash: newHash,
-    cachedAt: new Date().toISOString(),
+    cachedAt,
     valid: true,
-  });
+  };
 
-  // Extract and store dependencies as edges
+  // Extract dependencies before opening the SQLite transaction. Only the
+  // synchronous cache writes are batched; SAP/network work never runs inside it.
   const deps = extractDependencies(source, objectName, true);
-  let edges = 0;
   const fromId = objectName.toUpperCase();
-  for (const dep of deps) {
-    const edgeType = mapDepKindToEdgeType(dep.kind);
-    cachingLayer.cache.putEdge({
-      fromId,
-      toId: dep.name.toUpperCase(),
-      edgeType,
-      discoveredAt: new Date().toISOString(),
-      valid: true,
-    });
-    edges++;
-  }
+  const edgeRecords = deps.map((dep) => ({
+    fromId,
+    toId: dep.name.toUpperCase(),
+    edgeType: mapDepKindToEdgeType(dep.kind),
+    discoveredAt: cachedAt,
+    valid: true,
+  }));
 
-  return { status: 'fetched', edges };
+  return {
+    status: 'fetched',
+    edges: edgeRecords.length,
+    write: () => {
+      cachingLayer.cache.putSource(objectType, objectName, source, { etag });
+      cachingLayer.cache.putNode(node);
+      for (const edge of edgeRecords) cachingLayer.cache.putEdge(edge);
+    },
+  };
 }
 
 /**
@@ -283,57 +314,81 @@ async function indexFunctionGroup(
   cachingLayer: CachingLayer,
   groupName: string,
   packageName: string,
-): Promise<{ status: 'fetched' | 'skipped' | 'failed'; edges: number }> {
+): Promise<WarmupIndexResult> {
   try {
     const fg = await client.getFunctionGroup(groupName);
     let totalEdges = 0;
     let anyFetched = false;
+    const writers: Array<() => void> = [];
 
     // fg is a parsed object with functions list
     const fgData = typeof fg === 'string' ? JSON.parse(fg) : fg;
     const functions: string[] = fgData.functions ?? [];
 
     for (const funcName of functions) {
-      // Cache the group mapping
-      cachingLayer.cache.putFuncGroup(funcName, groupName);
+      const funcWriters: Array<() => void> = [() => cachingLayer.cache.putFuncGroup(funcName, groupName)];
 
       try {
         const cached = cachingLayer.getCachedSource('FUNC', funcName);
         const result = await client.getFunction(groupName, funcName, { ifNoneMatch: cached?.etag });
         const source = result.notModified && cached ? cached.source : result.source;
+        const etag = result.notModified && cached ? cached.etag : result.etag;
         const newHash = hashSource(source);
 
-        if (cached && cached.hash === newHash) continue;
+        if (cached && cached.hash === newHash) {
+          writers.push(() => {
+            for (const write of funcWriters) write();
+          });
+          continue;
+        }
 
-        cachingLayer.cache.putSource('FUNC', funcName, source);
-        cachingLayer.cache.putNode({
+        const cachedAt = new Date().toISOString();
+        const node = {
           id: `FUNC:${funcName}`.toUpperCase(),
           objectType: 'FUNC',
           objectName: funcName.toUpperCase(),
           packageName: packageName.toUpperCase(),
           sourceHash: newHash,
-          cachedAt: new Date().toISOString(),
+          cachedAt,
           valid: true,
-        });
+        };
 
         const deps = extractDependencies(source, funcName, true);
-        for (const dep of deps) {
-          cachingLayer.cache.putEdge({
-            fromId: funcName.toUpperCase(),
-            toId: dep.name.toUpperCase(),
-            edgeType: mapDepKindToEdgeType(dep.kind),
-            discoveredAt: new Date().toISOString(),
-            valid: true,
-          });
-          totalEdges++;
-        }
+        const edgeRecords = deps.map((dep) => ({
+          fromId: funcName.toUpperCase(),
+          toId: dep.name.toUpperCase(),
+          edgeType: mapDepKindToEdgeType(dep.kind),
+          discoveredAt: cachedAt,
+          valid: true,
+        }));
+        totalEdges += edgeRecords.length;
+        funcWriters.push(
+          () => cachingLayer.cache.putSource('FUNC', funcName, source, { etag }),
+          () => cachingLayer.cache.putNode(node),
+          ...edgeRecords.map((edge) => () => cachingLayer.cache.putEdge(edge)),
+        );
+        writers.push(() => {
+          for (const write of funcWriters) write();
+        });
         anyFetched = true;
       } catch {
         // Individual func fetch failure — continue with others
+        writers.push(() => {
+          for (const write of funcWriters) write();
+        });
       }
     }
 
-    return { status: anyFetched ? 'fetched' : 'skipped', edges: totalEdges };
+    return {
+      status: anyFetched ? 'fetched' : 'skipped',
+      edges: totalEdges,
+      write:
+        writers.length > 0
+          ? () => {
+              for (const write of writers) write();
+            }
+          : undefined,
+    };
   } catch {
     return { status: 'failed', edges: 0 };
   }

--- a/tests/unit/cache/memory.test.ts
+++ b/tests/unit/cache/memory.test.ts
@@ -203,6 +203,16 @@ describe('MemoryCache', () => {
   });
 
   describe('management', () => {
+    it('runs transaction callbacks inline', () => {
+      const result = cache.transaction(() => {
+        cache.putNode(makeNode('A'));
+        return 'done';
+      });
+
+      expect(result).toBe('done');
+      expect(cache.getNode('A')).not.toBeNull();
+    });
+
     it('returns correct stats including sourceCount and contractCount', () => {
       cache.putNode(makeNode('A'));
       cache.putNode(makeNode('B'));

--- a/tests/unit/cache/sqlite.test.ts
+++ b/tests/unit/cache/sqlite.test.ts
@@ -247,6 +247,17 @@ describe('SqliteCache', () => {
     expect(stats.contractCount).toBe(1);
   });
 
+  it('rolls back transaction writes when the callback throws', () => {
+    expect(() =>
+      cache.transaction(() => {
+        cache.putNode(makeNode('ROLLBACK'));
+        throw new Error('boom');
+      }),
+    ).toThrow('boom');
+
+    expect(cache.getNode('ROLLBACK')).toBeNull();
+  });
+
   it('clears all data including sources, dep graphs, and func groups', () => {
     cache.putNode(makeNode('A'));
     cache.putApi({ name: 'X', type: 'CLAS', releaseState: 'released' });

--- a/tests/unit/cache/warmup.test.ts
+++ b/tests/unit/cache/warmup.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AdtClient } from '../../../src/adt/client.js';
 import { CachingLayer } from '../../../src/cache/caching-layer.js';
 import { MemoryCache } from '../../../src/cache/memory.js';
+import { SqliteCache } from '../../../src/cache/sqlite.js';
 import { runWarmup } from '../../../src/cache/warmup.js';
 
 class TransactionTrackingCache extends MemoryCache {
@@ -13,37 +14,50 @@ class TransactionTrackingCache extends MemoryCache {
   }
 }
 
+class TransactionTrackingSqliteCache extends SqliteCache {
+  transactionCalls = 0;
+
+  override transaction<T>(fn: () => T): T {
+    this.transactionCalls += 1;
+    return super.transaction(fn);
+  }
+}
+
+// One CLAS that depends on one INTF, both returned in a single warmup batch.
+function makeWarmupClient(): AdtClient {
+  return {
+    runQuery: vi.fn(async (sql: string) => ({
+      rows: sql.includes("LIKE 'Z%'")
+        ? [
+            { OBJECT: 'CLAS', OBJ_NAME: 'ZCL_WARMUP_TX', DEVCLASS: 'ZPKG' },
+            { OBJECT: 'INTF', OBJ_NAME: 'ZIF_WARMUP_TX', DEVCLASS: 'ZPKG' },
+          ]
+        : [],
+    })),
+    getClass: vi.fn(async () => ({
+      source: [
+        'CLASS zcl_warmup_tx DEFINITION PUBLIC FINAL CREATE PUBLIC.',
+        '  PUBLIC SECTION.',
+        '    INTERFACES zif_warmup_tx.',
+        'ENDCLASS.',
+        'CLASS zcl_warmup_tx IMPLEMENTATION.',
+        'ENDCLASS.',
+      ].join('\n'),
+      etag: 'class-etag',
+    })),
+    getInterface: vi.fn(async () => ({
+      source: ['INTERFACE zif_warmup_tx PUBLIC.', 'ENDINTERFACE.'].join('\n'),
+      etag: 'interface-etag',
+    })),
+  } as unknown as AdtClient;
+}
+
 describe('cache warmup', () => {
   it('stores fetched object writes in one transaction per warmup batch', async () => {
     const cache = new TransactionTrackingCache();
     const cachingLayer = new CachingLayer(cache);
-    const client = {
-      runQuery: vi.fn(async (sql: string) => ({
-        rows: sql.includes("LIKE 'Z%'")
-          ? [
-              { OBJECT: 'CLAS', OBJ_NAME: 'ZCL_WARMUP_TX', DEVCLASS: 'ZPKG' },
-              { OBJECT: 'INTF', OBJ_NAME: 'ZIF_WARMUP_TX', DEVCLASS: 'ZPKG' },
-            ]
-          : [],
-      })),
-      getClass: vi.fn(async () => ({
-        source: [
-          'CLASS zcl_warmup_tx DEFINITION PUBLIC FINAL CREATE PUBLIC.',
-          '  PUBLIC SECTION.',
-          '    INTERFACES zif_warmup_tx.',
-          'ENDCLASS.',
-          'CLASS zcl_warmup_tx IMPLEMENTATION.',
-          'ENDCLASS.',
-        ].join('\n'),
-        etag: 'class-etag',
-      })),
-      getInterface: vi.fn(async () => ({
-        source: ['INTERFACE zif_warmup_tx PUBLIC.', 'ENDINTERFACE.'].join('\n'),
-        etag: 'interface-etag',
-      })),
-    } as unknown as AdtClient;
 
-    const result = await runWarmup(client, cachingLayer);
+    const result = await runWarmup(makeWarmupClient(), cachingLayer);
 
     expect(result).toMatchObject({ totalObjects: 2, fetched: 2, failed: 0 });
     expect(cache.transactionCalls).toBe(1);
@@ -51,5 +65,27 @@ describe('cache warmup', () => {
     expect(cache.getSource('INTF', 'ZIF_WARMUP_TX')?.etag).toBe('interface-etag');
     expect(cache.getNode('CLAS:ZCL_WARMUP_TX')).not.toBeNull();
     expect(cachingLayer.isWarmupAvailable).toBe(true);
+  });
+
+  // The MemoryCache test above only proves the closure-collection logic, since
+  // MemoryCache.transaction() is a no-op pass-through. This exercises the real
+  // better-sqlite3 transaction path — the actual target of this change — and
+  // proves writes (incl. ETags) survive the commit.
+  it('commits a warmup batch through a real SQLite transaction with ETags preserved', async () => {
+    const cache = new TransactionTrackingSqliteCache(':memory:');
+    const cachingLayer = new CachingLayer(cache);
+
+    try {
+      const result = await runWarmup(makeWarmupClient(), cachingLayer);
+
+      expect(result).toMatchObject({ totalObjects: 2, fetched: 2, failed: 0 });
+      expect(cache.transactionCalls).toBe(1);
+      expect(cache.getSource('CLAS', 'ZCL_WARMUP_TX')?.etag).toBe('class-etag');
+      expect(cache.getSource('INTF', 'ZIF_WARMUP_TX')?.etag).toBe('interface-etag');
+      expect(cache.getNode('CLAS:ZCL_WARMUP_TX')).not.toBeNull();
+      expect(cachingLayer.isWarmupAvailable).toBe(true);
+    } finally {
+      cache.close();
+    }
   });
 });

--- a/tests/unit/cache/warmup.test.ts
+++ b/tests/unit/cache/warmup.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AdtClient } from '../../../src/adt/client.js';
+import { CachingLayer } from '../../../src/cache/caching-layer.js';
+import { MemoryCache } from '../../../src/cache/memory.js';
+import { runWarmup } from '../../../src/cache/warmup.js';
+
+class TransactionTrackingCache extends MemoryCache {
+  transactionCalls = 0;
+
+  override transaction<T>(fn: () => T): T {
+    this.transactionCalls += 1;
+    return super.transaction(fn);
+  }
+}
+
+describe('cache warmup', () => {
+  it('stores fetched object writes in one transaction per warmup batch', async () => {
+    const cache = new TransactionTrackingCache();
+    const cachingLayer = new CachingLayer(cache);
+    const client = {
+      runQuery: vi.fn(async (sql: string) => ({
+        rows: sql.includes("LIKE 'Z%'")
+          ? [
+              { OBJECT: 'CLAS', OBJ_NAME: 'ZCL_WARMUP_TX', DEVCLASS: 'ZPKG' },
+              { OBJECT: 'INTF', OBJ_NAME: 'ZIF_WARMUP_TX', DEVCLASS: 'ZPKG' },
+            ]
+          : [],
+      })),
+      getClass: vi.fn(async () => ({
+        source: [
+          'CLASS zcl_warmup_tx DEFINITION PUBLIC FINAL CREATE PUBLIC.',
+          '  PUBLIC SECTION.',
+          '    INTERFACES zif_warmup_tx.',
+          'ENDCLASS.',
+          'CLASS zcl_warmup_tx IMPLEMENTATION.',
+          'ENDCLASS.',
+        ].join('\n'),
+        etag: 'class-etag',
+      })),
+      getInterface: vi.fn(async () => ({
+        source: ['INTERFACE zif_warmup_tx PUBLIC.', 'ENDINTERFACE.'].join('\n'),
+        etag: 'interface-etag',
+      })),
+    } as unknown as AdtClient;
+
+    const result = await runWarmup(client, cachingLayer);
+
+    expect(result).toMatchObject({ totalObjects: 2, fetched: 2, failed: 0 });
+    expect(cache.transactionCalls).toBe(1);
+    expect(cache.getSource('CLAS', 'ZCL_WARMUP_TX')?.etag).toBe('class-etag');
+    expect(cache.getSource('INTF', 'ZIF_WARMUP_TX')?.etag).toBe('interface-etag');
+    expect(cache.getNode('CLAS:ZCL_WARMUP_TX')).not.toBeNull();
+    expect(cachingLayer.isWarmupAvailable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a small `Cache.transaction()` primitive for SQLite and memory caches
- refactor cache warmup so each parallel fetch batch commits cache writes in one transaction
- preserve ADT ETags when warmup stores CLAS/INTF/FUNC source entries
- add transaction rollback, memory transaction, and warmup batch-transaction tests
- update caching docs and add the completed ralphex plan

## Validation
- `npm test -- tests/unit/cache/sqlite.test.ts tests/unit/cache/memory.test.ts tests/unit/cache/warmup.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

## Live SAP smoke
Read-only `SAPRead COMPONENTS` against the built CLI:
- NW 7.50 NPL over HTTPS: `SAP_BASIS=750`
- S/4HANA 2023 over HTTP: `SAP_BASIS=758`, `S4FND=108`
- ABAP Platform 2025 over HTTP: `SAP_BASIS=816`, `S4FND=109`
