### PR TITLE
chore(deploy): drop fixed route host so CF assigns a globally-unique default

### DIFF
--- a/docs_page/deployment-best-practices.md
+++ b/docs_page/deployment-best-practices.md
@@ -56,6 +56,8 @@ cf deploy mta_archives/arc1-mcp_*.mtar -e mta-ecc-dev.mtaext
 cf deploy mta_archives/arc1-mcp_*.mtar -e mta-ecc-prod.mtaext
 ```
 
+> **Route URL:** pin a `host:` in each `.mtaext` so the app gets the short, predictable URL its MCP clients connect to (`arc1-ecc-dev` → `https://arc1-ecc-dev.cfapps.<region>.hana.ondemand.com/mcp`). Without a pinned host the deploy service assigns a long, globally-unique auto-route that you only learn after deploy via `cf app <name>`. The host must be free across the *whole* shared `cfapps.<region>.hana.ondemand.com` domain (unique per region, not per subaccount), so use landscape-specific names. See the "Route host" block in `mta-overrides.mtaext.example`.
+
 ```
 CF Apps:
 ┌──────────────────────────────────┐

--- a/mta-overrides.mtaext.example
+++ b/mta-overrides.mtaext.example
@@ -139,16 +139,25 @@ modules:
       # landscapes with proper CA-signed certificates.
       # SAP_INSECURE: "false"
 
-    # ── Per-space naming override (host / xsappname) ─────────────────
-    # Base mta.yaml derives the route host and the XSUAA `xsappname` from the
-    # CF space via `${space}`, which must resolve to a valid host AND xsappname
-    # (lowercase letters, digits, hyphens — no spaces or underscores). If your
-    # space name violates that, or you want explicit names, pin them:
-    #   • add a `parameters:` block to the arc1-mcp-server module above (a
-    #     sibling of `properties:`):
+    # ── Route host — pick your public URL (recommended) ──────────────
+    # Base mta.yaml sets NO host, so the deploy service assigns a globally
+    # unique but long auto-host (e.g.
+    # myorg-1a2b3c4d-dev-myspace-arc1-mcp-server.cfapps.<region>...). To deploy
+    # under a short URL you control — the one your MCP clients connect to — pin
+    # `host:` here. Add a `parameters:` block to the arc1-mcp-server module
+    # above (a sibling of `properties:`):
     #       parameters:
-    #         host: arc1-mcp-prod
-    #   • and append this resource block (a sibling of `modules:`):
+    #         host: arc1-mcp-prod    # -> https://arc1-mcp-prod.cfapps.<region>.../mcp
+    # The host must be lowercase letters/digits/hyphens (no spaces/underscores)
+    # AND free on the shared `cfapps.<region>.hana.ondemand.com` domain (it is
+    # first-come-first-served across ALL subaccounts in that region) — pick a
+    # customer/landscape-specific name like `arc1-mcp-teag` to avoid clashes.
+    #
+    # ── XSUAA xsappname (optional, independent of the route) ─────────
+    # Base mta.yaml derives the XSUAA `xsappname` from the CF space via
+    # `${space}` (unique within your subaccount — fine to leave as-is). Pin it
+    # only if your space name isn't a valid xsappname or you want a fixed name.
+    # Append this resource block (a sibling of `modules:`):
     #       resources:
     #         - name: arc1-xsuaa
     #           parameters:

--- a/mta.yaml
+++ b/mta.yaml
@@ -52,12 +52,15 @@ modules:
       memory: 512M
       disk-quota: 1024M
       instances: 1
-      # Per-space route host. `${space}` is resolved by the deploy service at
-      # deploy time, so the SAME mtar deployed into different spaces of one
-      # subaccount gets a unique route each time (arc1-mcp-<space>.cfapps...).
-      # NOTE: the resolved value must be a DNS-valid host (lowercase, no
-      # underscores). Override explicitly if a space name violates that.
-      host: arc1-mcp-${space}
+      # No `host:` on purpose. The deploy service then assigns `${default-host}`
+      # (derived from org+space+app), which is GLOBALLY unique on the shared
+      # `cfapps.<region>.hana.ondemand.com` domain and always DNS-valid. CF
+      # routes must be unique across EVERY subaccount on that domain, not just
+      # within yours — a fixed `arc1-mcp-<space>` host collides as soon as two
+      # landscapes (or a space literally named "mcp") pick the same name.
+      # The default route is long/auto-generated; read it back with
+      # `cf app arc1-mcp-server`. To deploy under a short URL you choose, pin
+      # `host:` in your `mta-overrides.mtaext` (see mta-overrides.mtaext.example).
       health-check-type: http
       health-check-http-endpoint: /health
       # Node heap target sized to 87.5% of dyno memory (512M -> 448M) so V8 GCs


### PR DESCRIPTION
## Problem

A user (BTP admin) hit `route already exists` when deploying ARC-1 into a CF space named `mcp`. Root cause is in `mta.yaml`:

```yaml
host: arc1-mcp-${space}
```

`${space}` only varies the host by **space name**, so the route is unique *within one subaccount* but **not across the shared `cfapps.<region>.hana.ondemand.com` domain** — where CF routes are first-come-first-served across **every** subaccount in the region. Two landscapes (or a space literally named `mcp`) picking the same name collide. The old comment claimed this gave a "unique route each time", which is misleading.

## Fix

Remove the `host:` override. The deploy service then assigns `${default-host}` (derived from org+space+app), which:
- is **globally unique** — the org segment carries a random token (e.g. `…-7lrbs13d-dev-…`), the same form the user's *working* URL already had; and
- is always **DNS-valid** — the deploy service lowercases/strips/truncates it, so no more hand-built-host validity worries.

Trade-off: the default route is long and only known after deploy (`cf app arc1-mcp-server`). Admins who want a short, predictable URL pin `host:` in their gitignored `mta-overrides.mtaext` — now the documented, recommended path.

## Changes

- **`mta.yaml`** — drop `host: arc1-mcp-${space}`; rewrite the comment to explain the default-host behaviour and how to override.
- **`mta-overrides.mtaext.example`** — reframe the naming block as "Route host — pick your public URL (recommended)" with the lowercase/unique-per-region rules; keep `xsappname` (still `${space}`-derived, fine — unique per subaccount) as a separate optional note.
- **`docs_page/deployment-best-practices.md`** — add a Route-URL note tying the doc's existing `arc1-ecc-dev.cfapps…` example URLs to pinning `host:` in the `.mtaext`.

## Reviewer notes

- **No source/artifact change** — npm package and Docker image are byte-identical; this only affects CF deployment routing.
- **OAuth unaffected** — `xs-security.json` redirect URIs use `https://*.hana.ondemand.com/**`, which matches both the auto-host and any pinned host.
- **`xsappname` left alone** on purpose — uniqueness there is per-subaccount, and changing it has a larger blast radius (scope refs, role collections).
- Existing deployments that already pin a host (or use a customer-prefixed space name) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)