### PR TITLE
test: isolate concurrent integration/e2e runs, add teardown janitor, fix flake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,7 +173,10 @@ SAP_TRANSPORT=stdio              # or: http-streamable
 # ── Test runner (integration/e2e) — see docs/dev-guide.md "Testing — concurrent runs" ──
 # These configure the TEST harness, not the server; only needed when running
 # integration/e2e concurrently against one SAP system.
-# TEST_RUN_ID=ab                 # short id stamped into generated object names (else random per run)
+# TEST_RUN_ID                    # letters-only id stamped into generated object names. LEAVE UNSET for
+#                                # an automatic per-run id (recommended). Pin only to make ONE run's
+#                                # objects recognisable — never set the SAME value in two concurrent
+#                                # worktrees, or their generated names collide.
 # TEST_FILE_PARALLELISM=true     # opt into 2-file-parallel integration runs (default: sequential)
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/.env.example
+++ b/.env.example
@@ -166,9 +166,15 @@ SAP_TRANSPORT=stdio              # or: http-streamable
 # headers to http_request audit events. Sensitive headers redacted, bodies
 # truncated at 64KB. Not for production. Default: false.
 # ARC1_LOG_HTTP_DEBUG=false
-# ARC1_MAX_CONCURRENT=10
+# ARC1_MAX_CONCURRENT=10         # lower toward ~4 when several test runs share one small SAP system
 # ARC1_TOOL_MODE=standard        # standard|hyperfocused
 # SAP_VERBOSE=false
+
+# ── Test runner (integration/e2e) — see docs/dev-guide.md "Testing — concurrent runs" ──
+# These configure the TEST harness, not the server; only needed when running
+# integration/e2e concurrently against one SAP system.
+# TEST_RUN_ID=ab                 # short id stamped into generated object names (else random per run)
+# TEST_FILE_PARALLELISM=true     # opt into 2-file-parallel integration runs (default: sequential)
 
 # ═══════════════════════════════════════════════════════════════════════════
 # MIGRATED/REMOVED ENV VARS — these will error at startup in v0.7

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -127,18 +127,28 @@ duplicating it here proved to drift). The compact per-variable table stays in AG
 Multiple integration/e2e runs can target ONE SAP system at once (several git worktrees, or a local
 run overlapping CI) without interfering. Mechanics and seams:
 
-- **Run identity** — `tests/helpers/run-id.ts` exports `RUN_ID`, a 2-char token (`TEST_RUN_ID` env if
-  set, else random per process). Every generated object name embeds it: `generateUniqueName`
-  (`tests/integration/crud-harness.ts`) and the shared `uniqueName` / `uniqueLettersName`
-  (`tests/e2e/helpers.ts`). This closes the same-millisecond collision window that timestamp +
-  process-local counter alone left open. Set `TEST_RUN_ID` to pin a readable id.
+- **Run identity** — `tests/helpers/run-id.ts` exports `RUN_ID`, a short LETTERS-ONLY token
+  (`TEST_RUN_ID` env if set — sanitised to A-Z, capped at 4 — else 2 random letters per process;
+  letters-only so one token works for both the alphanumeric `uniqueName` and the BDEF/CDS-safe
+  `uniqueLettersName` with no lossy mapping). Every generated object name embeds it:
+  `generateUniqueName` (`tests/integration/crud-harness.ts`) and the shared `uniqueName` /
+  `uniqueLettersName` (`tests/e2e/helpers.ts`). This closes the same-millisecond cross-process
+  collision window. LEAVE `TEST_RUN_ID` UNSET for an automatic per-run id — pin it only to make one
+  run's objects recognisable, and never to the SAME value in two concurrent worktrees (they'd
+  collide). `run-id.ts` loads `.env` itself, so a `.env`-set `TEST_RUN_ID` is honoured regardless of
+  import order.
 - **One e2e server per run** — `npm run test:e2e:full` now runs `scripts/e2e-run-local.sh`, which picks
   a FREE port and per-run PID/log paths (`/tmp/arc1-e2e-<id>.pid`, `/tmp/arc1-e2e-logs/<id>/`) and
   exports `TEST_RUN_ID`, so two local full runs don't kill each other (the old fixed port 3000 + fixed
-  PID file meant the second run murdered the first). CI is unchanged: it runs start/test/stop
-  separately on the fixed port 3000, one run at a time via the `…-sap-live-a4h` concurrency group.
-  Overrides: `E2E_MCP_PORT` pins the port (skips the free-port probe and the listener sweep guard),
-  `E2E_PID_FILE` / `E2E_LOG_DIR` pin paths, `E2E_MCP_URL` points the vitest client at the server.
+  PID file meant the second run murdered the first). A trap stops the server even if start or the
+  tests fail, and the start script kills its own spawn on a health-check timeout, so a failed start
+  never leaks a write-enabled server. CI is unchanged: it runs start/test/stop separately on the fixed
+  port 3000, one run at a time via the `…-sap-live-a4h` concurrency group. Overrides: `E2E_MCP_PORT`
+  pins the port (skips the free-port probe and the listener sweep guard), `E2E_PID_FILE` /
+  `E2E_LOG_DIR` pin paths, `E2E_MCP_URL` points the vitest client at the server. Note: under the
+  orchestrator the e2e JSON/JUnit results land in the per-run `E2E_LOG_DIR`, not `test-results/` (so
+  `npm run test:runtime-report`, which reads `test-results/`, reflects the integration suite — the F1
+  measurement target — not orchestrated e2e runs).
 - **Shared fixtures tolerate races** — `tests/e2e/setup.ts` reconciles a concurrent create (423 /
   "already exists") by re-polling the system instead of skipping; only a genuinely different fixture
   source (another branch mid-run) is skipped, and `assertSyncedFixturesActive` re-checks once after a

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -116,5 +116,49 @@ duplicating it here proved to drift). The compact per-variable table stays in AG
 | Add skip policy test | `tests/helpers/skip-policy.ts` |
 | Add expected error assertion | `tests/helpers/expected-error.ts` |
 | Add CRUD integration test | `tests/integration/crud-harness.ts`, `tests/integration/crud.lifecycle.integration.test.ts` |
+| Run integration/e2e concurrently vs one SAP system / isolate runs | `tests/helpers/run-id.ts` (`RUN_ID`/`TEST_RUN_ID`), `scripts/e2e-run-local.sh` (per-run port/PID/log), `tests/e2e/setup.ts` (race-tolerant fixture sync) — see "Testing — concurrent runs" below |
+| Opt into faster parallel integration runs | `vitest.integration.config.ts` (`TEST_FILE_PARALLELISM=true`, `maxWorkers: 2`) — default sequential; measure with `npm run test:runtime-report` |
+| Sweep leaked test objects after a crashed run | `scripts/test-janitor.ts` (`npm run test:cleanup`; dry-run by default, `-- --execute` deletes), `tests/helpers/test-prefixes.ts` (prefixes + pure selector, derived from the fixture list) |
 | Modify CI coverage reporting | `scripts/ci/coverage-summary.mjs`, `.github/workflows/test.yml`, `.github/workflows/release.yml` |
 | Modify CI reliability reporting | `scripts/ci/collect-test-reliability.mjs`, `scripts/ci/assert-required-test-execution.mjs`, `.github/workflows/test.yml` |
+
+## Testing — concurrent runs, isolation & teardown
+
+Multiple integration/e2e runs can target ONE SAP system at once (several git worktrees, or a local
+run overlapping CI) without interfering. Mechanics and seams:
+
+- **Run identity** — `tests/helpers/run-id.ts` exports `RUN_ID`, a 2-char token (`TEST_RUN_ID` env if
+  set, else random per process). Every generated object name embeds it: `generateUniqueName`
+  (`tests/integration/crud-harness.ts`) and the shared `uniqueName` / `uniqueLettersName`
+  (`tests/e2e/helpers.ts`). This closes the same-millisecond collision window that timestamp +
+  process-local counter alone left open. Set `TEST_RUN_ID` to pin a readable id.
+- **One e2e server per run** — `npm run test:e2e:full` now runs `scripts/e2e-run-local.sh`, which picks
+  a FREE port and per-run PID/log paths (`/tmp/arc1-e2e-<id>.pid`, `/tmp/arc1-e2e-logs/<id>/`) and
+  exports `TEST_RUN_ID`, so two local full runs don't kill each other (the old fixed port 3000 + fixed
+  PID file meant the second run murdered the first). CI is unchanged: it runs start/test/stop
+  separately on the fixed port 3000, one run at a time via the `…-sap-live-a4h` concurrency group.
+  Overrides: `E2E_MCP_PORT` pins the port (skips the free-port probe and the listener sweep guard),
+  `E2E_PID_FILE` / `E2E_LOG_DIR` pin paths, `E2E_MCP_URL` points the vitest client at the server.
+- **Shared fixtures tolerate races** — `tests/e2e/setup.ts` reconciles a concurrent create (423 /
+  "already exists") by re-polling the system instead of skipping; only a genuinely different fixture
+  source (another branch mid-run) is skipped, and `assertSyncedFixturesActive` re-checks once after a
+  short delay so a still-settling activation doesn't fail the sync. The rap SAPActivate tests create
+  transient `$TMP` objects rather than mutating the shared fixtures.
+- **Teardown backstop** — normal runs clean up after themselves (`CrudRegistry` + lock-aware
+  `retryDelete`); a crashed/interrupted run leaks objects. `npm run test:cleanup`
+  (`scripts/test-janitor.ts`) sweeps leftovers whose name strict-prefix-matches a canonical test
+  prefix, excluding the managed persistent fixtures. Dry-run by default; `-- --execute` deletes.
+  Prefixes + the pure selector live in `tests/helpers/test-prefixes.ts` (derived from
+  `PERSISTENT_OBJECTS`), so the cleanup set can't drift from what the suites create. Needs only SAP
+  creds (no running server). RAP/FUGR objects are intentionally out of scope (they self-clean and
+  need ordered teardown).
+- **Optional file parallelism** — `TEST_FILE_PARALLELISM=true npm run test:integration` runs up to two
+  files in parallel (`maxWorkers: 2` cap in `vitest.integration.config.ts`; `fileParallelism:false`
+  forces it to 1 otherwise). Default stays sequential because parallel files once exhausted SAP work
+  processes ("Service cannot be reached"). Measure before/after with `npm run test:runtime-report` and
+  watch for that error class before raising the cap. Size it against the system's `rdisp/wp_no_dia`;
+  the e2e server's per-request fan-out is separately capped by `ARC1_MAX_CONCURRENT` (default 10 —
+  lower toward ~4 when several runs share one small system).
+- **Not yet shipped** (see `docs/plans/test-isolation-and-parallel-runs.md`): CI `retry: 1` paired
+  with flake telemetry (H2), a parallel read-only e2e project (F2), and a cross-run flake-aggregation
+  workflow (H3). The plan rates these measure-first / conditional on the F1 numbers.

