### PR TITLE
chore(deploy): make deprecated application-logs service opt-in (default off)

### DIFF
--- a/docs/plans/p3-optional-application-logs.md
+++ b/docs/plans/p3-optional-application-logs.md
@@ -1,0 +1,116 @@
+# P3 — Make the deprecated `application-logs` service optional (default off)
+
+**Date:** 2026-06-15
+**Branch:** `chore/optional-application-logs`
+**Source:** customer feedback (Manuel Fahrbach) — `application-logs` shows as *deprecated* with a
+warning at deploy; "was passiert denn, wenn ich kein Application Log mehr drin habe?" Marian: "vielleicht
+sollte ich das dann in die mtaext auslagern."
+
+## Problem
+
+`mta.yaml` unconditionally creates and binds the **SAP Application Logging Service**
+(`arc1-application-logs`, `service: application-logs`). That service is **deprecated** — SAP removed it
+from the list of Eligible Cloud Services on **2025-07-31** (SAP Note 3557260; replacement is **SAP Cloud
+Logging**, OpenTelemetry-based). Consequences today:
+
+- On subaccounts that still have it: a deprecation **warning** at every deploy (what Manuel saw).
+- On newer subaccounts where the service is no longer offered: `cf create-service application-logs lite`
+  is unavailable, so the MTA resource creation can **fail the whole deploy** — a hard block, not a warning.
+
+## Verified facts (live / sourced)
+
+- **Zero code dependency.** `src/adt/btp.ts` parses `VCAP_SERVICES` only for destination / connectivity /
+  xsuaa. Nothing reads an `application-logs` binding. Logs go to **stderr**; CF aggregates them. Removing
+  the binding has **no code impact** — `cf logs` / `cf logs --recent` still work; only the managed
+  aggregation backend (Kibana) goes away.
+- **MTA mechanism (verified against SAP's own `cf-mta-examples/active-optional-resources`):**
+  - `active` is a **resource-level** attribute (sibling of `type`/`parameters`), default `true`.
+    `active: false` ⇒ the service instance is **not created**, and a module that `requires:` it simply
+    **skips the binding** — no deploy failure. SAP's example literally uses `service: application-logs`
+    as the optional-resource demo.
+  - `active` can be **flipped per-deployment via an extension descriptor** (mtaext) — so opt-in is one
+    line in `mta-overrides.mtaext`.
+  - (`optional: true` is a different lever — "ignore failures for this service"; not needed here.)
+- **Schema:** arc1's `mta.yaml` is `_schema-version: "3.1"`. Spiked locally: `npx mbt validate` accepts
+  `active: false` on the resource **and** an mtaext setting `active: true` under 3.1. **No schema bump
+  needed.** (mbt 1.2.26.)
+
+## Decision: default OFF (`active: false`), documented opt-in
+
+Set the resource `active: false` in the base `mta.yaml`; keep the resource definition and the module's
+`requires:` entry intact (so opt-in is just flipping `active`). Rationale:
+
+- The service is removed from the catalog → **active-by-default risks hard deploy failures** on current
+  subaccounts. Off-by-default makes a fresh deploy robust everywhere. This is the stronger argument.
+- Kills the deprecation warning by default (Manuel's complaint).
+- **Tradeoff (call out loudly):** an *existing* deployment that currently relies on Kibana aggregation
+  loses it on its next `cf deploy` unless it opts back in. Acceptable because (a) the service is going
+  away regardless, (b) `cf logs` still works, (c) opt-in is one line, (d) we document it as a migration
+  note. Not silent: the PR body + docs flag it.
+
+Rejected alternative — default ON + documented opt-out: maximally backward-compatible but leaves every
+new deploy pulling a deprecated/removed service (warning, or hard failure on new subaccounts). Net worse.
+
+## Changes
+
+### 1. `mta.yaml`
+- Add `active: false` to the `arc1-application-logs` resource.
+- Replace the bare resource with a comment block: why it's off (deprecated, SAP Note 3557260, removed
+  2025-07-31), that `cf logs` still works, how to opt in (mtaext `active: true`), and the Cloud Logging
+  pointer.
+- Keep `requires: - name: arc1-application-logs` on the module (harmless when inactive; needed for opt-in).
+- Update the services-overview comment if any references it.
+
+### 2. `mta-overrides.mtaext.example`
+- Add a documented, commented opt-in block:
+  ```yaml
+  # ── Application logging (OFF by default — deprecated service) ─────
+  # SAP Application Logging Service is deprecated (SAP Note 3557260; use
+  # SAP Cloud Logging instead). It is NOT created by default. `cf logs`
+  # works without it. To re-enable CF log aggregation on a subaccount
+  # that still offers the service, flip the resource active:
+  # resources:
+  #   - name: arc1-application-logs
+  #     active: true
+  ```
+  (As a sibling of `modules:`, matching the existing `arc1-xsuaa` override example at the bottom.)
+
+### 3. Docs — `docs_page/btp-cloud-foundry-deployment.md`
+- The four-services table lists `Application Logs … Centralized log aggregation (Kibana)`. Change its row
+  to note **optional / off by default / deprecated**, with the opt-in pointer + Cloud Logging.
+- The MTA "services created automatically" prose says *four* services — adjust to "three by default
+  (XSUAA, Destination, Connectivity); Application Logs is optional/off."
+- Add a short note under the deploy/verify area: `cf logs --recent` works without the service.
+
+### 4. Docs — `docs_page/log-analysis.md`
+- The "Enabling File Logging → BTP Cloud Foundry" snippet and surrounding text: add one line that CF
+  `cf logs` works out of the box; managed aggregation needs the (optional) Application Logging service
+  or SAP Cloud Logging.
+
+### 5. Docs — `docs_page/roadmap.md` (roadmap note only; do NOT implement AMS/Cloud Logging)
+- One forward-looking bullet: migrate observability to **SAP Cloud Logging** (OpenTelemetry); track XSUAA
+  → AMS separately. Keeps the bigger migration visible without scope creep.
+
+### Out of scope
+- Implementing SAP Cloud Logging binding / OpenTelemetry export (separate, larger).
+- XSUAA → AMS migration (separate authorization topic; Manuel conflated the two — different deprecations).
+
+## Test plan
+
+1. `npm run btp:validate` — base `mta.yaml` **and** `mta-overrides.mtaext.example` validate (the CI
+   `mta-validate` gate).
+2. `npx mbt build` then inspect the generated `mta_archives/.../META-INF/mtad.yaml`: confirm
+   `arc1-application-logs` carries `active: false` and the module still lists the requires. This is the
+   definitive "deploy will skip it" check short of a real deploy.
+3. Add an mtaext opt-in spike (`active: true`) and `npx mbt validate -e` it — confirm opt-in is accepted
+   (already spiked; keep as a throwaway, do not commit).
+4. Full gate: `npm run build && npm run typecheck && npm run lint && npm test` (no code changed, but
+   confirm nothing regressed; biome formats yaml? no — md/ts only).
+5. **Live deploy is NOT required** for this PR (no target space provisioned for it; the change is
+   deploy-descriptor-only and verified via `mbt build` output). If the user wants belt-and-suspenders, a
+   real `cf deploy` to a throwaway space would confirm the resource is skipped — offer, don't assume.
+
+## Commit / PR
+- Conventional commit: `chore(deploy): make deprecated application-logs service opt-in (default off)`.
+  `chore:` ⇒ no release line, and the CI gate skips the SAP-hitting jobs (this change doesn't need SAP).
+- New PR from `chore/optional-application-logs` → `main`, with the migration-note tradeoff called out.

--- a/docs_page/btp-cloud-foundry-deployment.md
+++ b/docs_page/btp-cloud-foundry-deployment.md
@@ -123,14 +123,23 @@ npm run btp:build
 cf deploy mta_archives/arc1-mcp_*.mtar -e mta-overrides.mtaext
 ```
 
-The `mta.yaml` defines four BTP services that are created automatically:
+The `mta.yaml` creates three BTP services automatically, plus one optional service that is off by default:
 
 | Service | Instance Name | Plan | Purpose |
 |---------|--------------|------|---------|
 | XSUAA | `arc1-xsuaa` | `application` | MCP client OAuth authentication |
 | Destination | `arc1-destination` | `lite` | SAP system lookup |
 | Connectivity | `arc1-connectivity` | `lite` | Cloud Connector proxy |
-| Application Logs | `arc1-application-logs` | `lite` | Centralized log aggregation (Kibana) |
+| Application Logs | `arc1-application-logs` | `lite` | **Optional, off by default** — CF log aggregation (Kibana). The service is **deprecated** (SAP Note 3557260; use SAP Cloud Logging instead), so ARC-1 ships it with `active: false`. `cf logs` works without it; re-enable via `mta-overrides.mtaext` only on subaccounts that still offer it (see below). |
+
+> **Application Logs is off by default.** SAP removed the Application Logging
+> Service from the list of Eligible Cloud Services on 2025-07-31. Binding it by
+> default would warn where it still exists and **fail the deploy** on newer
+> subaccounts where it doesn't. ARC-1 logs to stderr regardless — `cf logs`
+> and `cf logs --recent` work out of the box. To opt back in to managed
+> aggregation, set the resource `active: true` in your `mta-overrides.mtaext`
+> (the template shows the block). For new observability, prefer **SAP Cloud
+> Logging** (OpenTelemetry).
 
 > **Multiple landscapes from one repo.** The gitignore matches any
 > `mta-*.mtaext`, so you can keep `mta-ecc-dev.mtaext`,

--- a/docs_page/log-analysis.md
+++ b/docs_page/log-analysis.md
@@ -16,6 +16,12 @@ env:
   ARC1_LOG_FILE: /tmp/arc1-audit.jsonl
 ```
 
+On BTP Cloud Foundry, ARC-1's stderr logs are always available via `cf logs arc1-mcp-server`
+(live) and `cf logs arc1-mcp-server --recent` (buffer) — no service binding required. The
+deprecated Application Logging Service (Kibana) is **off by default** (SAP Note 3557260); see
+[BTP Cloud Foundry Deployment](btp-cloud-foundry-deployment.md) to opt back in, or use **SAP Cloud
+Logging** for a managed observability stack.
+
 ## Log Levels
 
 Control stderr verbosity with `ARC1_LOG_LEVEL`:

--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -91,6 +91,7 @@ SORT RULES for this table — DO NOT BREAK when adding rows:
 | [FEAT-59](#feat-59) | Embeddable multi-tenant server (per-instance `systemType`) | P3 | M | Features |
 | [FEAT-61](#feat-61) | Tool Extension Points (custom tools on top of ARC-1) | P3 | M-L (phased) | Features |
 | [OPS-03](#ops-03) | Multi-System Routing | P3 | L | Ops |
+| [OPS-05](#ops-05) | SAP Cloud Logging (OpenTelemetry) observability — replace the deprecated Application Logging Service | P3 | M | Ops |
 | ~~[COMPAT-01](#compat-01)~~ | ~~modificationSupport guard in lockObject()~~ | ~~P0~~ | ~~XS~~ | ~~Completed 2026-04-16~~ |
 | ~~[COMPAT-02](#compat-02)~~ | ~~CSRF HEAD→GET fallback (S/4HANA Public Cloud)~~ | ~~P0~~ | ~~XS~~ | ~~Completed 2026-04-16~~ |
 | ~~[COMPAT-03](#compat-03)~~ | ~~V4 SRVB publish endpoint bug~~ | ~~P0~~ | ~~XS~~ | ~~Completed 2026-04-15~~ |
@@ -2005,6 +2006,23 @@ The following features are tracked but not planned for near-term implementation.
 **Why:** Enterprises have multiple SAP systems (DEV, QAS, PRD, sandboxes).
 
 **Why not:** Fundamentally changes the architecture — ARC-1 is a single-system gateway by design. Multi-system routing adds routing logic, session management per system, namespace separation, and tenant isolation complexity. If routing breaks, users from system A could theoretically access system B's data. Better handled at infrastructure level: run one ARC-1 per SAP system and use a load balancer or Kubernetes service mesh to route clients. This follows the 12-factor app pattern and keeps each instance simple and secure.
+
+---
+
+<a id="ops-05"></a>
+### OPS-05: SAP Cloud Logging (OpenTelemetry) observability
+| Field | Value |
+|-------|-------|
+| **Priority** | P3 |
+| **Effort** | M |
+| **Risk** | Low — additive; ARC-1 logs to stderr regardless |
+| **Status** | Not started |
+
+**What:** Optionally bind/emit to **SAP Cloud Logging** (OpenTelemetry-based logs, metrics, traces) as the managed observability backend, replacing the deprecated SAP Application Logging Service.
+
+**Why:** SAP removed the Application Logging Service from the list of Eligible Cloud Services on 2025-07-31 (SAP Note 3557260). ARC-1 already ships that service `active: false` and works on `cf logs` alone; Cloud Logging is the forward-looking managed stack for customers who want aggregation/dashboards.
+
+**Why not yet:** Larger than the off-by-default toggle already shipped — needs a Cloud Logging service binding, an OTLP exporter, and config plumbing. Tracked separately from the XSUAA→AMS authorization migration (a different deprecation often conflated with this one).
 
 ---
 

--- a/mta-overrides.mtaext.example
+++ b/mta-overrides.mtaext.example
@@ -163,3 +163,15 @@ modules:
     #           parameters:
     #             config:
     #               xsappname: arc1-mcp-prod
+
+# ── Application logging (OFF by default — deprecated service) ───────────
+# SAP Application Logging Service is deprecated (SAP Note 3557260; removed from
+# Eligible Cloud Services 2025-07-31 — use SAP Cloud Logging instead), so the
+# base mta.yaml ships it with `active: false` and does NOT create it. ARC-1
+# logs to stderr regardless, so `cf logs` / `cf logs --recent` keep working.
+# To re-enable CF log aggregation on a subaccount that still offers the
+# service, uncomment this resource block (a sibling of `modules:`) to flip the
+# resource active:
+# resources:
+#   - name: arc1-application-logs
+#     active: true

--- a/mta.yaml
+++ b/mta.yaml
@@ -128,6 +128,8 @@ modules:
       - name: arc1-xsuaa
       - name: arc1-destination
       - name: arc1-connectivity
+      # Bound only when the (deprecated) application-logs resource is active —
+      # off by default; skipped automatically while inactive. See resource below.
       - name: arc1-application-logs
 
 resources:
@@ -193,8 +195,21 @@ resources:
       service: connectivity
       service-plan: lite
 
+  # SAP Application Logging Service — OFF by default (`active: false`).
+  # The service is DEPRECATED: SAP removed it from the list of Eligible Cloud
+  # Services on 2025-07-31 (SAP Note 3557260; replacement: SAP Cloud Logging).
+  # Binding it by default would warn on subaccounts that still have it and
+  # HARD-FAIL the deploy on newer subaccounts where it is no longer offered.
+  # ARC-1 logs to stderr regardless, so `cf logs` / `cf logs --recent` keep
+  # working without it — only the managed aggregation backend (Kibana) is gone.
+  # To re-enable CF log aggregation on a subaccount that still offers the
+  # service, flip `active: true` in your `mta-overrides.mtaext` (see the
+  # template). `active` is overridable per-deploy via an extension descriptor;
+  # the module `requires:` entry above stays put and is simply skipped while
+  # the resource is inactive.
   - name: arc1-application-logs
     type: org.cloudfoundry.managed-service
+    active: false
     parameters:
       service: application-logs
       service-plan: lite


### PR DESCRIPTION
## What & why (P3)

The SAP **Application Logging Service** (`arc1-application-logs`) is **deprecated** — SAP removed it from
the list of Eligible Cloud Services on **2025-07-31** ([SAP Note 3557260](https://userapps.support.sap.com/sap/support/knowledge/en/3557260); replacement: **SAP Cloud Logging**). The base `mta.yaml` bound it unconditionally, which:

- **warns** at deploy on subaccounts that still have it (what the reporter saw), and
- **hard-fails the deploy** on newer subaccounts where the service is no longer offered.

This is the P3 follow-up to [#444](https://github.com/marianfoo/arc-1/pull/444).

## Change

- `mta.yaml`: set the `arc1-application-logs` resource **`active: false`** (off by default). The module's
  `requires:` entry is kept — when a resource is inactive the MTA deployer simply skips the binding (no
  failure). Pattern verified against SAP's own [`cf-mta-examples/active-optional-resources`](https://github.com/SAP-samples/cf-mta-examples/tree/main/active-optional-resources) (which, fittingly, uses `application-logs` as its optional-resource demo).
- `mta-overrides.mtaext.example`: documented one-line **opt-in** (`active: true`) for subaccounts that
  still offer the service.
- Docs: services table + callout in the CF deployment guide; a `cf logs` note in the Log Analysis guide;
  an **OPS-05** roadmap entry for the forward-looking SAP Cloud Logging (OpenTelemetry) migration.
- Plan/dossier: `docs/plans/p3-optional-application-logs.md`.

**No code change** — nothing reads the `application-logs` binding from `VCAP_SERVICES`; logging goes to
stderr and CF aggregates it.

## ⚠️ Behavior change (migration note)

An **existing** deployment that currently relies on the Application Logging Service (Kibana) will **lose
that managed aggregation on its next `cf deploy`** unless it opts back in (`active: true` in
`mta-overrides.mtaext`). `cf logs` / `cf logs --recent` keep working regardless. This default was chosen
because the service is being removed anyway and active-by-default *breaks* new deploys; the trade-off is
called out in the docs rather than left silent.

## Verification

- `npx mbt validate` — base `mta.yaml` **and** `mta-overrides.mtaext.example` validate under schema 3.1
  (no schema bump needed).
- `npx mbt build` → the generated `META-INF/mtad.yaml` carries `active: false` on the resource (the
  definitive "deploy will skip it" check) while the module still lists the requires.
- Full gate green: `lint`, `typecheck`, `test` (3844), roadmap anchor sync.
- A real `cf deploy` was **not** run (deploy-descriptor-only change, verified via the generated `mtad.yaml`); happy to do a throwaway-space deploy if you want belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)