### PR TITLE
fix(config): empty env values fall back to defaults (fail closed, not fail open)

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -221,15 +221,20 @@ export function resolveConfig(args: string[]): { config: ServerConfig; sources: 
     return undefined;
   };
 
+  // An empty flag/env value (a cleared install-dialog field, or a shell-expanded unset $VAR) is
+  // treated as "not provided" and falls through to the default instead of overriding it with "".
+  // This stops non-empty defaults (e.g. SAP_CLIENT=100, SAP_LANGUAGE=EN) from being silently
+  // dropped — an empty client would otherwise log the user on to the system default client.
   const resolveStr = (flag: string, envVar: string, defaultVal: string, fieldName: string): string => {
     const flagVal = getFlag(flag);
-    if (flagVal !== undefined) {
+    if (flagVal !== undefined && flagVal !== '') {
       sources[fieldName] = { flag: `--${flag}` };
       return flagVal;
     }
-    if (process.env[envVar] !== undefined) {
+    const envVal = process.env[envVar];
+    if (envVal !== undefined && envVal !== '') {
       sources[fieldName] = { env: envVar };
-      return process.env[envVar] as string;
+      return envVal;
     }
     sources[fieldName] = 'default';
     return defaultVal;
@@ -334,15 +339,26 @@ export function resolveConfig(args: string[]): { config: ServerConfig; sources: 
   if (pkgs !== undefined) {
     const raw = pkgs.split(',').map((p) => p.trim());
     const filtered = raw.filter((p) => p.length > 0);
-    if (raw.length !== filtered.length) {
+    if (filtered.length === 0) {
+      // Empty / separator-only value ("" or ",," from a shell-expanded unset $VAR, or a cleared
+      // install-dialog field). Treat as "not provided" and keep the $TMP default — do NOT fall
+      // through to [], which safety.ts treats as "all packages allowed". Use '*' for unrestricted.
       logger.warn(
-        "SAP_ALLOWED_PACKAGES contained empty entries — likely shell expansion of unset $VARs. Use single quotes: SAP_ALLOWED_PACKAGES='$TMP,Z*'",
-        { raw: pkgs, parsed: filtered },
+        "SAP_ALLOWED_PACKAGES resolved to no packages — keeping the $TMP default (writes are NOT unrestricted). Set it to '*' to allow all packages explicitly.",
+        { raw: pkgs },
       );
+      sources.allowedPackages = 'default';
+    } else {
+      if (raw.length !== filtered.length) {
+        logger.warn(
+          "SAP_ALLOWED_PACKAGES contained empty entries — likely shell expansion of unset $VARs. Use single quotes: SAP_ALLOWED_PACKAGES='$TMP,Z*'",
+          { raw: pkgs, parsed: filtered },
+        );
+      }
+      config.allowedPackages = filtered;
+      sources.allowedPackages =
+        getFlag('allowed-packages') !== undefined ? { flag: '--allowed-packages' } : { env: 'SAP_ALLOWED_PACKAGES' };
     }
-    config.allowedPackages = filtered;
-    sources.allowedPackages =
-      getFlag('allowed-packages') !== undefined ? { flag: '--allowed-packages' } : { env: 'SAP_ALLOWED_PACKAGES' };
   } else {
     sources.allowedPackages = 'default';
   }

--- a/tests/unit/server/config.test.ts
+++ b/tests/unit/server/config.test.ts
@@ -228,17 +228,35 @@ describe('parseArgs', () => {
     expect(config.allowedPackages).toEqual(['Z*', '$TMP']);
   });
 
-  it('filters out empty entries from SAP_ALLOWED_PACKAGES (e.g. shell-expanded unset $VARs)', () => {
-    // Simulates `SAP_ALLOWED_PACKAGES=$tmp,$locals,$*` with unset shell vars → ",,"
+  it('keeps the $TMP default when SAP_ALLOWED_PACKAGES is empty (fail closed, NOT unrestricted)', () => {
+    // "" or ",," (shell-expanded unset $VARs, or a cleared install-dialog field) must NOT become []
+    // — [] means "all packages allowed" in safety.ts. Empty falls back to the safe $TMP default;
+    // unrestricted stays an explicit opt-in via '*'.
     process.env.SAP_ALLOWED_PACKAGES = ',,';
-    const config = parseArgs([]);
-    expect(config.allowedPackages).toEqual([]);
+    expect(parseArgs([]).allowedPackages).toEqual(['$TMP']);
+    process.env.SAP_ALLOWED_PACKAGES = '';
+    expect(parseArgs([]).allowedPackages).toEqual(['$TMP']);
   });
 
   it('filters empty entries but keeps valid ones', () => {
     process.env.SAP_ALLOWED_PACKAGES = 'Z*,,$TMP,';
     const config = parseArgs([]);
     expect(config.allowedPackages).toEqual(['Z*', '$TMP']);
+  });
+
+  it('still allows explicit unrestricted writes via *', () => {
+    process.env.SAP_ALLOWED_PACKAGES = '*';
+    expect(parseArgs([]).allowedPackages).toEqual(['*']);
+  });
+
+  it('keeps the SAP_CLIENT / SAP_LANGUAGE defaults when the env value is empty', () => {
+    // A cleared install-dialog field sends "" — it must fall back to the default, not override it.
+    // An empty client would otherwise drop the sap-client param and log on to the system default.
+    process.env.SAP_CLIENT = '';
+    process.env.SAP_LANGUAGE = '';
+    const config = parseArgs([]);
+    expect(config.client).toBe('100');
+    expect(config.language).toBe('EN');
   });
 
   describe('legacy config migration errors', () => {


### PR DESCRIPTION
## Summary

Empty-string config values were treated as *"explicitly set to nothing"*, overriding non-empty
defaults — a **fail-open** footgun. It has always existed for env/`.env`/CLI, but the new install
dialogs (MCPB bundle + Claude Code plugin in #425) **expose it to non-technical users**: clearing a
pre-filled field sends `""`.

Found while reviewing #425; split out because it fixes core config parsing for *all* entry points, not just the dialogs.

## The two cases

**`SAP_ALLOWED_PACKAGES` → unrestricted writes (the serious one)**
`""` (or `",,"`) parsed to `[]`, and `safety.ts` treats an empty allowlist as **"all packages allowed"**. So clearing the "Allowed Packages" field (with writes on) silently widened the write scope from `$TMP` to *every* package — productive `Z*`/`Y*` included.

**`SAP_CLIENT` / `SAP_LANGUAGE` → wrong client**
`""` won over the `100`/`EN` defaults, then `buildUrl` drops the falsy `sap-client` param → SAP logs you on to the **system default client**, no error.

## Fix

- `resolveStr`: an empty flag/env value is treated as *not provided* and falls through to the default. Every string field benefits; all `resolveStr` defaults are safe or strictly safer under this rule (no field uses `""` as a meaningful distinct value).
- `SAP_ALLOWED_PACKAGES`: an empty/separator-only value keeps the `$TMP` default instead of falling through to `[]`. **Unrestricted stays an explicit opt-in via `*`.**
- Booleans were already fail-closed (`resolveBool` enables only on `'true'`/`'1'`); this brings strings in line.

## Tests
- The existing `config.test.ts` case that **codified** `""` → `[]` now asserts `""` → `['$TMP']`.
- Added: `*` still yields `['*']` (explicit unrestricted preserved); empty `SAP_CLIENT`/`SAP_LANGUAGE` → `100`/`EN`.
- Full gate green: typecheck, lint, validate:policy, check:sizes, `npm test` (3771), build.

## Relation to #425
The dialog warning added in [#425](https://github.com/marianfoo/arc-1/pull/425) ("leaving empty allows ALL packages") becomes **belt-and-suspenders** once this lands — empty is now safe. Worth softening that warning text in #425 after both merge (or I can do it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)