--- a/docs/plans/test-isolation-and-parallel-runs.md
+++ b/docs/plans/test-isolation-and-parallel-runs.md
@@ -1,0 +1,243 @@
+# Test Isolation, Parallel Instances & Flakiness Plan
+
+Status: P0–P2 + F1 shipped 2026-06-12 (H1, A1, A2, B1–B3, C1, C2, D1, E1/E2, F1, G1). Remaining /
+deferred: H2 (CI retry + flake telemetry — needs the vitest-4 reporter retry format verified first),
+F2 (parallel read-only e2e project — conditional on F1's CI numbers), H3 (cross-run flake-aggregation
+workflow), E3 (run manifest, optional), H4/H5 (SABP unit-test follow-up; flip execution-assert to
+enforce). C3/G2/G3/F3 remain explicitly rejected (§7).
+
+Goal: multiple integration/e2e runs (several local worktrees, local + CI) can target the **same SAP
+system at the same time** without affecting each other, each with proper teardown; selectively
+parallelize tests for speed; retire the remaining CI flakiness.
+
+---
+
+## 1. What actually interferes today (evidence)
+
+### 1.1 Same machine — two e2e runs kill each other (critical)
+
+- `scripts/e2e-start-local.sh:8-48` — fixed port `3000`, fixed PID file `/tmp/arc1-e2e.pid`, and a
+  belt-and-suspenders `lsof -tiTCP:$PORT | kill`. A second `test:e2e:start` **terminates the first
+  run's MCP server mid-flight**. This is the most violent interference and entirely local.
+- `E2E_LOG_DIR` defaults to a shared `/tmp/arc1-e2e-logs`; the start script truncates the log
+  (`> "${LOG_FILE}"`, line 69), so concurrent runs also destroy each other's logs.
+- Not affected: `test-results/*.json` and skip-NDJSON are cwd-relative (worktrees isolate them);
+  e2e runs with `ARC1_CACHE=memory` (line 80), so no sqlite cache file is shared.
+
+### 1.2 Same SAP system — shared persistent e2e fixtures (high)
+
+- 8 fixed-name fixtures in `$TMP` (`tests/e2e/fixtures.ts:30-79`: `ZARC1_TEST_REPORT`,
+  `ZARC1_E2E_DUMP`, `ZIF_ARC1_TEST`, `ZCL_ARC1_TEST`, `ZCL_ARC1_TEST_UT`, `ZTABL_ARC1_I33`,
+  `ZI_ARC1_I33_ROOT`, `ZI_ARC1_I33_PROJ`).
+- Sync (`tests/e2e/setup.ts`) **deletes + recreates on source drift**. Two runs on *different
+  branches* with different fixture sources will ping-pong the objects and break each other's
+  read-back assertions. Two runs on the *same* branch race only on first-create/recreate
+  (423 / "already exists" → classified as skip, so the loser silently skips tests).
+- `rap.e2e.test.ts:150-170` **mutates a shared fixture**: the `SAPActivate` tests lock+activate
+  `ZARC1_TEST_REPORT`. Two concurrent runs → 423 lock conflicts. (This same code path produced the
+  06-05 `SABP` package-ceiling failures — see §3.)
+- `assertSyncedFixturesActive()` (end of sync) can also trip over another instance that is mid-
+  recreate (its fixture is legitimately inactive for a few seconds).
+
+### 1.3 Same SAP system — name-collision window (medium-low)
+
+- Integration: `generateUniqueName` (`tests/integration/crud-harness.ts:21-28`) =
+  `prefix_` + last 6 chars of `Date.now().toString(36)` + a **process-local counter that starts
+  at 0**. Two runs launched in the same millisecond produce *identical* names (same ms, both at
+  counter 0). Unlikely per call, but the failure mode is a confusing cross-run 423/"already exists".
+- E2E: three different ad-hoc `uniqueName()` copies (`ddic-write.e2e.test.ts:12`,
+  `class-section-surgery.e2e.test.ts:17`, `func-write.e2e.test.ts:17`) plus a raw
+  `Date.now().slice(-6)` in `activation-failure.e2e.test.ts:48`. Most include `Math.random()`
+  (good), but the helpers are duplicated and inconsistent; none carry a run identity.
+- A per-run **local package** namespace already exists as prior art: `rap-write.e2e.test.ts:37`
+  creates `$ARC1T_<unique>` packages, allowlisted via `SAP_ALLOWED_PACKAGES='$TMP,$ARC1T_*'`.
+
+### 1.4 Same SAP system — work-process budget (medium)
+
+- Each e2e server runs with `ARC1_MAX_CONCURRENT=10` (default). Tests are sequential, so a single
+  run keeps ~1-3 requests in flight; two or three concurrent runs are typically fine, but each
+  *additional* parallelism experiment (§6) multiplies this. The integration config comment
+  (`vitest.integration.config.ts:13-15`) records that parallel files have already exhausted WPs
+  once ("Service cannot be reached").
+
+### 1.5 Leakage without teardown (medium)
+
+- Integration cleanup is good in-run (`CrudRegistry` + `retryDelete` 5× exponential backoff,
+  `crud-harness.ts:81-141`) but **crash/CTRL-C/timeout leaks objects** with no sweeper.
+- Transport tests create CTS requests described `ARC-1 IT …`; a4h has no transport routes, so
+  leftovers accumulate as local TRs.
+- `$ARC1T_*` packages and `ZARC1_*`/`ZCL_ARC1_E303*`/`ZARC360*`/`ZSTR_ARC1*` objects from aborted
+  runs accumulate in `$TMP`.
+- E2E persistent fixtures intentionally persist; `npm run test:e2e:fixtures:clean` already exists
+  for explicit removal (`tests/e2e/sync-fixtures.ts`).
+
+### 1.6 What is already solved
+
+- **CI vs CI**: all SAP-touching jobs (`integration`, `e2e`, `sap-slow`) share the job-level
+  concurrency group `${{ github.repository }}-sap-live-a4h` with `cancel-in-progress: false` —
+  verified empirically (6-run burst on 06-12 executed strictly back-to-back, queue waits up to
+  32 min). The remaining unprotected combinations are **local↔local** and **local↔CI**.
+- In-run isolation between test *files* of one run: unique names + per-file clients.
+
+## 2. Goals / non-goals
+
+Goals:
+1. N concurrent runs (any mix of local/CI) against one SAP system don't fail or skip because of
+   each other.
+2. Every run tears down what it created, including after crashes (janitor backstop).
+3. Shorter wall-clock where safe (within-run parallelism), without re-triggering WP exhaustion.
+4. Retire the active CI flake; make future flakes visible instead of anecdotal.
+
+Non-goals: sharding one logical suite across machines; isolating runs that *change fixture
+sources* on diverging branches (rare; documented limitation unless §5-C3 is ever needed);
+serializing third parties outside this repo.
+
+## 3. CI failure history (last ~3 weeks, analyzed 2026-06-12)
+
+| When | Failure | Class | Status |
+|---|---|---|---|
+| 06-10 (runs 27263405092, 27301375927) | `adt.integration.test.ts > getCdsTestCases > returns suggested test cases` — `Test timed out in 30000ms` | SAP-transient | **Active flake** — only one. No per-test timeout; the ATC test in the same file uses 90 000 ms |
+| 06-05 ×3 | `rap.e2e.test.ts > SAPActivate` — `package 'SABP' blocked by safety configuration` | Deterministic regression from #357 (allowedPackages ceiling on activation; old system resolved fixture's real package as `SABP`) | Sidestepped by the 06-06 A4H-2025 migration, **not code-fixed** — latent for on-prem 758 |
+| 06-03→06-05 ×6+ | `transport.integration.test.ts` hooks (10 s) + `runAtcCheck` (30 s) timeouts | SAP-transient (old A4H 2023 health) | Fixed: hookTimeout→60 s (#353) + system migration (#365) |
+| 06-06 ×2 | e2e LOCK/UNLOCK `Service cannot be reached` | Infra during CI target migration | One-off |
+| 06-05, 06-11 | Trivy release gate (docker publish) | Release infra, not tests | Tracked in `release.yml` comments |
+
+Since 06-07: 32 of the last 40 Test runs green, 0 test failures except the two `getCdsTestCases`
+timeouts. Reliability tooling exists per-run (`scripts/ci/collect-test-reliability.mjs` → step
+summary + 7-day artifacts) but there is **no cross-run aggregation**, so flake detection is manual.
+
+## 4. Design concept: run identity
+
+Introduce one tiny seam used everywhere: a **run ID** — `TEST_RUN_ID` env var if set, else
+generated once per process (3 base36 chars from `crypto.randomBytes`). Everything a run creates
+embeds it (object names; log/PID paths; optionally `$ARC1T_<RUNID>_*` packages). This is the
+foundation for both cross-instance safety and janitor attribution. ABAP name budget stays intact:
+`prefix(≤20) + '_' + runId(3) + ts(5) + counter(1+)` ≤ 30 — current longest prefixes are 14 chars.
+
+## 5. Suggestions, each evaluated
+
+Effort: S < ½ day, M = 1-2 days, L > 2 days. Verdicts: ✅ recommend, 🟡 recommend with caveat,
+❌ not recommended.
+
+### A — Run-scoped naming
+
+| # | Suggestion | Evaluation |
+|---|---|---|
+| A1 | **Add run-ID entropy to `generateUniqueName`** (`crud-harness.ts:21`): new `tests/helpers/run-id.ts` exporting `RUN_ID`; suffix becomes `${RUN_ID}${ts5}${counter}`. | Effort **S**, risk ~0 (names stay ≤30, the existing length throw still guards). Closes the same-millisecond collision and makes every leaked object attributable to a run. **✅ Do first.** |
+| A2 | **One shared e2e `uniqueName()`** in `tests/e2e/helpers.ts` (run-ID + ms + random), delete the 3 local copies + the raw `Date.now()` in `activation-failure.e2e.test.ts:48`. | Effort **S**, risk ~0. Consistency + distributed safety; also the hook point for any future namespace scheme. **✅** |
+
+### B — Same-machine independence (e2e server)
+
+| # | Suggestion | Evaluation |
+|---|---|---|
+| B1 | **Dynamic port + per-run paths.** `e2e-start-local.sh`: when `E2E_MCP_PORT` is unset, pick a free port (`node net.listen(0)` probe); derive `LOG_DIR=/tmp/arc1-e2e-logs/<RUN_ID>` and `PID_FILE=$LOG_DIR/mcp-server.pid`. Because each `npm run` is a separate process, `test:e2e:full` must become one orchestrating script (`scripts/e2e-run-local.sh`) that picks the port once and exports `E2E_MCP_URL` for the vitest step (or the start script writes `$LOG_DIR/port` and `tests/e2e/global-setup.ts` reads it when `E2E_MCP_URL` is unset). | Effort **M** (script plumbing + global-setup fallback), risk low. Removes the single worst interference. **✅** |
+| B2 | **Stop killing strangers.** Drop the `lsof` port-sweep (lines 36-48) or scope it to an explicitly stale own PID file; `e2e-stop-local.sh` kills only its own `$PID_FILE`. Keep the existing zombie warning in `global-setup.ts` (server >10 min old). | Effort **S**, risk: leftover zombies no longer auto-reaped → mitigate with an explicit `test:e2e:stop --all` flag for manual cleanup. **✅ ships with B1** (pointless before it: with fixed port 3000, killing the listener is the only way to start). |
+| B3 | Per-run log dir also fixes the log-truncation clobber (1.1). | Free with B1. **✅** |
+
+### C — Shared persistent fixtures
+
+| # | Suggestion | Evaluation |
+|---|---|---|
+| C1 | **Concurrency-tolerant fixture sync.** In `tests/e2e/setup.ts`: on 423/"already exists"/"invalid lock handle" during create/recreate, **retry 2-3× with backoff, then re-check existence + source** before classifying as skip (another instance probably just created the identical object — that's success, not skip). Same tolerance window (one re-poll after ~5 s) in `assertSyncedFixturesActive()`. | Effort **S-M**, risk low (pure test-infra). Converts the loser of a sync race from "silently skips a chunk of e2e" to "proceeds normally". **✅** |
+| C2 | **Stop mutating shared fixtures.** `rap.e2e.test.ts` SAPActivate tests create their own transient `ZARC1_ACT_<unique>` program (create→activate→batch-activate→delete) instead of activating `ZARC1_TEST_REPORT`. | Effort **S**, risk ~0, double win: removes the only cross-run *mutation* of a persistent fixture **and** de-fuses the latent SABP-class failure (activating a long-lived fixture whose real-package resolution can surprise, §3). Cost: +1 create/delete (~2 s). **✅** |
+| C3 | **Full per-run fixture namespace** (template `{{NS}}` tokens into the `.abap` fixtures, create per run, delete in teardown). | Honest evaluation: the fixture set has **cross-object references** (`ZI_ARC1_I33_ROOT` selects from `ZTABL_ARC1_I33`; `…_PROJ` projects `…_ROOT`; tests assert on these names in read-backs), so this means consistent token substitution across fixtures *and* test assertions, plus per-run create/activate of 8 objects (~30-60 s setup) every run, plus harder on-system debugging. Effort **L**, risk medium. With C1+C2 in place the residual conflict is only "two branches with *different fixture sources* run simultaneously" — rare and self-healing on re-run. **❌ for now; revisit only if cross-branch fixture churn becomes routine.** |
+
+### D — SAP load budget
+
+| # | Suggestion | Evaluation |
+|---|---|---|
+| D1 | Make the shared-system budget explicit: `E2E_MAX_CONCURRENT` env passthrough in `e2e-start-local.sh` (default stays 10; document "use 4 when sharing the system"), and document expected per-run in-flight counts in `docs/dev-guide.md`. Optionally probe `rdisp/wp_no_dia` once and print it in the start banner. | Effort **S**, risk 0. Mostly documentation; the real protection is that suites stay sequential by default. **✅ (docs-grade)** |
+
+### E — Teardown & janitor
+
+| # | Suggestion | Evaluation |
+|---|---|---|
+| E1 | **Janitor script** (`scripts/test-janitor.ts`, npm `test:cleanup`): search (informationsystem/search or TADIR via existing client) for the canonical test prefixes — `ZARC1_*`, `ZCL_ARC1_E303*`, `ZCL_ARC1_CSURG*`, `ZARC360*`, `ZSTR_ARC1*`, `ZRES_*`, `$ARC1T_*` packages — minus the 8 persistent fixture names, and delete via the existing `retryDelete`. Prefix list lives in **one exported module** shared with the tests (playbook §3: derive, don't copy). Run manually or as an optional weekly `workflow_dispatch`/cron job inside the same `sap-live-a4h` concurrency group. Names embed the run-ID+timestamp after A1, so the janitor can also report *which* run leaked. | Effort **M**, risk: deleting an in-flight run's objects if executed concurrently → run it inside the same CI concurrency group, and locally only when idle; with A1 it can additionally skip objects whose embedded timestamp is < 2 h old (timestamp is truncated base36 — treat as heuristic, not proof). **✅** |
+| E2 | Janitor sweeps leftover `ARC-1 IT` transports (release or delete empty local TRs). | Effort **S** on top of E1. **✅ nice-to-have** |
+| E3 | **Run manifest**: tests append created objects to `test-results/created-objects.ndjson` so a crashed run can be cleaned precisely (`test:cleanup --manifest <file>`). | Effort **S** (CrudRegistry already centralizes registration; add a file sink). Worth it mainly as janitor input; skip if E1's prefix sweep feels sufficient. **🟡 optional** |
+
+### F — Parallelism within one run (performance)
+
+| # | Suggestion | Evaluation |
+|---|---|---|
+| F1 | **Integration: env-gated file parallelism.** `vitest.integration.config.ts`: `fileParallelism: process.env.TEST_FILE_PARALLELISM === 'true'` with `poolOptions.forks.maxForks: 2` (cap!). Within-run isolation already holds (unique names, per-file clients, per-file sequential). The constraint is purely SAP WP load — which is why it failed before, uncapped. Measure with the existing `test:runtime-report` before/after; integration job is ~4 min today, expect ~35-45% off the test phase with 2 forks. | Effort **S** config + **M** validation (3-5 CI runs watching for "Service cannot be reached"). Risk medium — kill-switch is the env var, default stays sequential. Caveats: `transport.integration.test.ts` CTS hooks and `audit-logging` are fork-isolated, fine; bump `maxForks` only after D1 documents the budget. **🟡 worthwhile experiment, opt-in, after A1/E1** |
+| F2 | **E2E: parallel read-only project.** Split a second vitest project for the read-only files (`smoke`, `navigate`, `sapread-grep`, `revisions`, `server-driven-read`, `cds-context`, `cds-impact`, `diagnostics`, `concurrency-read`) with `maxForks: 2` against the one shared server (server handles concurrent sessions; `concurrency-read.e2e.test.ts` already proves 3 simultaneous calls). Mutating + timing-sensitive files stay sequential — **`cache.e2e.test.ts` must never parallelize** (asserts `cachedMs < firstMs`). | Effort **M** (project split + CI wiring), payoff moderate (e2e ≈ 4-5 min total; maybe 1-2 min saved), risk medium (the old config comment warns about queueing/cascades — mitigated by the cap and the reconnect-retry in `helpers.ts:113-164`). **🟡 do after F1 proves the pattern; skip if F1's numbers disappoint** |
+| F3 | Parallelize `integration` and `e2e` CI jobs against each other. | They share the SAP system and deliberately sit in one concurrency group; `needs: integration` also sequences them. Removing that trades reliability for ~4 min. **❌** |
+
+### G — Cross-actor coordination (local ↔ CI)
+
+| # | Suggestion | Evaluation |
+|---|---|---|
+| G1 | **Advisory pre-flight**: `e2e-start-local.sh`/integration docs gain an optional `gh run list --status in_progress` check that *warns* "CI is currently running against this SAP system". | Effort **S**, advisory only (no hard block — devs may want to proceed). **✅ cheap courtesy** |
+| G2 | **SAP-side run lease** (hold an ADT lock on a sentinel object for the run's duration; other instances queue). | Long-held ADT locks die with session timeouts, leases leak on crash and then block everyone, and once A1/B/C land the *need* disappears (runs genuinely don't collide). Complexity > benefit. **❌** |
+| G3 | Shared self-hosted runner as the single SAP gateway for local + CI. | Over-engineering for a one-developer system. **❌** |
+
+### H — Flakiness
+
+| # | Suggestion | Evaluation |
+|---|---|---|
+| H1 | **Fix the one active flake**: per-test `timeout: 90_000` on the `getCdsTestCases` I_CURRENCY test (`adt.integration.test.ts:2262`), matching the 90 s ATC precedent in the same file. | Effort **XS** (one options object). **✅ quick win — do immediately** |
+| H2 | **`retry: 1` in CI for integration + e2e configs** (`retry: process.env.CI ? 1 : 0`) **paired with flake telemetry**: extend `collect-test-reliability.mjs` to surface retried-then-passed tests as a "flaky" list in the step summary, so retries never silently mask decay. Verification step: confirm what the vitest 4 JSON reporter emits for retries (`retryCount`/`retryReasons`); if absent, parse the JUnit XML or use the blob reporter. | Effort **M**. Risk: retries without telemetry would hide real regressions — telemetry is therefore a hard prerequisite, not an add-on. **🟡 recommend in this paired form only** |
+| H3 | **Cross-run flake aggregation**: a small scheduled workflow (weekly) that walks the last ~50 runs' `test-results-*` artifacts via `gh api` and produces a failure/flake leaderboard in its step summary. | Effort **M**, value: turns today's manual archaeology (this document's §3) into a 1-click report. Lightweight alternative: keep doing it ad-hoc with an agent. **🟡 nice-to-have, after H2** |
+| H4 | **SABP latent regression**: C2 removes the trigger path in e2e; additionally add a unit test pinning "activation package-ceiling check uses the object's real package, with `$TMP` fixtures resolving to `$TMP` on 758-style responses" or a release-gated tolerance. | Effort **S-M** investigation. **✅ track as follow-up issue** (it will bite an on-prem 758 user, not CI) |
+| H5 | Flip `assert-required-test-execution.mjs` from `--mode warn` to enforce once P0/P1 land, so a silently-skipping suite fails the build. | Effort **XS**, after skip rates stabilize. **✅ later** |
+
+## 6. Roadmap
+
+**P0 — quick wins (≈ ½ day, immediately shippable)**
+H1 timeout fix · A1 run-ID in `generateUniqueName` · A2 shared e2e `uniqueName` · D1 docs.
+Acceptance: two simultaneous `npm run test:integration` runs (two worktrees) pass with zero
+cross-run "already exists"/423.
+
+**P1 — independent concurrent e2e runs (≈ 2-3 days)**
+B1+B2+B3 dynamic port / per-run paths / scoped kill · C1 sync tolerance · C2 de-mutate fixtures.
+Acceptance: two simultaneous `npm run test:e2e:full` on one machine both pass; local e2e
+overlapping a CI e2e run (same branch) passes without fixture-race skips.
+
+**P2 — teardown hygiene (≈ 1-2 days)**
+E1 janitor (+E2 transports, optional E3 manifest) · G1 advisory pre-flight · H4 SABP follow-up.
+Acceptance: after a `kill -9`'d run, `npm run test:cleanup` leaves no `Z*ARC*`/`$ARC1T_*` leftovers
+beyond the 8 persistent fixtures.
+
+**P3 — performance & telemetry (experimental, measure-first)**
+F1 integration `maxForks: 2` experiment → keep only if 3-5 consecutive CI runs stay clean ·
+H2 retry+flake telemetry · then optionally F2 e2e read-only project and H3 aggregation.
+Acceptance: integration job time reduced ≥25% with no new "Service cannot be reached" class
+failures across a week of runs.
+
+Dependency note: P3-F1 *increases* per-run SAP load — only start it after P0/P1 reduce the chance
+that a second run is hammering the system at the same time.
+
+## 7. Explicitly rejected
+
+- **C3 per-run fixture namespacing** — cost (cross-referenced DDLS/TABL renames, per-run setup
+  time, debuggability) outweighs the residual risk it covers once C1+C2 exist.
+- **G2 SAP-side lease / G3 gateway runner** — fragile or oversized; the design goal is runs that
+  *don't need* mutual exclusion.
+- **F3 parallel integration↔e2e CI jobs** — deliberately serialized today; keep.
+
+## 8. Open questions
+
+1. `rdisp/wp_no_dia` on a4h-2025 — worth probing once (D1) to size `maxForks` and shared-run
+   budgets with data instead of folklore.
+2. Does the vitest 4 JSON reporter expose retry information for H2, or do we need the JUnit/blob
+   reporter? (Verify before committing to the telemetry format.)
+3. How often do two *branches with diverging fixture sources* actually run concurrently? If this
+   becomes routine (e.g. several Claude worktree sessions all editing fixtures), revisit C3.
+
+## Appendix: file map per suggestion
+
+| Item | Files |
+|---|---|
+| A1 | `tests/integration/crud-harness.ts`, new `tests/helpers/run-id.ts` |
+| A2 | `tests/e2e/helpers.ts`, `tests/e2e/{ddic-write,class-section-surgery,func-write,activation-failure}.e2e.test.ts` |
+| B1-B3 | `scripts/e2e-start-local.sh`, `scripts/e2e-stop-local.sh`, new `scripts/e2e-run-local.sh` (or port-file read in `tests/e2e/global-setup.ts`), `package.json` |
+| C1 | `tests/e2e/setup.ts` (`classifyFixtureError`, sync loop, `assertSyncedFixturesActive`) |
+| C2 | `tests/e2e/rap.e2e.test.ts` |
+| D1 | `scripts/e2e-start-local.sh`, `docs/dev-guide.md`, `.env.example` |
+| E1-E3 | new `scripts/test-janitor.ts`, shared prefix module (e.g. `tests/helpers/test-prefixes.ts`), `package.json`, optional workflow |
+| F1 | `vitest.integration.config.ts` |
+| F2 | new `tests/e2e/vitest.e2e.readonly.config.ts` or vitest projects, `.github/workflows/test.yml` |
+| H1 | `tests/integration/adt.integration.test.ts:2262` |
+| H2 | `vitest.integration.config.ts`, `tests/e2e/vitest.e2e.config.ts`, `scripts/ci/collect-test-reliability.mjs` |
+| H3 | new `.github/workflows/flake-report.yml` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -381,9 +381,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -398,9 +398,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -415,9 +415,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -432,9 +432,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -449,9 +449,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -483,9 +483,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -500,9 +500,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -517,9 +517,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -534,9 +534,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -568,9 +568,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -619,9 +619,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -636,9 +636,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -653,9 +653,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -687,9 +687,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -704,9 +704,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -721,9 +721,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -738,9 +738,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -755,9 +755,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -772,9 +772,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -2393,9 +2393,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2406,32 +2406,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "test:e2e:stop": "bash scripts/e2e-stop-local.sh",
     "test:e2e:deploy": "bash scripts/e2e-deploy.sh",
     "test:e2e:stop:remote": "bash scripts/e2e-stop.sh",
-    "test:e2e:full": "npm run build && npm run test:e2e:start && npm run test:e2e; EXIT=$?; npm run test:e2e:stop; exit $EXIT",
+    "test:e2e:full": "bash scripts/e2e-run-local.sh",
     "test:e2e:skip-summary": "vitest run --config tests/e2e/vitest.e2e.config.ts --reporter=verbose 2>&1 | node scripts/ci/summarize-skips.mjs",
     "test:reliability-report": "node scripts/ci/collect-test-reliability.mjs",
     "test:runtime-report": "node scripts/ci/test-runtime-summary.mjs",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test:e2e:slow": "npm run test:e2e:fixtures && vitest run --config tests/e2e/vitest.e2e.slow.config.ts",
     "test:e2e:fixtures": "tsx tests/e2e/sync-fixtures.ts",
     "test:e2e:fixtures:clean": "tsx tests/e2e/sync-fixtures.ts --clean",
+    "test:cleanup": "tsx scripts/test-janitor.ts",
     "test:e2e:start": "bash scripts/e2e-start-local.sh",
     "test:e2e:stop": "bash scripts/e2e-stop-local.sh",
     "test:e2e:deploy": "bash scripts/e2e-deploy.sh",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,9 @@
     "undici": "^8.4.1",
     "zod": "^4.3.6"
   },
+  "overrides": {
+    "esbuild": "^0.28.1"
+  },
   "lint-staged": {
     "*.{ts,js,json}": "biome check --write --no-errors-on-unmatched"
   },

--- a/scripts/e2e-local-utils.mjs
+++ b/scripts/e2e-local-utils.mjs
@@ -8,7 +8,35 @@
  */
 
 import { readFileSync } from 'node:fs';
+import { createServer } from 'node:net';
 import { pathToFileURL } from 'node:url';
+
+/**
+ * Generate a short, letters-only run id (3 uppercase A-Z chars). Letters-only so
+ * it survives tests/helpers/run-id.ts sanitization unchanged and is valid inside
+ * BDEF/CDS identifiers. `rng` is injectable for deterministic tests.
+ */
+export function generateRunId(rng = Math.random) {
+  let n = Math.floor(rng() * 26 * 26 * 26);
+  let s = '';
+  for (let i = 0; i < 3; i++) {
+    s = String.fromCharCode(65 + (n % 26)) + s;
+    n = Math.floor(n / 26);
+  }
+  return s;
+}
+
+/** Resolve a free TCP port by binding to port 0 and reading the assigned port. */
+export function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.on('error', reject);
+    srv.listen(0, () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
 
 export function readHealthField(rawJson, field) {
   try {
@@ -104,7 +132,17 @@ async function main() {
     return;
   }
 
-  console.error('Usage: node scripts/e2e-local-utils.mjs <health-field|error-summary> ...');
+  if (command === 'run-id') {
+    console.log(generateRunId());
+    return;
+  }
+
+  if (command === 'free-port') {
+    console.log(await findFreePort());
+    return;
+  }
+
+  console.error('Usage: node scripts/e2e-local-utils.mjs <health-field|error-summary|run-id|free-port> ...');
   process.exitCode = 1;
 }
 

--- a/scripts/e2e-run-local.sh
+++ b/scripts/e2e-run-local.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/e2e-run-local.sh
+# Orchestrate a full local E2E run that is ISOLATED from any other run against
+# the same SAP system: it picks a free port, a per-run id, and per-run PID/log
+# paths, then builds → starts the MCP server → syncs fixtures + runs vitest →
+# stops the server. Two `npm run test:e2e:full` invocations on one machine no
+# longer collide (the old fixed port 3000 + fixed PID file meant the second run
+# killed the first).
+#
+# CI does NOT use this script — it runs the start/test/stop steps separately
+# with the default port 3000 (one run at a time, enforced by a concurrency
+# group), so that path is unchanged.
+set -euo pipefail
+
+# ── Per-run identity ─────────────────────────────────────────────────
+# Short alphanumeric token; also exported as TEST_RUN_ID so the TS layer
+# (tests/helpers/run-id.ts) stamps the SAME id into generated object names.
+RUN_ID="${TEST_RUN_ID:-$(node -e "process.stdout.write((Math.floor(Math.random()*46656)).toString(36).toUpperCase().padStart(3,'0'))")}"
+export TEST_RUN_ID="${RUN_ID}"
+
+# ── Free port (unless caller pinned one) ─────────────────────────────
+if [ -z "${E2E_MCP_PORT:-}" ]; then
+  E2E_MCP_PORT="$(node -e "const s=require('net').createServer();s.listen(0,()=>{const p=s.address().port;s.close(()=>process.stdout.write(String(p)))})")"
+  # The port was just probed free — tell the start script not to sweep it
+  # (sweeping is the "kill whatever is on this port" belt-and-suspenders that
+  # must never reach into another run).
+  export E2E_SKIP_PORT_SWEEP=1
+fi
+export E2E_MCP_PORT
+export E2E_MCP_URL="${E2E_MCP_URL:-http://localhost:${E2E_MCP_PORT}/mcp}"
+
+# ── Per-run PID + log paths ──────────────────────────────────────────
+export E2E_PID_FILE="${E2E_PID_FILE:-/tmp/arc1-e2e-${RUN_ID}.pid}"
+export E2E_LOG_DIR="${E2E_LOG_DIR:-/tmp/arc1-e2e-logs/${RUN_ID}}"
+
+echo ""
+echo "======================================================================"
+echo "  E2E full run (isolated)"
+echo "    run id:   ${RUN_ID}"
+echo "    port:     ${E2E_MCP_PORT}"
+echo "    url:      ${E2E_MCP_URL}"
+echo "    log dir:  ${E2E_LOG_DIR}"
+echo "======================================================================"
+
+# ── Advisory: warn if CI is hammering the same SAP system right now ───
+# Non-fatal — runs are isolated by run-id; this only flags work-process
+# contention. Silently skipped when gh is absent / unauthenticated.
+if command -v gh > /dev/null 2>&1; then
+  RUNNING="$(GH_PAGER=cat gh run list --status in_progress --limit 20 \
+    --json workflowName --jq '[.[]|select(.workflowName=="Test" or .workflowName=="SAP Slow Tests")]|length' 2> /dev/null || echo 0)"
+  if [ "${RUNNING:-0}" != "0" ]; then
+    echo ""
+    echo "  ⚠ ${RUNNING} CI run(s) touching the SAP system are in progress."
+    echo "    Your run is isolated, but heavy overlap can exhaust SAP work processes."
+  fi
+fi
+
+# ── build → start → test → stop ──────────────────────────────────────
+npm run build
+npm run test:e2e:start
+
+set +e
+npm run test:e2e
+TEST_EXIT=$?
+set -e
+
+npm run test:e2e:stop || true
+exit "${TEST_EXIT}"

--- a/scripts/e2e-run-local.sh
+++ b/scripts/e2e-run-local.sh
@@ -15,12 +15,12 @@ set -euo pipefail
 # ── Per-run identity ─────────────────────────────────────────────────
 # Short alphanumeric token; also exported as TEST_RUN_ID so the TS layer
 # (tests/helpers/run-id.ts) stamps the SAME id into generated object names.
-RUN_ID="${TEST_RUN_ID:-$(node -e "process.stdout.write((Math.floor(Math.random()*46656)).toString(36).toUpperCase().padStart(3,'0'))")}"
+RUN_ID="${TEST_RUN_ID:-$(node scripts/e2e-local-utils.mjs run-id)}"
 export TEST_RUN_ID="${RUN_ID}"
 
 # ── Free port (unless caller pinned one) ─────────────────────────────
 if [ -z "${E2E_MCP_PORT:-}" ]; then
-  E2E_MCP_PORT="$(node -e "const s=require('net').createServer();s.listen(0,()=>{const p=s.address().port;s.close(()=>process.stdout.write(String(p)))})")"
+  E2E_MCP_PORT="$(node scripts/e2e-local-utils.mjs free-port)"
   # The port was just probed free — tell the start script not to sweep it
   # (sweeping is the "kill whatever is on this port" belt-and-suspenders that
   # must never reach into another run).
@@ -57,6 +57,12 @@ fi
 
 # ── build → start → test → stop ──────────────────────────────────────
 npm run build
+
+# Always stop the server, even if start or the tests fail under `set -e`. The old
+# inline test:e2e:full ran stop unconditionally; this trap preserves that so a
+# failed start can never leak the spawned (write-enabled) MCP server.
+trap 'npm run test:e2e:stop || true' EXIT
+
 npm run test:e2e:start
 
 set +e
@@ -64,5 +70,4 @@ npm run test:e2e
 TEST_EXIT=$?
 set -e
 
-npm run test:e2e:stop || true
 exit "${TEST_EXIT}"

--- a/scripts/e2e-start-local.sh
+++ b/scripts/e2e-start-local.sh
@@ -121,4 +121,8 @@ echo "   PID alive: $(kill -0 $NEW_PID 2>/dev/null && echo 'yes' || echo 'NO')"
 echo "-- Server log (last 50 lines): --"
 tail -50 "${LOG_FILE}"
 echo "-- End of server log --"
+# Don't leak the server we just spawned — it may still be coming up and would
+# otherwise hold SAP sessions with no owner. Diagnostics are already printed above.
+kill "$NEW_PID" 2>/dev/null || true
+rm -f "$PID_FILE"
 exit 1

--- a/scripts/e2e-start-local.sh
+++ b/scripts/e2e-start-local.sh
@@ -8,7 +8,10 @@ set -euo pipefail
 MCP_PORT="${E2E_MCP_PORT:-3000}"
 LOG_DIR="${E2E_LOG_DIR:-/tmp/arc1-e2e-logs}"
 LOG_FILE="${LOG_DIR}/mcp-server.log"
-PID_FILE="/tmp/arc1-e2e.pid"
+# Per-run PID file when set by scripts/e2e-run-local.sh, so concurrent local
+# runs don't clobber each other's PID tracking. Defaults to the shared path
+# (CI and single-run dev use this).
+PID_FILE="${E2E_PID_FILE:-/tmp/arc1-e2e.pid}"
 
 mkdir -p "${LOG_DIR}"
 
@@ -35,7 +38,12 @@ fi
 
 # Kill anything still on the port (belt-and-suspenders). Prefer lsof because
 # it works on macOS and Linux; fuser's "<port>/tcp" form is Linux-specific.
-if command -v lsof > /dev/null 2>&1; then
+# Skipped when scripts/e2e-run-local.sh already probed a free port for this run:
+# there's nothing of ours to reap, and sweeping must never reach into a
+# concurrent run that happens to be on a neighbouring port.
+if [ "${E2E_SKIP_PORT_SWEEP:-0}" = "1" ]; then
+  echo "-- Port ${MCP_PORT} was probed free for this run; skipping listener sweep"
+elif command -v lsof > /dev/null 2>&1; then
   LISTENER_PIDS=$(lsof -tiTCP:"${MCP_PORT}" -sTCP:LISTEN 2>/dev/null || true)
   if [ -n "${LISTENER_PIDS}" ]; then
     echo "-- Stopping process(es) listening on port ${MCP_PORT}: ${LISTENER_PIDS//$'\n'/ }"

--- a/scripts/e2e-stop-local.sh
+++ b/scripts/e2e-stop-local.sh
@@ -3,7 +3,8 @@
 # Stops the local MCP server and shows error summary.
 set -euo pipefail
 
-PID_FILE="/tmp/arc1-e2e.pid"
+# Match the (optionally per-run) PID file chosen by e2e-start-local.sh.
+PID_FILE="${E2E_PID_FILE:-/tmp/arc1-e2e.pid}"
 LOG_DIR="${E2E_LOG_DIR:-/tmp/arc1-e2e-logs}"
 LOG_FILE="${LOG_DIR}/mcp-server.log"
 

--- a/scripts/test-janitor.ts
+++ b/scripts/test-janitor.ts
@@ -33,7 +33,11 @@ async function main(): Promise<void> {
 
   const hits: AdtSearchResult[] = [];
   for (const prefix of TEST_OBJECT_PREFIXES) {
-    const results = await client.searchObject(prefix, SEARCH_CAP);
+    // The trailing `*` is ESSENTIAL: ADT quick-search does NOT do implicit prefix
+    // matching — searchObject('ZARC1') returns 0 hits, searchObject('ZARC1*')
+    // returns the matches (verified live). selectSweepCandidates re-filters with a
+    // strict bare-name startsWith, so the wildcard only widens the server query.
+    const results = await client.searchObject(`${prefix}*`, SEARCH_CAP);
     hits.push(...results);
     if (results.length >= SEARCH_CAP) {
       console.warn(

--- a/scripts/test-janitor.ts
+++ b/scripts/test-janitor.ts
@@ -1,0 +1,86 @@
+/**
+ * Test-object janitor.
+ *
+ * Sweeps leftover transient objects that a crashed / interrupted integration or
+ * e2e run left on the SAP system (normal runs clean up after themselves). Finds
+ * objects whose name strict-prefix-matches one of TEST_OBJECT_PREFIXES, excludes
+ * the managed persistent fixtures, and deletes them with the same lock-aware
+ * retry the suites use.
+ *
+ * SAFE BY DEFAULT — dry run unless `--execute` is passed:
+ *   npm run test:cleanup              # list what WOULD be deleted
+ *   npm run test:cleanup -- --execute # actually delete
+ *
+ * Needs SAP credentials (TEST_SAP_URL / SAP_URL …), the same as the integration
+ * suite. Does not require a running MCP server.
+ */
+
+import { unrestrictedSafetyConfig } from '../src/adt/safety.js';
+import type { AdtSearchResult } from '../src/adt/types.js';
+import { retryDelete } from '../tests/integration/crud-harness.js';
+import { getTestClient } from '../tests/integration/helpers.js';
+import { selectSweepCandidates, TEST_OBJECT_PREFIXES } from '../tests/helpers/test-prefixes.js';
+
+const SEARCH_CAP = 200;
+
+async function main(): Promise<void> {
+  const execute = process.argv.includes('--execute');
+  const client = getTestClient();
+  const safety = unrestrictedSafetyConfig();
+
+  console.log(`\n[janitor] ${execute ? 'EXECUTE' : 'DRY RUN'} — scanning for leftover test objects...`);
+  console.log(`[janitor] prefixes: ${TEST_OBJECT_PREFIXES.join(', ')}\n`);
+
+  const hits: AdtSearchResult[] = [];
+  for (const prefix of TEST_OBJECT_PREFIXES) {
+    const results = await client.searchObject(prefix, SEARCH_CAP);
+    hits.push(...results);
+    if (results.length >= SEARCH_CAP) {
+      console.warn(
+        `[janitor] ⚠ prefix "${prefix}" hit the ${SEARCH_CAP}-result cap — some matches may be missing; re-run after this pass.`,
+      );
+    }
+  }
+
+  const candidates = selectSweepCandidates(hits);
+  if (candidates.length === 0) {
+    console.log('[janitor] No leftover test objects found. Nothing to do.');
+    return;
+  }
+
+  console.log(`[janitor] ${candidates.length} candidate leftover object(s):`);
+  for (const c of candidates) {
+    console.log(`  ${c.type.padEnd(10)} ${c.name.padEnd(30)} [pkg ${c.packageName || '?'}]`);
+  }
+
+  if (!execute) {
+    console.log('\n[janitor] Dry run — pass `-- --execute` to delete. No objects were modified.');
+    return;
+  }
+
+  console.log('');
+  let deleted = 0;
+  const failed: string[] = [];
+  for (const c of candidates) {
+    const result = await retryDelete(client.http, safety, c.uri);
+    if (result.success) {
+      deleted++;
+      console.log(`  ✓ deleted ${c.type} ${c.name}`);
+    } else {
+      failed.push(`${c.type} ${c.name}`);
+      console.warn(`  ✗ ${c.type} ${c.name}: ${result.lastError ?? 'unknown error'}`);
+    }
+  }
+
+  console.log(`\n[janitor] Deleted ${deleted}/${candidates.length}. Failed: ${failed.length}.`);
+  if (failed.length > 0) {
+    console.log(`[janitor] Still present (delete manually if stale): ${failed.join(', ')}`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`\n[janitor] failed: ${message}`);
+  process.exit(1);
+});

--- a/tests/e2e/activation-failure.e2e.test.ts
+++ b/tests/e2e/activation-failure.e2e.test.ts
@@ -22,7 +22,14 @@ import { fileURLToPath } from 'node:url';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { skipTest } from '../helpers/skip-policy.js';
-import { callTool, classifyToolErrorSkip, connectClient, expectToolError, expectToolSuccess } from './helpers.js';
+import {
+  callTool,
+  classifyToolErrorSkip,
+  connectClient,
+  expectToolError,
+  expectToolSuccess,
+  uniqueName,
+} from './helpers.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = join(__dirname, '..', 'fixtures', 'abap');
@@ -44,9 +51,8 @@ describe('E2E SAPActivate failure path (PR #179 regression)', () => {
 
   it('reports activation failure with a clear error message for a deliberately broken PROG', async (ctx) => {
     const brokenSource = readFileSync(join(FIXTURES_DIR, 'zarc1_e2e_act_broken.abap'), 'utf-8');
-    // Unique name per run to avoid collisions on parallel CI executions.
-    const suffix = Date.now().toString(36).slice(-6);
-    const progName = `ZARC1_E2E_ACTBROKE_${suffix}`.toUpperCase();
+    // Unique, run-scoped name so concurrent CI/local executions never collide.
+    const progName = uniqueName('ZARC1_E2E_ACTBRK');
 
     let created = false;
     try {

--- a/tests/e2e/class-section-surgery.e2e.test.ts
+++ b/tests/e2e/class-section-surgery.e2e.test.ts
@@ -12,14 +12,7 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { skipTest } from '../helpers/skip-policy.js';
-import { callTool, connectClient, expectToolSuccess, expectToolSuccessOrSkip } from './helpers.js';
-
-function uniqueName(prefix: string): string {
-  const suffix = `${Date.now().toString(36)}${Math.floor(Math.random() * 1e5)
-    .toString(36)
-    .padStart(3, '0')}`.toUpperCase();
-  return `${prefix}_${suffix}`.slice(0, 30);
-}
+import { callTool, connectClient, expectToolSuccess, expectToolSuccessOrSkip, uniqueName } from './helpers.js';
 
 const PROBE_V1 = (name: string) => `CLASS ${name.toLowerCase()} DEFINITION PUBLIC FINAL CREATE PUBLIC.
   PUBLIC SECTION.

--- a/tests/e2e/ddic-write.e2e.test.ts
+++ b/tests/e2e/ddic-write.e2e.test.ts
@@ -7,14 +7,8 @@ import {
   expectToolSuccess,
   expectToolSuccessOrSkip,
   skipOnBatchCreateFailure,
+  uniqueName,
 } from './helpers.js';
-
-function uniqueName(prefix: string): string {
-  const suffix = `${Date.now().toString(36)}${Math.floor(Math.random() * 1e5)
-    .toString(36)
-    .padStart(3, '0')}`.toUpperCase();
-  return `${prefix}_${suffix}`.slice(0, 30);
-}
 
 function parsePossiblyCachedJson(text: string): any {
   return JSON.parse(text.replace(/^\[cached(?::revalidated)?\]\n/, ''));

--- a/tests/e2e/func-params.e2e.test.ts
+++ b/tests/e2e/func-params.e2e.test.ts
@@ -9,21 +9,14 @@
 
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { callTool, connectClient, expectToolError, expectToolSuccess, expectToolSuccessOrSkip } from './helpers.js';
-
-function uniqueName(prefix: string): string {
-  const toLetters = (n: number): string => {
-    let s = '';
-    let v = n;
-    while (v > 0) {
-      s = String.fromCharCode(65 + (v % 26)) + s;
-      v = Math.floor(v / 26);
-    }
-    return s || 'A';
-  };
-  const suffix = `${toLetters(Date.now())}${toLetters(Math.floor(Math.random() * 1e6))}`;
-  return `${prefix}${suffix}`.slice(0, 30);
-}
+import {
+  callTool,
+  connectClient,
+  expectToolError,
+  expectToolSuccess,
+  expectToolSuccessOrSkip,
+  uniqueLettersName as uniqueName,
+} from './helpers.js';
 
 async function bestEffortDeleteFm(client: Client, group: string, name: string): Promise<void> {
   try {

--- a/tests/e2e/func-write.e2e.test.ts
+++ b/tests/e2e/func-write.e2e.test.ts
@@ -10,22 +10,14 @@
 
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { callTool, connectClient, expectToolError, expectToolSuccess, expectToolSuccessOrSkip } from './helpers.js';
-
-/** Generate a collision-safe unique name (letters-only suffix). */
-function uniqueName(prefix: string): string {
-  const toLetters = (n: number): string => {
-    let s = '';
-    let v = n;
-    while (v > 0) {
-      s = String.fromCharCode(65 + (v % 26)) + s;
-      v = Math.floor(v / 26);
-    }
-    return s || 'A';
-  };
-  const suffix = `${toLetters(Date.now())}${toLetters(Math.floor(Math.random() * 1e6))}`;
-  return `${prefix}${suffix}`.slice(0, 30);
-}
+import {
+  callTool,
+  connectClient,
+  expectToolError,
+  expectToolSuccess,
+  expectToolSuccessOrSkip,
+  uniqueLettersName as uniqueName,
+} from './helpers.js';
 
 /** Best-effort delete helper — for FUNC requires `group`. */
 async function bestEffortDeleteFm(client: Client, group: string, name: string): Promise<void> {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -12,12 +12,48 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { expect } from 'vitest';
+import { RUN_ID, RUN_ID_ALPHA } from '../helpers/run-id.js';
 import { skipTest } from '../helpers/skip-policy.js';
 
 /** MCP tool call result shape */
 export interface ToolResult {
   content: Array<{ type: string; text: string }>;
   isError?: boolean;
+}
+
+/**
+ * Generate a collision-safe, ABAP-valid unique object name for E2E writes.
+ * Embeds the per-run id (tests/helpers/run-id.ts) plus a timestamp and a random
+ * component, so two runs against the same SAP system never collide. Truncated to
+ * the ABAP 30-char object-name limit; keep prefixes short enough that the
+ * `_${RUN_ID}…` suffix survives the truncation.
+ */
+export function uniqueName(prefix: string): string {
+  const rand = Math.floor(Math.random() * 1e5)
+    .toString(36)
+    .toUpperCase()
+    .padStart(3, '0');
+  const ts = Date.now().toString(36).toUpperCase();
+  return `${prefix}_${RUN_ID}${ts}${rand}`.slice(0, 30);
+}
+
+/**
+ * Like {@link uniqueName} but the generated suffix is letters-only — for object
+ * types that reject digits in the generated portion (e.g. function-group naming
+ * in func-write.e2e). The prefix may still contain digits; only the suffix is
+ * constrained.
+ */
+export function uniqueLettersName(prefix: string): string {
+  const toLetters = (n: number): string => {
+    let s = '';
+    let v = n;
+    while (v > 0) {
+      s = String.fromCharCode(65 + (v % 26)) + s;
+      v = Math.floor(v / 26);
+    }
+    return s || 'A';
+  };
+  return `${prefix}${RUN_ID_ALPHA}${toLetters(Date.now())}${toLetters(Math.floor(Math.random() * 1e6))}`.slice(0, 30);
 }
 
 /** Server identity from /health endpoint */

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -12,7 +12,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { expect } from 'vitest';
-import { RUN_ID, RUN_ID_ALPHA } from '../helpers/run-id.js';
+import { RUN_ID } from '../helpers/run-id.js';
 import { skipTest } from '../helpers/skip-policy.js';
 
 /** MCP tool call result shape */
@@ -53,7 +53,11 @@ export function uniqueLettersName(prefix: string): string {
     }
     return s || 'A';
   };
-  return `${prefix}${RUN_ID_ALPHA}${toLetters(Date.now())}${toLetters(Math.floor(Math.random() * 1e6))}`.slice(0, 30);
+  // RUN_ID is letters-only, so no separate mapping is needed. Random BEFORE the
+  // timestamp so per-call entropy survives caller-side truncation — rap-write
+  // call sites do `.slice(0, 16)` for ≤16-char CDS/TABL names, which would
+  // otherwise chop a trailing random component off entirely.
+  return `${prefix}${RUN_ID}${toLetters(Math.floor(Math.random() * 1e6))}${toLetters(Date.now())}`.slice(0, 30);
 }
 
 /** Server identity from /health endpoint */

--- a/tests/e2e/rap-write-helpers.ts
+++ b/tests/e2e/rap-write-helpers.ts
@@ -1,23 +1,14 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { callTool } from './helpers.js';
 
-/** Generate a collision-safe unique name with a given prefix (max 30 chars).
- *  Uses letters-only encoding to avoid ABAP/CDS identifier issues —
- *  digit sequences like "00" confuse the BDEF parser in certain positions. */
-export function uniqueName(prefix: string): string {
-  // Encode timestamp + random as letters only (A-Z, base 26)
-  const toLetters = (n: number): string => {
-    let s = '';
-    let v = n;
-    while (v > 0) {
-      s = String.fromCharCode(65 + (v % 26)) + s;
-      v = Math.floor(v / 26);
-    }
-    return s || 'A';
-  };
-  const suffix = `${toLetters(Date.now())}${toLetters(Math.floor(Math.random() * 1e6))}`;
-  return `${prefix}${suffix}`.slice(0, 30);
-}
+/**
+ * Generate a collision-safe unique name with a given prefix (max 30 chars).
+ * Re-exports the shared letters-only generator: RAP/BDEF identifiers must avoid
+ * digit sequences like "00" that confuse the BDEF parser in certain positions,
+ * and the letters-only form also carries the per-run id (run-scoped to keep
+ * concurrent runs against one SAP system from colliding).
+ */
+export { uniqueLettersName as uniqueName } from './helpers.js';
 
 /** Best-effort delete helper. Swallows all errors. */
 export async function bestEffortDelete(client: Client, type: string, name: string): Promise<void> {

--- a/tests/e2e/rap.e2e.test.ts
+++ b/tests/e2e/rap.e2e.test.ts
@@ -13,6 +13,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { skipTest } from '../helpers/skip-policy.js';
 import {
   callTool,
+  classifyToolErrorSkip,
   connectClient,
   expectToolError,
   expectToolSuccess,
@@ -158,6 +159,7 @@ describe('E2E RAP Completeness Tests', () => {
     // on 7.5x the fixture's resolved real package tripped the activation
     // package-ceiling check (the 06-05 "package 'SABP' blocked" CI failures).
     const actNames: string[] = [];
+    let setupSkip: string | null = null;
 
     beforeAll(async () => {
       for (let i = 0; i < 2; i++) {
@@ -169,7 +171,18 @@ describe('E2E RAP Completeness Tests', () => {
           source: `REPORT ${name.toLowerCase()}.\nWRITE: / 'arc1 activate test'.`,
           package: '$TMP',
         });
-        expectToolSuccess(create);
+        if (create.isError) {
+          // A classified backend gap (e.g. NW 7.50 lock-handle 423) should SKIP
+          // these tests, not hard-fail them — matching every other create-in-test
+          // in this suite. beforeAll has no ctx, so stash the reason and skip in
+          // each test below.
+          const skip = classifyToolErrorSkip(create);
+          if (skip) {
+            setupSkip = skip;
+            return;
+          }
+          expectToolSuccess(create); // genuinely unexpected → fail loudly
+        }
         actNames.push(name);
       }
     });
@@ -184,13 +197,21 @@ describe('E2E RAP Completeness Tests', () => {
       }
     });
 
-    it('activates a single object successfully', async () => {
+    it('activates a single object successfully', async (ctx) => {
+      if (setupSkip) {
+        skipTest(ctx, setupSkip);
+        return;
+      }
       const result = await callTool(client, 'SAPActivate', { type: 'PROG', name: actNames[0] });
       const text = expectToolSuccess(result);
       expect(text).toContain(actNames[0]);
     });
 
-    it('batch activates multiple objects together', async () => {
+    it('batch activates multiple objects together', async (ctx) => {
+      if (setupSkip) {
+        skipTest(ctx, setupSkip);
+        return;
+      }
       const result = await callTool(client, 'SAPActivate', {
         objects: actNames.map((name) => ({ type: 'PROG', name })),
       });

--- a/tests/e2e/rap.e2e.test.ts
+++ b/tests/e2e/rap.e2e.test.ts
@@ -11,7 +11,14 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { skipTest } from '../helpers/skip-policy.js';
-import { callTool, connectClient, expectToolError, expectToolSuccess, expectToolSuccessOrSkip } from './helpers.js';
+import {
+  callTool,
+  connectClient,
+  expectToolError,
+  expectToolSuccess,
+  expectToolSuccessOrSkip,
+  uniqueName,
+} from './helpers.js';
 
 function parsePossiblyCachedJson(text: string): any {
   return JSON.parse(text.replace(/^\[cached(?::revalidated)?\]\n/, ''));
@@ -145,28 +152,52 @@ describe('E2E RAP Completeness Tests', () => {
   // ── SAPActivate: Single + Batch ───────────────────────────────────
 
   describe('SAPActivate', () => {
+    // Use transient $TMP programs created per run rather than activating the
+    // shared persistent fixtures (ZARC1_TEST_REPORT / ZCL_ARC1_TEST). Mutating
+    // those caused cross-run 423 lock conflicts when two runs overlapped, and
+    // on 7.5x the fixture's resolved real package tripped the activation
+    // package-ceiling check (the 06-05 "package 'SABP' blocked" CI failures).
+    const actNames: string[] = [];
+
+    beforeAll(async () => {
+      for (let i = 0; i < 2; i++) {
+        const name = uniqueName(`ZARC1_ACT${i}`);
+        const create = await callTool(client, 'SAPWrite', {
+          action: 'create',
+          type: 'PROG',
+          name,
+          source: `REPORT ${name.toLowerCase()}.\nWRITE: / 'arc1 activate test'.`,
+          package: '$TMP',
+        });
+        expectToolSuccess(create);
+        actNames.push(name);
+      }
+    });
+
+    afterAll(async () => {
+      for (const name of actNames) {
+        try {
+          await callTool(client, 'SAPWrite', { action: 'delete', type: 'PROG', name });
+        } catch {
+          // best-effort-cleanup
+        }
+      }
+    });
+
     it('activates a single object successfully', async () => {
-      // Activating an already-active managed fixture is a no-op, but still
-      // exercises SAPActivate inside the CI allowedPackages ceiling.
-      const result = await callTool(client, 'SAPActivate', {
-        type: 'PROG',
-        name: 'ZARC1_TEST_REPORT',
-      });
+      const result = await callTool(client, 'SAPActivate', { type: 'PROG', name: actNames[0] });
       const text = expectToolSuccess(result);
-      expect(text).toContain('ZARC1_TEST_REPORT');
+      expect(text).toContain(actNames[0]);
     });
 
     it('batch activates multiple objects together', async () => {
       const result = await callTool(client, 'SAPActivate', {
-        objects: [
-          { type: 'PROG', name: 'ZARC1_TEST_REPORT' },
-          { type: 'CLAS', name: 'ZCL_ARC1_TEST' },
-        ],
+        objects: actNames.map((name) => ({ type: 'PROG', name })),
       });
       const text = expectToolSuccess(result);
       expect(text).toContain('2 objects');
-      expect(text).toContain('ZARC1_TEST_REPORT');
-      expect(text).toContain('ZCL_ARC1_TEST');
+      expect(text).toContain(actNames[0]);
+      expect(text).toContain(actNames[1]);
     });
   });
 

--- a/tests/e2e/setup.ts
+++ b/tests/e2e/setup.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { bareObjectName } from '../helpers/test-prefixes.js';
 import { PERSISTENT_OBJECTS, readFixture } from './fixtures.js';
 import { callTool, type ToolResult } from './helpers.js';
 
@@ -207,23 +208,37 @@ async function createActivateOrReconcile(
     const msg = err instanceof Error ? err.message : String(err);
     const reason = classifyFixtureError(msg);
     if (reason === null) throw err;
-    const recon = await reconcileConcurrentFixture(client, obj, desiredSource);
-    if (recon === 'reconciled') {
-      console.log(`    [setup] ${label}: produced by a concurrent run — reconciled (source matches)`);
-      summary.unchanged.push(label);
-      verifiedActiveSources.add(label);
-      return;
-    }
-    if (recon === 'drift') {
-      const driftReason =
-        'Concurrent run created a different version of this fixture (likely another branch) — re-run once it finishes';
-      console.warn(`    [setup] ${label}: skipping ${mode} — ${driftReason}`);
-      summary.skipped.push({ label, reason: driftReason });
-      return;
+    // Only a create RACE (a concurrent run beat us to the same object) is worth
+    // re-polling; release gaps / stale phantoms can never appear via a re-check,
+    // so skip them immediately as before (no wasted poll/backoff).
+    if (isConcurrencyRaceError(msg)) {
+      const recon = await reconcileConcurrentFixture(client, obj, desiredSource);
+      if (recon === 'reconciled') {
+        console.log(`    [setup] ${label}: produced by a concurrent run — reconciled (source matches)`);
+        summary.unchanged.push(label);
+        verifiedActiveSources.add(label);
+        return;
+      }
+      if (recon === 'drift') {
+        const driftReason =
+          'Concurrent run created a different version of this fixture (likely another branch) — re-run once it finishes';
+        console.warn(`    [setup] ${label}: skipping ${mode} — ${driftReason}`);
+        summary.skipped.push({ label, reason: driftReason });
+        return;
+      }
     }
     console.warn(`    [setup] ${label}: skipping ${mode} — ${reason}`);
     summary.skipped.push({ label, reason });
   }
+}
+
+/** A create error that looks like a lost race — another run created the same object first. */
+function isConcurrencyRaceError(message: string): boolean {
+  return (
+    /status 423.*invalid lock handle/i.test(message) ||
+    /already exists/i.test(message) ||
+    /does already exist/i.test(message)
+  );
 }
 
 /**
@@ -241,18 +256,28 @@ async function reconcileConcurrentFixture(
   desiredSource: string,
 ): Promise<'reconciled' | 'drift' | 'absent'> {
   const expectedType = obj.type.toUpperCase();
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    await delay(1500 * attempt);
-    const types = await findExistingObjectTypes(client, obj.name);
-    if (!types.includes(expectedType)) continue;
-    const live = normalizeSource(await readObjectSource(client, obj.type, obj.name), obj.type);
-    if (live !== desiredSource) return 'drift';
+  // Probe first (an "already exists" race means the object is there NOW), then a
+  // single short re-poll for a still-in-flight create. The whole body is guarded
+  // so a read/search failure mid-reconcile (release-gapped source read, object
+  // locked by the other run) returns 'absent' and the caller records the
+  // ORIGINAL skip — never an uncaught throw that aborts the entire sync.
+  for (let attempt = 1; attempt <= 2; attempt++) {
     try {
-      await activateObject(client, obj.type, obj.name);
+      const types = await findExistingObjectTypes(client, obj.name);
+      if (types.includes(expectedType)) {
+        const live = normalizeSource(await readObjectSource(client, obj.type, obj.name), obj.type);
+        if (live !== desiredSource) return 'drift';
+        try {
+          await activateObject(client, obj.type, obj.name);
+        } catch {
+          // best-effort — the other run may hold the lock or have already activated it
+        }
+        return 'reconciled';
+      }
     } catch {
-      // best-effort — the other run may hold the lock or have already activated it
+      // fall through to the retry / 'absent' — see the comment above
     }
-    return 'reconciled';
+    if (attempt < 2) await delay(1500);
   }
   return 'absent';
 }
@@ -334,9 +359,9 @@ async function findExistingObjectTypes(client: Client, name: string): Promise<st
     const objectType = getString(entry, 'objectType');
     if (!objectName || !objectType) continue;
     // On NW 7.50 the search result decorates the name with a display suffix
-    // like "ZIF_ARC1_TEST (Interface)". Normalize by stripping anything after
-    // the first space or "(" so equality matches the bare object name.
-    const bareName = objectName.split(/\s|\(/)[0];
+    // like "ZIF_ARC1_TEST (Interface)". Normalize to the bare name (shared with
+    // the janitor's selector) so equality matches.
+    const bareName = bareObjectName(objectName);
     if (bareName.toUpperCase() !== name.toUpperCase()) continue;
     types.add(objectType.split('/')[0].toUpperCase());
   }
@@ -359,9 +384,11 @@ async function assertSyncedFixturesActive(
   if (checkedFixtures.length === 0) return;
 
   let inactiveFixtures = await findInactiveFixtures(client, checkedFixtures);
-  if (inactiveFixtures.length > 0) {
-    // A concurrent run's activation (or our own, just issued) may still be
-    // settling. Wait briefly and re-check once before declaring failure.
+  // Only wait-and-recheck if THIS run actually issued an activation that might
+  // still be settling. If everything was already unchanged, an inactive fixture
+  // is a durable problem — fail fast instead of paying a blind 5s.
+  const issuedActivations = summary.created.length > 0 || summary.recreated.length > 0;
+  if (inactiveFixtures.length > 0 && issuedActivations) {
     await delay(5000);
     inactiveFixtures = await findInactiveFixtures(client, checkedFixtures);
   }

--- a/tests/e2e/setup.ts
+++ b/tests/e2e/setup.ts
@@ -94,17 +94,7 @@ export async function syncPersistentFixtures(client: Client): Promise<FixtureSyn
 
     if (!hasExpectedType && existingTypes.length === 0) {
       console.log(`    [setup] ${label}: missing -> creating from ${obj.fixture}`);
-      try {
-        await createObjectFromFixture(client, obj);
-        await activateObject(client, obj.type, obj.name);
-        summary.created.push(label);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        const reason = classifyFixtureError(msg);
-        if (reason === null) throw err;
-        console.warn(`    [setup] ${label}: skipping — ${reason}`);
-        summary.skipped.push({ label, reason });
-      }
+      await createActivateOrReconcile(client, obj, desiredSource, summary, verifiedActiveSources, 'create');
       continue;
     }
 
@@ -135,17 +125,7 @@ export async function syncPersistentFixtures(client: Client): Promise<FixtureSyn
     }
 
     console.log(`    [setup] ${label}: recreating from ${obj.fixture}`);
-    try {
-      await createObjectFromFixture(client, obj);
-      await activateObject(client, obj.type, obj.name);
-      summary.recreated.push(label);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      const reason = classifyFixtureError(msg);
-      if (reason === null) throw err;
-      console.warn(`    [setup] ${label}: skipping recreate — ${reason}`);
-      summary.skipped.push({ label, reason });
-    }
+    await createActivateOrReconcile(client, obj, desiredSource, summary, verifiedActiveSources, 'recreate');
   }
 
   await assertSyncedFixturesActive(client, summary, verifiedActiveSources);
@@ -198,6 +178,83 @@ async function createObjectFromFixture(client: Client, obj: PersistentObject): P
 async function activateObject(client: Client, type: string, name: string): Promise<void> {
   const activateResult = await callTool(client, 'SAPActivate', { type, name });
   assertToolSuccess(activateResult, `activate ${type} ${name}`);
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Create + activate a fixture, tolerating a concurrent run that produced the
+ * same object microseconds earlier. On a known backend-quirk error (423 /
+ * "already exists" — see {@link classifyFixtureError}) we re-check the system
+ * before skipping: a parallel worktree / CI run may simply have won the create
+ * race, in which case the object is already correct and we record it as
+ * unchanged rather than skipping a chunk of the suite.
+ */
+async function createActivateOrReconcile(
+  client: Client,
+  obj: PersistentObject,
+  desiredSource: string,
+  summary: FixtureSyncSummary,
+  verifiedActiveSources: Set<string>,
+  mode: 'create' | 'recreate',
+): Promise<void> {
+  const label = `${obj.type} ${obj.name}`;
+  try {
+    await createObjectFromFixture(client, obj);
+    await activateObject(client, obj.type, obj.name);
+    (mode === 'create' ? summary.created : summary.recreated).push(label);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const reason = classifyFixtureError(msg);
+    if (reason === null) throw err;
+    const recon = await reconcileConcurrentFixture(client, obj, desiredSource);
+    if (recon === 'reconciled') {
+      console.log(`    [setup] ${label}: produced by a concurrent run — reconciled (source matches)`);
+      summary.unchanged.push(label);
+      verifiedActiveSources.add(label);
+      return;
+    }
+    if (recon === 'drift') {
+      const driftReason =
+        'Concurrent run created a different version of this fixture (likely another branch) — re-run once it finishes';
+      console.warn(`    [setup] ${label}: skipping ${mode} — ${driftReason}`);
+      summary.skipped.push({ label, reason: driftReason });
+      return;
+    }
+    console.warn(`    [setup] ${label}: skipping ${mode} — ${reason}`);
+    summary.skipped.push({ label, reason });
+  }
+}
+
+/**
+ * After a create race, poll a few times to see whether the object now exists on
+ * SAP and matches our fixture:
+ *   - 'reconciled' — present with matching source (another run won; we idempotently
+ *     re-activate in case that run hasn't finished activating yet)
+ *   - 'drift'      — present but DIFFERENT source (a genuinely conflicting writer,
+ *     e.g. another branch) — caller skips rather than fighting it
+ *   - 'absent'     — still not there, so the original error stands
+ */
+async function reconcileConcurrentFixture(
+  client: Client,
+  obj: PersistentObject,
+  desiredSource: string,
+): Promise<'reconciled' | 'drift' | 'absent'> {
+  const expectedType = obj.type.toUpperCase();
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    await delay(1500 * attempt);
+    const types = await findExistingObjectTypes(client, obj.name);
+    if (!types.includes(expectedType)) continue;
+    const live = normalizeSource(await readObjectSource(client, obj.type, obj.name), obj.type);
+    if (live !== desiredSource) return 'drift';
+    try {
+      await activateObject(client, obj.type, obj.name);
+    } catch {
+      // best-effort — the other run may hold the lock or have already activated it
+    }
+    return 'reconciled';
+  }
+  return 'absent';
 }
 
 // Types SAPWrite(action="delete") accepts. SAP-generated siblings like STOB (structure
@@ -301,7 +358,13 @@ async function assertSyncedFixturesActive(
   const checkedFixtures = PERSISTENT_OBJECTS.filter((obj) => !skippedLabels.has(`${obj.type} ${obj.name}`));
   if (checkedFixtures.length === 0) return;
 
-  const inactiveFixtures = await findInactiveFixtures(client, checkedFixtures);
+  let inactiveFixtures = await findInactiveFixtures(client, checkedFixtures);
+  if (inactiveFixtures.length > 0) {
+    // A concurrent run's activation (or our own, just issued) may still be
+    // settling. Wait briefly and re-check once before declaring failure.
+    await delay(5000);
+    inactiveFixtures = await findInactiveFixtures(client, checkedFixtures);
+  }
   if (inactiveFixtures.length > 0) {
     const details = inactiveFixtures
       .map((obj) => {

--- a/tests/e2e/sktd-write.e2e.test.ts
+++ b/tests/e2e/sktd-write.e2e.test.ts
@@ -14,14 +14,14 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { requireOrSkip, SkipReason } from '../helpers/skip-policy.js';
-import { callTool, connectClient, expectToolError, expectToolSuccess, expectToolSuccessOrSkip } from './helpers.js';
-
-function uniqueName(prefix: string): string {
-  const suffix = `${Date.now().toString(36)}${Math.floor(Math.random() * 1e5)
-    .toString(36)
-    .padStart(3, '0')}`.toUpperCase();
-  return `${prefix}${suffix}`.slice(0, 30);
-}
+import {
+  callTool,
+  connectClient,
+  expectToolError,
+  expectToolSuccess,
+  expectToolSuccessOrSkip,
+  uniqueName,
+} from './helpers.js';
 
 describe('E2E SKTD (Knowledge Transfer Document) tests', () => {
   let client: Client;

--- a/tests/helpers/run-id.ts
+++ b/tests/helpers/run-id.ts
@@ -23,9 +23,17 @@
  */
 
 import 'dotenv/config';
-import { randomBytes } from 'node:crypto';
 
-const LETTERS = 26;
+/**
+ * A random uppercase letter A-Z. `Math.random` (NOT a cryptographically secure
+ * source) is the right tool here: this is a throwaway test-object-name token, not
+ * a security value, so there is no need for crypto randomness — and using it
+ * avoids the modulo/division bias CodeQL flags on crypto sources. Matches
+ * scripts/e2e-local-utils.mjs `generateRunId`.
+ */
+function randomLetter(): string {
+  return String.fromCharCode(65 + Math.floor(Math.random() * 26));
+}
 
 /**
  * Resolve a run id from a raw env value, falling back to a random token.
@@ -37,8 +45,7 @@ export function deriveRunId(rawEnv: string | undefined): string {
   if (sanitized) return sanitized.slice(0, 4);
   // 2 random uppercase letters (676 combinations) — ample to separate the
   // handful of runs that realistically overlap on one SAP system.
-  const n = randomBytes(2).readUInt16BE(0) % (LETTERS * LETTERS);
-  return String.fromCharCode(65 + Math.floor(n / LETTERS)) + String.fromCharCode(65 + (n % LETTERS));
+  return randomLetter() + randomLetter();
 }
 
 /** Stable per-process run id (uppercase letters, 2-4 chars). */

--- a/tests/helpers/run-id.ts
+++ b/tests/helpers/run-id.ts
@@ -9,20 +9,23 @@
  * generated name closes that window.
  *
  * Resolution order:
- *   1. `TEST_RUN_ID` env var — set by scripts/e2e-run-local.sh so the shell-side
- *      paths (port/PID/log dir) and the TS-side object names share one identity.
- *      Sanitised to A-Z0-9 and capped at 4 chars.
- *   2. A random 2-char base36 token, derived once per process.
+ *   1. `TEST_RUN_ID` env var — set by scripts/e2e-run-local.sh (shell-exported)
+ *      so the shell paths (port/PID/log dir) and the TS object names share one
+ *      id. Sanitised to A-Z and capped at 4 chars.
+ *   2. A random 2-letter token, derived once per process.
  *
- * The token is deliberately tiny (2 chars ≈ 1296 values) so it barely dents the
- * ABAP 30-char object-name budget while still separating the handful of runs
- * that could realistically overlap on one system.
+ * The token is LETTERS-ONLY (not base36): letters are valid in every identifier
+ * the suites generate, including BDEF/CDS names, so one token works for both the
+ * alphanumeric `uniqueName` and the letters-only `uniqueLettersName` without a
+ * lossy digit→letter mapping. `dotenv/config` is imported so a `TEST_RUN_ID` set
+ * in `.env` is honoured regardless of module import order (the integration
+ * suite's dotenv loader may run after this module).
  */
 
+import 'dotenv/config';
 import { randomBytes } from 'node:crypto';
 
-/** Number of base36 values a 2-char token spans (36 * 36). */
-const TWO_CHAR_BASE36 = 1296;
+const LETTERS = 26;
 
 /**
  * Resolve a run id from a raw env value, falling back to a random token.
@@ -30,17 +33,13 @@ const TWO_CHAR_BASE36 = 1296;
  * re-importing the module to re-trigger the random fallback.
  */
 export function deriveRunId(rawEnv: string | undefined): string {
-  const sanitized = rawEnv?.toUpperCase().replace(/[^A-Z0-9]/g, '');
+  const sanitized = rawEnv?.toUpperCase().replace(/[^A-Z]/g, '');
   if (sanitized) return sanitized.slice(0, 4);
-  return (randomBytes(2).readUInt16BE(0) % TWO_CHAR_BASE36).toString(36).toUpperCase().padStart(2, '0');
+  // 2 random uppercase letters (676 combinations) — ample to separate the
+  // handful of runs that realistically overlap on one SAP system.
+  const n = randomBytes(2).readUInt16BE(0) % (LETTERS * LETTERS);
+  return String.fromCharCode(65 + Math.floor(n / LETTERS)) + String.fromCharCode(65 + (n % LETTERS));
 }
 
-/** Stable per-process run id (uppercase, alphanumeric, 2-4 chars). */
+/** Stable per-process run id (uppercase letters, 2-4 chars). */
 export const RUN_ID = deriveRunId(process.env.TEST_RUN_ID);
-
-/**
- * Letters-only form of `RUN_ID`, for object types whose generated suffix must
- * not contain digits (e.g. the function-group naming in func-write.e2e). Maps
- * each digit 0-9 to A-J so the value stays stable and collision-equivalent.
- */
-export const RUN_ID_ALPHA = RUN_ID.replace(/[0-9]/g, (d) => String.fromCharCode(65 + Number(d)));

--- a/tests/helpers/run-id.ts
+++ b/tests/helpers/run-id.ts
@@ -1,0 +1,46 @@
+/**
+ * Per-run identity for test object names and artifact paths.
+ *
+ * Two test runs against the SAME SAP system — e.g. two git worktrees, or a local
+ * run overlapping a CI run — must not generate colliding ABAP object names.
+ * Timestamp + a process-local counter (the previous scheme) still collides when
+ * two processes start in the same millisecond: both read the same `Date.now()`
+ * and both begin their counter at 0. Mixing a short per-run token into every
+ * generated name closes that window.
+ *
+ * Resolution order:
+ *   1. `TEST_RUN_ID` env var — set by scripts/e2e-run-local.sh so the shell-side
+ *      paths (port/PID/log dir) and the TS-side object names share one identity.
+ *      Sanitised to A-Z0-9 and capped at 4 chars.
+ *   2. A random 2-char base36 token, derived once per process.
+ *
+ * The token is deliberately tiny (2 chars ≈ 1296 values) so it barely dents the
+ * ABAP 30-char object-name budget while still separating the handful of runs
+ * that could realistically overlap on one system.
+ */
+
+import { randomBytes } from 'node:crypto';
+
+/** Number of base36 values a 2-char token spans (36 * 36). */
+const TWO_CHAR_BASE36 = 1296;
+
+/**
+ * Resolve a run id from a raw env value, falling back to a random token.
+ * Exported (rather than only `RUN_ID`) so it can be unit-tested without
+ * re-importing the module to re-trigger the random fallback.
+ */
+export function deriveRunId(rawEnv: string | undefined): string {
+  const sanitized = rawEnv?.toUpperCase().replace(/[^A-Z0-9]/g, '');
+  if (sanitized) return sanitized.slice(0, 4);
+  return (randomBytes(2).readUInt16BE(0) % TWO_CHAR_BASE36).toString(36).toUpperCase().padStart(2, '0');
+}
+
+/** Stable per-process run id (uppercase, alphanumeric, 2-4 chars). */
+export const RUN_ID = deriveRunId(process.env.TEST_RUN_ID);
+
+/**
+ * Letters-only form of `RUN_ID`, for object types whose generated suffix must
+ * not contain digits (e.g. the function-group naming in func-write.e2e). Maps
+ * each digit 0-9 to A-J so the value stays stable and collision-equivalent.
+ */
+export const RUN_ID_ALPHA = RUN_ID.replace(/[0-9]/g, (d) => String.fromCharCode(65 + Number(d)));

--- a/tests/helpers/test-prefixes.ts
+++ b/tests/helpers/test-prefixes.ts
@@ -1,24 +1,30 @@
 /**
  * Canonical naming the ARC-1 test suites use for the throwaway SAP objects they
  * create, plus a pure selector the janitor (scripts/test-janitor.ts) uses to
- * decide what to sweep. Single source of truth so a new test prefix can't drift
- * out of the cleanup set silently (see Engineering Playbook §3 in AGENTS.md).
+ * decide what to sweep.
  */
 
+import type { AdtSearchResult } from '../../src/adt/types.js';
 import { PERSISTENT_OBJECTS } from '../e2e/fixtures.js';
 
 /** Exact names of managed persistent fixtures — these must NEVER be swept. */
 export const PERSISTENT_FIXTURE_NAMES: readonly string[] = PERSISTENT_OBJECTS.map((o) => o.name);
 
 /**
- * Name prefixes the integration + e2e suites use for transient objects. The
- * janitor sweeps leftovers (from crashed/interrupted runs) that start with one
- * of these. Kept deliberately to cleanly-deletable workbench types (PROG/CLAS/
- * INTF/DDLS/TABL/DOMA/DTEL); RAP/FUGR fixtures self-clean in finally blocks and
- * need ordered teardown, so they're intentionally out of scope here.
+ * Name prefixes the integration + e2e suites use for transient objects, for the
+ * janitor to sweep leftovers from crashed/interrupted runs.
+ *
+ * This is a CURATED list, NOT auto-derived — keep it in step with the prefixes
+ * the suites pass to uniqueName/generateUniqueName. `ZARC1` covers the whole
+ * ZARC1* namespace (incl. ZARC1FG/FM function groups, ZARC1MC message classes,
+ * ZARC1SKTD, …). Deletion is best-effort: standalone objects delete cleanly,
+ * while types needing ordered teardown (FUNC modules under a group, RAP behavior
+ * pools) may be reported as failures to remove manually. The `$ARC1T_*` PACKAGES
+ * that RAP tests create are NOT swept here — delete those manually (e.g. SE80) if
+ * they accumulate.
  */
 export const TEST_OBJECT_PREFIXES: readonly string[] = [
-  'ZARC1_', // broad integration + e2e: ZARC1_ACT*, ZARC1_DOMA*, ZARC1_E2E_*, ZARC1_TDOM*, …
+  'ZARC1', // the whole ZARC1* test namespace (ZARC1_*, ZARC1FG, ZARC1MC, ZARC1SKTD, …)
   'ZARC360', // #360 schema-pollution tests
   'ZCL_ARC1', // ZCL_ARC1_E303*, ZCL_ARC1_CSURG*, …
   'ZIF_ARC1',
@@ -28,16 +34,8 @@ export const TEST_OBJECT_PREFIXES: readonly string[] = [
   'ZRES_', // ZRES_TADIR_*, ZRES_TGHOST_*, ZRES_*PAR/CHD
 ];
 
-/** Package-name prefixes the suites create (e.g. RAP local packages). */
-export const TEST_PACKAGE_PREFIXES: readonly string[] = ['$ARC1T_'];
-
-/** Minimal shape of a search hit the selector needs (subset of AdtSearchResult). */
-export interface SweepableObject {
-  objectName: string;
-  objectType: string;
-  uri: string;
-  packageName: string;
-}
+/** Minimal shape of a search hit the selector needs. */
+export type SweepableObject = Pick<AdtSearchResult, 'objectName' | 'objectType' | 'uri' | 'packageName'>;
 
 /** A leftover object the janitor may delete. */
 export interface SweepCandidate {
@@ -48,10 +46,20 @@ export interface SweepCandidate {
 }
 
 /**
+ * Strip the NW 7.50 search-result display decoration ("ZIF_X (Interface)") to
+ * the bare object name. Shared with tests/e2e/setup.ts so the janitor and the
+ * fixture-sync agree on what an object is called (otherwise a decorated hit
+ * would slip past the persistent-fixture exclusion below).
+ */
+export function bareObjectName(objectName: string): string {
+  return objectName.split(/\s|\(/)[0];
+}
+
+/**
  * From raw search hits, pick the objects that are (a) NOT a persistent fixture
  * and (b) STRICT-prefix-match one of the test prefixes (ADT quick-search is
- * fuzzy/substring, so the strict `startsWith` filter is what keeps unrelated
- * objects safe). De-duplicated by type+name.
+ * fuzzy, so the strict bare-name `startsWith` filter is what keeps unrelated
+ * objects safe). De-duplicated by bare type + name.
  */
 export function selectSweepCandidates(
   results: readonly SweepableObject[],
@@ -62,11 +70,12 @@ export function selectSweepCandidates(
   const upperPrefixes = prefixes.map((p) => p.toUpperCase());
   const byKey = new Map<string, SweepCandidate>();
   for (const r of results) {
-    const name = r.objectName?.toUpperCase();
+    const name = bareObjectName(r.objectName ?? '').toUpperCase();
     if (!name || !r.uri) continue;
     if (exclude.has(name)) continue;
     if (!upperPrefixes.some((p) => name.startsWith(p))) continue;
-    byKey.set(`${r.objectType}|${name}`, {
+    const bareType = (r.objectType?.split('/')[0] ?? r.objectType ?? '').toUpperCase();
+    byKey.set(`${bareType}|${name}`, {
       name,
       type: r.objectType,
       uri: r.uri,

--- a/tests/helpers/test-prefixes.ts
+++ b/tests/helpers/test-prefixes.ts
@@ -1,0 +1,77 @@
+/**
+ * Canonical naming the ARC-1 test suites use for the throwaway SAP objects they
+ * create, plus a pure selector the janitor (scripts/test-janitor.ts) uses to
+ * decide what to sweep. Single source of truth so a new test prefix can't drift
+ * out of the cleanup set silently (see Engineering Playbook §3 in AGENTS.md).
+ */
+
+import { PERSISTENT_OBJECTS } from '../e2e/fixtures.js';
+
+/** Exact names of managed persistent fixtures — these must NEVER be swept. */
+export const PERSISTENT_FIXTURE_NAMES: readonly string[] = PERSISTENT_OBJECTS.map((o) => o.name);
+
+/**
+ * Name prefixes the integration + e2e suites use for transient objects. The
+ * janitor sweeps leftovers (from crashed/interrupted runs) that start with one
+ * of these. Kept deliberately to cleanly-deletable workbench types (PROG/CLAS/
+ * INTF/DDLS/TABL/DOMA/DTEL); RAP/FUGR fixtures self-clean in finally blocks and
+ * need ordered teardown, so they're intentionally out of scope here.
+ */
+export const TEST_OBJECT_PREFIXES: readonly string[] = [
+  'ZARC1_', // broad integration + e2e: ZARC1_ACT*, ZARC1_DOMA*, ZARC1_E2E_*, ZARC1_TDOM*, …
+  'ZARC360', // #360 schema-pollution tests
+  'ZCL_ARC1', // ZCL_ARC1_E303*, ZCL_ARC1_CSURG*, …
+  'ZIF_ARC1',
+  'ZI_ARC1', // DDLS views
+  'ZTABL_ARC1',
+  'ZSTR_ARC1',
+  'ZRES_', // ZRES_TADIR_*, ZRES_TGHOST_*, ZRES_*PAR/CHD
+];
+
+/** Package-name prefixes the suites create (e.g. RAP local packages). */
+export const TEST_PACKAGE_PREFIXES: readonly string[] = ['$ARC1T_'];
+
+/** Minimal shape of a search hit the selector needs (subset of AdtSearchResult). */
+export interface SweepableObject {
+  objectName: string;
+  objectType: string;
+  uri: string;
+  packageName: string;
+}
+
+/** A leftover object the janitor may delete. */
+export interface SweepCandidate {
+  name: string;
+  type: string;
+  uri: string;
+  packageName: string;
+}
+
+/**
+ * From raw search hits, pick the objects that are (a) NOT a persistent fixture
+ * and (b) STRICT-prefix-match one of the test prefixes (ADT quick-search is
+ * fuzzy/substring, so the strict `startsWith` filter is what keeps unrelated
+ * objects safe). De-duplicated by type+name.
+ */
+export function selectSweepCandidates(
+  results: readonly SweepableObject[],
+  prefixes: readonly string[] = TEST_OBJECT_PREFIXES,
+  excludeNames: readonly string[] = PERSISTENT_FIXTURE_NAMES,
+): SweepCandidate[] {
+  const exclude = new Set(excludeNames.map((n) => n.toUpperCase()));
+  const upperPrefixes = prefixes.map((p) => p.toUpperCase());
+  const byKey = new Map<string, SweepCandidate>();
+  for (const r of results) {
+    const name = r.objectName?.toUpperCase();
+    if (!name || !r.uri) continue;
+    if (exclude.has(name)) continue;
+    if (!upperPrefixes.some((p) => name.startsWith(p))) continue;
+    byKey.set(`${r.objectType}|${name}`, {
+      name,
+      type: r.objectType,
+      uri: r.uri,
+      packageName: r.packageName,
+    });
+  }
+  return [...byKey.values()];
+}

--- a/tests/integration/adt.integration.test.ts
+++ b/tests/integration/adt.integration.test.ts
@@ -2280,7 +2280,10 @@ describe('ADT Integration Tests', () => {
       }
       // I_CURRENCY has calculated fields → at least one CALCULATION case naming a calculatedField.
       expect(result.testCases.some((tc) => tc.semanticType === 'CALCULATION' && !!tc.calculatedField)).toBe(true);
-    });
+      // The first testcases call against a CDS view can take >30s on a cold 8.16 system
+      // (observed timing out the default 30s in CI runs 27263405092 / 27301375927). Match
+      // the 90s precedent used by the runAtcCheck tests in this file.
+    }, 90_000);
 
     it('surfaces a 400 for a nonexistent CDS entity (8.16+; skips on older releases)', async (ctx) => {
       const disco = await fetchDiscoveryDocument(client.http);

--- a/tests/integration/crud-harness.ts
+++ b/tests/integration/crud-harness.ts
@@ -10,17 +10,20 @@
 import { deleteObject, lockObject } from '../../src/adt/crud.js';
 import type { AdtHttpClient } from '../../src/adt/http.js';
 import type { SafetyConfig } from '../../src/adt/safety.js';
+import { RUN_ID } from '../helpers/run-id.js';
 
 let nameCounter = 0;
 
 /**
  * Generate a unique ABAP-valid object name.
- * Returns `${prefix}_${timestamp_base36}${counter_base36}` — uppercase, max 30 chars.
- * Uses a monotonic counter to guarantee uniqueness even within the same millisecond.
+ * Returns `${prefix}_${RUN_ID}${timestamp_base36}${counter_base36}` — uppercase, max 30 chars.
+ * The per-run id (see tests/helpers/run-id.ts) separates concurrent runs against
+ * the same SAP system; the monotonic counter guarantees uniqueness within a run
+ * even inside the same millisecond.
  */
 export function generateUniqueName(prefix: string): string {
-  const suffix = `${Date.now().toString(36)}${(nameCounter++).toString(36)}`.toUpperCase().slice(-6);
-  const name = `${prefix}_${suffix}`;
+  const tail = `${Date.now().toString(36)}${(nameCounter++).toString(36)}`.toUpperCase().slice(-5);
+  const name = `${prefix}_${RUN_ID}${tail}`;
   if (name.length > 30) {
     throw new Error(`Generated name "${name}" exceeds 30 characters. Use a shorter prefix.`);
   }

--- a/tests/unit/helpers/run-id.test.ts
+++ b/tests/unit/helpers/run-id.test.ts
@@ -1,35 +1,31 @@
 import { describe, expect, it } from 'vitest';
-import { deriveRunId, RUN_ID, RUN_ID_ALPHA } from '../../helpers/run-id.js';
+import { deriveRunId, RUN_ID } from '../../helpers/run-id.js';
 
 describe('deriveRunId', () => {
-  it('uses TEST_RUN_ID when set — uppercased, alnum-only, capped at 4 chars', () => {
+  it('uses TEST_RUN_ID when set — uppercased, letters-only, capped at 4 chars', () => {
     expect(deriveRunId('AB')).toBe('AB');
-    expect(deriveRunId('ab12')).toBe('AB12');
-    expect(deriveRunId('a-b_c.d')).toBe('ABCD'); // non-alnum stripped, then capped
+    expect(deriveRunId('abcd')).toBe('ABCD');
+    expect(deriveRunId('a-b_c.d')).toBe('ABCD'); // non-letters stripped, then capped
+    expect(deriveRunId('ab12')).toBe('AB'); // digits stripped
     expect(deriveRunId('toolongvalue')).toBe('TOOL'); // capped at 4
   });
 
-  it('falls back to a 2-char alphanumeric token when env is empty/blank/non-alnum', () => {
-    for (const raw of [undefined, '', '   ', '!!!']) {
-      expect(deriveRunId(raw)).toMatch(/^[A-Z0-9]{2}$/);
+  it('falls back to a 2-letter token when env is empty/blank/digits-only', () => {
+    for (const raw of [undefined, '', '   ', '!!!', '12']) {
+      expect(deriveRunId(raw)).toMatch(/^[A-Z]{2}$/);
     }
   });
 
   it('produces more than one distinct token across many fallback draws', () => {
     const seen = new Set<string>();
     for (let i = 0; i < 200; i++) seen.add(deriveRunId(undefined));
-    // 200 draws from 1296 values — astronomically unlikely to be all identical.
+    // 200 draws from 676 values — astronomically unlikely to be all identical.
     expect(seen.size).toBeGreaterThan(1);
   });
 });
 
-describe('RUN_ID / RUN_ID_ALPHA', () => {
-  it('RUN_ID is a short uppercase alphanumeric token', () => {
-    expect(RUN_ID).toMatch(/^[A-Z0-9]{2,4}$/);
-  });
-
-  it('RUN_ID_ALPHA is letters-only and the same length as RUN_ID', () => {
-    expect(RUN_ID_ALPHA).toMatch(/^[A-Z]{2,4}$/);
-    expect(RUN_ID_ALPHA.length).toBe(RUN_ID.length);
+describe('RUN_ID', () => {
+  it('is a short uppercase letters-only token', () => {
+    expect(RUN_ID).toMatch(/^[A-Z]{2,4}$/);
   });
 });

--- a/tests/unit/helpers/run-id.test.ts
+++ b/tests/unit/helpers/run-id.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { deriveRunId, RUN_ID, RUN_ID_ALPHA } from '../../helpers/run-id.js';
+
+describe('deriveRunId', () => {
+  it('uses TEST_RUN_ID when set — uppercased, alnum-only, capped at 4 chars', () => {
+    expect(deriveRunId('AB')).toBe('AB');
+    expect(deriveRunId('ab12')).toBe('AB12');
+    expect(deriveRunId('a-b_c.d')).toBe('ABCD'); // non-alnum stripped, then capped
+    expect(deriveRunId('toolongvalue')).toBe('TOOL'); // capped at 4
+  });
+
+  it('falls back to a 2-char alphanumeric token when env is empty/blank/non-alnum', () => {
+    for (const raw of [undefined, '', '   ', '!!!']) {
+      expect(deriveRunId(raw)).toMatch(/^[A-Z0-9]{2}$/);
+    }
+  });
+
+  it('produces more than one distinct token across many fallback draws', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 200; i++) seen.add(deriveRunId(undefined));
+    // 200 draws from 1296 values — astronomically unlikely to be all identical.
+    expect(seen.size).toBeGreaterThan(1);
+  });
+});
+
+describe('RUN_ID / RUN_ID_ALPHA', () => {
+  it('RUN_ID is a short uppercase alphanumeric token', () => {
+    expect(RUN_ID).toMatch(/^[A-Z0-9]{2,4}$/);
+  });
+
+  it('RUN_ID_ALPHA is letters-only and the same length as RUN_ID', () => {
+    expect(RUN_ID_ALPHA).toMatch(/^[A-Z]{2,4}$/);
+    expect(RUN_ID_ALPHA.length).toBe(RUN_ID.length);
+  });
+});

--- a/tests/unit/helpers/test-prefixes.test.ts
+++ b/tests/unit/helpers/test-prefixes.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { PERSISTENT_FIXTURE_NAMES, type SweepableObject, selectSweepCandidates } from '../../helpers/test-prefixes.js';
+
+function hit(objectName: string, objectType = 'PROG/P'): SweepableObject {
+  return {
+    objectName,
+    objectType,
+    uri: `/sap/bc/adt/programs/programs/${objectName.toLowerCase()}`,
+    packageName: '$TMP',
+  };
+}
+
+describe('selectSweepCandidates', () => {
+  it('keeps strict-prefix matches and drops substring-only matches', () => {
+    const out = selectSweepCandidates([hit('ZARC1_ACT0AB'), hit('YZARC1_NOPE'), hit('ZARC360D_X')]);
+    expect(out.map((c) => c.name).sort()).toEqual(['ZARC1_ACT0AB', 'ZARC360D_X']);
+  });
+
+  it('never sweeps persistent fixtures', () => {
+    const fixture = PERSISTENT_FIXTURE_NAMES[0]; // e.g. ZARC1_TEST_REPORT — matches ZARC1_ prefix
+    const out = selectSweepCandidates([hit(fixture), hit('ZARC1_LEFTOVER')]);
+    expect(out.map((c) => c.name)).toEqual(['ZARC1_LEFTOVER']);
+  });
+
+  it('deduplicates by type + name', () => {
+    expect(selectSweepCandidates([hit('ZARC1_DUP'), hit('ZARC1_DUP')])).toHaveLength(1);
+  });
+
+  it('treats the same name under different types as distinct', () => {
+    const out = selectSweepCandidates([hit('ZARC1_X', 'PROG/P'), hit('ZARC1_X', 'CLAS/OC')]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('ignores hits without a name or uri', () => {
+    const out = selectSweepCandidates([
+      { objectName: '', objectType: 'PROG/P', uri: '/x', packageName: '$TMP' },
+      { objectName: 'ZARC1_NOURI', objectType: 'PROG/P', uri: '', packageName: '$TMP' },
+    ]);
+    expect(out).toHaveLength(0);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(selectSweepCandidates([hit('zarc1_lower')]).map((c) => c.name)).toEqual(['ZARC1_LOWER']);
+  });
+});

--- a/tests/unit/helpers/test-prefixes.test.ts
+++ b/tests/unit/helpers/test-prefixes.test.ts
@@ -17,9 +17,27 @@ describe('selectSweepCandidates', () => {
   });
 
   it('never sweeps persistent fixtures', () => {
-    const fixture = PERSISTENT_FIXTURE_NAMES[0]; // e.g. ZARC1_TEST_REPORT — matches ZARC1_ prefix
+    const fixture = PERSISTENT_FIXTURE_NAMES[0]; // e.g. ZARC1_TEST_REPORT — matches ZARC1 prefix
     const out = selectSweepCandidates([hit(fixture), hit('ZARC1_LEFTOVER')]);
     expect(out.map((c) => c.name)).toEqual(['ZARC1_LEFTOVER']);
+  });
+
+  it('strips NW 7.50 name decoration before excluding fixtures and matching prefixes', () => {
+    const decoratedFixture: SweepableObject = {
+      objectName: `${PERSISTENT_FIXTURE_NAMES[2]} (Interface)`, // ZIF_ARC1_TEST (Interface)
+      objectType: 'INTF/OI',
+      uri: '/sap/bc/adt/oo/interfaces/zif_arc1_test',
+      packageName: '$TMP',
+    };
+    const decoratedLeftover: SweepableObject = {
+      objectName: 'ZCL_ARC1_E303A (Class)',
+      objectType: 'CLAS/OC',
+      uri: '/sap/bc/adt/oo/classes/zcl_arc1_e303a',
+      packageName: '$TMP',
+    };
+    const out = selectSweepCandidates([decoratedFixture, decoratedLeftover]);
+    // The decorated fixture is still excluded; the decorated leftover is matched on its bare name.
+    expect(out.map((c) => c.name)).toEqual(['ZCL_ARC1_E303A']);
   });
 
   it('deduplicates by type + name', () => {

--- a/tests/unit/integration/crud-harness.test.ts
+++ b/tests/unit/integration/crud-harness.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RUN_ID } from '../../helpers/run-id.js';
 import {
   buildCreateXml,
   CrudRegistry,
@@ -16,6 +17,11 @@ describe('generateUniqueName', () => {
   it('produces names <= 30 characters', () => {
     const name = generateUniqueName('ZARC1_IT');
     expect(name.length).toBeLessThanOrEqual(30);
+  });
+
+  it('embeds the per-run id so concurrent runs do not collide', () => {
+    const name = generateUniqueName('ZARC1_IT');
+    expect(name).toContain(`_${RUN_ID}`);
   });
 
   it('produces different names on sequential calls even within the same millisecond', () => {

--- a/tests/unit/scripts/e2e-local-utils.test.ts
+++ b/tests/unit/scripts/e2e-local-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isErrorLogLine, readHealthField, summarizeLogErrors } from '../../../scripts/e2e-local-utils.mjs';
+import {
+  generateRunId,
+  isErrorLogLine,
+  readHealthField,
+  summarizeLogErrors,
+} from '../../../scripts/e2e-local-utils.mjs';
 
 describe('e2e-local-utils', () => {
   describe('readHealthField', () => {
@@ -19,6 +24,17 @@ describe('e2e-local-utils', () => {
       expect(readHealthField('{"version":"0.9.6"}', 'startedAt')).toBe('unknown');
       expect(readHealthField('{"version":{"nested":true}}', 'version')).toBe('unknown');
       expect(readHealthField('{not-json', 'version')).toBe('unknown');
+    });
+  });
+
+  describe('generateRunId', () => {
+    it('produces 3 uppercase letters', () => {
+      expect(generateRunId()).toMatch(/^[A-Z]{3}$/);
+    });
+
+    it('is deterministic given an injected rng and spans the full A-Z range', () => {
+      expect(generateRunId(() => 0)).toBe('AAA');
+      expect(generateRunId(() => 0.9999999)).toBe('ZZZ');
     });
   });
 

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -10,9 +10,17 @@ export default defineConfig({
     // Live SAP suite hooks can list CTS state or seed objects; keep this above
     // the default 10s so setup/cleanup does not fail before tests can skip.
     hookTimeout: 60000,
-    // Run test files one at a time — SAP has limited work processes and
-    // parallel files exhaust them, causing "Service cannot be reached" errors.
-    fileParallelism: false,
+    // Run test files one at a time by DEFAULT — SAP has limited work processes
+    // and parallel files have exhausted them before ("Service cannot be
+    // reached"). Opt in to a capped 2-file-parallel run to shorten wall-clock:
+    //   TEST_FILE_PARALLELISM=true npm run test:integration
+    // The maxWorkers cap bounds WP pressure; measure with `npm run
+    // test:runtime-report` and watch for "Service cannot be reached" before
+    // raising it. Tests WITHIN a file stay sequential (sequence, below).
+    // (fileParallelism:false forces maxWorkers to 1, so the cap only bites when
+    // the opt-in is on.)
+    fileParallelism: process.env.TEST_FILE_PARALLELISM === 'true',
+    maxWorkers: 2,
     // Run tests within each file sequentially to avoid SAP session conflicts
     sequence: {
       concurrent: false,


### PR DESCRIPTION
Lets multiple integration/e2e runs target one SAP system at once (git worktrees, or a
local run overlapping CI) without interfering, with proper per-run teardown; adds opt-in
parallelism, a leaked-object janitor, and fixes the one active CI flake. Implements
P0–P2 + F1 of `docs/plans/test-isolation-and-parallel-runs.md`.

A `/code-review high` pass over the first 8 commits caught real bugs (including a severe
one) — the last 6 commits fix them. All findings and verification are summarized below.

## What & why

- **Run identity** (`tests/helpers/run-id.ts`): a short letters-only `RUN_ID` (`TEST_RUN_ID`
  env, else random per process) embedded in every generated object name — closes the
  same-millisecond cross-process collision window. Unifies six duplicated `uniqueName`
  copies into one shared `uniqueName`/`uniqueLettersName`.
- **Per-run e2e server** (`scripts/e2e-run-local.sh`): `test:e2e:full` picks a free port +
  per-run PID/log paths, so two local runs stop killing each other. A trap stops the server
  even on a failed start; the start script kills its own spawn on a health-check timeout.
  CI is unchanged (port 3000, one run at a time via its concurrency group).
- **Race-tolerant fixture sync** (`tests/e2e/setup.ts`): reconcile a concurrent create
  instead of silently skipping; fully guarded so a reconcile read failure can never abort
  the whole sync. The rap SAPActivate tests use transient `$TMP` objects, not shared
  fixtures (also de-fuses the 06-05 "package 'SABP' blocked" failure).
- **Janitor** (`npm run test:cleanup`): sweeps leaked objects from crashed runs; dry-run by
  default, `-- --execute` deletes. Prefixes + selector in one shared, normalization-aware
  module. (Found 400+ real leftovers on the test system once the search was fixed.)
- **Opt-in parallelism**: `TEST_FILE_PARALLELISM=true npm run test:integration` (capped at
  `maxWorkers: 2`).
- **Flake fix**: `getCdsTestCases` timeout 30s→90s (failed CI runs 27263405092 / 27301375927).

## Review fixes (commits 9–14)

| Severity | Fix |
|---|---|
| **Severe** | Janitor was a silent no-op — ADT quick-search needs an explicit `*` (verified live: `ZARC1` → 0 hits, `ZARC1*` → matches). Now finds the 400+ leftovers it missed. |
| Regression | Orphaned write-enabled server on a failed `set -e` start — added a stop trap + start-script self-cleanup. |
| Regression | `reconcileConcurrentFixture` could throw out of the sync's catch and hard-abort the whole e2e run on a 7.50 source-read gap — fully guarded now. |
| Correctness | `RUN_ID_ALPHA` digit→letter fold was non-injective (distinct runs could collide); `TEST_RUN_ID` from `.env` was silently ignored (import order); `.slice(0,16)` rap call sites lost all random entropy. Fixed: letters-only `RUN_ID`, `dotenv`-loaded, random-before-timestamp. |
| Correctness | rap SAPActivate `beforeAll` hard-failed on classified backend quirks instead of skipping — now routes through `classifyToolErrorSkip`. |
| Cleanup | Janitor name normalization (7.50 decoration) shared with fixture-sync; broadened prefixes; `SweepableObject` = `Pick<AdtSearchResult,…>`; run-id/free-port moved to tested util subcommands; honest "curated list" comment. |

## Tests
typecheck, **3768 unit tests**, lint, size ratchet, policy, build all pass. New unit tests
for the run-id helper, the janitor selector (incl. 7.50 decoration), and the util
subcommands. Janitor search fix verified live against the test system. Integration/e2e
validate live in CI.

## Deferred (plan §3.6 / review "below the cut")
H2 (CI retry + flake telemetry), F2 (parallel read-only e2e project), H3 (flake-aggregation
workflow), H4 (SABP latent-regression unit test); the full 3-generator unification, a
PID-identity health check, and a prefix-coverage enforcement test (noted, not done).
C3/G2/G3/F3 remain explicitly rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
