### PR TITLE
fix(http): handle 304/204/205 null-body status on Cloud Connector proxy path

### DIFF
--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -1238,6 +1238,8 @@ export class AdtHttpClient {
       // yields '' not null). Pass null so a 304 from a conditional GET (ETag
       // revalidation) survives the proxy path instead of crashing the write
       // (e.g. edit_method's read-before-write through the Cloud Connector).
+      // (1xx informational statuses are null-body too, but never surface here:
+      // undici's Client doesn't return them as a final status and ADT never emits them.)
       const isNullBodyStatus = resp.statusCode === 204 || resp.statusCode === 205 || resp.statusCode === 304;
       return new Response(isNullBodyStatus ? null : responseBody, {
         status: resp.statusCode,

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -1233,7 +1233,13 @@ export class AdtHttpClient {
         }
       }
 
-      return new Response(responseBody, {
+      // Statuses 204/205/304 are "null body status" per the Fetch spec — the
+      // Response constructor throws if given a non-null body (and `.text()`
+      // yields '' not null). Pass null so a 304 from a conditional GET (ETag
+      // revalidation) survives the proxy path instead of crashing the write
+      // (e.g. edit_method's read-before-write through the Cloud Connector).
+      const isNullBodyStatus = resp.statusCode === 204 || resp.statusCode === 205 || resp.statusCode === 304;
+      return new Response(isNullBodyStatus ? null : responseBody, {
         status: resp.statusCode,
         headers: responseHeaders,
       });

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -1368,6 +1368,27 @@ describe('AdtHttpClient', () => {
       // The path should be the full URL (standard HTTP proxy protocol)
       expect(clientRequestPath(0)).toBe('http://sap.example.com:8000/path?sap-client=001&sap-language=EN');
     });
+
+    it('handles a 304 (null-body status) from the proxy without crashing the Response constructor', async () => {
+      // Regression: a conditional GET (If-None-Match) that revalidates to 304
+      // over the Cloud Connector proxy must not throw "Invalid response status
+      // code 304" — that crashed edit_method's read-before-write on RISE/CC.
+      mockClientRequest.mockResolvedValueOnce(mockClientResponse(304, '', { etag: '"abc"' }));
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        btpProxy: {
+          host: 'proxy.example.com',
+          port: 20003,
+          protocol: 'http',
+          getProxyToken: async () => 'proxy-token',
+        },
+      });
+
+      const resp = await client.get('/path', { 'If-None-Match': '"abc"' });
+      expect(resp.statusCode).toBe(304);
+      expect(resp.body).toBe('');
+    });
   });
 
   // ─── 503 Retry ──────────────────────────────────────────────────────

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -1388,6 +1388,9 @@ describe('AdtHttpClient', () => {
       const resp = await client.get('/path', { 'If-None-Match': '"abc"' });
       expect(resp.statusCode).toBe(304);
       expect(resp.body).toBe('');
+      // The ETag must survive the proxy reconstruction — that's what lets the
+      // caching layer serve the cached source on a 304 revalidation.
+      expect(resp.headers.etag).toBe('"abc"');
     });
   });
 


### PR DESCRIPTION
## TL;DR

On Cloud Connector / RISE deployments, **any write whose read-before-write revalidates a cached object crashes** when SAP returns `304 Not Modified`. The connectivity-proxy code path reconstructs an HTTP `Response` by hand with a non-null body on a null-body status, which the Fetch spec forbids — so the constructor throws. One-line semantic fix + regression test.

## Symptom (observed in the field)

S/4 on-prem reached via BTP Cloud Connector + Principal Propagation. `SAPWrite action=edit_method` fails with:

```
ADT network error: Response constructor: Invalid response status code 304
Hint: Cannot reach the SAP system. Run SAPRead(type="SYSTEM") once as a connectivity probe before retrying...
```

The hint is misleading — **the SAP system was up the whole time.** Logs also showed many `304`s, which led to the root cause.

## Root-cause analysis

1. ARC-1 caches source by `(type, name, version)` with the SAP **ETag** and revalidates via conditional GET (`If-None-Match`). Unchanged object → SAP answers **`304`**. Expected, healthy; lots of 304 = good cache-hit rate.

2. `edit_method` does a **read-before-write**: it GETs the class source to splice the method. The object is cached, so that read is a conditional GET → **304**.

3. On Cloud Connector / RISE, every ADT call goes through `doProxyRequest()` (`src/adt/http.ts`), which does **not** use `fetch()` — it uses `undici.Client` and **manually reconstructs** a `Response`:

   ```ts
   const responseBody = await resp.body.text();   // '' for a 304 — empty string, NOT null
   return new Response(responseBody, { status: resp.statusCode /* 304 */, headers });
   ```

   Per the WHATWG Fetch spec, **204 / 205 / 304** are *null-body statuses*: the `Response` constructor **throws** if given a non-null body. `''` is non-null → `TypeError: Response constructor: Invalid response status code 304`, surfaced as `AdtNetworkError`.

### Why it was never seen before
The direct `fetch()` path (local stdio / direct HTTP) returns a native 304 `Response` and never reconstructs one, so 304 flows through fine. The bug is **specific to the Cloud Connector / RISE proxy path**.

### Why the 304s and the write error are the same root cause
The 304s in the logs are the read-cache revalidation; the write failure is that same 304 crashing the hand-rolled `Response` during the read-before-write. One problem, not two.

## The fix

`src/adt/http.ts` — pass a `null` body for null-body statuses:

```ts
const isNullBodyStatus = resp.statusCode === 204 || resp.statusCode === 205 || resp.statusCode === 304;
return new Response(isNullBodyStatus ? null : responseBody, { status: resp.statusCode, headers: responseHeaders });
```

The 304 then reaches `handleResponse()` normally (`< 400`, so not an error), `fetchSource()` sets `notModified: true`, and the caching layer serves the cached source — the write proceeds.

## Scope / blast radius

- Only touches the **proxy reconstruction** path (`doProxyRequest`). The direct `fetch()` path is unchanged.
- No behavior change for 200 / 4xx / 5xx.
- Restores correctness **and** keeps the ETag cache benefit (no need for the `ARC1_CACHE=none` workaround).

## Tests

Regression test added in `tests/unit/adt/http.test.ts` (`proxy configuration` block), driving a 304 through the proxy path:
- **Without the fix:** fails with the exact field error (`AdtNetworkError: … Invalid response status code 304`).
- **With the fix:** passes (`statusCode === 304`, body `''`).

`http.test.ts` (121 passing), `npm run typecheck`, and `biome check` all green.

## Operator workaround (pre-fix)

`ARC1_CACHE=none` stops sending `If-None-Match` (no 304, no crash) at the cost of re-downloading sources every call. The fix removes the need for it.

---
Validated live on a Cloud Connector sandbox deployment before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)