### PR TITLE
fix(startup): quiet expected feature-probe log noise + deployment/onboarding docs

### DIFF
--- a/docs/research/2026-06-15-startup-probe-log-noise.md
+++ b/docs/research/2026-06-15-startup-probe-log-noise.md
@@ -1,0 +1,151 @@
+# Startup feature-probe log noise + onboarding doc gaps (P0/P1/P2)
+
+**Date:** 2026-06-15
+**Source:** customer feedback (Manuel Fahrbach, TEAG deployment) — see chat thread.
+**Scope:** one PR covering P0 (code), P1 + P2 (docs). P3 (mta logging-service hygiene / AMS) is a
+separate follow-up.
+
+---
+
+## Problem
+
+A perfectly healthy ARC-1 startup logs a wall of `WARN: [http_request]` lines for ADT endpoints that
+are simply **not installed / not activated** on the target system. Admins (esp. non-devs deploying to
+BTP CF) read these as errors and can't tell a benign "feature absent" from a real permission problem.
+
+The infra to suppress this already exists — [`http.ts`](../../src/adt/http.ts) downgrades an expected
+404 to `debug` when `suppressNotFoundLog` is set — but the **startup probes never pass it**, and it is
+404-only (one probe legitimately returns **400**).
+
+## Root cause (verified live)
+
+`probeFeatures()` in [`src/adt/features.ts`](../../src/adt/features.ts) runs ~7 capability/discovery
+GETs in parallel at startup. Every non-2xx is **expected data** captured by the classifier
+(`classifyFeatureProbeStatus` / `classifyTextSearchError` / `classifyAuthProbeError`) and re-reported
+cleanly at a higher layer (feature map; the `Authorization probe: …` INFO/WARN lines in
+[`server.ts`](../../src/server/server.ts); the contextual `ADT discovery unavailable …` warn in
+[`discovery.ts`](../../src/adt/discovery.ts)). But each GET throws `AdtApiError` on `>= 400`
+([http.ts `handleResponse`](../../src/adt/http.ts)), and the single catch in `request()` logs
+`http_request` at **WARN** unless `suppressNotFoundLog && status === 404`. So the raw WARN is pure,
+duplicate noise for these calls.
+
+Key subtlety: the **rap** probe hits `/sap/bc/adt/ddic/ddl/sources`, which **intentionally returns
+400** without query params — the classifier treats that 400 as `available: true` (the probe's *success*
+signal). Yet it logs at WARN. So a 404-only suppression is insufficient; a probe must suppress **any**
+expected non-2xx.
+
+## Live evidence
+
+Captured by running `node dist/index.js --url … --user … --password … --client 001` (stdio) and reading
+stderr. Identical noise pattern on both releases; the exact set varies by what's installed, which is why
+hardcoding statuses is wrong and a per-call "this is a probe" flag is right.
+
+**a4h — S/4HANA 2023, SAP_BASIS 758** (5 noise WARNs):
+```
+WARN [http_request] GET /sap/bc/adt/ddic/sysinfo/hanainfo            404
+WARN [http_request] GET /sap/bc/adt/debugger/amdp                    404
+WARN [http_request] GET /sap/bc/adt/ddic/ddl/sources                 400   ← rap probe SUCCESS, mislogged
+WARN [http_request] GET /sap/bc/adt/filestore/ui5-bsp                404
+WARN [http_request] GET /sap/bc/adt/repository/informationsystem/textSearch?…  404
+INFO Authorization probe: object search access is available
+INFO Authorization probe: transport access is available
+```
+
+**a4h-2025 — ABAP Platform 2025, SAP_BASIS 816** (6 noise WARNs — adds abapGit, matches Manuel's
+screenshot exactly):
+```
+WARN [http_request] GET /sap/bc/adt/ddic/sysinfo/hanainfo            404
+WARN [http_request] GET /sap/bc/adt/abapgit/repos                    404
+WARN [http_request] GET /sap/bc/adt/ddic/ddl/sources                 400
+WARN [http_request] GET /sap/bc/adt/filestore/ui5-bsp                404
+WARN [http_request] GET /sap/bc/adt/debugger/amdp                    404
+WARN [http_request] GET /sap/bc/adt/repository/informationsystem/textSearch?…  404
+INFO Authorization probe: object search access is available
+INFO Authorization probe: transport access is available
+```
+
+The two `Authorization probe: … is available` INFO lines are the green-light signal (P1 doc anchor).
+
+## Startup probe call inventory (all in features.ts unless noted)
+
+| line | endpoint | expected miss |
+|------|----------|---------------|
+| 111  | each `PROBES[]` endpoint (hana/abapGit/gcts/rap/amdp/ui5/transport/ui5repo/flp) | 404 absent; **400 = rap success**; 405 |
+| 260  | `/sap/bc/adt/system/components` | 4xx → silently `{}` |
+| 285  | `/sap/bc/adt/abapsource/syntax/configurations` | 4xx → silently `undefined` |
+| 350  | `…/informationsystem/textSearch?…` (probeTextSearch) | 404 not activated; 501 < 7.51 |
+| 405  | `…/informationsystem/search?…` (probeSearchAccess) | 403 → reported at server.ts:375 |
+| 422  | `/sap/bc/adt/cts/transportrequests?user=__PROBE__` (probeTransportAccess) | 403 → server.ts:381 |
+| discovery.ts:35 | `/sap/bc/adt/discovery` | error → contextual warn at discovery.ts:44 |
+
+Every one has higher-layer reporting, so the raw `http_request` WARN is always redundant for these.
+
+---
+
+## Plan
+
+### P0 — code: mark startup probes so expected misses log at `debug`
+
+1. **`src/adt/http.ts`** — add `probe?: boolean` to `AdtRequestOptions` (next to `suppressNotFoundLog`,
+   with a doc comment: capability/discovery probe; any non-2xx is expected, log at debug). In the
+   `request()` catch (the `AdtApiError` branch, ~line 755) compute:
+   ```ts
+   const isProbeMiss = options?.probe === true;                                  // any status
+   const isSuppressedNotFound = options?.suppressNotFoundLog === true && err.statusCode === 404;
+   const level = isProbeMiss || isSuppressedNotFound ? 'debug' : 'warn';
+   ```
+   Leave `suppressNotFoundLog` (404-only) untouched for its existing callers (crud.ts:294, client.ts:477).
+2. **`src/adt/features.ts`** — pass `{ probe: true }` to the 6 startup GETs (lines 111, 260, 285, 350,
+   405, 422). For 111 and 350 the call has no headers arg → `client.get(url, undefined, { probe: true })`.
+3. **`src/adt/discovery.ts`** — pass `{ probe: true }` to the line-35 GET (keeps its contextual warn).
+
+### P0 — tests
+
+- **`tests/unit/adt/http.test.ts`** — mirror the existing "logs expected 404s at debug" test: assert a
+  `{ probe: true }` GET logs the `http_request` event at `debug` for **both** a 404 and a **400**
+  (the 400 is the case `suppressNotFoundLog` can't cover); and that a plain GET (no opts) still logs WARN.
+- **`tests/unit/adt/features.test.ts`** — assert the probe loop / probeTextSearch pass `probe: true`
+  (spy on `client.get` mock and check the 3rd arg), so a future refactor can't silently drop it. Match
+  whatever mocking style features.test.ts already uses.
+
+### P1 — docs: healthy-startup reference + scope/OAuth troubleshooting
+
+- **`docs_page/log-analysis.md`** — new "What a healthy startup looks like" section: paste the real
+  transcript above (post-fix: the probe misses are gone from default WARN; show the INFO green-light
+  lines + `Authorization probe: … is available`). State plainly: those two probe lines = SAP perms OK;
+  a `… denied —` / `… not available —` line, or a `403`, = check `S_DEVELOP` / `S_ADT_RES`. Add a short
+  "OAuth scope troubleshooting" note: stale DCR/xsuaa cache → re-login / incognito; role collection must
+  be assigned under the **correct IdP** (e.g. `--of-idp sap.custom`, not `sap.default`).
+- **`docs_page/btp-cloud-foundry-deployment.md`** — link to the new section ("After deploy, confirm a
+  healthy startup → see Log Analysis").
+
+### P2 — docs: BAS-only deploy path + quickstart `--insecure`
+
+- **`docs_page/btp-cloud-foundry-deployment.md`** — short "Deploy entirely from BAS (no local dev env)"
+  subsection: clone/`git pull` the repo in a BAS dev space, `mbt build`, `cf deploy` — the path a non-dev
+  admin can follow without a local toolchain.
+- **`docs_page/quickstart.md:37`** — show `--insecure` as an actual flag in the verify command block,
+  not only in prose. **Verified live:** a bare `--insecure` does NOT work — `getFlag()` in `config.ts`
+  needs a following value, and `resolveBool` only enables on `'true'`/`'1'`, so `--insecure` alone (or
+  followed by another `--flag`) resolves to *false* and a self-signed cert still fails with `fetch
+  failed`. Tested against `https://a4h…:50001`: `--insecure true` → preflight succeeds; bare
+  `--insecure` (last arg) → `fetch failed`. Doc must show `--insecure true`. (Manuel was right.)
+
+### Out of scope (P3, separate PR)
+
+`application-logs` service is deprecated; make it optional via `mta-overrides.mtaext` and/or plan
+AMS / cloud-logging. Tracked separately.
+
+## Verification
+
+- `npm test`, `npm run typecheck`, `npm run lint`, `npm run build`.
+- **Live re-capture** on a4h (758) and a4h-2025 (816): the 5–6 probe WARNs disappear from default log
+  output; the `Authorization probe: … is available` INFO lines remain. This is the definitive check.
+
+## Phase-1 exit gate
+
+- [x] Exact endpoints + live response **content** (404/400 bodies) captured on 758 **and** 816
+- [x] Behavior is ARC-1-internal logging (no ADT contract change); classifier semantics read in full
+- [x] Per-release: verified identical pattern on 758 + 816; fix is release-invariant by construction
+- [x] Every affected file listed (http.ts, features.ts, discovery.ts, 2 test files, 3 docs)
+- [x] Findings written here with cited evidence

--- a/docs_page/btp-cloud-foundry-deployment.md
+++ b/docs_page/btp-cloud-foundry-deployment.md
@@ -57,6 +57,25 @@ Deploy ARC-1 on SAP BTP Cloud Foundry, connecting to an on-premise SAP system vi
 
 MTA (Multi-Target Application) deployment bundles ARC-1 with its BTP service dependencies (XSUAA, Destination, Connectivity) into a single deployable archive. Services are created automatically.
 
+!!! tip "No local dev environment? Deploy entirely from SAP Business Application Studio (BAS)"
+    You do **not** need a local toolchain to deploy ARC-1. SAP Business Application Studio ships with
+    `git`, the `cf` CLI, and `mbt` (MTA Build Tool) preinstalled — so a BTP admin can deploy and
+    configure ARC-1 without setting up a developer machine.
+
+    1. In the BTP Cockpit, open **Business Application Studio** and create a **Dev Space** (the *Full
+       Stack Cloud Application* type already has CF tools).
+    2. Open a terminal in the Dev Space and run the same steps as below:
+       ```bash
+       git clone https://github.com/marianfoo/arc-1.git
+       cd arc-1
+       cp mta-overrides.mtaext.example mta-overrides.mtaext   # edit your destinations + flags
+       cf login -a <your-cf-api-endpoint>                     # target the org/space to deploy into
+       npm ci                                                 # mbt's before-all build needs deps
+       npm run btp:build-deploy-ext
+       ```
+    3. To redeploy a newer version later, just `git pull` in the same Dev Space and re-run
+       `npm run btp:build-deploy-ext`. Everything stays inside BTP — nothing is built or stored locally.
+
 ### 1. Configure your landscape via `mta-overrides.mtaext`
 
 `mta.yaml` ships with placeholder destinations (`your-basic-destination` / `your-pp-destination`) and conservative safety defaults (writes off, free SQL off, package allowlist `$TMP`). Every landscape must override at least the two destination names — deploying `mta.yaml` as-is will fail with a "destination not found" error from BTP, which is the intended fail-fast signal.
@@ -138,6 +157,28 @@ The base `mta.yaml` already configures these properties (override any of them vi
 - `SAP_PP_ENABLED: "true"` — per-user principal propagation
 - `SAP_XSUAA_AUTH: "true"` — XSUAA OAuth for MCP clients
 - `SAP_ALLOW_*: "false"` and `SAP_ALLOWED_PACKAGES: "$TMP"` — safe defaults; widen only as needed
+
+### 4. Verify a healthy startup
+
+After the app starts, the startup log tells you immediately whether ARC-1 reached SAP and the SAP user
+has the right authorizations — **before** you connect an MCP client:
+
+```bash
+cf logs arc1-mcp-server --recent
+```
+
+Look for the two green-light lines (you can also read these in the **Logs** tab of the app in the BTP
+Cockpit):
+
+```
+INFO: Authorization probe: object search access is available
+INFO: Authorization probe: transport access is available
+```
+
+`404`/`400` probe lines for optional features (abapGit, AMDP, RAP, UI5, …) are **expected and harmless**
+— they're logged at `debug`, not `warn`, and just mean those capabilities aren't installed. A clean
+startup has no `WARN` lines from probing. For the full annotated transcript, the green/red signals, and
+OAuth scope troubleshooting, see **[Log Analysis → What a Healthy Startup Looks Like](log-analysis.md#what-a-healthy-startup-looks-like)**.
 
 ---
 

--- a/docs_page/log-analysis.md
+++ b/docs_page/log-analysis.md
@@ -44,6 +44,88 @@ The file sink always receives ALL events regardless of stderr level.
 | `elicitation_sent` | info | Elicitation prompt sent to client |
 | `elicitation_response` | info | User response to elicitation |
 
+## What a Healthy Startup Looks Like
+
+After you deploy (or run locally), the **startup transcript is the fastest way to confirm SAP
+connectivity and authorization are working** — before you ever make a tool call. On BTP Cloud Foundry,
+read it with `cf logs arc1-mcp-server --recent` (or the **Logs** tab of the app in the BTP Cockpit).
+
+A healthy startup at the default `info` level looks like this (real output, S/4HANA 2023 / ABAP
+Platform 2025):
+
+```
+INFO: [server_start] {"version":"0.9.x","transport":"stdio","allowWrites":...,"url":"http://your-sap:50000"}
+INFO: ARC-1 starting {"version":"0.9.x","transport":"...","url":"..."}
+INFO: SAP semaphore {"maxConcurrent":10,"scope":"server-wide"}
+INFO: Object cache enabled {"mode":"auto",...}
+INFO: ARC-1 MCP server running on stdio          # (or: "ARC-1 HTTP server started" on BTP)
+INFO: Startup auth preflight succeeded for shared SAP credentials. {"endpoint":"/sap/bc/adt/core/discovery"}
+INFO: Authorization probe: object search access is available
+INFO: Authorization probe: transport access is available
+```
+
+### The two green-light signals
+
+```
+INFO: Authorization probe: object search access is available
+INFO: Authorization probe: transport access is available
+```
+
+**These two lines mean your SAP authorizations are correct.** If you see them, ARC-1 reached SAP,
+authenticated, and the SAP user can search the repository and read transports — the foundation every
+tool call builds on. (Under principal propagation the preflight is skipped — each user authenticates at
+runtime — so you'll instead see `Skipped startup auth preflight: principal propagation mode is enabled`;
+the per-user authorization probe then runs on that user's first call.)
+
+If instead you see either of:
+
+```
+WARN: Authorization probe: object search access denied — <reason>
+INFO: Authorization probe: transport access is not available — <reason>
+```
+
+…the SAP **user** is missing an authorization (not an ARC-1 bug). Search/read needs `S_DEVELOP` and
+`S_ADT_RES` (read-only users need `S_ADT_RES` with `ACTVT = 01 AND 02` — several ADT reads are POSTs).
+See [Authorization](authorization.md) and [Principal Propagation](principal-propagation-setup.md).
+
+### "Feature not available" is normal, not an error
+
+ARC-1 probes optional capabilities at startup (abapGit, AMDP, RAP/CDS, UI5, HANA info, source search,
+…). Any capability your system doesn't have simply returns `404` (not installed / ICF service not
+active) or `400` — **this is expected and is recorded as data, not an error.** These probe misses are
+logged at `debug`, so they do **not** appear at the default `info` level. A clean startup has **no
+`WARN` lines** from probing.
+
+If you run with `ARC1_LOG_LEVEL=debug`, you'll see them — and they're still harmless:
+
+```
+DEBUG: [http_request] {"method":"GET","path":"/sap/bc/adt/abapgit/repos","statusCode":404,...}
+DEBUG: [http_request] {"method":"GET","path":"/sap/bc/adt/debugger/amdp","statusCode":404,...}
+DEBUG: [http_request] {"method":"GET","path":"/sap/bc/adt/ddic/ddl/sources","statusCode":400,...}
+```
+
+These just mean abapGit/AMDP aren't installed and the RAP probe returned its expected `400` — ARC-1
+disables those features gracefully and serves the rest. The resolved feature set is what matters, not
+the individual probe responses.
+
+> A genuine problem looks different: a `WARN`/`error` `auth_scope_denied`, a `401` on the auth
+> preflight, an `Authorization probe: … denied` line, or `Startup auth preflight failed` — those are
+> worth investigating; a `404` probe miss at `debug` is not.
+
+### OAuth scope errors on the MCP client (not SAP)
+
+A different failure class: the MCP client (Claude, Copilot, …) can't complete OAuth and reports an
+`invalid_scope` / scope error even though your user has the right role collection. This is almost always
+a **stale cache**, not a missing authorization:
+
+- Log out of the MCP client's OAuth session and reconnect — or use a fresh/incognito browser window for
+  the consent step. A previous deployment's XSUAA/DCR client registration is often cached.
+- Verify the role collection is assigned under the **correct identity provider**. If your subaccount
+  uses a custom IdP (e.g. SAP IAS), assign the role collection to the user *under that IdP*
+  (`--of-idp <your-idp>`), not the default SAP ID service — otherwise the JWT carries no ARC-1 scopes.
+- After a redeploy that recreated the XSUAA service, give the client one clean re-login; cached
+  `client_id`s from the old service instance produce scope errors until they re-register.
+
 ## Analyzing Logs with jq
 
 ### Recent Errors

--- a/docs_page/quickstart.md
+++ b/docs_page/quickstart.md
@@ -24,7 +24,8 @@ That's it. No global install, no config files.
 ```bash
 npx arc-1@latest --url https://your-sap-host:44300 \
                  --user YOUR_USER --password YOUR_PASS \
-                 --client 100
+                 --client 100 \
+                 --insecure true   # only for self-signed dev certs; omit on trusted TLS
 ```
 
 You should see a startup line like:
@@ -34,7 +35,13 @@ INFO: auth: MCP=[none] SAP=basic (shared)
 INFO: ARC-1 MCP server running on stdio
 ```
 
-Hit `Ctrl+C` to stop. If this failed, check TLS (`--insecure` for self-signed dev certs), the client number, and that the user can log into SE80 via the web GUI.
+Hit `Ctrl+C` to stop. If this failed, check TLS, the client number, and that the user can log into SE80 via the web GUI.
+
+!!! warning "`--insecure` needs an explicit value"
+    Pass `--insecure true` (or `--insecure=true`), **not** a bare `--insecure`. The flag takes a value;
+    `--insecure` on its own is parsed as *off*, so a self-signed cert still fails with `fetch failed`.
+    The same applies to the other boolean flags (`--allow-writes true`, etc.) and to the `SAP_INSECURE=true`
+    environment variable.
 
 ### If direct ADT HTTP(S) is not reachable
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2734,16 +2734,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2942,9 +2942,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5053,9 +5053,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.15.tgz",
-      "integrity": "sha512-qpgllRxrLqwsMAGRdLhsEr9bepaOQk1rxH1xT2coBXLaEB/bfkqQj1j7RMxwMfnYrvO1ZnFMiwX+wBVgnsyn0g==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,9 @@
     "zod": "^4.3.6"
   },
   "overrides": {
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "form-data": "^4.0.6",
+    "vite": "^8.0.16"
   },
   "lint-staged": {
     "*.{ts,js,json}": "biome check --write --no-errors-on-unmatched"

--- a/src/adt/discovery.ts
+++ b/src/adt/discovery.ts
@@ -32,7 +32,7 @@ export function hasNhiWorkspace(xml: string): boolean {
  */
 export async function fetchDiscoveryDocument(client: AdtHttpClient): Promise<DiscoveryFetchResult> {
   try {
-    const resp = await client.get('/sap/bc/adt/discovery', { Accept: 'application/atomsvc+xml' });
+    const resp = await client.get('/sap/bc/adt/discovery', { Accept: 'application/atomsvc+xml' }, { probe: true });
     return { map: parseDiscoveryDocument(resp.body), nhiPresent: hasNhiWorkspace(resp.body) };
   } catch (err) {
     const reason =

--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -108,7 +108,7 @@ export async function probeFeatures(
     Promise.all(
       probesToRun.map(async (probe) => {
         try {
-          await client.get(probe.endpoint);
+          await client.get(probe.endpoint, undefined, { probe: true });
           return classifyFeatureProbeStatus(probe.id, 200);
         } catch (err) {
           if (err instanceof AdtApiError) {
@@ -257,7 +257,11 @@ interface SystemDetection {
  */
 async function detectSystemFromComponents(client: AdtHttpClient): Promise<SystemDetection> {
   try {
-    const resp = await client.get('/sap/bc/adt/system/components', { Accept: 'application/atom+xml;type=feed' });
+    const resp = await client.get(
+      '/sap/bc/adt/system/components',
+      { Accept: 'application/atom+xml;type=feed' },
+      { probe: true },
+    );
     if (resp.statusCode >= 400) return {};
     const components = parseInstalledComponents(resp.body);
     const basis = components.find((c) => c.name.toUpperCase() === 'SAP_BASIS');
@@ -282,9 +286,11 @@ async function detectSystemFromComponents(client: AdtHttpClient): Promise<System
  */
 async function detectReleaseFromSyntaxConfigurations(client: AdtHttpClient): Promise<string | undefined> {
   try {
-    const resp = await client.get('/sap/bc/adt/abapsource/syntax/configurations', {
-      Accept: 'application/vnd.sap.adt.syntaxconfigurations+xml',
-    });
+    const resp = await client.get(
+      '/sap/bc/adt/abapsource/syntax/configurations',
+      { Accept: 'application/vnd.sap.adt.syntaxconfigurations+xml' },
+      { probe: true },
+    );
     if (resp.statusCode >= 400) return undefined;
     const configs = parseSyntaxConfigurations(resp.body);
     return configs.find((c) => c.version === 'X')?.etag || undefined;
@@ -347,7 +353,13 @@ export function detectSystemType(
  */
 export async function probeTextSearch(client: AdtHttpClient): Promise<{ available: boolean; reason?: string }> {
   try {
-    await client.get('/sap/bc/adt/repository/informationsystem/textSearch?searchString=SY-SUBRC&maxResults=1');
+    await client.get(
+      '/sap/bc/adt/repository/informationsystem/textSearch?searchString=SY-SUBRC&maxResults=1',
+      undefined,
+      {
+        probe: true,
+      },
+    );
     return { available: true };
   } catch (err: unknown) {
     if (err && typeof err === 'object' && 'statusCode' in err) {
@@ -404,6 +416,8 @@ async function probeSearchAccess(client: AdtHttpClient): Promise<{ available: bo
   try {
     const resp = await client.get(
       '/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=CL_ABAP_*&maxResults=1',
+      undefined,
+      { probe: true },
     );
     if (resp.statusCode < 400) {
       return { available: true };
@@ -419,7 +433,7 @@ async function probeSearchAccess(client: AdtHttpClient): Promise<{ available: bo
 
 async function probeTransportAccess(client: AdtHttpClient): Promise<{ available: boolean; reason?: string }> {
   try {
-    const resp = await client.get('/sap/bc/adt/cts/transportrequests?user=__PROBE__');
+    const resp = await client.get('/sap/bc/adt/cts/transportrequests?user=__PROBE__', undefined, { probe: true });
     if (resp.statusCode < 400) {
       return { available: true };
     }

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -42,6 +42,16 @@ export interface AdtRequestOptions {
    * Callers that handle those 404s can opt into debug-level audit logging.
    */
   suppressNotFoundLog?: boolean;
+  /**
+   * Startup capability/discovery probe. ANY non-2xx is expected here (the feature
+   * is simply absent/not activated, or the endpoint intentionally 400s without
+   * query params, e.g. the RAP probe on `/ddic/ddl/sources`). The outcome is
+   * captured as structured data and re-reported at a higher layer (feature map,
+   * the `Authorization probe: …` lines, the contextual discovery warn), so the
+   * raw `http_request` failure is logged at debug instead of warn to keep a
+   * healthy startup quiet. Unlike `suppressNotFoundLog` this is not limited to 404.
+   */
+  probe?: boolean;
 }
 
 /**
@@ -752,7 +762,12 @@ export class AdtHttpClient {
       // Log failed HTTP requests
       const durationMs = Date.now() - httpStart;
       if (err instanceof AdtApiError) {
-        const level = options?.suppressNotFoundLog && err.statusCode === 404 ? 'debug' : 'warn';
+        // Probe calls expect misses (feature absent / intentional 400); their outcome is
+        // reported at a higher layer, so the raw failure is debug-level noise. suppressNotFoundLog
+        // stays 404-only for its callers (optional class includes etc.).
+        const isProbeMiss = options?.probe === true;
+        const isSuppressedNotFound = options?.suppressNotFoundLog === true && err.statusCode === 404;
+        const level = isProbeMiss || isSuppressedNotFound ? 'debug' : 'warn';
         logger.emitAudit({
           timestamp: new Date().toISOString(),
           level,

--- a/tests/unit/adt/discovery.test.ts
+++ b/tests/unit/adt/discovery.test.ts
@@ -94,9 +94,11 @@ describe('ADT Discovery', () => {
       const client = mockClient(async () => ({ body: xml }));
       const { map } = await fetchDiscoveryDocument(client);
       expect(map.size).toBe(9);
-      expect((client as any).get).toHaveBeenCalledWith('/sap/bc/adt/discovery', {
-        Accept: 'application/atomsvc+xml',
-      });
+      expect((client as any).get).toHaveBeenCalledWith(
+        '/sap/bc/adt/discovery',
+        { Accept: 'application/atomsvc+xml' },
+        { probe: true },
+      );
     });
 
     it('returns empty map on 404', async () => {

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -475,9 +475,25 @@ describe('Feature Detection', () => {
       const client = mockProbeClient();
       await probeFeatures(client, defaultConfig);
 
-      expect((client as any).get).toHaveBeenCalledWith('/sap/bc/adt/discovery', {
-        Accept: 'application/atomsvc+xml',
-      });
+      expect((client as any).get).toHaveBeenCalledWith(
+        '/sap/bc/adt/discovery',
+        { Accept: 'application/atomsvc+xml' },
+        { probe: true },
+      );
+    });
+
+    it('marks every startup probe GET as a probe so expected misses log at debug, not warn', async () => {
+      const client = mockProbeClient();
+      await probeFeatures(client, defaultConfig);
+
+      // Every startup GET (feature probes, textSearch, auth probes, system/components,
+      // syntax configurations, discovery) must pass { probe: true } — otherwise an
+      // expected 404/400 miss logs a scary WARN on a perfectly healthy startup.
+      const calls = (client as any).get.mock.calls as Array<[string, unknown, { probe?: boolean }?]>;
+      expect(calls.length).toBeGreaterThan(0);
+      for (const [url, , opts] of calls) {
+        expect(opts, `startup GET ${url} must pass { probe: true }`).toMatchObject({ probe: true });
+      }
     });
 
     it('does not fail feature probing when discovery request fails', async () => {
@@ -543,9 +559,11 @@ describe('Feature Detection', () => {
       const result = await probeFeatures(client, defaultConfig);
 
       expect(result.abapRelease).toBe('757');
-      expect((client as any).get).toHaveBeenCalledWith('/sap/bc/adt/abapsource/syntax/configurations', {
-        Accept: 'application/vnd.sap.adt.syntaxconfigurations+xml',
-      });
+      expect((client as any).get).toHaveBeenCalledWith(
+        '/sap/bc/adt/abapsource/syntax/configurations',
+        { Accept: 'application/vnd.sap.adt.syntaxconfigurations+xml' },
+        { probe: true },
+      );
     });
 
     it('skips syntax-configurations probe when components feed already yields a release', async () => {

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -422,6 +422,47 @@ describe('AdtHttpClient', () => {
       emitSpy.mockRestore();
     });
 
+    it('logs probe misses at debug level for any status (404 and 400)', async () => {
+      const { logger } = await import('../../../src/server/logger.js');
+
+      // 404 — feature absent (e.g. abapGit/AMDP not installed)
+      const spy404 = vi.spyOn(logger, 'emitAudit').mockImplementation(() => undefined);
+      mockFetch.mockResolvedValueOnce(mockResponse(404, 'No suitable resource found'));
+      await expect(
+        new AdtHttpClient(getDefaultConfig()).get('/sap/bc/adt/abapgit/repos', undefined, { probe: true }),
+      ).rejects.toThrow(AdtApiError);
+      const ev404 = spy404.mock.calls.map((c) => c[0]).find((e) => e.event === 'http_request' && e.statusCode === 404);
+      expect(ev404?.level).toBe('debug');
+      spy404.mockRestore();
+
+      // 400 — the RAP probe (`/ddic/ddl/sources`) intentionally 400s without query params;
+      // suppressNotFoundLog (404-only) can't cover this, which is why `probe` exists.
+      const spy400 = vi.spyOn(logger, 'emitAudit').mockImplementation(() => undefined);
+      mockFetch.mockResolvedValueOnce(mockResponse(400, 'uriMappingError'));
+      await expect(
+        new AdtHttpClient(getDefaultConfig()).get('/sap/bc/adt/ddic/ddl/sources', undefined, { probe: true }),
+      ).rejects.toThrow(AdtApiError);
+      const ev400 = spy400.mock.calls.map((c) => c[0]).find((e) => e.event === 'http_request' && e.statusCode === 400);
+      expect(ev400?.level).toBe('debug');
+      spy400.mockRestore();
+    });
+
+    it('logs a non-probe 404 at warn level (default — no opt-in)', async () => {
+      const { logger } = await import('../../../src/server/logger.js');
+      const emitSpy = vi.spyOn(logger, 'emitAudit').mockImplementation(() => undefined);
+      mockFetch.mockResolvedValueOnce(mockResponse(404, 'Object not found'));
+
+      await expect(
+        new AdtHttpClient(getDefaultConfig()).get('/sap/bc/adt/programs/programs/ZNOPE/source/main'),
+      ).rejects.toThrow(AdtApiError);
+
+      const failedRequest = emitSpy.mock.calls
+        .map((call) => call[0])
+        .find((event) => event.event === 'http_request' && event.statusCode === 404);
+      expect(failedRequest?.level).toBe('warn');
+      emitSpy.mockRestore();
+    });
+
     it('throws AdtApiError on 500', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(500, 'Internal Server Error'));
 


### PR DESCRIPTION
## What & why

Customer feedback (TEAG BTP deployment): a **perfectly healthy** ARC-1 startup logs a wall of
`WARN: [http_request]` lines for ADT endpoints that simply aren't installed/activated on the target
system. Admins — especially non-devs deploying to BTP CF — read these as errors and can't tell a benign
"feature absent" from a real permission problem.

This PR bundles the fix (P0) with the doc gaps the same user hit (P1/P2). P3 (deprecated
`application-logs` service / AMS) is a separate follow-up.

### P0 — code: log expected probe misses at `debug`, not `warn`

Every startup probe in `probeFeatures()` runs a capability/discovery GET whose non-2xx outcome is
**expected data** — it's classified and re-reported at a higher layer (the resolved feature map, the
`Authorization probe: …` lines, the contextual discovery warn). But each GET throws on `>= 400`, and the
single catch in `request()` logged it at WARN unless `suppressNotFoundLog && status === 404`. The RAP
probe on `/ddic/ddl/sources` intentionally returns **400** (its success signal), which 404-only
suppression can't cover.

- New `probe?: boolean` request option: an expected miss of **any** status logs at `debug`.
- `suppressNotFoundLog` stays 404-only for its existing callers (optional class includes, etc.).
- All 7 startup probe/discovery GETs marked as probes.
- Downgraded events still reach the file/BTP audit sinks and `--verbose` stderr — nothing is lost, only
  the noisy default-level WARN is gone.

### P1 — docs: healthy-startup reference + scope/OAuth troubleshooting

- New **"What a Healthy Startup Looks Like"** section in the Log Analysis guide: the real annotated
  transcript, the two `Authorization probe: … is available` green-light lines, why 404/400 probe misses
  are expected, and an OAuth-scope troubleshooting note (stale DCR/xsuaa cache, wrong IdP).
- Linked from the BTP CF deployment guide as a post-deploy verification step (`cf logs …`).

### P2 — docs: BAS deploy path + `--insecure` fix

- Document deploying **entirely from SAP Business Application Studio** (no local toolchain — BAS ships
  git/cf/mbt), so a BTP admin can deploy without a dev machine.
- Fix the quickstart `--insecure` example: the flag needs an explicit value (`--insecure true`); a bare
  `--insecure` parses as *off* and a self-signed cert still fails with `fetch failed`.

## Live verification

| System | Release | Before | After |
|--------|---------|--------|-------|
| a4h (S/4HANA 2023) | SAP_BASIS 758 | 5 probe WARNs | **0** WARNs, green-light INFO intact |
| a4h-2025 (ABAP Platform 2025) | SAP_BASIS 816 | 6 probe WARNs (matches reporter's screenshot) | **0** WARNs |

Also verified live: `--insecure true` connects over HTTPS (:50001) while a bare `--insecure` fails with
`fetch failed` — confirming the doc fix.

## Tests

- `tests/unit/adt/http.test.ts`: probe option logs **404 and 400** at debug; a non-probe 404 still logs warn.
- `tests/unit/adt/features.test.ts`: asserts **every** startup GET passes `{ probe: true }` (guards against future drift).
- Full gate green: `build`, `typecheck`, `lint`, `validate:policy`, `check:sizes`, `test` (3844 passed).

Research dossier: `docs/research/2026-06-15-startup-probe-log-noise.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)