### PR TITLE
test(server): de-flake auth-rate-limit (one server per test) + diagnosable transport errors

### DIFF
--- a/docs/plans/completed/fix-auth-rate-limit-test-flake.md
+++ b/docs/plans/completed/fix-auth-rate-limit-test-flake.md
@@ -144,8 +144,9 @@ including 429, is the system under test and must never be retried).
       only the bare reject changes.
 - [ ] Add one failure-path unit test (~1 test) in a new `describe('test helpers')`:
       create `withJsonServer`, `await close()` it, then `post()` → expect the rejection message to
-      match `/POST \/authorize request #\d+ failed: /` (proves the context wrapper; the retry path
-      is exercised implicitly since ECONNREFUSED to a closed server retries once then rejects).
+      match `/POST \/authorize request #\d+ failed/` — no trailing `: ` since the retry path's
+      message is "failed after retry: <code>" (proves the context wrapper; the retry path is
+      exercised implicitly since ECONNREFUSED to a closed server retries once then rejects).
 - [ ] Run `npx vitest run tests/unit/server/auth-rate-limit.test.ts` — 17/17 green, then
       `npm test` — all green.
 

--- a/docs/plans/completed/fix-auth-rate-limit-test-flake.md
+++ b/docs/plans/completed/fix-auth-rate-limit-test-flake.md
@@ -1,0 +1,180 @@
+# Fix the `auth-rate-limit.test.ts` full-suite flake (per-request server churn)
+
+## Overview
+
+One full-suite run (2026-06-12, during PR #406 verification) failed exactly two tests in
+`tests/unit/server/auth-rate-limit.test.ts` — both passed in isolation and on re-run, both failed
+*fast* (13ms/2ms vs a normal multi-request runtime), and both are the heaviest users of the
+`fireJsonPost` helper, which creates a **new HTTP server per request** (`listen(0)` → 1 request →
+`close()`; the bug_006 test alone churns 16 server lifecycles). The sibling helper `fireRequests`
+in the same file already uses the correct one-server-for-N-requests lifecycle and none of its tests
+flaked. This plan removes the churn (one server per test), adds error context + a bounded
+transport-level retry so any future occurrence is self-diagnosing instead of a bare reject, and
+records the validation protocol. Evidence and hypothesis ranking:
+[docs/research/auth-rate-limit-test-flake.md](../../research/auth-rate-limit-test-flake.md) — cite it,
+don't re-derive.
+
+Honest framing baked into this plan: the flake was **not reproduced** (0/25 isolated, 0/3 full
+suites); the fix targets the best-evidenced structural mechanism (H1: transient socket error under
+full-suite load rejecting the bare per-request promise) and is a pure consistency win with
+`fireRequests` even if H1 were wrong. No production code changes; rate-limit assertions stay
+byte-identical.
+
+## Context
+
+### Current State
+
+- `tests/unit/server/auth-rate-limit.test.ts` (352 lines, 16 tests) has two HTTP helpers with
+  divergent lifecycles: `fireRequests` (~line 34) — ONE `http.createServer(app)` + `listen(0)` for
+  N requests, close once; `fireJsonPost` (~line 192) — a NEW server per call, closed in `finally`,
+  with `req.on('error', reject)` rejecting bare (no path/iteration/syscall context).
+- The two historically-flaky tests both live in `describe('/authorize JSON-RPC dispatch (Copilot
+  Studio MCP fix via skip())')` and call `fireJsonPost` in loops:
+  `it('regression (bug_006): POST /authorize with falsy jsonrpc still uses the OAuth cap')`
+  (~line 268; 4 IPs × 4 requests = 16 server lifecycles) and
+  `it('JSON-RPC /authorize and /mcp use independent stores (separate caps each)')` (~line 294;
+  7 lifecycles). Two more tests in that describe use the helper with fewer calls — the dispatch
+  describe has 4 tests total and FIVE textual `fireJsonPost` call sites (~249, ~261, ~284, ~306,
+  ~311; the independent-stores test calls from two sites).
+- Hypotheses H2 (60s-window timing) and H3 (cross-test bucket pollution) are ruled out in the
+  dossier — fresh app+store per test, distinct IPs, <1s runtimes vs a 60s fixed window.
+- `src/server/auth-rate-limit.ts` is NOT implicated; nothing in this plan touches `src/`.
+
+### Target State
+
+`fireJsonPost`'s per-request server churn is gone: each test obtains one listening server and a
+`post()` closure, fires its requests through it, and closes once. Transport-level errors (no HTTP
+response at all) are retried once for known-transient syscalls and otherwise rejected with a
+message naming the path, request index, and `err.code`. The flake's most plausible mechanism is
+structurally removed; if anything ever fails there again, the failure text says exactly what broke.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `tests/unit/server/auth-rate-limit.test.ts` | The only file changed: helpers + the 5 call sites in the dispatch describe |
+| `tests/unit/server/mcp-rate-limit.test.ts` | Verify-only: confirmed it has NO references to this file or its helpers (its header points at dispatch-rate-limit.test.ts); unaffected |
+| `src/server/auth-rate-limit.ts` | Verify-only: must NOT change |
+| `docs/research/auth-rate-limit-test-flake.md` | Dossier — status flipped when this lands |
+
+### Verified Live Evidence
+
+Not SAP-touching (test infrastructure only). Reproduction attempts on main @ `0855e2c6`
+(2026-06-12, recorded in the dossier): 25× isolated `npx vitest run
+tests/unit/server/auth-rate-limit.test.ts` → 0 failures; 3× full `npm test` (3,754 tests) →
+0 failures. The single observed occurrence (PR #406 gate run) failed the two named tests in
+13ms/2ms with truncated failure text.
+
+### Design Principles
+
+1. **Remove the mechanism, don't mask the symptom** — no `test.retry()`/vitest retries (they would
+   hide real limiter regressions). The only retry permitted is at the HTTP-transport level (request
+   errored before ANY response), once, for `ECONNRESET`/`ECONNREFUSED`/`EADDRNOTAVAIL`, with a
+   `console.warn` so it is visible in output. A 429 (or any HTTP response) is NEVER retried — that
+   is the behavior under test.
+2. **Assertions stay byte-identical** — the rate-limit semantics of all 16 tests are untouched;
+   only the transport plumbing changes.
+3. **Mirror the in-file prior art** — `fireRequests` is the lifecycle template; the refactored
+   helper should make the two visibly consistent.
+4. **Test-only change** — `test(server):` commit, no release, no production diff. Release-invariant
+   by construction (no SAP interaction).
+
+## Development Approach
+
+Mechanical refactor with the suite as the harness: restructure the helper, update the five call
+sites in the dispatch describe one test at a time, run the file after each. The "failure path" here
+is the helper's own error path — covered by asserting the new error message shape via a request to
+a deliberately-closed server (one new unit test). Then run the flake-hunt protocol (Task 3) to
+demonstrate stability under the same conditions used for the baseline. Scope guard: do NOT touch
+`fireRequests`' lifecycle (already correct) beyond adopting the same error-context wrapper, and do
+NOT modify `src/`.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Replace `fireJsonPost`'s per-request server with a one-server-per-test helper
+
+**Files:**
+- Modify: `tests/unit/server/auth-rate-limit.test.ts` (helper at ~192 + 5 call sites in
+  `describe('/authorize JSON-RPC dispatch (Copilot Studio MCP fix via skip())')` at ~172–313)
+
+`fireJsonPost` creates and tears down an `http.Server` for every request (16 lifecycles in the
+bug_006 test) — the front-runner mechanism for the one observed full-suite flake (dossier H1) and
+inconsistent with the in-file `fireRequests` template. Replace it with a one-server closure API.
+
+- [ ] Replace `fireJsonPost(app, path, body, ip)` with a `withJsonServer` helper directly above the
+      dispatch describe. Shape (embed exactly; adjust only if compilation requires):
+
+      async function withJsonServer(app: express.Express): Promise<{
+        post: (path: string, body: object, ip?: string) => Promise<{ status: number; headers: Record<string, string> }>;
+        close: () => Promise<void>;
+      }> { /* one http.createServer(app) + listen(0); post() reuses the port; close() once */ }
+
+      `post()` keeps the exact request shape of today's `fireJsonPost` (JSON body, Content-Type,
+      Content-Length, `X-Forwarded-For: ip` defaulting to `'10.7.7.1'`).
+- [ ] Update the five call sites in the dispatch describe to
+      `const srv = await withJsonServer(app); try { ... await srv.post(path, body, ip) ... } finally { await srv.close(); }` —
+      assertions and request sequences byte-identical (e.g. bug_006 still fires 4×4 across its four
+      IPs; independent-stores still fires its 6-request sequence + the 7th expecting 429).
+- [ ] Internal request counter: `post()` tracks an incrementing index per server for error messages
+      (Task 2 uses it).
+- [ ] Run `npx vitest run tests/unit/server/auth-rate-limit.test.ts` — 16/16 green, then
+      `npm test` — all green.
+
+### Task 2: Error context + bounded transport-level retry in both helpers
+
+**Files:**
+- Modify: `tests/unit/server/auth-rate-limit.test.ts` (`withJsonServer.post` from Task 1, and
+  `fireRequests` at ~34)
+
+The observed flake failed with truncated, context-free output. Make any future transport failure
+name itself, and absorb the known-transient syscalls once (transport errors only — an HTTP response,
+including 429, is the system under test and must never be retried).
+
+- [ ] In `withJsonServer.post`: on `req.on('error', err)`, if `err.code` is one of
+      `ECONNRESET | ECONNREFUSED | EADDRNOTAVAIL` AND this is the first attempt for this request,
+      `console.warn(\`auth-rate-limit test: transient \${err.code} on \${path} request #\${i}, retrying once\`)`
+      and retry the same request once; otherwise reject with
+      `new Error(\`POST \${path} request #\${i} failed: \${err.code ?? err.message}\`)`.
+- [ ] Apply the same error-context wrapper (context message; retry optional but consistent) to
+      `fireRequests`' inner `req.on('error', reject)` (~line 73) — its lifecycle is already correct,
+      only the bare reject changes.
+- [ ] Add one failure-path unit test (~1 test) in a new `describe('test helpers')`:
+      create `withJsonServer`, `await close()` it, then `post()` → expect the rejection message to
+      match `/POST \/authorize request #\d+ failed: /` (proves the context wrapper; the retry path
+      is exercised implicitly since ECONNREFUSED to a closed server retries once then rejects).
+- [ ] Run `npx vitest run tests/unit/server/auth-rate-limit.test.ts` — 17/17 green, then
+      `npm test` — all green.
+
+### Task 3: Flake-hunt validation + dossier closeout
+
+**Files:**
+- Modify: `docs/research/auth-rate-limit-test-flake.md` (status + results)
+
+Stability can't be proven, but the baseline protocol from the dossier can be re-run on the fixed
+code and recorded. This is the plan's acceptance evidence.
+
+- [ ] Run the isolation loop: `for i in $(seq 1 25); do npx vitest run
+      tests/unit/server/auth-rate-limit.test.ts 2>&1 | grep -E "Tests  "; done` — expect 25× all-pass.
+- [ ] Run 3× full `npm test` — expect 3× all-pass (this matches the pre-fix baseline; the claim is
+      "no regression + mechanism removed", not "flake proven gone" — say so honestly).
+- [ ] Update the dossier: Status → "Implemented — churn removed + diagnosability added; see
+      docs/plans/completed/fix-auth-rate-limit-test-flake.md", append the post-fix protocol results,
+      and note that H1 remains unproven-but-removed.
+- [ ] Run `npm run typecheck` and `npm run lint` — clean.
+
+### Task 4: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass (count unchanged +1: the new helper
+      failure-path test).
+- [ ] Run typecheck: `npm run typecheck` — no errors.
+- [ ] Run lint: `npm run lint` — no errors.
+- [ ] `git diff src/` is EMPTY — test-only change (the plan's core constraint).
+- [ ] Grep the file for `fireJsonPost` — zero residual references (helper fully replaced).
+- [ ] Commit message: `test(server): one server per test in auth-rate-limit (de-flake) + diagnosable
+      transport errors` — no release.
+- [ ] Move this plan to `docs/plans/completed/`, then fix any relative links inside it (completed
+      plans sit one directory deeper — the dossier link at the top becomes `../../research/...`).

--- a/docs/research/auth-rate-limit-test-flake.md
+++ b/docs/research/auth-rate-limit-test-flake.md
@@ -1,0 +1,84 @@
+# Research: `auth-rate-limit.test.ts` full-suite flake
+
+**Date:** 2026-06-12
+**Status:** Implemented — churn removed (one server per test) + diagnosability added; see
+`docs/plans/completed/fix-auth-rate-limit-test-flake.md`. Post-fix protocol (main @ `c646c68a`):
+25/25 isolated runs pass; 3/3 full `npm test` (3,764 tests) pass — same all-green as the pre-fix
+baseline, so the claim is **"mechanism removed + no regression"**, NOT "flake proven gone" (H1
+remains unproven-but-structurally-removed). Any future occurrence now names its path, request index,
+and syscall instead of failing bare.
+
+## The observation (one occurrence, 2026-06-12, during PR #406 verification)
+
+One full `npm test` run failed exactly two tests; both passed in isolation (16/16) and on an
+immediate full-suite re-run (3722/3722):
+
+```
+❯ tests/unit/server/auth-rate-limit.test.ts (16 tests | 2 failed) 82ms
+  × regression (bug_006): POST /authorize with falsy jsonrpc still uses the OAuth cap  13ms
+  × JSON-RPC /authorize and /mcp use independent stores (separate caps each)  2ms
+```
+
+Notable: **fast failures** (13ms / 2ms — a passing bug_006 run does 16 HTTP round-trips and takes
+far longer), the failure text was not captured (log truncation), and the two failing tests are
+exactly the two heaviest users of the `fireJsonPost` helper.
+
+## Reproduction attempts (main @ 0855e2c6, this machine)
+
+- 25× sequential isolated runs of the file: **0 failures**.
+- 3× full `npm test` (3,754 tests each): **0 failures**.
+
+→ Rare flake (≲1 in ~6+ full-suite runs historically; not on demand). The plan therefore cannot rest
+on a reproduced root cause; it must (a) remove the structural defect that best explains the
+signature and (b) make any future occurrence self-diagnosing.
+
+## Code analysis — the structural defect
+
+`tests/unit/server/auth-rate-limit.test.ts` has two HTTP helpers with **divergent lifecycles**:
+
+- `fireRequests` (line 34): creates **one** `http.Server` (`listen(0)`), fires N requests through
+  it, closes once. Used by the basic limiter tests — none of which flaked.
+- `fireJsonPost` (line 192): creates a **new server per request** — `listen(0)` → one request →
+  `server.close()` — inside the per-request promise; `req.on('error', reject)` turns any transient
+  socket error into a test failure with no context.
+
+The two flaky tests hammer that per-request lifecycle hardest:
+- bug_006 (line 268): 4 IP variants × 4 requests = **16 listen/connect/close cycles** in one test.
+- independent-stores (line 294): 7 cycles.
+
+### Hypotheses, ranked
+
+| # | Mechanism | Fits the signature? | Verdict |
+|---|---|---|---|
+| **H1** | Per-request server churn: under full-suite load (parallel vitest workers, heavy socket traffic), a transient `connect`/`listen` error (ECONNRESET/ECONNREFUSED/EADDRNOTAVAIL during ephemeral-port pressure) rejects the bare promise → instant test failure | **Yes** — explains fast-fail (2ms/13ms), full-suite-only occurrence, and why only the per-request-server tests failed | **Front-runner** |
+| H2 | express-rate-limit window timing (60s fixed window resets mid-test) | No — each test builds a fresh app/store; tests run <1s; a fresh store's reset fires 60s after creation | Implausible |
+| H3 | Cross-test bucket pollution (shared IP keys) | No — vitest isolates module registries per file; within the file each test builds a fresh app; bug_006 uses distinct IPs per variant | Implausible |
+| H4 | `captureAuditEvents` sink leak (sinks registered per test, never removed — line 17) | No — neither flaky test registers a capture sink; the leak only costs wasted writes | Non-cause (hygiene note only) |
+
+Supporting H1: Node's `server.close()` is awaited per request, so each cycle also races socket
+teardown (`TIME_WAIT` accumulation across 3,754-test runs); and an `Error: connect ECONNRESET`
+rejection produces precisely an assertion-less fast failure that a truncated reporter line (`× …
+2ms`) would show.
+
+## Fix direction (for the plan)
+
+1. **Remove the churn:** rewrite `fireJsonPost` to the `fireRequests` lifecycle — one server per
+   test (helper returns `{ post(path, body, ip), close() }` or takes a request list), eliminating
+   15 of 16 listen/close cycles in bug_006. This is also a pure consistency fix with the
+   neighboring helper, worth doing even if H1 were wrong.
+2. **Make failures diagnosable:** wrap request errors with context (`path`, iteration, `err.code`)
+   so the NEXT occurrence — if any — names its syscall instead of failing bare. Optionally retry
+   once on the known-transient codes (ECONNRESET/ECONNREFUSED) *at the helper level* with a logged
+   warning; do NOT use vitest retry (it would mask real limiter regressions).
+3. **No assertion changes** — the tests' rate-limit semantics stay byte-identical.
+4. **Validation protocol** (proving a negative): 25× isolated loop + 3× full suite (the harness used
+   above, commands recorded here), plus reading the helper diff for lifecycle equivalence. State
+   plainly in the PR that the flake was not reproduced and the fix targets the best-evidenced
+   structural mechanism.
+
+**Commit type:** `test(server):` — test-infrastructure only, no production change, no release.
+
+## Non-goals
+
+- `captureAuditEvents` sink-leak cleanup (H4) — harmless; note only.
+- Touching `src/server/auth-rate-limit.ts` — nothing implicates production code.

--- a/tests/unit/server/auth-rate-limit.test.ts
+++ b/tests/unit/server/auth-rate-limit.test.ts
@@ -57,6 +57,12 @@ async function fireRequests(
         },
         (response) => {
           response.on('data', () => {});
+          // A reset between headers and body emits 'error' on the IncomingMessage, NOT on req —
+          // without this handler the promise never settles and vitest dies with a context-free
+          // unhandled error (the exact bare-failure class this helper exists to eliminate).
+          response.on('error', (err: NodeJS.ErrnoException) =>
+            reject(new Error(`GET /test request #${i + 1} response failed: ${err.code ?? err.message}`)),
+          );
           response.on('end', () => {
             resolve({
               status: response.statusCode ?? 0,
@@ -195,6 +201,11 @@ describe('/authorize JSON-RPC dispatch (Copilot Studio MCP fix via skip())', () 
 
   // Transport errors (no HTTP response at all) that are worth one retry under full-suite load.
   // An HTTP response — including 429, the behavior under test — never reaches the retry path.
+  // Known residual (accepted): a request the server COUNTED but whose response bytes were lost
+  // mid-flight also surfaces as ECONNRESET; the retry then consumes a second bucket slot, which
+  // could flip an expected 200 into 429 one request early. On loopback the realistic ECONNRESET
+  // causes are connect-phase/stale-socket resets the server never counted, so the retry is the
+  // right trade-off — and the console.warn below leaves a breadcrumb if the double-count ever bites.
   const TRANSIENT_CODES = new Set(['ECONNRESET', 'ECONNREFUSED', 'EADDRNOTAVAIL']);
 
   /**
@@ -237,6 +248,9 @@ describe('/authorize JSON-RPC dispatch (Copilot Studio MCP fix via skip())', () 
           },
           (response) => {
             response.on('data', () => {});
+            // Mid-body resets emit 'error' on the IncomingMessage, not on req — without this the
+            // promise never settles (the bare-failure class this helper exists to eliminate).
+            response.on('error', reject);
             response.on('end', () => {
               resolve({
                 status: response.statusCode ?? 0,

--- a/tests/unit/server/auth-rate-limit.test.ts
+++ b/tests/unit/server/auth-rate-limit.test.ts
@@ -70,7 +70,11 @@ async function fireRequests(
           });
         },
       );
-      req.on('error', reject);
+      // Name the failing request so a transport error under full-suite load is self-diagnosing
+      // (mirrors withJsonServer.post; see docs/research/auth-rate-limit-test-flake.md).
+      req.on('error', (err: NodeJS.ErrnoException) =>
+        reject(new Error(`GET /test request #${i + 1} failed: ${err.code ?? err.message}`)),
+      );
       req.end();
     });
     codes.push(res.status);
@@ -189,21 +193,36 @@ describe('/authorize JSON-RPC dispatch (Copilot Studio MCP fix via skip())', () 
     return app;
   }
 
-  async function fireJsonPost(
-    app: express.Express,
-    path: string,
-    body: object,
-    ip = '10.7.7.1',
-  ): Promise<{ status: number; headers: Record<string, string> }> {
+  // Transport errors (no HTTP response at all) that are worth one retry under full-suite load.
+  // An HTTP response — including 429, the behavior under test — never reaches the retry path.
+  const TRANSIENT_CODES = new Set(['ECONNRESET', 'ECONNREFUSED', 'EADDRNOTAVAIL']);
+
+  /**
+   * One server per test (mirrors `fireRequests`), replacing the former `fireJsonPost` that created
+   * and tore down a fresh `http.Server` per request — 16 listen/close cycles in the bug_006 test
+   * alone, the front-runner mechanism for the rare full-suite flake (docs/research/
+   * auth-rate-limit-test-flake.md). `post()` reuses the one listening port; transport errors are
+   * retried once for the known-transient codes and otherwise rejected with the path + request index
+   * + syscall so any future failure is self-diagnosing instead of a bare reject.
+   */
+  async function withJsonServer(app: express.Express): Promise<{
+    post: (path: string, body: object, ip?: string) => Promise<{ status: number; headers: Record<string, string> }>;
+    close: () => Promise<void>;
+  }> {
     const http = await import('node:http');
     const server = http.createServer(app);
     await new Promise<void>((r) => server.listen(0, r));
     const addr = server.address();
     if (!addr || typeof addr === 'string') throw new Error('server not listening');
     const port = addr.port;
-    const payload = JSON.stringify(body);
-    try {
-      return await new Promise<{ status: number; headers: Record<string, string> }>((resolve, reject) => {
+    let counter = 0;
+
+    function once(
+      path: string,
+      payload: string,
+      ip: string,
+    ): Promise<{ status: number; headers: Record<string, string> }> {
+      return new Promise((resolve, reject) => {
         const req = http.request(
           {
             hostname: '127.0.0.1',
@@ -235,34 +254,62 @@ describe('/authorize JSON-RPC dispatch (Copilot Studio MCP fix via skip())', () 
         req.write(payload);
         req.end();
       });
-    } finally {
-      await new Promise<void>((r) => server.close(() => r()));
     }
+
+    async function post(path: string, body: object, ip = '10.7.7.1') {
+      const n = ++counter;
+      const payload = JSON.stringify(body);
+      try {
+        return await once(path, payload, ip);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code && TRANSIENT_CODES.has(code)) {
+          console.warn(`auth-rate-limit test: transient ${code} on ${path} request #${n}, retrying once`);
+          try {
+            return await once(path, payload, ip);
+          } catch (retryErr) {
+            const rc = (retryErr as NodeJS.ErrnoException).code ?? (retryErr as Error).message;
+            throw new Error(`POST ${path} request #${n} failed after retry: ${rc}`);
+          }
+        }
+        throw new Error(`POST ${path} request #${n} failed: ${code ?? (err as Error).message}`);
+      }
+    }
+
+    return { post, close: () => new Promise<void>((r) => server.close(() => r())) };
   }
 
   it('JSON-RPC POST /authorize uses the /mcp cap, not the OAuth cap', async () => {
     // OAuth cap=2, /mcp cap=10. Fire 5 JSON-RPC POSTs to /authorize — all should pass
     // (would be capped at 2 if the OAuth limiter were applied).
-    const app = buildApp(2, 10);
-    const results: number[] = [];
-    for (let i = 0; i < 5; i++) {
-      const r = await fireJsonPost(app, '/authorize', { jsonrpc: '2.0', id: i, method: 'tools/list' });
-      results.push(r.status);
+    const srv = await withJsonServer(buildApp(2, 10));
+    try {
+      const results: number[] = [];
+      for (let i = 0; i < 5; i++) {
+        const r = await srv.post('/authorize', { jsonrpc: '2.0', id: i, method: 'tools/list' });
+        results.push(r.status);
+      }
+      expect(results).toEqual([200, 200, 200, 200, 200]);
+    } finally {
+      await srv.close();
     }
-    expect(results).toEqual([200, 200, 200, 200, 200]);
   });
 
   it('non-JSON-RPC POST /authorize still uses the OAuth cap', async () => {
     // OAuth cap=2. A POST body WITHOUT jsonrpc field (a real OAuth flow) — should hit
     // the OAuth cap at request 3.
-    const app = buildApp(2, 10);
-    const results: number[] = [];
-    for (let i = 0; i < 4; i++) {
-      const r = await fireJsonPost(app, '/authorize', { client_id: 'foo', response_type: 'code' });
-      results.push(r.status);
+    const srv = await withJsonServer(buildApp(2, 10));
+    try {
+      const results: number[] = [];
+      for (let i = 0; i < 4; i++) {
+        const r = await srv.post('/authorize', { client_id: 'foo', response_type: 'code' });
+        results.push(r.status);
+      }
+      expect(results.slice(0, 2)).toEqual([200, 200]);
+      expect(results.slice(2)).toEqual([429, 429]);
+    } finally {
+      await srv.close();
     }
-    expect(results.slice(0, 2)).toEqual([200, 200]);
-    expect(results.slice(2)).toEqual([429, 429]);
   });
 
   it('regression (bug_006): POST /authorize with falsy jsonrpc still uses the OAuth cap', async () => {
@@ -277,17 +324,21 @@ describe('/authorize JSON-RPC dispatch (Copilot Studio MCP fix via skip())', () 
       { falsy: 0, ip: '10.6.6.3' },
       { falsy: false, ip: '10.6.6.4' },
     ];
-    const app = buildApp(2, 10);
-    for (const { falsy, ip } of variants) {
-      const results: number[] = [];
-      for (let i = 0; i < 4; i++) {
-        const r = await fireJsonPost(app, '/authorize', { jsonrpc: falsy, client_id: 'foo' }, ip);
-        results.push(r.status);
+    const srv = await withJsonServer(buildApp(2, 10));
+    try {
+      for (const { falsy, ip } of variants) {
+        const results: number[] = [];
+        for (let i = 0; i < 4; i++) {
+          const r = await srv.post('/authorize', { jsonrpc: falsy, client_id: 'foo' }, ip);
+          results.push(r.status);
+        }
+        // Per-IP OAuth bucket of 2; the 3rd and 4th requests from the same IP
+        // must hit 429 — proving the OAuth limiter is applied to falsy-jsonrpc traffic.
+        expect(results.slice(0, 2)).toEqual([200, 200]);
+        expect(results.slice(2)).toEqual([429, 429]);
       }
-      // Per-IP OAuth bucket of 2; the 3rd and 4th requests from the same IP
-      // must hit 429 — proving the OAuth limiter is applied to falsy-jsonrpc traffic.
-      expect(results.slice(0, 2)).toEqual([200, 200]);
-      expect(results.slice(2)).toEqual([429, 429]);
+    } finally {
+      await srv.close();
     }
   });
 
@@ -299,17 +350,30 @@ describe('/authorize JSON-RPC dispatch (Copilot Studio MCP fix via skip())', () 
     // and not worth the complexity of a custom shared store.
     //
     // mcpCap=3. Fire 3 JSON-RPC POSTs each to /authorize and /mcp → all 6 pass.
-    const app = buildApp(2, 3);
-    const results: { path: string; status: number }[] = [];
-    const sequence = ['/authorize', '/authorize', '/authorize', '/mcp', '/mcp', '/mcp'];
-    for (const path of sequence) {
-      const r = await fireJsonPost(app, path, { jsonrpc: '2.0', id: 1, method: 'tools/list' });
-      results.push({ path, status: r.status });
+    const srv = await withJsonServer(buildApp(2, 3));
+    try {
+      const results: { path: string; status: number }[] = [];
+      const sequence = ['/authorize', '/authorize', '/authorize', '/mcp', '/mcp', '/mcp'];
+      for (const path of sequence) {
+        const r = await srv.post(path, { jsonrpc: '2.0', id: 1, method: 'tools/list' });
+        results.push({ path, status: r.status });
+      }
+      expect(results.every((r) => r.status === 200)).toBe(true);
+      // But each individual route still enforces its own cap.
+      const next = await srv.post('/authorize', { jsonrpc: '2.0', id: 4, method: 'tools/list' });
+      expect(next.status).toBe(429);
+    } finally {
+      await srv.close();
     }
-    expect(results.every((r) => r.status === 200)).toBe(true);
-    // But each individual route still enforces its own cap.
-    const next = await fireJsonPost(app, '/authorize', { jsonrpc: '2.0', id: 4, method: 'tools/list' });
-    expect(next.status).toBe(429);
+  });
+
+  it('post() rejects with path + request index context when the server is closed (diagnosability)', async () => {
+    // The former helper rejected bare on transport errors, producing context-free fast failures
+    // like the one observed full-suite flake. A closed server now yields a named rejection (and
+    // the ECONNREFUSED retry path runs once before it). See docs/research/auth-rate-limit-test-flake.md.
+    const srv = await withJsonServer(buildApp(2, 10));
+    await srv.close();
+    await expect(srv.post('/authorize', { jsonrpc: '2.0' })).rejects.toThrow(/POST \/authorize request #\d+ failed/);
   });
 });
 


### PR DESCRIPTION
## What

De-flake `tests/unit/server/auth-rate-limit.test.ts`. Plan + dossier: [completed/fix-auth-rate-limit-test-flake.md](docs/plans/completed/fix-auth-rate-limit-test-flake.md), [research/auth-rate-limit-test-flake.md](docs/research/auth-rate-limit-test-flake.md).

## The observation

One full `npm test` run (during PR #406 verification) failed exactly two tests — both passed in isolation (16/16) and on immediate re-run, both failed **fast** (13ms/2ms), and both are the heaviest users of the `fireJsonPost` helper, which created and tore down a **new `http.Server` per request** (16 listen/close cycles in the bug_006 test alone). The sibling `fireRequests` helper already used the correct one-server-for-N lifecycle and never flaked.

## Fix

- **`fireJsonPost` → `withJsonServer(app)`** returning `{ post(), close() }`: one listening server per test, reused across requests (mirrors `fireRequests`). Removes the per-request churn that is the best-evidenced mechanism (dossier H1).
- **Diagnosable transport errors:** request errors now reject with `POST <path> request #N failed: <syscall>`, and retry **once** for `ECONNRESET`/`ECONNREFUSED`/`EADDRNOTAVAIL` with a logged warning. An HTTP response — including `429`, the behavior under test — never reaches the retry path. Same wrapper added to `fireRequests`.
- New diagnosability test: `post()` against a closed server rejects with the named message.

## Honest framing

The flake was **not reproduced** (0/25 isolated + 0/3 full suites pre-fix). This PR **removes the mechanism** and makes any future occurrence self-diagnosing — it does not claim to "prove" the flake gone. Rate-limit assertions are byte-identical; **`git diff src/` is empty** (test-only).

## Validation (post-fix, recorded in the dossier)

- 25/25 isolated runs of the file pass.
- 3/3 full `npm test` (**3,764 tests**) pass.
- typecheck / lint / check:sizes green.

`test(server):` → no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review round (2 finder agents)

Three findings, fixed in the follow-up commit: (1) **neither helper attached `response.on('error')`** — a reset between headers and body emits `'error'` on the IncomingMessage, not on `req`, so the promise never settled and vitest died with a context-free unhandled error, the exact bare-failure class this PR eliminates; both helpers now route it into the named rejection. (2) The accepted **retry double-count residual** (a counted-but-undelivered request retried = second bucket slot) is now documented at `TRANSIENT_CODES` with the reasoning for keeping the retry. (3) The archived plan's prescribed rejection regex contradicted its own retry-path message — corrected. Assertion-identity audit of the 4 converted tests vs origin/main came back byte-identical; Node 22 `server.close()` idle-socket behavior empirically verified (no hang).
