### PR TITLE
docs: ARC-1 vs SAP ABAP MCP Server — neutral decision guide

### DIFF
--- a/docs_page/arc-1-vs-sap-abap-mcp-server.md
+++ b/docs_page/arc-1-vs-sap-abap-mcp-server.md
@@ -1,22 +1,34 @@
 # ARC-1 vs. the SAP ABAP MCP Server — Decision Guide
 
-This page compares **ARC-1** with **SAP's official ABAP MCP Server** (the one bundled with *ABAP
-Development Tools for VS Code* and *ADT for Eclipse*) so you can decide which to run — **only
-ARC-1, only the SAP ABAP MCP Server, or both together.**
+This page compares **ARC-1** with **SAP's official ABAP MCP Server** (the *ADT MCP Server* bundled
+with *ABAP Development Tools for VS Code* and *ADT for Eclipse*) so you can decide which to run —
+**only ARC-1, only the SAP ABAP MCP Server, or both together.**
 
 !!! note "Neutral by design"
     This is a decision aid, not a sales page. The two products were built for *different jobs* and
-    the honest answer for many teams is **"use both"**. Where ARC-1 is stronger it says so; where the
+    the honest answer for many teams is **"use both."** Where ARC-1 is stronger it says so; where the
     SAP server is stronger it says so just as plainly. Pick the column that matches **your** situation,
     not the one with more checkmarks.
 
-!!! info "How the facts here were gathered (2026-06-16)"
-    The SAP server's facts were taken from a **live install** running in Eclipse on the author's
-    machine (`ADT MCP Server` v1.0.0, MCP protocol `2025-06-18`, Jetty 12.1.9) bound to an on-premise
-    **S/4HANA 2023** system, cross-checked against SAP's GA announcements at Sapphire 2026 and SAP
-    Community posts (linked under [Sources](#sources)). Tool names, schemas and the creatable-object
-    list below were read directly from that running server. The SAP server evolves quickly — treat
-    counts and tool names as a snapshot, not a contract.
+!!! info "How the facts here were sourced — public vs. snapshot"
+    Two kinds of evidence are mixed below, and the difference matters:
+
+    - **Public / primary sources** (strongest): SAP's Marketplace listing, the **SAP Help "Model
+      Context Protocol Tools"** page (which lists the toolset and a per-tool *Joule License* column),
+      the SAP Help *Enabling/Configuring ADT MCP Server* pages, SAP-samples workshop material
+      (RAP130), SAP News, the ARC-1 repository/docs, and the MCP specification. The **20-tool set,
+      the exact tool IDs, and the licensing split below are confirmed against SAP Help.** See
+      [Sources](#sources).
+    - **Author's live snapshot (2026-06-16, label these as observed, not product-wide):** a running
+      `ADT MCP Server` v1.0.0 in Eclipse on the author's machine — MCP protocol `2025-06-18` (the
+      revision *that server reported*; newer MCP revisions exist), Jetty 12.1.9 — bound to **one**
+      on-prem **S/4HANA 2023** backend. Tool counts, creatable-object lists and "no resources/prompts"
+      are **backend/version dependent**; treat them as a snapshot, not a guarantee.
+
+**One-line verdict:** if you are **one developer working in your IDE on a modern ABAP/RAP system**,
+the SAP server is the most frictionless, best-integrated choice. If you need **a shared, governed,
+audited endpoint for many users / non-IDE agents / on-prem & classic ABAP / SQL · git · transports ·
+dumps**, that is ARC-1's design center. Many teams run **both**.
 
 ---
 
@@ -24,24 +36,19 @@ ARC-1, only the SAP ABAP MCP Server, or both together.**
 
 | | **ARC-1** | **SAP ABAP MCP Server** |
 |---|---|---|
-| **What it is** | Independent MCP server that translates AI tool calls into ADT REST calls | MCP server SAP ships *inside* ADT for VS Code / Eclipse |
-| **Vendor / support** | Community open-source (MIT); no SAP support contract | SAP SE; first-party, supported, on SAP's roadmap |
-| **Where it runs** | BTP Cloud Foundry, Docker, npm/`npx`, or local stdio | A headless ADT engine on your laptop (`localhost` only) |
-| **Primary design center** | **Centrally hosted, multi-user, admin-governed** | **Single developer, zero-config, inside the IDE** |
+| **What it is** | Independent MCP server translating AI tool calls into ADT REST calls | The *ADT MCP Server* SAP ships *inside* ADT for VS Code / Eclipse |
+| **Vendor / support** | Community open-source (MIT); no SAP support contract | SAP SE, first-party. The **extension is official/GA**, but SAP flags the **MCP server itself as experimental, "not intended for productive use"** |
+| **Where it runs** | BTP Cloud Foundry, Docker, npm/`npx`, or local stdio | A local server the IDE starts on `localhost` only |
+| **Primary design center** | **Centrally hosted, multi-user, admin-governed** | **Single developer, local, inside the IDE** |
 | **Auth to the *server*** | XSUAA OAuth · OIDC JWT · API key · (stdio = none) | Auto-generated bearer token on `localhost` |
 | **Auth to *SAP*** | Per-user principal propagation, or shared service user | Your own ADT logon session / SAP user |
-| **Central config / policy** | Yes — server-wide safety ceiling, scopes, audit | No — each developer's machine, no policy layer |
-| **MCP clients** | Any (Claude, Copilot Studio, Cursor, CLI, JetBrains, web…) | Local IDE agents (Copilot Agent Mode, Joule) + any local client |
-| **System reach** | Any system with ADT — on-prem ECC 7.4+, NW, S/4 on-prem, RISE, Cloud, BTP | On-prem (RFC) + Public Cloud/BTP (HTTP); RAP/ABAP-Cloud focus |
-| **Object types** | Classic **and** modern (PROG, FUGR, TABL, DOMA, DTEL, MSAG, ENHO… + CLAS, CDS, RAP) | RAP/ABAP-Cloud-centric; broader on some on-prem systems; no Dynpro/WebDynpro |
-| **Reads source over MCP?** | Yes — `SAPRead` / `SAPSearch` are first-class tools | Not on the tested release — reading is the IDE editor's job (see §6) |
-| **Server-side AI** | None — uses *your* LLM (Claude/GPT/Gemini/…) | Optional **Joule** AI (SAP-ABAP-1 model) for ATC fixes & generation |
-| **Cost** | Free (you pay only your infra + your LLM) | Extension free; **Joule AI features are licensed** (AI units; free promo to Sep 2026) |
-
-**One-line verdict:** if you are **one developer working in your IDE on a modern ABAP/RAP system**,
-the SAP server is the most frictionless, best-integrated choice. If you need **a shared, governed,
-audited endpoint for many users / non-IDE agents / on-prem & classic ABAP / SQL · git · transports ·
-dumps**, that is exactly what ARC-1 is for. Many teams run **both**.
+| **Central governance** | Yes — server-wide safety ceiling, scopes, central audit | No central multi-user policy/audit layer (local IDE settings + your SAP authorizations) |
+| **MCP clients** | Any (Claude, Copilot Studio, Cursor, CLI, JetBrains, web…) | Intended for local IDE agents; any local client *can* connect with URL+token |
+| **System reach** | Systems exposing the ADT REST endpoints a tool needs (on-prem→cloud) | On-prem/Private Cloud via RFC, Public Cloud/BTP via HTTP; RAP/ABAP-Cloud focus |
+| **Object types** | Classic **and** modern (PROG, FUGR, TABL, DOMA, DTEL, MSAG, ENHO… + CLAS, CDS, RAP) | RAP/ABAP-Cloud-centric (broader on some on-prem backends); Dynpro/Web Dynpro not planned |
+| **Reads source over MCP?** | Yes — `SAPRead`/`SAPSearch` are first-class tools | Not in the documented toolset — reading is the IDE editor/virtual-workspace's job (see §6) |
+| **Server-side AI** | None — uses *your* LLM (Claude/GPT/Gemini/…) | Optional **Joule** AI (SAP-ABAP-1 model) for ATC AI-fix tools |
+| **Cost** | Free (you pay only your infra + your LLM) | Extension free; **only the 2 ATC AI-fix tools require a Joule licence** (per SAP Help) |
 
 ---
 
@@ -54,11 +61,11 @@ Start here. The detail sections below justify each row.
 - You work **inside VS Code or Eclipse** and want the AI to act on the code you already have open.
 - Your system is **S/4HANA (Cloud/RISE/recent on-prem) or BTP ABAP** and your work is **RAP / ABAP
   Cloud / clean-core**.
-- You want **zero setup** — reuse your ADT logon, flip one checkbox, done.
-- You want **SAP's own AI** (Joule / SAP-ABAP-1) for ATC fix proposals and RAP+Fiori generation, and
-  you have (or will buy) the licence.
-- You value a **first-party, supported, roadmap-backed** tool and the integrated **debugger /
-  completion / form editors** that come with the IDE.
+- You want **near-zero setup** — reuse your ADT logon, enable one setting, done.
+- You want **SAP's own AI** (Joule / SAP-ABAP-1) for ATC fix proposals, and you have (or will buy) the
+  licence for it.
+- You value a **first-party** tool and the integrated **debugger / completion / form editors** that
+  come with the IDE — and you are comfortable that SAP currently labels the MCP server *experimental*.
 
 ### Pick ARC-1 if…
 
@@ -73,19 +80,19 @@ Start here. The detail sections below justify each row.
 - You work on **on-prem ECC / NetWeaver / older S/4** or with **classic objects** (reports, function
   groups, DDIC domains/data elements, message classes, enhancements) — or you need **free SQL,
   git (gCTS/abapGit), transport release, or ST22 dump / trace analysis**.
-- You want to keep your **choice of LLM** (Claude, GPT, Gemini, Mistral, …) and not route through
-  SAP's AI hub.
+- You want to keep your **choice of LLM** (Claude, GPT, Gemini, Mistral, …).
 
 ### Run both if… (common for teams that have adopted VS Code ADT)
 
 - Developers use the **SAP server in-IDE** for fast, context-aware editing, debugging, RAP generation
   and Joule AI fixes **on their personal dev systems**, **and**
 - The team/platform runs **ARC-1 centrally** for the things the SAP server doesn't do: governed
-  multi-user access, non-IDE agents, classic-object and on-prem reach, SQL, git, transports, runtime
-  diagnostics, and a central audit log.
+  multi-user access, non-IDE agents, classic-object and on-prem reach, SQL, git, transport release,
+  and runtime diagnostics, with a central audit log.
 
-They don't conflict — the tool namespaces differ (`sap-abap-adt` vs `SAPRead`/`SAPWrite`/…), and an
-agent can have both connected at once.
+They don't conflict — the tool namespaces differ (`abap_*` vs `SAPRead`/`SAPWrite`/…), and an agent
+can hold both connections at once. *This is a reasoned architecture recommendation, not a
+vendor-endorsed pattern.*
 
 ### Scenario cheat-sheet
 
@@ -95,7 +102,7 @@ agent can have both connected at once.
 | Solo dev, modern types, wants SAP-tuned AI fixes | **SAP server** (+ Joule licence) |
 | Team wants one governed endpoint with audit + scopes | **ARC-1** |
 | AI agent on **Copilot Studio / Joule Studio / a website** | **ARC-1** (remote MCP + JWT) |
-| On-prem ECC 7.4 / NetWeaver / pre-2023 S/4 | **ARC-1** |
+| On-prem ECC 7.4 / NetWeaver / pre-2023 S/4 | **ARC-1** (validate per tool — see §8) |
 | Heavy **classic ABAP** (reports, FUGR, DDIC, messages, enhancements) | **ARC-1** |
 | Need **SQL / git / transport release / ST22 dumps / traces** | **ARC-1** |
 | Migration / clean-core at scale across many systems | **ARC-1** (often **+** SAP server per dev) |
@@ -112,32 +119,33 @@ agent can have both connected at once.
     **ADT REST** requests (`/sap/bc/adt/*`) — the same public API the Eclipse ADT client uses.
 
     - **Distribution:** `npx arc-1`, global npm install, Docker, or a deployed BTP Cloud Foundry app.
-    - **Maturity:** production, write-capable, multi-user. Open source (MIT), community-maintained.
+    - **Maturity:** the project **positions itself** as production-ready, write-capable and multi-user;
+      it is open source (MIT), community-maintained (no independent SLA/adoption evidence is claimed
+      here).
     - **Design center:** a **centrally hosted, admin-governed, multi-tenant** proxy — one server, many
       AI users, each mapped to their own SAP identity, every call audited and policy-checked.
     - **Tool model:** **12 intent tools** (e.g. `SAPRead`, `SAPWrite`) with a `type`/`action`
-      parameter, instead of 200+ endpoint tools — keeps the LLM's tool list small. A "hyperfocused"
-      mode collapses to a single ~200-token tool for tight context windows.
+      parameter, instead of 200+ endpoint tools. A "hyperfocused" mode collapses to a single
+      ~200-token tool for tight context windows.
 
 === "SAP ABAP MCP Server"
 
-    An MCP server SAP **bundles inside its IDE tooling** — *ABAP Development Tools for VS Code*
-    (publisher SAP SE, GA at Sapphire 2026, on the VS Code Marketplace) and *ADT for Eclipse*. The MCP
-    layer is part of a **larger redesign**: a headless **ABAP Language Server** (the Eclipse ADT client
-    repackaged) plus the **ABAP MCP Server** on top.
+    The **ADT MCP Server** SAP **bundles inside its IDE tooling** — *ABAP Development Tools for VS
+    Code* (publisher SAP SE, the official ADT extension, free on the Marketplace) and *ADT for
+    Eclipse*. The MCP layer is part of a **larger redesign**: a headless **ABAP Language Server** (the
+    Eclipse ADT client repackaged) plus the **ABAP MCP Server** on top.
 
-    - **Distribution:** ships with the extension; **not** a standalone package you host. It runs as a
-      small **Streamable-HTTP server on `localhost`** (an auto-selected port, e.g. 2234/2236) launched
+    - **Distribution:** ships with the extension; **not** a standalone package you host. When enabled it
+      runs as a **local HTTP server** at `http://localhost:<port>/mcp` (default port **2236**), started
       by the IDE.
-    - **Maturity:** v1.0.0, GA but explicitly **disabled by default** (enable
-      `ABAP > AI: Enable ADT MCP Server`). SAP positions Eclipse as the flagship IDE "until VS Code
-      reaches feature parity," but notes the **same MCP tools are offered in both** because they live in
-      the shared core layer.
-    - **Design center:** **one developer, zero-config**, agentic AI on the code in their IDE.
-    - **Tool model:** ~20 narrowly-scoped, **heavily prompt-engineered** tools (USE WHEN / TYPICAL
-      WORKFLOW / human-in-the-loop transport selection), grouped by workflow (creation, generation,
-      ATC, activation, tests, transport, business services). The set is partly **server-driven** —
-      it adapts to what the connected backend offers.
+    - **Maturity / status:** the **extension is official and GA**, but SAP's own material states *"The
+      ADT MCP Server is an experimental feature that may change at any time without notice. It is not
+      intended for productive use."* It is **disabled by default** (enable `adt.mcpServer.enabled`, UI
+      label "Adt: Enable MCP Server" — labels may vary by release).
+    - **Design center:** **one developer, local**, agentic AI on the code in their IDE.
+    - **Tool model:** **20 tools** (per SAP Help, see §7.1), heavily prompt-engineered (USE WHEN /
+      TYPICAL WORKFLOW / human-in-the-loop transport selection), grouped by workflow. Part of the set
+      is **server-driven** — it adapts to what the connected backend offers.
 
 ---
 
@@ -147,24 +155,24 @@ agent can have both connected at once.
 flowchart LR
   subgraph SAP_MODEL["SAP ABAP MCP Server — per developer"]
     direction TB
-    A1["AI agent in IDE<br/>(Copilot Agent Mode / Joule)"] -->|localhost + bearer| A2["ADT MCP Server<br/>(headless ADT engine)"]
+    A1["AI agent in IDE<br/>(Copilot Agent Mode / Joule)"] -->|localhost + bearer token| A2["ADT MCP Server<br/>(in the ADT extension)"]
     A2 -->|RFC on-prem / HTTP cloud| A3["Your SAP system<br/>(your ADT session)"]
   end
   subgraph ARC1_MODEL["ARC-1 — centrally hosted"]
     direction TB
     B1["Many AI clients<br/>Claude · Copilot Studio · Cursor · CLI · web"] -->|HTTPS + OAuth/JWT/API key| B2["ARC-1 server<br/>(safety ceiling · scopes · audit)"]
     B2 -->|ADT REST + principal propagation| B3["BTP Destination + Cloud Connector"]
-    B3 --> B4["Any SAP system with ADT"]
+    B3 --> B4["SAP systems with the needed ADT endpoints"]
   end
 ```
 
 | Dimension | ARC-1 | SAP ABAP MCP Server |
 |---|---|---|
 | Process model | A server you deploy (CF app / container / `npx` / stdio) | A `localhost` process the IDE starts for you |
-| Network exposure | Remote over HTTPS (or local stdio) | **`localhost` only** + DNS-rebinding guard (Host must be localhost/127.0.0.1) |
+| Network exposure | Remote over HTTPS (or local stdio) | **`localhost` only** + auto-generated bearer token (a Host-header / DNS-rebinding guard was also observed in teardown) |
 | Multi-user | **Yes** — one endpoint, many users | No — one server per developer machine, bound to one ADT session |
 | Connection to SAP | ADT REST (HTTP) everywhere, incl. on-prem via Cloud Connector | **RFC** for on-prem/Private Cloud, **HTTP** for Public Cloud/BTP |
-| Runtime footprint | Lightweight Node process | A bundled headless ADT/Equinox engine (heavier; the price of full ADT fidelity) |
+| Runtime footprint | Lightweight Node process | Bundled inside the ADT engine (heavier; the price of full ADT fidelity) |
 | Who operates it | You (or your platform team) | SAP's extension; nothing to operate |
 
 **Takeaway:** the SAP server is a *personal* component — there is no notion of "host it for the team."
@@ -174,48 +182,53 @@ ARC-1 is a *shared service* — that is its whole point, and also why it asks mo
 
 ## 5. Authentication & identity
 
-This is one of the sharpest differences and a frequent reason to choose ARC-1 for teams.
+This is one of the sharpest differences and a frequent reason teams choose ARC-1.
 
 | Layer | ARC-1 | SAP ABAP MCP Server |
 |---|---|---|
-| **Auth to the MCP server** | XSUAA OAuth 2.0 · external OIDC JWT (e.g. Entra ID) · API keys (`key:profile`); stdio has none | A single auto-generated **bearer token** stored in an IDE setting; trusted because it's `localhost`-only |
+| **Auth to the MCP server** | XSUAA OAuth 2.0 · external OIDC JWT (e.g. Entra ID) · API keys (`key:profile`); stdio has none | A single auto-generated **bearer token**, trusted because the server is `localhost`-only |
 | **Per-AI-user identity** | Yes — JWT/`clientId`/`userName` flows through every call | No concept of multiple MCP users |
 | **Auth to SAP** | **Principal propagation**: each AI user → their own SAP user via BTP Destination Service + Cloud Connector; or a shared service user | Reuses **your** ADT logon session / SAP user |
-| **Multiple auth mechanisms at once** | Yes — XSUAA + OIDC + API key can coexist on one server | n/a (single local developer) |
-| **SAP-side authorizations** | Enforced by SAP (`S_DEVELOP`, `S_ADT_RES`, `S_TRANSPRT`) **and** ARC-1 scopes as defense-in-depth | Enforced by SAP for **your** user; that's the only gate |
+| **Multiple auth mechanisms at once** | Yes — XSUAA + OIDC + API key can coexist | n/a (single local developer) |
+| **SAP-side authorizations** | Enforced by SAP (`S_DEVELOP`, `S_ADT_RES`, `S_TRANSPRT`) **and** ARC-1 scopes as defense-in-depth | Enforced by SAP for **your** user |
+
+!!! note "Both share one hard limit"
+    Neither tool can grant SAP rights the backend user doesn't have. **ARC-1 can only restrict
+    further; the SAP backend's own authorizations still decide final access** in both products.
 
 !!! tip "What this means in practice"
     On the SAP server, "who is the AI acting as?" is simply **you** — clean and correct for a single
     developer on their own system. ARC-1 answers the harder enterprise question: *"a shared agent
     serves 50 people — how does each call run as the right SAP user, with the right rights, and leave
-    an audit record?"* If you only ever have the first question, the SAP server's model is simpler. If
-    you have the second, ARC-1 is built for it.
+    an audit record?"* If you only ever have the first question, the SAP server's model is simpler.
 
 ---
 
 ## 6. Central configuration & governance
 
-The SAP server has **no policy/config layer** — by design. It is a developer tool: it does what your
-SAP user is allowed to do, on your machine, full stop. There is nothing for an admin to centrally
-configure, restrict, or audit across users, because there is no "across users."
+The SAP ADT MCP Server **does not provide a central multi-user policy, scope and audit layer
+comparable to ARC-1.** In SAP's model, control is primarily **local IDE configuration plus the
+developer's SAP authorizations and backend workflow controls** such as the human-in-the-loop transport
+selection its tools enforce. That is appropriate for a personal developer tool — there simply is no
+"across users" dimension to govern.
 
 ARC-1's reason to exist is the opposite: an **admin-controlled safety ceiling** that every call passes
-through, no matter which user or client made it.
+through, regardless of which user or client made it.
 
 | Governance control | ARC-1 | SAP ABAP MCP Server |
 |---|---|---|
-| Read-only by default | **Yes** — writes are opt-in (`SAP_ALLOW_WRITES`) | No server-side gate (your SAP auth is the only limit) |
-| Separate gates for data preview / free SQL / transport writes / git writes | **Yes**, each independent | n/a |
+| Read-only by default | **Yes** — writes are opt-in (`SAP_ALLOW_WRITES`) | No server-side gate (your SAP authorizations are the limit) |
+| Separate gates for data preview / free SQL / transport writes / git writes | **Yes**, each independent | n/a (those tools aren't exposed) |
 | **Package allowlist** (e.g. `$TMP`, `Z*`, subtree) enforced fail-closed on every mutation | **Yes** | No |
 | **Per-action deny** (e.g. block `SAPWrite.delete`) | **Yes** (`SAP_DENY_ACTIONS`) | No |
 | **Scopes** (read / write / data / sql / transports / git / admin) | **Yes**, per user/profile | No |
 | **Rate limiting** (per-IP OAuth, per-user MCP, server-wide SAP semaphore) | **Yes**, three layers | No |
 | **Central audit log** of every call with user identity | **Yes** (stderr / file / **BTP Audit Log**) | No central log; activity is implicit in the SAP system |
-| Where config lives | Central (server env/CLI/`.env`), one source of truth | Per-developer IDE settings + `~/.adtls/destinations.json` |
+| Local configuration | Central server env/CLI/`.env`, one source of truth | Per-developer IDE settings (enable flag, port) + `~/.adtls/destinations.json` + the developer's SAP auth |
 
 !!! warning "The honest counterpoint"
-    For a **single developer on a sandbox / personal dev tier**, all of this governance is overhead
-    they don't need. "It just runs as me with my rights" is the *right* amount of control there. ARC-1's
+    For a **single developer on a sandbox / personal dev tier**, ARC-1's governance is overhead they
+    don't need. "It runs as me with my rights" is the *right* amount of control there. ARC-1's
     governance earns its keep when an AI endpoint is **shared**, **automated**, or **pointed at systems
     where uncontrolled writes are unacceptable** — not on a lone developer's `$TMP` playground.
 
@@ -223,31 +236,43 @@ through, no matter which user or client made it.
 
 ## 7. Capabilities & tool surface
 
-### 7.1 The SAP server's tools (live read, 2026-06-16 — 20 tools)
+### 7.1 The SAP server's tools — 20 tools (SAP Help canonical list)
 
-| Group | Tools | What they do |
+The table below uses the **exact tool IDs published on the SAP Help "Model Context Protocol Tools"
+page**, including its per-tool **Joule License** column.
+
+| Toolset | Tool IDs | Joule licence |
 |---|---|---|
-| **Object creation** (server-driven, 4 steps) | `get_all_creatable_objects` · `get_object_type_details` · `run_validation` · `create_object` | Enumerate creatable types on the backend, fetch the per-type form schema, validate, then create. The type list comes **from the backend**, so it tracks new object types automatically. |
-| **RAP generators** | `generators-list_generators` · `generators-get_schema` · `generators-generate_objects` | Backend "generator" framework, e.g. `x-ui-service` (full RAP + Fiori UI) and `webapi-service` (API only). |
-| **Activation & tests** | `activate_objects` · `run_unit_tests` | Activate URIs (returns syntax diagnostics on failure); run ABAP Unit. |
-| **ATC** | `atc_run` · `atc_get_result` · `atc_execute_deterministic_quickfixes` · `atc_apply_ai_fix` · `atc_get_ai_fix_result` | Run ATC, poll results, apply deterministic quickfixes, and — with **Joule** — apply **AI-generated fixes** to eligible findings. |
-| **Transport** | `transport-get` · `transport-create` · `transport-unifiedDifference` | Validate/list TRs, create a TR (always after a human picks), paginated unified diff of a TR. Tool prompts force **human-in-the-loop** TR selection. |
-| **Business services** | `business_services-fetch_services` · `business_services-fetch_service_information` | Read OData services from a service binding (for Fiori app generation handoff). |
-| **Destinations** | `list_destinations` | List the ADT destinations configured in the IDE. |
+| **ABAP Server Destinations** | `abap_lists_destinations` | Not required |
+| **ABAP Object Creation** | `abap_creation-get_all_creatable_objects` · `abap_creation-get_object_type_details` · `abap_creation-run_validation` · `abap_creation-create_object` | Not required |
+| **ABAP Object Activation** | `abap_activate_objects` | Not required |
+| **ABAP Transport** | `abap_transport-get` · `abap_transport-create` · `abap_transport-unifiedDifference` | Not required |
+| **Execute ABAP Unit Test** | `abap_run_unit_tests` | Not required |
+| **ABAP Repository Object Generation** | `abap_generators-list_generators` · `abap_generators-get_schema` · `abap_generators-generate_objects` | Not required |
+| **ABAP Business Service** | `abap_business_services-fetch_services` · `abap_business_services-fetch_service_information` | Not required |
+| **ABAP Test Cockpit** | `abap_run_atc` · `abap_atc_get_result` · `abap_atc_execute_deterministic_quickfixes` · `abap_atc_apply_ai_fix` · `abap_atc_get_ai_fix_result` | **Required** for the two AI-fix tools (`abap_atc_apply_ai_fix`, `abap_atc_get_ai_fix_result`); others not required |
+
+!!! note "Names: documented vs. tested build"
+    The IDs above are SAP's **published** list. The build tested live on 2026-06-16 returned the **same
+    20 tools** and the same grouping, with **two minor ID variants** — `abap_list_destinations`
+    (vs. documented `abap_lists_destinations`) and `abap_atc_run` (vs. documented `abap_run_atc`).
+    Treat exact separators as build-dependent and trust your client's own `tools/list` over any
+    article. The set is also **backend/version dependent** — newer backends may add tools (SAP's
+    roadmap includes an *ABAP object search* tool).
 
 Notable about this surface:
 
-- **No source-read, search, or where-used tool** was present on the tested S/4HANA 2023 backend.
-  SAP's roadmap adds an *"ABAP object search"* MCP tool, but on **newer backends only** (announced for
-  BTP 2611 / S/4 Cloud Public 2702 / Private 2027). **In the IDE this doesn't matter** — the agent reads
-  code through the editor / virtual workspace (Copilot can "find a function and read it" because the
-  *workspace*, not the MCP server, serves the file). **For a non-IDE MCP client on an older system,
-  it does matter:** there may be no way to read source via MCP alone.
-- **No `resources` or `prompts`** — it's a pure *tools* server.
-- It does **not** expose free SQL, git, transport *release/delete*, or runtime diagnostics (ST22 dumps,
-  traces).
-- Its real superpower is the **server-driven creation + generator framework** and (with a licence) the
-  **Joule AI fix/generation** — neither of which ARC-1 has.
+- **No source-read, search, or where-used tool** is in the documented set. **In the IDE this doesn't
+  matter** — the agent reads code through the editor / virtual workspace (Copilot can "find a function
+  and read it" because the *workspace*, not the MCP server, serves the file). **For a non-IDE MCP
+  client, it does matter:** there may be no way to read source via the MCP server alone.
+- On the tested backend the server exposed **only tools** (`resources/list` and `prompts/list`
+  returned *Method not found*) — an observed snapshot, not a documented guarantee.
+- It does **not** expose free SQL, git, transport *release/delete*, or runtime diagnostics (ST22
+  dumps, traces) — none appear in SAP's public examples or the tested server.
+- Its real strengths are the **server-driven creation + generator framework** (e.g. an *OData UI
+  Service from Scratch*) and, **with a Joule licence**, the **AI-fix tools** — neither of which ARC-1
+  has.
 
 ### 7.2 ARC-1's tools (12 intent tools)
 
@@ -266,30 +291,33 @@ Notable about this surface:
 | `SAPDiagnose` | `syntax` · `atc` · `quickfix`/`apply_quickfix` · ABAP Unit · **ST22 dumps** · **traces** · gateway/system messages · RAP preflight · CDS test-case suggestions |
 | `SAPManage` | Package create/delete/move (DEVC) · FLP catalogs/groups/tiles · feature probe · cache stats |
 
+All gated operations also depend on the target system exposing the needed ADT/OData services and the
+SAP user being authorized.
+
 ### 7.3 Capability matrix
 
 | Capability | ARC-1 | SAP ABAP MCP Server |
 |---|:---:|:---:|
 | Create objects | ✅ (AFF + classic builders) | ✅ (server-driven, auto-tracks new types) |
-| Update / edit source | ✅ incl. method/section surgery | ⚠️ via IDE editor + LS (not an MCP write tool on tested release) |
+| Update / edit source | ✅ incl. method/section surgery | ⚠️ via IDE editor + LS (no MCP write-source tool in the documented set) |
 | Activate | ✅ | ✅ |
 | Run ABAP Unit | ✅ | ✅ |
 | ATC run + results | ✅ | ✅ |
 | ATC **deterministic** quickfix | ✅ (`quickfix`/`apply_quickfix`) | ✅ |
-| ATC **AI** fix (model-generated) | ❌ (use your client LLM manually) | ✅ **Joule / SAP-ABAP-1** (licensed) |
-| RAP + Fiori generators (x-ui-service) | ⚠️ scaffolding + skills, not the backend generator catalog | ✅ native generator framework |
-| Read source **over MCP** | ✅ `SAPRead` | ❌ on tested release (IDE editor reads instead) |
-| Search / where-used **over MCP** | ✅ | ❌ on tested release (roadmap: newer backends) |
+| ATC **AI** fix (model-generated) | ❌ (use your client LLM manually) | ✅ **Joule** — requires a Joule licence |
+| RAP + repository-object generators | ⚠️ scaffolding + skills, not the backend generator catalog | ✅ native generator framework |
+| Read source **over MCP** | ✅ `SAPRead` | ❌ not in the documented toolset (IDE editor reads instead) |
+| Search / where-used **over MCP** | ✅ | ❌ not in the documented toolset (roadmap: object-search tool) |
 | Free SQL | ✅ (gated) | ❌ |
 | Table data preview | ✅ (gated) | ❌ |
 | Git (gCTS / abapGit) | ✅ (gated) | ❌ |
-| Transport create / assign / list / diff | ✅ | ✅ |
+| Transport create / get / diff | ✅ | ✅ |
 | Transport **release / delete** | ✅ (gated) | ❌ |
 | Runtime diagnostics — **ST22 dumps, traces** | ✅ | ❌ |
 | Pretty Printer / offline lint | ✅ | ⚠️ formatting via IDE, no abaplint |
 | Integrated **debugger** | ❌ (MCP is RPC) | ✅ (in the IDE) |
 | Inline completion / form editors | ❌ | ✅ (in the IDE) |
-| Server-side AI model | ❌ (bring your own LLM) | ✅ Joule (SAP-ABAP-1) |
+| Server-side AI model | ❌ (bring your own LLM) | ✅ Joule (SAP-ABAP-1), licensed |
 
 ⚠️ = available but indirectly / partially, or only inside the IDE.
 
@@ -297,26 +325,33 @@ Notable about this surface:
 
 ## 8. System & object-type reach
 
+!!! note "Read this as four separate axes — they don't move together"
+    SAP's stack mixes three distinct things the draft must not conflate: **(a) base IDE/backend
+    connectivity**, **(b) which MCP tools a given backend exposes**, and **(c) Joule/ABAP-AI
+    availability + licensing**. ARC-1 adds a fourth: **(d) which ADT REST endpoints a given system
+    actually exposes**, which varies by release and decides per-tool coverage.
+
 | | ARC-1 | SAP ABAP MCP Server |
 |---|---|---|
-| On-prem S/4HANA | ✅ | ✅ (via RFC; RAP/ABAP-Cloud focus) |
-| **On-prem ECC 7.4+ / NetWeaver 7.5x** | ✅ | ⚠️ extension supports old releases for basics, but AI features need BTP/AI Core |
+| On-prem S/4HANA | ✅ where ADT endpoints exist | ✅ (via RFC; RAP/ABAP-Cloud focus) |
+| **On-prem ECC 7.4+ / NetWeaver** | ⚠️ validate **per tool** — older ECC/NW vary widely in ADT endpoint coverage | ⚠️ extension connects to old releases for basics; AI features need BTP/AI Core |
 | RISE / Private Cloud | ✅ | ✅ |
 | S/4HANA Cloud Public | ✅ | ✅ |
 | BTP ABAP (Steampunk) | ✅ | ✅ |
-| **Classic procedural** (PROG, FUGR/FUNC, includes) | ✅ | ⚠️ creatable on some on-prem backends (seen live on S/4 2023); not the focus |
-| **DDIC** (TABL, STRU) | ✅ | ✅ (TABL/DT, TABL/DS seen live) |
+| **Classic procedural** (PROG, FUGR/FUNC, includes) | ✅ | ⚠️ creatable on some on-prem backends (observed live on S/4 2023); not the focus |
+| **DDIC** (TABL, STRU) | ✅ | ✅ (TABL/DT, TABL/DS observed live) |
 | **DOMA / DTEL / MSAG / SHLP / ENHO / XSLT** | ✅ | ❌ (not in the creatable set observed) |
 | Modern (CLAS, INTF, DDLS, DDLX, DCLS, BDEF, SRVD, SRVB, DRAS…) | ✅ | ✅ |
-| **Dynpro / Web Dynpro / module pools** | ⚠️ limited (ADT itself is thin here) | ❌ explicitly excluded by SAP |
+| **Dynpro / Web Dynpro / module pools** | ⚠️ limited (ADT itself is thin here) | ❌ not planned (SAP states classic Dynpro/Web Dynpro are not in the current focus) |
 
-!!! note "Live nuance worth knowing"
-    On the tested **on-prem S/4HANA 2023** system, the SAP server's `get_all_creatable_objects`
-    returned **classic** types too — Program, Function Group/Module/Include, Database Table, Structure,
-    Interface, Lock Object, Type Group — i.e. broader than a strict "modern-only" reading. But it still
-    **omitted** core DDIC types (DOMA, DTEL), message classes (MSAG), search helps (SHLP), and
-    enhancements (ENHO), and there was **no way to read or search** any of them over MCP. ARC-1 covers
-    those types and the read/search path.
+!!! note "Live nuance worth knowing (observed on one S/4HANA 2023 on-prem backend)"
+    On the tested system, the SAP server's `abap_creation-get_all_creatable_objects` returned **classic**
+    types too — Program, Function Group/Module/Include, Database Table, Structure, Interface, Lock
+    Object, Type Group — i.e. broader than a strict "modern-only" reading. But it still **omitted** core
+    DDIC types (DOMA, DTEL), message classes (MSAG), search helps (SHLP), and enhancements (ENHO), and
+    there was **no way to read or search** any of them over MCP. This is a backend-driven snapshot, not a
+    product-wide guarantee. ARC-1 covers those types and the read/search path where the backend exposes
+    the endpoints.
 
 ---
 
@@ -324,18 +359,21 @@ Notable about this surface:
 
 | Client | ARC-1 | SAP ABAP MCP Server |
 |---|:---:|:---:|
-| GitHub Copilot (Agent Mode) in VS Code/Eclipse | ✅ | ✅ (auto-listed as `sap-abap-adt`) |
+| GitHub Copilot (Agent Mode) in VS Code/Eclipse | ✅ | ✅ (the primary client SAP demonstrates) |
 | SAP Joule (in-IDE) | ✅ | ✅ |
-| Claude Desktop | ✅ | ⚠️ only if pointed at the localhost URL+token (not its intended use) |
+| Claude Desktop | ✅ | ⚠️ technically, if pointed at the localhost URL+token |
 | **Microsoft Copilot Studio** (remote agents) | ✅ | ❌ (no remote endpoint) |
 | **SAP Joule Studio** (custom agents) | ✅ | ❌ |
-| Cursor | ✅ | ⚠️ shares the VS Code extension family; in-IDE only |
+| Cursor / other VS-Code-family editors | ✅ | ⚠️ in-IDE; needs a client that supports the virtual-workspace filesystem |
 | Gemini CLI / custom CLI agents | ✅ | ⚠️ localhost only |
 | JetBrains / web apps / CI | ✅ | ❌ |
 
-The SAP server is reachable by **any local MCP client** that points at its `localhost` URL with the
-bearer token — but it is **localhost-only by design**, so "team server" and "cloud agent platform"
-use cases are off the table. ARC-1 is the one you expose (securely) to remote and automated clients.
+**SAP's supported/intended scenario is a local IDE agent against a local ADT MCP Server.** A local
+MCP-compatible client *can* technically connect to the `localhost` URL with the token, but the server
+is **not designed as a remote, centrally hosted team endpoint** — so "team server" and "cloud agent
+platform" use cases are off the table. ARC-1 is the one you expose (securely) to remote and automated
+clients. SAP also notes that an agent must support **VS Code's virtual-workspace filesystem** to read
+repository objects in the IDE.
 
 ---
 
@@ -343,15 +381,15 @@ use cases are off the table. ARC-1 is the one you expose (securely) to remote an
 
 | | ARC-1 | SAP ABAP MCP Server |
 |---|---|---|
-| Transport security | HTTPS; CORS allowlist; OAuth/JWT/API-key | `localhost` + DNS-rebinding guard + bearer token |
-| Blast radius if token leaks | Token/JWT scoped + rate-limited; admin can revoke | Anyone *on that machine* who reads the token gets the developer's full ADT rights |
-| Write safety | Default-deny + allowlists + deny-actions + scopes | Whatever the developer's SAP user can do |
-| Auditability | Central, per-user, structured (incl. BTP Audit Log) | Rely on the SAP system's own logging |
+| Trust boundary | Shared/remote — HTTPS, CORS allowlist, OAuth/JWT/API-key | **Local-machine** — `localhost` + bearer token |
+| Blast radius if token leaks | Token/JWT scoped + rate-limited; admin can revoke | Anyone *on that machine* who reads the token gets the developer's ADT rights (observed; confirm token storage with SAP docs) |
+| Write safety | Default-deny + allowlists + deny-actions + scopes | The developer's SAP authorizations are the gate; **SAP authorizations remain final** |
+| Auditability | Central, per-user, structured (incl. BTP Audit Log) | The SAP system's own logging |
 | Secrets handling | `.env`/service keys redacted in logs; never committed | Token in IDE settings; destinations in `~/.adtls/` |
 
-Neither is "insecure" — they make **different trust assumptions**. The SAP server trusts the
-developer's own machine and SAP authorizations. ARC-1 assumes a shared, possibly hostile-adjacent
-environment and adds layers accordingly.
+Neither is "insecure" — they make **different trust assumptions**. The SAP server assumes a
+**local-machine trust boundary** and relies on the developer's SAP authorizations. ARC-1 assumes a
+shared, possibly hostile-adjacent environment and adds layers accordingly.
 
 ---
 
@@ -364,10 +402,12 @@ SAP server's home turf and ARC-1 matches it there:
 
     1. Install the *ABAP Development Tools for VS Code* extension (or use Eclipse ADT).
     2. Create a destination / logon to your SAP system.
-    3. Enable **`ABAP > AI: Enable ADT MCP Server`**.
-    4. Your IDE AI agent (Copilot Agent Mode / Joule) auto-discovers `sap-abap-adt`.
+    3. Enable the setting **`adt.mcpServer.enabled`** (UI label "Adt: Enable MCP Server" — labels may
+       vary by release). The server starts at `http://localhost:<port>/mcp` (default port **2236**).
+    4. Your IDE AI agent (Copilot Agent Mode / Joule) discovers the tools.
 
-    **Effort: minutes. Zero infrastructure.** This is the benchmark for frictionless.
+    **Effort: minutes. Zero infrastructure.** This is the benchmark for frictionless. (Remember SAP
+    marks the MCP server *experimental, not for productive use*.)
 
 === "ARC-1 (local stdio)"
 
@@ -396,30 +436,33 @@ SAP server's home turf and ARC-1 matches it there:
 
 | | ARC-1 | SAP ABAP MCP Server |
 |---|---|---|
-| The server itself | Free, open source (MIT) | Free (ships with the extension) |
-| AI model | **Bring your own** (you pay your LLM provider) | **Joule for Developers** AI features are licensed — consumption-based **AI units** (free promotional period through **September 2026**) |
+| The server itself | Free, open source (MIT) | Free (ships with the official extension) |
+| AI model | **Bring your own** (you pay your LLM provider) | Per SAP Help, **only `abap_atc_apply_ai_fix` and `abap_atc_get_ai_fix_result` require a Joule licence**; the other 18 tools do not |
+| Joule / ABAP-AI commercial terms | n/a | SAP/community sources describe consumption-based **AI units** with a promotional free period through **September 2026** — **confirm current SKU / region / terms with SAP** |
 | Infrastructure | Your BTP CF / container / host | Your laptop (none extra) |
-| Vendor lock-in | None (any LLM, any ADT system) | AI features tie to SAP's GenAI hub / AI Core |
+| Vendor lock-in | None (any LLM, any ADT system) | AI-fix tools tie to SAP's GenAI hub / AI Core |
 
-The SAP server's **non-AI** tools (create, activate, test, ATC run, transport) don't need the Joule
-licence; the **AI** tools (`atc_apply_ai_fix`, AI generation) do, and need BTP/AI Core — so on a pure
-on-prem system without AI Core, the AI tools won't function even though they're listed.
+So the SAP server's **18 non-AI tools** (destinations, creation, activation, unit test, ATC run/result,
+deterministic quickfix, transport, generators, business services) carry **no Joule licence**; only the
+**two AI-fix tools** do, and those need BTP/AI Core — so on a pure on-prem system without AI Core they
+won't function even if listed.
 
 ---
 
 ## 13. Using them together
 
-A pattern that works well for a modern team that has adopted VS Code ADT:
+A pattern that works well for a modern team that has adopted VS Code ADT (a **recommended
+architecture**, not a vendor-endorsed one):
 
 - **Per developer, in the IDE:** the SAP server for context-aware editing, debugging, ABAP
-  Unit/ATC, RAP+Fiori generation, and Joule AI fixes on their **personal dev system**.
+  Unit/ATC, repository-object generation and Joule AI fixes on their **personal dev system**, **and**
 - **Centrally, for everyone & for agents:** ARC-1 as the **governed, audited** endpoint for
   multi-user access, **non-IDE agents** (Copilot Studio, Joule Studio, CI), **on-prem/classic** reach,
   and the operations the SAP server omits — **SQL, git, transport release, ST22 dumps/traces**.
 
-They coexist cleanly: distinct tool namespaces, and an agent can hold both connections. A reasonable
-division of labour is *"SAP server writes & generates the modern code you're editing; ARC-1 governs
-access, reaches the rest of the estate, and handles ops."*
+They coexist cleanly: distinct tool namespaces (`abap_*` vs `SAPRead`/`SAPWrite`/…), and an agent can
+hold both connections. A reasonable division of labour is *"SAP server writes & generates the modern
+code you're editing; ARC-1 governs access, reaches the rest of the estate, and handles ops."*
 
 ---
 
@@ -427,13 +470,13 @@ access, reaches the rest of the estate, and handles ops."*
 
 === "SAP ABAP MCP Server is better at…"
 
-    - **Zero-config** in-IDE experience; reuses your ADT session.
-    - **First-party & supported**, on SAP's roadmap, evolving fast.
-    - **Server-driven creation + RAP/Fiori generators** that auto-track backend capabilities.
-    - **Joule AI** (SAP-ABAP-1) fix proposals & generation — a model tuned on ABAP.
+    - **Near-zero-config** in-IDE experience; reuses your ADT session.
+    - **First-party**, on SAP's roadmap, evolving fast (currently labelled experimental).
+    - **Server-driven creation + repository-object generators** that auto-track backend capabilities.
+    - **Joule AI** (SAP-ABAP-1) ATC fix proposals — a model tuned on ABAP (licensed).
     - The surrounding **IDE**: debugger, completion, navigation, form editors, virtual workspace.
     - **Human-in-the-loop** transport selection baked into the tools.
-    - Identical tools across **Eclipse and VS Code**.
+    - The same MCP tooling offered across **Eclipse and VS Code** (per SAP/community materials).
 
 === "ARC-1 is better at…"
 
@@ -441,42 +484,48 @@ access, reaches the rest of the estate, and handles ops."*
     - **Enterprise auth**: XSUAA + OIDC + API key, and **per-user principal propagation**.
     - **Governance**: read-only default, package allowlists, deny-actions, scopes, rate limits, and a
       **central audit log**.
-    - **Reach**: on-prem ECC/NetWeaver/older S/4, and **classic objects** (PROG, FUGR, DDIC, MSAG,
-      ENHO…), plus **read/search over MCP** everywhere.
+    - **Reach**: classic objects (PROG, FUGR, DDIC, MSAG, ENHO…) and **read/search over MCP** wherever
+      the backend exposes the endpoints.
     - **Ops breadth**: free SQL, git, transport release/delete, **ST22 dumps & traces**.
     - **Any MCP client** (Copilot Studio, Joule Studio, CLI, web, JetBrains) and **any LLM**.
-    - **Works anywhere ADT does**, with no cloud/AI-Core dependency and no licence.
+    - **No cloud/AI-Core dependency and no licence** for any of its tools.
 
 ### ARC-1's honest limitations
 
 To keep this balanced: ARC-1 is **not** a drop-in replacement for the SAP server's IDE experience.
 
-- It's **community open source** — no SAP support contract or SLA.
+- It's **community open source** — no SAP support contract or SLA; "production-ready" is the project's
+  own positioning.
 - **You** operate and secure it (for the central deployment).
 - **No server-side AI model** — output quality is whatever your chosen LLM produces.
 - **No IDE UX** — no debugger, no inline completion, no form editors; it's RPC tools.
 - Its ADT layer is **hand-maintained**; new SAP object types/editors may need ARC-1 code, whereas
   SAP's server-driven framework adapts automatically.
-- For a **lone developer on a modern dev system living in the IDE**, the SAP server is simply the
+- Per-tool reach depends on the **backend's ADT/OData endpoints** — older ECC/NetWeaver should be
+  validated per feature.
+- For a **lone developer on a modern dev system living in the IDE**, the SAP server is the
   better-fitting, lower-friction tool — and ARC-1 doesn't pretend otherwise.
 
 ---
 
 ## Sources
 
-Live verification (this machine, 2026-06-16): `tools/list` and sample `tools/call` against the running
-`ADT MCP Server` v1.0.0 on `localhost`, bound to an on-prem S/4HANA 2023 destination.
+### Public / primary sources
 
-SAP & community references:
+- [ABAP Development Tools for VS Code — Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=SAPSE.adt-vscode) — official SAP SE extension: free, integrated AI/MCP, debugger, Unit, ATC, transports, RFC/HTTP connectivity, additional licence for certain Joule features.
+- [SAP Help — Model Context Protocol Tools](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/243d050c1be846e788f38f8c23c45d3a.html) — **canonical toolset, exact tool IDs, and per-tool Joule License column** (source for §7.1 and §12).
+- [SAP Help — Configuring ADT MCP Server](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/ed94320814734d97801f51a5b6deb802.html) — URL `http://localhost:<port>/mcp`, port preference, auto-generated bearer token.
+- [SAP Help — Enabling ADT MCP Server](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/6f6e72852b9746ffbe083d5a818fbbec.html) — local HTTP server enablement.
+- [SAP-samples — RAP130 Exercise 1: Enable the ADT MCP Server](https://github.com/SAP-samples/abap-platform-rap130/blob/main/exercises/ex01/README.md) — `adt.mcpServer.enabled`, default port 2236, Copilot Agent mode, and the **experimental / "not intended for productive use"** warning.
+- [SAP News — Agentic AI and ABAP](https://news.sap.com/2026/05/agentic-ai-will-change-the-market/) and [SAP Business AI Release Highlights Q4 2025](https://news.sap.com/2026/01/sap-business-ai-release-highlights-q4-2025/) — SAP-ABAP-1 foundation model availability/training context.
+- [SAP Community — ADT for VS Code: Your Questions Answered](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-your-questions-answered/ba-p/14400848) · [Everything You Need to Know](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-vs-code-everything-you-need-to-know/ba-p/14258129) · [2026 Roadmap for Joule for Developers](https://community.sap.com/t5/technology-blog-posts-by-sap/our-2026-roadmap-for-joule-for-developers-abap-ai-capabilities/ba-p/14360358) — feature scope, classic-model caveats, and the promotional-period context (confirm commercial terms with SAP).
+- [Model Context Protocol specification — 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18) — the revision the tested server reported (newer revisions exist).
+- ARC-1: [Architecture](architecture.md) · [Auth overview](enterprise-auth.md) · [Authorization & roles](authorization.md) · [Configuration reference](configuration-reference.md) · [Tools reference](tools.md) · [Security guide](security-guide.md).
 
-- [ABAP Development Tools for VS Code — Everything You Need to Know](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-vs-code-everything-you-need-to-know/ba-p/14258129)
-- [ABAP Development Tools for VS Code — Your Questions Answered](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-your-questions-answered/ba-p/14400848)
-- [The Future of ABAP is Here: VS Code ADT, Zero-Config MCP, and AI Co-pilots](https://community.sap.com/t5/technology-blog-posts-by-members/the-future-of-abap-is-here-vs-code-adt-zero-config-mcp-and-ai-co-pilots/ba-p/14408186)
-- [ABAP development tools for VS Code is now available on the Marketplace](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-is-now-available-on-the-vs/ba-p/14402120)
-- [Our 2026 Roadmap for Joule for Developers ABAP AI capabilities](https://community.sap.com/t5/technology-blog-posts-by-sap/our-2026-roadmap-for-joule-for-developers-abap-ai-capabilities/ba-p/14360358)
-- [SAP Help Portal — ABAP Development Tools for Visual Studio Code](https://help.sap.com/docs/abap-cloud/abap-development-tools-for-visual-studio-code/abap-development-tools-for-visual-studio-code)
-- [SAP's official MCP servers list](https://likweitan.github.io/sap-mcp-servers-official/) (CAP, Fiori, UI5, MDK — the ADT MCP server ships *in the IDE*, not as an npm package)
+### Author's live snapshot (2026-06-16 — observed, not product-wide)
 
-ARC-1 references: [Architecture](architecture.md) · [Auth overview](enterprise-auth.md) ·
-[Authorization & roles](authorization.md) · [Configuration reference](configuration-reference.md) ·
-[Tools reference](tools.md) · [Security guide](security-guide.md).
+A running `ADT MCP Server` v1.0.0 in Eclipse on the author's machine (MCP protocol `2025-06-18`, Jetty
+12.1.9), bound to one on-prem **S/4HANA 2023** backend: `tools/list` returned the 20-tool set (with the
+two ID variants noted in §7.1), `resources/list`/`prompts/list` returned *Method not found*, and
+`abap_creation-get_all_creatable_objects` returned the creatable-type list discussed in §8. These exact
+counts/lists are **backend/version dependent** — verify against your own `tools/list`.

--- a/docs_page/arc-1-vs-sap-abap-mcp-server.md
+++ b/docs_page/arc-1-vs-sap-abap-mcp-server.md
@@ -166,6 +166,7 @@ flowchart LR
 | Process model | A server you deploy (CF app / container / `npx` / stdio) | A `localhost` process the IDE starts for you |
 | Network exposure | Remote over HTTPS (or local stdio) | **`localhost` only** + auto-generated bearer token (a Host-header / DNS-rebinding guard was also observed in teardown) |
 | Multi-user | **Yes** — one endpoint, many users | No — one server per developer machine, tied to the IDE session |
+| Multiple SAP systems | One SAP system per server instance (a central BTP deployment routes to its configured destination; many systems → many instances/destinations) | **Yes** — every tool takes a `destination` arg, so one running server spans all the systems your IDE has configured |
 | Connection to SAP | ADT REST (HTTP) everywhere, incl. on-prem via Cloud Connector | **Inherits the IDE destination**: RFC (SNC/SSO) on-prem, HTTP (OAuth) cloud |
 | Runtime footprint | Lightweight Node process | Bundled inside the ADT engine (heavier; the price of full ADT fidelity) |
 | Who operates it | You (or your platform team) | SAP's extension; nothing to operate |
@@ -311,6 +312,8 @@ user being authorized.
 | Inline completion / form editors | ❌ | ✅ (in the IDE) |
 | Server-side AI model | ❌ (bring your own LLM) | ✅ Joule (licensed; model not publicly pinned) |
 | Rate limiting | ✅ (3 layers) | ❌ |
+| Multiple SAP systems in one server | ❌ (one system per instance) | ✅ (`destination` arg per tool) |
+| Token efficiency (hyperfocused / context compression / method surgery) | ✅ | ❌ (verbose tool descriptions) |
 
 ⚠️ = available but indirectly / partially, or only inside the IDE.
 
@@ -380,6 +383,7 @@ automated clients — Copilot Studio agents, CI pipelines, web apps, scheduled a
 | Write safety | Default-deny + allowlists + deny-actions + scopes | The developer's SAP authorizations are the gate; **SAP authorizations remain final** |
 | Auditability | Central, per-user, structured (incl. BTP Audit Log) | The SAP system's own logging |
 | Secrets handling | `.env`/service keys redacted in logs; never committed | Token in IDE settings; destinations in the IDE config |
+| Supply-chain hardening | Dependabot · CodeQL · Trivy image scan · npm provenance · SHA-pinned actions · `SECURITY.md` | Closed-source; covered by SAP's PSRT process |
 
 Neither is "insecure" — they make **different trust assumptions**. The SAP server assumes a **local-machine
 trust boundary** and relies on SAP authorizations; ARC-1 assumes a shared, possibly hostile-adjacent
@@ -509,6 +513,8 @@ Namespaces differ (`abap_*` vs `SAPRead`/`SAPWrite`/…) and an agent can hold s
     - **Joule AI** ATC fix proposals (licensed, BTP-hosted).
     - The surrounding **IDE**: debugger, completion, navigation, form editors, virtual workspace.
     - **Human-in-the-loop** transport selection baked into the tools.
+    - **Multi-destination** — one running server spans every system configured in your IDE (each tool
+      takes a `destination` arg), handy when you hop between systems.
     - The same MCP tooling across **Eclipse and VS Code**.
 
 === "ARC-1 is better at…"
@@ -523,6 +529,8 @@ Namespaces differ (`abap_*` vs `SAPRead`/`SAPWrite`/…) and an agent can hold s
     - **Ops breadth**: free SQL, git, transport release/delete, **ST22 dumps & traces**.
     - **Any MCP client** and **any LLM**; multiple **distribution** options (`.mcpb`, Claude Code plugin +
       skills, Docker, npm, BTP connector).
+    - **Token efficiency** — hyperfocused 1-tool mode (~200 tokens), context compression, and
+      method-level surgery keep tight context windows and mid-tier LLMs viable.
     - **No cloud/AI-Core dependency and no licence** for any tool.
 
 ### ARC-1's honest limitations

--- a/docs_page/arc-1-vs-sap-abap-mcp-server.md
+++ b/docs_page/arc-1-vs-sap-abap-mcp-server.md
@@ -1,0 +1,482 @@
+# ARC-1 vs. the SAP ABAP MCP Server — Decision Guide
+
+This page compares **ARC-1** with **SAP's official ABAP MCP Server** (the one bundled with *ABAP
+Development Tools for VS Code* and *ADT for Eclipse*) so you can decide which to run — **only
+ARC-1, only the SAP ABAP MCP Server, or both together.**
+
+!!! note "Neutral by design"
+    This is a decision aid, not a sales page. The two products were built for *different jobs* and
+    the honest answer for many teams is **"use both"**. Where ARC-1 is stronger it says so; where the
+    SAP server is stronger it says so just as plainly. Pick the column that matches **your** situation,
+    not the one with more checkmarks.
+
+!!! info "How the facts here were gathered (2026-06-16)"
+    The SAP server's facts were taken from a **live install** running in Eclipse on the author's
+    machine (`ADT MCP Server` v1.0.0, MCP protocol `2025-06-18`, Jetty 12.1.9) bound to an on-premise
+    **S/4HANA 2023** system, cross-checked against SAP's GA announcements at Sapphire 2026 and SAP
+    Community posts (linked under [Sources](#sources)). Tool names, schemas and the creatable-object
+    list below were read directly from that running server. The SAP server evolves quickly — treat
+    counts and tool names as a snapshot, not a contract.
+
+---
+
+## 1. At a glance
+
+| | **ARC-1** | **SAP ABAP MCP Server** |
+|---|---|---|
+| **What it is** | Independent MCP server that translates AI tool calls into ADT REST calls | MCP server SAP ships *inside* ADT for VS Code / Eclipse |
+| **Vendor / support** | Community open-source (MIT); no SAP support contract | SAP SE; first-party, supported, on SAP's roadmap |
+| **Where it runs** | BTP Cloud Foundry, Docker, npm/`npx`, or local stdio | A headless ADT engine on your laptop (`localhost` only) |
+| **Primary design center** | **Centrally hosted, multi-user, admin-governed** | **Single developer, zero-config, inside the IDE** |
+| **Auth to the *server*** | XSUAA OAuth · OIDC JWT · API key · (stdio = none) | Auto-generated bearer token on `localhost` |
+| **Auth to *SAP*** | Per-user principal propagation, or shared service user | Your own ADT logon session / SAP user |
+| **Central config / policy** | Yes — server-wide safety ceiling, scopes, audit | No — each developer's machine, no policy layer |
+| **MCP clients** | Any (Claude, Copilot Studio, Cursor, CLI, JetBrains, web…) | Local IDE agents (Copilot Agent Mode, Joule) + any local client |
+| **System reach** | Any system with ADT — on-prem ECC 7.4+, NW, S/4 on-prem, RISE, Cloud, BTP | On-prem (RFC) + Public Cloud/BTP (HTTP); RAP/ABAP-Cloud focus |
+| **Object types** | Classic **and** modern (PROG, FUGR, TABL, DOMA, DTEL, MSAG, ENHO… + CLAS, CDS, RAP) | RAP/ABAP-Cloud-centric; broader on some on-prem systems; no Dynpro/WebDynpro |
+| **Reads source over MCP?** | Yes — `SAPRead` / `SAPSearch` are first-class tools | Not on the tested release — reading is the IDE editor's job (see §6) |
+| **Server-side AI** | None — uses *your* LLM (Claude/GPT/Gemini/…) | Optional **Joule** AI (SAP-ABAP-1 model) for ATC fixes & generation |
+| **Cost** | Free (you pay only your infra + your LLM) | Extension free; **Joule AI features are licensed** (AI units; free promo to Sep 2026) |
+
+**One-line verdict:** if you are **one developer working in your IDE on a modern ABAP/RAP system**,
+the SAP server is the most frictionless, best-integrated choice. If you need **a shared, governed,
+audited endpoint for many users / non-IDE agents / on-prem & classic ABAP / SQL · git · transports ·
+dumps**, that is exactly what ARC-1 is for. Many teams run **both**.
+
+---
+
+## 2. Decision guide — only ARC-1, only SAP, or both?
+
+Start here. The detail sections below justify each row.
+
+### Pick the SAP ABAP MCP Server if…
+
+- You work **inside VS Code or Eclipse** and want the AI to act on the code you already have open.
+- Your system is **S/4HANA (Cloud/RISE/recent on-prem) or BTP ABAP** and your work is **RAP / ABAP
+  Cloud / clean-core**.
+- You want **zero setup** — reuse your ADT logon, flip one checkbox, done.
+- You want **SAP's own AI** (Joule / SAP-ABAP-1) for ATC fix proposals and RAP+Fiori generation, and
+  you have (or will buy) the licence.
+- You value a **first-party, supported, roadmap-backed** tool and the integrated **debugger /
+  completion / form editors** that come with the IDE.
+
+### Pick ARC-1 if…
+
+- You need a **shared, always-on MCP endpoint** that **many users or agents** connect to (a team
+  server, CI, an agent platform) rather than a per-laptop process.
+- You need **non-IDE clients**: Microsoft Copilot Studio, Joule Studio, Gemini CLI, a custom agent,
+  a web app — anything that speaks remote MCP over HTTP.
+- You need **central governance**: read-only by default, package allowlists, per-action deny rules,
+  per-user scopes, rate limits, and a **central audit trail** of every call.
+- You need **per-user SAP identity at scale** — XSUAA + BTP Destination Service principal
+  propagation maps each AI user to their own SAP user.
+- You work on **on-prem ECC / NetWeaver / older S/4** or with **classic objects** (reports, function
+  groups, DDIC domains/data elements, message classes, enhancements) — or you need **free SQL,
+  git (gCTS/abapGit), transport release, or ST22 dump / trace analysis**.
+- You want to keep your **choice of LLM** (Claude, GPT, Gemini, Mistral, …) and not route through
+  SAP's AI hub.
+
+### Run both if… (common for teams that have adopted VS Code ADT)
+
+- Developers use the **SAP server in-IDE** for fast, context-aware editing, debugging, RAP generation
+  and Joule AI fixes **on their personal dev systems**, **and**
+- The team/platform runs **ARC-1 centrally** for the things the SAP server doesn't do: governed
+  multi-user access, non-IDE agents, classic-object and on-prem reach, SQL, git, transports, runtime
+  diagnostics, and a central audit log.
+
+They don't conflict — the tool namespaces differ (`sap-abap-adt` vs `SAPRead`/`SAPWrite`/…), and an
+agent can have both connected at once.
+
+### Scenario cheat-sheet
+
+| Your situation | Recommended |
+|---|---|
+| Solo dev, RAP on S/4 Cloud/BTP, lives in VS Code | **SAP server** |
+| Solo dev, modern types, wants SAP-tuned AI fixes | **SAP server** (+ Joule licence) |
+| Team wants one governed endpoint with audit + scopes | **ARC-1** |
+| AI agent on **Copilot Studio / Joule Studio / a website** | **ARC-1** (remote MCP + JWT) |
+| On-prem ECC 7.4 / NetWeaver / pre-2023 S/4 | **ARC-1** |
+| Heavy **classic ABAP** (reports, FUGR, DDIC, messages, enhancements) | **ARC-1** |
+| Need **SQL / git / transport release / ST22 dumps / traces** | **ARC-1** |
+| Migration / clean-core at scale across many systems | **ARC-1** (often **+** SAP server per dev) |
+| Modern shop that adopted VS Code ADT **and** runs agent platforms | **Both** |
+
+---
+
+## 3. What each product is
+
+=== "ARC-1"
+
+    A standalone **TypeScript MCP server** (npm package `arc-1`, Docker image
+    `ghcr.io/marianfoo/arc-1`) that implements the Model Context Protocol and turns AI tool calls into
+    **ADT REST** requests (`/sap/bc/adt/*`) — the same public API the Eclipse ADT client uses.
+
+    - **Distribution:** `npx arc-1`, global npm install, Docker, or a deployed BTP Cloud Foundry app.
+    - **Maturity:** production, write-capable, multi-user. Open source (MIT), community-maintained.
+    - **Design center:** a **centrally hosted, admin-governed, multi-tenant** proxy — one server, many
+      AI users, each mapped to their own SAP identity, every call audited and policy-checked.
+    - **Tool model:** **12 intent tools** (e.g. `SAPRead`, `SAPWrite`) with a `type`/`action`
+      parameter, instead of 200+ endpoint tools — keeps the LLM's tool list small. A "hyperfocused"
+      mode collapses to a single ~200-token tool for tight context windows.
+
+=== "SAP ABAP MCP Server"
+
+    An MCP server SAP **bundles inside its IDE tooling** — *ABAP Development Tools for VS Code*
+    (publisher SAP SE, GA at Sapphire 2026, on the VS Code Marketplace) and *ADT for Eclipse*. The MCP
+    layer is part of a **larger redesign**: a headless **ABAP Language Server** (the Eclipse ADT client
+    repackaged) plus the **ABAP MCP Server** on top.
+
+    - **Distribution:** ships with the extension; **not** a standalone package you host. It runs as a
+      small **Streamable-HTTP server on `localhost`** (an auto-selected port, e.g. 2234/2236) launched
+      by the IDE.
+    - **Maturity:** v1.0.0, GA but explicitly **disabled by default** (enable
+      `ABAP > AI: Enable ADT MCP Server`). SAP positions Eclipse as the flagship IDE "until VS Code
+      reaches feature parity," but notes the **same MCP tools are offered in both** because they live in
+      the shared core layer.
+    - **Design center:** **one developer, zero-config**, agentic AI on the code in their IDE.
+    - **Tool model:** ~20 narrowly-scoped, **heavily prompt-engineered** tools (USE WHEN / TYPICAL
+      WORKFLOW / human-in-the-loop transport selection), grouped by workflow (creation, generation,
+      ATC, activation, tests, transport, business services). The set is partly **server-driven** —
+      it adapts to what the connected backend offers.
+
+---
+
+## 4. Architecture & where it runs
+
+```mermaid
+flowchart LR
+  subgraph SAP_MODEL["SAP ABAP MCP Server — per developer"]
+    direction TB
+    A1["AI agent in IDE<br/>(Copilot Agent Mode / Joule)"] -->|localhost + bearer| A2["ADT MCP Server<br/>(headless ADT engine)"]
+    A2 -->|RFC on-prem / HTTP cloud| A3["Your SAP system<br/>(your ADT session)"]
+  end
+  subgraph ARC1_MODEL["ARC-1 — centrally hosted"]
+    direction TB
+    B1["Many AI clients<br/>Claude · Copilot Studio · Cursor · CLI · web"] -->|HTTPS + OAuth/JWT/API key| B2["ARC-1 server<br/>(safety ceiling · scopes · audit)"]
+    B2 -->|ADT REST + principal propagation| B3["BTP Destination + Cloud Connector"]
+    B3 --> B4["Any SAP system with ADT"]
+  end
+```
+
+| Dimension | ARC-1 | SAP ABAP MCP Server |
+|---|---|---|
+| Process model | A server you deploy (CF app / container / `npx` / stdio) | A `localhost` process the IDE starts for you |
+| Network exposure | Remote over HTTPS (or local stdio) | **`localhost` only** + DNS-rebinding guard (Host must be localhost/127.0.0.1) |
+| Multi-user | **Yes** — one endpoint, many users | No — one server per developer machine, bound to one ADT session |
+| Connection to SAP | ADT REST (HTTP) everywhere, incl. on-prem via Cloud Connector | **RFC** for on-prem/Private Cloud, **HTTP** for Public Cloud/BTP |
+| Runtime footprint | Lightweight Node process | A bundled headless ADT/Equinox engine (heavier; the price of full ADT fidelity) |
+| Who operates it | You (or your platform team) | SAP's extension; nothing to operate |
+
+**Takeaway:** the SAP server is a *personal* component — there is no notion of "host it for the team."
+ARC-1 is a *shared service* — that is its whole point, and also why it asks more of you to stand up.
+
+---
+
+## 5. Authentication & identity
+
+This is one of the sharpest differences and a frequent reason to choose ARC-1 for teams.
+
+| Layer | ARC-1 | SAP ABAP MCP Server |
+|---|---|---|
+| **Auth to the MCP server** | XSUAA OAuth 2.0 · external OIDC JWT (e.g. Entra ID) · API keys (`key:profile`); stdio has none | A single auto-generated **bearer token** stored in an IDE setting; trusted because it's `localhost`-only |
+| **Per-AI-user identity** | Yes — JWT/`clientId`/`userName` flows through every call | No concept of multiple MCP users |
+| **Auth to SAP** | **Principal propagation**: each AI user → their own SAP user via BTP Destination Service + Cloud Connector; or a shared service user | Reuses **your** ADT logon session / SAP user |
+| **Multiple auth mechanisms at once** | Yes — XSUAA + OIDC + API key can coexist on one server | n/a (single local developer) |
+| **SAP-side authorizations** | Enforced by SAP (`S_DEVELOP`, `S_ADT_RES`, `S_TRANSPRT`) **and** ARC-1 scopes as defense-in-depth | Enforced by SAP for **your** user; that's the only gate |
+
+!!! tip "What this means in practice"
+    On the SAP server, "who is the AI acting as?" is simply **you** — clean and correct for a single
+    developer on their own system. ARC-1 answers the harder enterprise question: *"a shared agent
+    serves 50 people — how does each call run as the right SAP user, with the right rights, and leave
+    an audit record?"* If you only ever have the first question, the SAP server's model is simpler. If
+    you have the second, ARC-1 is built for it.
+
+---
+
+## 6. Central configuration & governance
+
+The SAP server has **no policy/config layer** — by design. It is a developer tool: it does what your
+SAP user is allowed to do, on your machine, full stop. There is nothing for an admin to centrally
+configure, restrict, or audit across users, because there is no "across users."
+
+ARC-1's reason to exist is the opposite: an **admin-controlled safety ceiling** that every call passes
+through, no matter which user or client made it.
+
+| Governance control | ARC-1 | SAP ABAP MCP Server |
+|---|---|---|
+| Read-only by default | **Yes** — writes are opt-in (`SAP_ALLOW_WRITES`) | No server-side gate (your SAP auth is the only limit) |
+| Separate gates for data preview / free SQL / transport writes / git writes | **Yes**, each independent | n/a |
+| **Package allowlist** (e.g. `$TMP`, `Z*`, subtree) enforced fail-closed on every mutation | **Yes** | No |
+| **Per-action deny** (e.g. block `SAPWrite.delete`) | **Yes** (`SAP_DENY_ACTIONS`) | No |
+| **Scopes** (read / write / data / sql / transports / git / admin) | **Yes**, per user/profile | No |
+| **Rate limiting** (per-IP OAuth, per-user MCP, server-wide SAP semaphore) | **Yes**, three layers | No |
+| **Central audit log** of every call with user identity | **Yes** (stderr / file / **BTP Audit Log**) | No central log; activity is implicit in the SAP system |
+| Where config lives | Central (server env/CLI/`.env`), one source of truth | Per-developer IDE settings + `~/.adtls/destinations.json` |
+
+!!! warning "The honest counterpoint"
+    For a **single developer on a sandbox / personal dev tier**, all of this governance is overhead
+    they don't need. "It just runs as me with my rights" is the *right* amount of control there. ARC-1's
+    governance earns its keep when an AI endpoint is **shared**, **automated**, or **pointed at systems
+    where uncontrolled writes are unacceptable** — not on a lone developer's `$TMP` playground.
+
+---
+
+## 7. Capabilities & tool surface
+
+### 7.1 The SAP server's tools (live read, 2026-06-16 — 20 tools)
+
+| Group | Tools | What they do |
+|---|---|---|
+| **Object creation** (server-driven, 4 steps) | `get_all_creatable_objects` · `get_object_type_details` · `run_validation` · `create_object` | Enumerate creatable types on the backend, fetch the per-type form schema, validate, then create. The type list comes **from the backend**, so it tracks new object types automatically. |
+| **RAP generators** | `generators-list_generators` · `generators-get_schema` · `generators-generate_objects` | Backend "generator" framework, e.g. `x-ui-service` (full RAP + Fiori UI) and `webapi-service` (API only). |
+| **Activation & tests** | `activate_objects` · `run_unit_tests` | Activate URIs (returns syntax diagnostics on failure); run ABAP Unit. |
+| **ATC** | `atc_run` · `atc_get_result` · `atc_execute_deterministic_quickfixes` · `atc_apply_ai_fix` · `atc_get_ai_fix_result` | Run ATC, poll results, apply deterministic quickfixes, and — with **Joule** — apply **AI-generated fixes** to eligible findings. |
+| **Transport** | `transport-get` · `transport-create` · `transport-unifiedDifference` | Validate/list TRs, create a TR (always after a human picks), paginated unified diff of a TR. Tool prompts force **human-in-the-loop** TR selection. |
+| **Business services** | `business_services-fetch_services` · `business_services-fetch_service_information` | Read OData services from a service binding (for Fiori app generation handoff). |
+| **Destinations** | `list_destinations` | List the ADT destinations configured in the IDE. |
+
+Notable about this surface:
+
+- **No source-read, search, or where-used tool** was present on the tested S/4HANA 2023 backend.
+  SAP's roadmap adds an *"ABAP object search"* MCP tool, but on **newer backends only** (announced for
+  BTP 2611 / S/4 Cloud Public 2702 / Private 2027). **In the IDE this doesn't matter** — the agent reads
+  code through the editor / virtual workspace (Copilot can "find a function and read it" because the
+  *workspace*, not the MCP server, serves the file). **For a non-IDE MCP client on an older system,
+  it does matter:** there may be no way to read source via MCP alone.
+- **No `resources` or `prompts`** — it's a pure *tools* server.
+- It does **not** expose free SQL, git, transport *release/delete*, or runtime diagnostics (ST22 dumps,
+  traces).
+- Its real superpower is the **server-driven creation + generator framework** and (with a licence) the
+  **Joule AI fix/generation** — neither of which ARC-1 has.
+
+### 7.2 ARC-1's tools (12 intent tools)
+
+| Tool | Covers |
+|---|---|
+| `SAPRead` | Read source & metadata for **any** ADT object type; `grep`; where-used; version history; method-level surgery reads |
+| `SAPSearch` | `quick_search`, `tadir_lookup` (ADT / DB / both) |
+| `SAPWrite` | Create / update / delete; class- & method-section surgery; RAP scaffolding & `generate_behavior_implementation`; `batch_create` |
+| `SAPActivate` | Activate (single & batch, ED064-aware); publish/unpublish service bindings |
+| `SAPNavigate` | Go-to-definition, references, where-used, completion |
+| `SAPQuery` | Free SQL **and** table-data preview (both admin-gated) |
+| `SAPTransport` | `create` · `assign` · `list` · `history` · `release` · `delete` (gated) |
+| `SAPGit` | Full gCTS / abapGit: clone, pull, push, stage, commit, branches, repos… (gated) |
+| `SAPContext` | Dependency / contract / compressed-context extraction for LLMs |
+| `SAPLint` | abaplint (offline) + Pretty Printer + formatter settings |
+| `SAPDiagnose` | `syntax` · `atc` · `quickfix`/`apply_quickfix` · ABAP Unit · **ST22 dumps** · **traces** · gateway/system messages · RAP preflight · CDS test-case suggestions |
+| `SAPManage` | Package create/delete/move (DEVC) · FLP catalogs/groups/tiles · feature probe · cache stats |
+
+### 7.3 Capability matrix
+
+| Capability | ARC-1 | SAP ABAP MCP Server |
+|---|:---:|:---:|
+| Create objects | ✅ (AFF + classic builders) | ✅ (server-driven, auto-tracks new types) |
+| Update / edit source | ✅ incl. method/section surgery | ⚠️ via IDE editor + LS (not an MCP write tool on tested release) |
+| Activate | ✅ | ✅ |
+| Run ABAP Unit | ✅ | ✅ |
+| ATC run + results | ✅ | ✅ |
+| ATC **deterministic** quickfix | ✅ (`quickfix`/`apply_quickfix`) | ✅ |
+| ATC **AI** fix (model-generated) | ❌ (use your client LLM manually) | ✅ **Joule / SAP-ABAP-1** (licensed) |
+| RAP + Fiori generators (x-ui-service) | ⚠️ scaffolding + skills, not the backend generator catalog | ✅ native generator framework |
+| Read source **over MCP** | ✅ `SAPRead` | ❌ on tested release (IDE editor reads instead) |
+| Search / where-used **over MCP** | ✅ | ❌ on tested release (roadmap: newer backends) |
+| Free SQL | ✅ (gated) | ❌ |
+| Table data preview | ✅ (gated) | ❌ |
+| Git (gCTS / abapGit) | ✅ (gated) | ❌ |
+| Transport create / assign / list / diff | ✅ | ✅ |
+| Transport **release / delete** | ✅ (gated) | ❌ |
+| Runtime diagnostics — **ST22 dumps, traces** | ✅ | ❌ |
+| Pretty Printer / offline lint | ✅ | ⚠️ formatting via IDE, no abaplint |
+| Integrated **debugger** | ❌ (MCP is RPC) | ✅ (in the IDE) |
+| Inline completion / form editors | ❌ | ✅ (in the IDE) |
+| Server-side AI model | ❌ (bring your own LLM) | ✅ Joule (SAP-ABAP-1) |
+
+⚠️ = available but indirectly / partially, or only inside the IDE.
+
+---
+
+## 8. System & object-type reach
+
+| | ARC-1 | SAP ABAP MCP Server |
+|---|---|---|
+| On-prem S/4HANA | ✅ | ✅ (via RFC; RAP/ABAP-Cloud focus) |
+| **On-prem ECC 7.4+ / NetWeaver 7.5x** | ✅ | ⚠️ extension supports old releases for basics, but AI features need BTP/AI Core |
+| RISE / Private Cloud | ✅ | ✅ |
+| S/4HANA Cloud Public | ✅ | ✅ |
+| BTP ABAP (Steampunk) | ✅ | ✅ |
+| **Classic procedural** (PROG, FUGR/FUNC, includes) | ✅ | ⚠️ creatable on some on-prem backends (seen live on S/4 2023); not the focus |
+| **DDIC** (TABL, STRU) | ✅ | ✅ (TABL/DT, TABL/DS seen live) |
+| **DOMA / DTEL / MSAG / SHLP / ENHO / XSLT** | ✅ | ❌ (not in the creatable set observed) |
+| Modern (CLAS, INTF, DDLS, DDLX, DCLS, BDEF, SRVD, SRVB, DRAS…) | ✅ | ✅ |
+| **Dynpro / Web Dynpro / module pools** | ⚠️ limited (ADT itself is thin here) | ❌ explicitly excluded by SAP |
+
+!!! note "Live nuance worth knowing"
+    On the tested **on-prem S/4HANA 2023** system, the SAP server's `get_all_creatable_objects`
+    returned **classic** types too — Program, Function Group/Module/Include, Database Table, Structure,
+    Interface, Lock Object, Type Group — i.e. broader than a strict "modern-only" reading. But it still
+    **omitted** core DDIC types (DOMA, DTEL), message classes (MSAG), search helps (SHLP), and
+    enhancements (ENHO), and there was **no way to read or search** any of them over MCP. ARC-1 covers
+    those types and the read/search path.
+
+---
+
+## 9. MCP client & IDE compatibility
+
+| Client | ARC-1 | SAP ABAP MCP Server |
+|---|:---:|:---:|
+| GitHub Copilot (Agent Mode) in VS Code/Eclipse | ✅ | ✅ (auto-listed as `sap-abap-adt`) |
+| SAP Joule (in-IDE) | ✅ | ✅ |
+| Claude Desktop | ✅ | ⚠️ only if pointed at the localhost URL+token (not its intended use) |
+| **Microsoft Copilot Studio** (remote agents) | ✅ | ❌ (no remote endpoint) |
+| **SAP Joule Studio** (custom agents) | ✅ | ❌ |
+| Cursor | ✅ | ⚠️ shares the VS Code extension family; in-IDE only |
+| Gemini CLI / custom CLI agents | ✅ | ⚠️ localhost only |
+| JetBrains / web apps / CI | ✅ | ❌ |
+
+The SAP server is reachable by **any local MCP client** that points at its `localhost` URL with the
+bearer token — but it is **localhost-only by design**, so "team server" and "cloud agent platform"
+use cases are off the table. ARC-1 is the one you expose (securely) to remote and automated clients.
+
+---
+
+## 10. Security posture (summary)
+
+| | ARC-1 | SAP ABAP MCP Server |
+|---|---|---|
+| Transport security | HTTPS; CORS allowlist; OAuth/JWT/API-key | `localhost` + DNS-rebinding guard + bearer token |
+| Blast radius if token leaks | Token/JWT scoped + rate-limited; admin can revoke | Anyone *on that machine* who reads the token gets the developer's full ADT rights |
+| Write safety | Default-deny + allowlists + deny-actions + scopes | Whatever the developer's SAP user can do |
+| Auditability | Central, per-user, structured (incl. BTP Audit Log) | Rely on the SAP system's own logging |
+| Secrets handling | `.env`/service keys redacted in logs; never committed | Token in IDE settings; destinations in `~/.adtls/` |
+
+Neither is "insecure" — they make **different trust assumptions**. The SAP server trusts the
+developer's own machine and SAP authorizations. ARC-1 assumes a shared, possibly hostile-adjacent
+environment and adds layers accordingly.
+
+---
+
+## 11. Setup effort
+
+Both are **easy for the local single-developer case** — that's worth saying plainly, because it's the
+SAP server's home turf and ARC-1 matches it there:
+
+=== "SAP ABAP MCP Server (local)"
+
+    1. Install the *ABAP Development Tools for VS Code* extension (or use Eclipse ADT).
+    2. Create a destination / logon to your SAP system.
+    3. Enable **`ABAP > AI: Enable ADT MCP Server`**.
+    4. Your IDE AI agent (Copilot Agent Mode / Joule) auto-discovers `sap-abap-adt`.
+
+    **Effort: minutes. Zero infrastructure.** This is the benchmark for frictionless.
+
+=== "ARC-1 (local stdio)"
+
+    ```bash
+    npx arc-1@latest --url https://your-sap-host:44300 --user YOUR_USER
+    ```
+
+    **Effort: minutes.** One command; point your MCP client at it. As easy as the SAP server for a
+    single developer.
+
+=== "ARC-1 (the target architecture)"
+
+    Centrally hosted on **BTP Cloud Foundry** with XSUAA OAuth, BTP Destination Service + Cloud
+    Connector for principal propagation, and the audit-log sink. This unlocks the multi-user/governed
+    story — and it's **more work**: BTP entitlements, destinations, role collections, deployment.
+
+!!! important "The key trade-off in one sentence"
+    ARC-1 is *just as easy as the SAP server* when run locally — but running it locally is **not where
+    its value is**. Its design center is the **central, governed deployment**, which costs real setup.
+    The SAP server is purpose-built for the local case and asks for **nothing**. Choose based on which
+    *architecture* you actually need, not on the 5-minute quick-start (both win that).
+
+---
+
+## 12. Cost & licensing
+
+| | ARC-1 | SAP ABAP MCP Server |
+|---|---|---|
+| The server itself | Free, open source (MIT) | Free (ships with the extension) |
+| AI model | **Bring your own** (you pay your LLM provider) | **Joule for Developers** AI features are licensed — consumption-based **AI units** (free promotional period through **September 2026**) |
+| Infrastructure | Your BTP CF / container / host | Your laptop (none extra) |
+| Vendor lock-in | None (any LLM, any ADT system) | AI features tie to SAP's GenAI hub / AI Core |
+
+The SAP server's **non-AI** tools (create, activate, test, ATC run, transport) don't need the Joule
+licence; the **AI** tools (`atc_apply_ai_fix`, AI generation) do, and need BTP/AI Core — so on a pure
+on-prem system without AI Core, the AI tools won't function even though they're listed.
+
+---
+
+## 13. Using them together
+
+A pattern that works well for a modern team that has adopted VS Code ADT:
+
+- **Per developer, in the IDE:** the SAP server for context-aware editing, debugging, ABAP
+  Unit/ATC, RAP+Fiori generation, and Joule AI fixes on their **personal dev system**.
+- **Centrally, for everyone & for agents:** ARC-1 as the **governed, audited** endpoint for
+  multi-user access, **non-IDE agents** (Copilot Studio, Joule Studio, CI), **on-prem/classic** reach,
+  and the operations the SAP server omits — **SQL, git, transport release, ST22 dumps/traces**.
+
+They coexist cleanly: distinct tool namespaces, and an agent can hold both connections. A reasonable
+division of labour is *"SAP server writes & generates the modern code you're editing; ARC-1 governs
+access, reaches the rest of the estate, and handles ops."*
+
+---
+
+## 14. Where each genuinely wins
+
+=== "SAP ABAP MCP Server is better at…"
+
+    - **Zero-config** in-IDE experience; reuses your ADT session.
+    - **First-party & supported**, on SAP's roadmap, evolving fast.
+    - **Server-driven creation + RAP/Fiori generators** that auto-track backend capabilities.
+    - **Joule AI** (SAP-ABAP-1) fix proposals & generation — a model tuned on ABAP.
+    - The surrounding **IDE**: debugger, completion, navigation, form editors, virtual workspace.
+    - **Human-in-the-loop** transport selection baked into the tools.
+    - Identical tools across **Eclipse and VS Code**.
+
+=== "ARC-1 is better at…"
+
+    - **Central, multi-user hosting** with one governed endpoint.
+    - **Enterprise auth**: XSUAA + OIDC + API key, and **per-user principal propagation**.
+    - **Governance**: read-only default, package allowlists, deny-actions, scopes, rate limits, and a
+      **central audit log**.
+    - **Reach**: on-prem ECC/NetWeaver/older S/4, and **classic objects** (PROG, FUGR, DDIC, MSAG,
+      ENHO…), plus **read/search over MCP** everywhere.
+    - **Ops breadth**: free SQL, git, transport release/delete, **ST22 dumps & traces**.
+    - **Any MCP client** (Copilot Studio, Joule Studio, CLI, web, JetBrains) and **any LLM**.
+    - **Works anywhere ADT does**, with no cloud/AI-Core dependency and no licence.
+
+### ARC-1's honest limitations
+
+To keep this balanced: ARC-1 is **not** a drop-in replacement for the SAP server's IDE experience.
+
+- It's **community open source** — no SAP support contract or SLA.
+- **You** operate and secure it (for the central deployment).
+- **No server-side AI model** — output quality is whatever your chosen LLM produces.
+- **No IDE UX** — no debugger, no inline completion, no form editors; it's RPC tools.
+- Its ADT layer is **hand-maintained**; new SAP object types/editors may need ARC-1 code, whereas
+  SAP's server-driven framework adapts automatically.
+- For a **lone developer on a modern dev system living in the IDE**, the SAP server is simply the
+  better-fitting, lower-friction tool — and ARC-1 doesn't pretend otherwise.
+
+---
+
+## Sources
+
+Live verification (this machine, 2026-06-16): `tools/list` and sample `tools/call` against the running
+`ADT MCP Server` v1.0.0 on `localhost`, bound to an on-prem S/4HANA 2023 destination.
+
+SAP & community references:
+
+- [ABAP Development Tools for VS Code — Everything You Need to Know](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-vs-code-everything-you-need-to-know/ba-p/14258129)
+- [ABAP Development Tools for VS Code — Your Questions Answered](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-your-questions-answered/ba-p/14400848)
+- [The Future of ABAP is Here: VS Code ADT, Zero-Config MCP, and AI Co-pilots](https://community.sap.com/t5/technology-blog-posts-by-members/the-future-of-abap-is-here-vs-code-adt-zero-config-mcp-and-ai-co-pilots/ba-p/14408186)
+- [ABAP development tools for VS Code is now available on the Marketplace](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-is-now-available-on-the-vs/ba-p/14402120)
+- [Our 2026 Roadmap for Joule for Developers ABAP AI capabilities](https://community.sap.com/t5/technology-blog-posts-by-sap/our-2026-roadmap-for-joule-for-developers-abap-ai-capabilities/ba-p/14360358)
+- [SAP Help Portal — ABAP Development Tools for Visual Studio Code](https://help.sap.com/docs/abap-cloud/abap-development-tools-for-visual-studio-code/abap-development-tools-for-visual-studio-code)
+- [SAP's official MCP servers list](https://likweitan.github.io/sap-mcp-servers-official/) (CAP, Fiori, UI5, MDK — the ADT MCP server ships *in the IDE*, not as an npm package)
+
+ARC-1 references: [Architecture](architecture.md) · [Auth overview](enterprise-auth.md) ·
+[Authorization & roles](authorization.md) · [Configuration reference](configuration-reference.md) ·
+[Tools reference](tools.md) · [Security guide](security-guide.md).

--- a/docs_page/arc-1-vs-sap-abap-mcp-server.md
+++ b/docs_page/arc-1-vs-sap-abap-mcp-server.md
@@ -4,31 +4,28 @@ This page compares **ARC-1** with **SAP's official ABAP MCP Server** (the *ADT M
 with *ABAP Development Tools for VS Code* and *ADT for Eclipse*) so you can decide which to run —
 **only ARC-1, only the SAP ABAP MCP Server, or both together.**
 
-!!! note "Neutral by design"
-    This is a decision aid, not a sales page. The two products were built for *different jobs* and
-    the honest answer for many teams is **"use both."** Where ARC-1 is stronger it says so; where the
-    SAP server is stronger it says so just as plainly. Pick the column that matches **your** situation,
-    not the one with more checkmarks.
+!!! note "Neutral by design — and not either/or"
+    This is a decision aid, not a sales page. The two products were built for *different jobs* and the
+    honest answer for many teams is **"use both"** — and you are **not limited to these two**: MCP is
+    composable, so you can run ARC-1, the SAP ADT MCP Server, the [SAP docs/notes MCP
+    servers](#14-its-not-eitheror-the-composable-mcp-ecosystem) and a skills layer side by side. Where
+    ARC-1 is stronger it says so; where the SAP server is stronger it says so just as plainly.
 
 !!! info "How the facts here were sourced — public vs. snapshot"
-    Two kinds of evidence are mixed below, and the difference matters:
-
     - **Public / primary sources** (strongest): SAP's Marketplace listing, the **SAP Help "Model
-      Context Protocol Tools"** page (which lists the toolset and a per-tool *Joule License* column),
-      the SAP Help *Enabling/Configuring ADT MCP Server* pages, SAP-samples workshop material
-      (RAP130), SAP News, the ARC-1 repository/docs, and the MCP specification. The **20-tool set,
-      the exact tool IDs, and the licensing split below are confirmed against SAP Help.** See
-      [Sources](#sources).
-    - **Author's live snapshot (2026-06-16, label these as observed, not product-wide):** a running
-      `ADT MCP Server` v1.0.0 in Eclipse on the author's machine — MCP protocol `2025-06-18` (the
-      revision *that server reported*; newer MCP revisions exist), Jetty 12.1.9 — bound to **one**
-      on-prem **S/4HANA 2023** backend. Tool counts, creatable-object lists and "no resources/prompts"
-      are **backend/version dependent**; treat them as a snapshot, not a guarantee.
+      Context Protocol Tools"** page (toolset + per-tool *Joule License* column), SAP Help
+      *Enabling/Configuring ADT MCP Server*, SAP-samples (RAP130), SAP News, the
+      [ARC-1 repo/docs](https://github.com/marianfoo/arc-1), and the MCP spec. The **20-tool set, exact
+      IDs, and licensing split** below are confirmed against SAP Help. See [Sources](#sources).
+    - **Author's live snapshot (2026-06-16 — observed, not product-wide):** a running `ADT MCP Server`
+      v1.0.0 in **Eclipse** (port **2234**, MCP protocol `2025-06-18` *as that server reported it* —
+      newer MCP revisions exist; Jetty 12.1.9) bound to **one** on-prem **S/4HANA 2023** backend. Tool
+      counts and creatable-object lists are **backend/version dependent** — treat them as a snapshot.
 
 **One-line verdict:** if you are **one developer working in your IDE on a modern ABAP/RAP system**,
 the SAP server is the most frictionless, best-integrated choice. If you need **a shared, governed,
-audited endpoint for many users / non-IDE agents / on-prem & classic ABAP / SQL · git · transports ·
-dumps**, that is ARC-1's design center. Many teams run **both**.
+audited endpoint for many users / non-IDE agents (Copilot Studio, automation, CI) / on-prem & classic
+ABAP / SQL · git · transports · dumps**, that is ARC-1's design center. Many teams run **both**.
 
 ---
 
@@ -38,23 +35,21 @@ dumps**, that is ARC-1's design center. Many teams run **both**.
 |---|---|---|
 | **What it is** | Independent MCP server translating AI tool calls into ADT REST calls | The *ADT MCP Server* SAP ships *inside* ADT for VS Code / Eclipse |
 | **Vendor / support** | Community open-source (MIT); no SAP support contract | SAP SE, first-party. The **extension is official/GA**, but SAP flags the **MCP server itself as experimental, "not intended for productive use"** |
-| **Where it runs** | BTP Cloud Foundry, Docker, npm/`npx`, or local stdio | A local server the IDE starts on `localhost` only |
-| **Primary design center** | **Centrally hosted, multi-user, admin-governed** | **Single developer, local, inside the IDE** |
+| **Where it runs** | BTP Cloud Foundry, Docker, npm/`npx`, or local stdio | A local HTTP server the IDE starts on `localhost` (default port **2234**) |
+| **Distribution** | npm · Docker · **`.mcpb` one-click bundle** · **Claude Code plugin (+18 skills)** · cross-agent skills CLI · BTP connector | Bundled in the SAP ADT extension (VS Code + Eclipse) |
 | **Auth to the *server*** | XSUAA OAuth · OIDC JWT · API key · (stdio = none) | Auto-generated bearer token on `localhost` |
-| **Auth to *SAP*** | Per-user principal propagation, or shared service user | Your own ADT logon session / SAP user |
-| **Central governance** | Yes — server-wide safety ceiling, scopes, central audit | No central multi-user policy/audit layer (local IDE settings + your SAP authorizations) |
-| **MCP clients** | Any (Claude, Copilot Studio, Cursor, CLI, JetBrains, web…) | Intended for local IDE agents; any local client *can* connect with URL+token |
-| **System reach** | Systems exposing the ADT REST endpoints a tool needs (on-prem→cloud) | On-prem/Private Cloud via RFC, Public Cloud/BTP via HTTP; RAP/ABAP-Cloud focus |
-| **Object types** | Classic **and** modern (PROG, FUGR, TABL, DOMA, DTEL, MSAG, ENHO… + CLAS, CDS, RAP) | RAP/ABAP-Cloud-centric (broader on some on-prem backends); Dynpro/Web Dynpro not planned |
-| **Reads source over MCP?** | Yes — `SAPRead`/`SAPSearch` are first-class tools | Not in the documented toolset — reading is the IDE editor/virtual-workspace's job (see §6) |
-| **Server-side AI** | None — uses *your* LLM (Claude/GPT/Gemini/…) | Optional **Joule** AI (SAP-ABAP-1 model) for ATC AI-fix tools |
-| **Cost** | Free (you pay only your infra + your LLM) | Extension free; **only the 2 ATC AI-fix tools require a Joule licence** (per SAP Help) |
+| **Auth to *SAP*** | Per-user principal propagation, or shared service user | **Inherits the IDE's ADT destination** — RFC (SNC/SSO) on-prem, HTTP+OAuth cloud |
+| **Central governance** | Yes — safety ceiling, scopes, package allowlist, **rate limits**, central audit | None (local IDE settings + your SAP authorizations); **no rate limiting** |
+| **MCP clients** | Any — Claude, **Copilot Studio, automation/CI**, Cursor, CLI, JetBrains, web | Intended for local IDE agents; any local client *can* connect with URL+token |
+| **System reach** | Systems exposing the ADT REST endpoints a tool needs (on-prem→cloud) | **Connects to old & new** (ADT VS Code supports down to NW 7.3 EHP1 SP04); modern/RAP/AI need newer/cloud backends |
+| **Object types** | Classic **and** modern (PROG, FUGR, TABL, DOMA, DTEL, MSAG, ENHO… + CLAS, CDS, RAP) | 24 creatable types observed (CLAS, INTF, CDS, RAP, FUGR, PROG, TABL…); **no DOMA/DTEL/MSAG/SHLP/ENHO**; Dynpro not planned |
+| **Writes to SAP?** | Yes — create/update/delete + surgery + RAP scaffolding | **Yes — creates & generates objects** (`abap_creation-create_object`, `abap_generators-*`); editing existing source is done in the IDE editor |
+| **Server-side AI** | None — uses *your* LLM (Claude/GPT/Gemini/…) | Optional **Joule** AI (model not publicly pinned) for the 2 ATC AI-fix tools — licensed |
+| **Cost** | Free (you pay only your infra + your LLM) | Extension free; **only the 2 ATC AI-fix tools need a Joule licence** (BTP-hosted, not on pure on-prem) |
 
 ---
 
 ## 2. Decision guide — only ARC-1, only SAP, or both?
-
-Start here. The detail sections below justify each row.
 
 ### Pick the SAP ABAP MCP Server if…
 
@@ -62,37 +57,33 @@ Start here. The detail sections below justify each row.
 - Your system is **S/4HANA (Cloud/RISE/recent on-prem) or BTP ABAP** and your work is **RAP / ABAP
   Cloud / clean-core**.
 - You want **near-zero setup** — reuse your ADT logon, enable one setting, done.
-- You want **SAP's own AI** (Joule / SAP-ABAP-1) for ATC fix proposals, and you have (or will buy) the
-  licence for it.
-- You value a **first-party** tool and the integrated **debugger / completion / form editors** that
-  come with the IDE — and you are comfortable that SAP currently labels the MCP server *experimental*.
+- You want **SAP's own AI** for ATC fix proposals (Joule), and you have the BTP-hosted Joule licence.
+- You value a **first-party** tool and the integrated **debugger / completion / form editors** — and
+  you are comfortable that SAP currently labels the MCP server *experimental*.
 
 ### Pick ARC-1 if…
 
-- You need a **shared, always-on MCP endpoint** that **many users or agents** connect to (a team
-  server, CI, an agent platform) rather than a per-laptop process.
-- You need **non-IDE clients**: Microsoft Copilot Studio, Joule Studio, Gemini CLI, a custom agent,
-  a web app — anything that speaks remote MCP over HTTP.
+- You need a **shared, always-on MCP endpoint** for **many users or agents** (team server, CI, an
+  agent platform) rather than a per-laptop process.
+- You need **non-IDE clients**: **Microsoft Copilot Studio, automation/CI scenarios**, Joule Studio,
+  Gemini CLI, a custom agent, a web app — anything that speaks remote MCP over HTTP.
 - You need **central governance**: read-only by default, package allowlists, per-action deny rules,
-  per-user scopes, rate limits, and a **central audit trail** of every call.
-- You need **per-user SAP identity at scale** — XSUAA + BTP Destination Service principal
-  propagation maps each AI user to their own SAP user.
+  per-user scopes, **rate limits**, and a **central audit trail**.
+- You need **per-user SAP identity at scale** (XSUAA + BTP Destination Service principal propagation).
 - You work on **on-prem ECC / NetWeaver / older S/4** or with **classic objects** (reports, function
   groups, DDIC domains/data elements, message classes, enhancements) — or you need **free SQL,
   git (gCTS/abapGit), transport release, or ST22 dump / trace analysis**.
 - You want to keep your **choice of LLM** (Claude, GPT, Gemini, Mistral, …).
 
-### Run both if… (common for teams that have adopted VS Code ADT)
+### Run both — and add more — if… (common for teams on VS Code ADT)
 
-- Developers use the **SAP server in-IDE** for fast, context-aware editing, debugging, RAP generation
-  and Joule AI fixes **on their personal dev systems**, **and**
-- The team/platform runs **ARC-1 centrally** for the things the SAP server doesn't do: governed
-  multi-user access, non-IDE agents, classic-object and on-prem reach, SQL, git, transport release,
-  and runtime diagnostics, with a central audit log.
-
-They don't conflict — the tool namespaces differ (`abap_*` vs `SAPRead`/`SAPWrite`/…), and an agent
-can hold both connections at once. *This is a reasoned architecture recommendation, not a
-vendor-endorsed pattern.*
+- Developers use the **SAP server in-IDE** for context-aware editing, debugging, RAP generation and
+  Joule AI fixes **on their personal dev systems**, **and**
+- The team/platform runs **ARC-1 centrally** for governed multi-user access, **non-IDE agents**, on-prem
+  & classic reach, SQL, git, transport release, and runtime diagnostics — with a central audit log,
+- plus **docs/notes MCP servers and a skills layer** (see §14). They don't conflict — namespaces differ
+  (`abap_*` vs `SAPRead`/`SAPWrite`/…) and an agent can hold several connections at once. *This is a
+  reasoned architecture recommendation, not a vendor-endorsed pattern.*
 
 ### Scenario cheat-sheet
 
@@ -101,12 +92,12 @@ vendor-endorsed pattern.*
 | Solo dev, RAP on S/4 Cloud/BTP, lives in VS Code | **SAP server** |
 | Solo dev, modern types, wants SAP-tuned AI fixes | **SAP server** (+ Joule licence) |
 | Team wants one governed endpoint with audit + scopes | **ARC-1** |
-| AI agent on **Copilot Studio / Joule Studio / a website** | **ARC-1** (remote MCP + JWT) |
+| AI agent on **Copilot Studio / automation / a website** | **ARC-1** (remote MCP + JWT) |
 | On-prem ECC 7.4 / NetWeaver / pre-2023 S/4 | **ARC-1** (validate per tool — see §8) |
 | Heavy **classic ABAP** (reports, FUGR, DDIC, messages, enhancements) | **ARC-1** |
 | Need **SQL / git / transport release / ST22 dumps / traces** | **ARC-1** |
-| Migration / clean-core at scale across many systems | **ARC-1** (often **+** SAP server per dev) |
-| Modern shop that adopted VS Code ADT **and** runs agent platforms | **Both** |
+| Want docs search, SAP Notes, RAP/CDS skills alongside | **Add the docs MCP + skills** (§14) |
+| Modern shop that adopted VS Code ADT **and** runs agent platforms | **Both (+ docs MCP + skills)** |
 
 ---
 
@@ -115,37 +106,41 @@ vendor-endorsed pattern.*
 === "ARC-1"
 
     A standalone **TypeScript MCP server** (npm package `arc-1`, Docker image
-    `ghcr.io/marianfoo/arc-1`) that implements the Model Context Protocol and turns AI tool calls into
-    **ADT REST** requests (`/sap/bc/adt/*`) — the same public API the Eclipse ADT client uses.
+    `ghcr.io/marianfoo/arc-1`) that turns AI tool calls into **ADT REST** requests (`/sap/bc/adt/*`) —
+    the same public API the Eclipse ADT client uses.
 
-    - **Distribution:** `npx arc-1`, global npm install, Docker, or a deployed BTP Cloud Foundry app.
-    - **Maturity:** the project **positions itself** as production-ready, write-capable and multi-user;
-      it is open source (MIT), community-maintained (no independent SLA/adoption evidence is claimed
-      here).
+    - **Distribution — "and other stuff":** `npx`/global npm; **Docker**; a **`.mcpb` one-click bundle**
+      for Claude Desktop; a **Claude Code plugin** that bundles the server **and 18 SAP skills**
+      (RAP, CDS, ABAP Unit, clean-core, UI5); a **cross-agent skills CLI** (`npx skills add` for Cursor,
+      Copilot, Codex, Gemini CLI); and a **remote BTP CF connector** (URL + XSUAA OAuth). See
+      [Install in Claude](install-in-claude.md).
+    - **Maturity:** the project **positions itself** as production-ready, write-capable, multi-user; open
+      source (MIT), community-maintained (no independent SLA claimed here).
     - **Design center:** a **centrally hosted, admin-governed, multi-tenant** proxy — one server, many
       AI users, each mapped to their own SAP identity, every call audited and policy-checked.
-    - **Tool model:** **12 intent tools** (e.g. `SAPRead`, `SAPWrite`) with a `type`/`action`
-      parameter, instead of 200+ endpoint tools. A "hyperfocused" mode collapses to a single
-      ~200-token tool for tight context windows.
+    - **Tool model:** **12 intent tools** with a `type`/`action` parameter (vs 200+ endpoint tools), plus
+      a "hyperfocused" 1-tool mode for tight context windows.
 
 === "SAP ABAP MCP Server"
 
-    The **ADT MCP Server** SAP **bundles inside its IDE tooling** — *ABAP Development Tools for VS
-    Code* (publisher SAP SE, the official ADT extension, free on the Marketplace) and *ADT for
-    Eclipse*. The MCP layer is part of a **larger redesign**: a headless **ABAP Language Server** (the
-    Eclipse ADT client repackaged) plus the **ABAP MCP Server** on top.
+    The **ADT MCP Server** SAP **bundles inside its IDE tooling** — *ABAP Development Tools for VS Code*
+    (official SAP SE extension, free on the Marketplace) and *ADT for Eclipse*. It sits on a **larger
+    redesign**: a headless **ABAP Language Server** (the Eclipse ADT client repackaged) plus the **ABAP
+    MCP Server** on top.
 
     - **Distribution:** ships with the extension; **not** a standalone package you host. When enabled it
-      runs as a **local HTTP server** at `http://localhost:<port>/mcp` (default port **2236**), started
-      by the IDE.
-    - **Maturity / status:** the **extension is official and GA**, but SAP's own material states *"The
-      ADT MCP Server is an experimental feature that may change at any time without notice. It is not
-      intended for productive use."* It is **disabled by default** (enable `adt.mcpServer.enabled`, UI
-      label "Adt: Enable MCP Server" — labels may vary by release).
-    - **Design center:** **one developer, local**, agentic AI on the code in their IDE.
-    - **Tool model:** **20 tools** (per SAP Help, see §7.1), heavily prompt-engineered (USE WHEN /
-      TYPICAL WORKFLOW / human-in-the-loop transport selection), grouped by workflow. Part of the set
-      is **server-driven** — it adapts to what the connected backend offers.
+      runs as a **local HTTP server** at `http://localhost:<port>/mcp` (port **2234** in the tested
+      Eclipse install; SAP-samples VS Code material references 2236; configurable 1024–65535), with an
+      **auto-generated bearer token**.
+    - **Maturity / status:** the **extension is official and GA**, but SAP's own material states *"The ADT
+      MCP Server is an experimental feature that may change at any time without notice. It is not
+      intended for productive use."* It is **disabled by default** (Eclipse: *ABAP Development → MCP
+      Server → Enable ADT MCP Server*; VS Code: `adt.mcpServer.enabled` / "Adt: Enable MCP Server").
+    - **AI:** the AI capabilities are **Joule for Developers**, a separately-licensed BTP-hosted service —
+      see §12. **The specific model is not publicly pinned** (it is *not* simply "SAP-ABAP-1"); SAP's
+      GenAI Hub orchestrates a mix of foundation models plus an SAP ABAP-trained model.
+    - **Tool model:** **20 tools** (per SAP Help, §7.1), heavily prompt-engineered, partly **server-driven**
+      (adapts to what the connected backend offers).
 
 ---
 
@@ -155,12 +150,12 @@ vendor-endorsed pattern.*
 flowchart LR
   subgraph SAP_MODEL["SAP ABAP MCP Server — per developer"]
     direction TB
-    A1["AI agent in IDE<br/>(Copilot Agent Mode / Joule)"] -->|localhost + bearer token| A2["ADT MCP Server<br/>(in the ADT extension)"]
-    A2 -->|RFC on-prem / HTTP cloud| A3["Your SAP system<br/>(your ADT session)"]
+    A1["AI agent in IDE<br/>(Copilot Agent Mode / Joule)"] -->|localhost:2234 + bearer token| A2["ADT MCP Server<br/>(in the ADT extension)"]
+    A2 -->|inherits the IDE's ADT destination<br/>RFC+SNC on-prem / HTTP+OAuth cloud| A3["Your SAP system"]
   end
   subgraph ARC1_MODEL["ARC-1 — centrally hosted"]
     direction TB
-    B1["Many AI clients<br/>Claude · Copilot Studio · Cursor · CLI · web"] -->|HTTPS + OAuth/JWT/API key| B2["ARC-1 server<br/>(safety ceiling · scopes · audit)"]
+    B1["Many AI clients<br/>Claude · Copilot Studio · automation · CLI · web"] -->|HTTPS + OAuth/JWT/API key| B2["ARC-1 server<br/>(safety ceiling · scopes · rate limits · audit)"]
     B2 -->|ADT REST + principal propagation| B3["BTP Destination + Cloud Connector"]
     B3 --> B4["SAP systems with the needed ADT endpoints"]
   end
@@ -170,67 +165,72 @@ flowchart LR
 |---|---|---|
 | Process model | A server you deploy (CF app / container / `npx` / stdio) | A `localhost` process the IDE starts for you |
 | Network exposure | Remote over HTTPS (or local stdio) | **`localhost` only** + auto-generated bearer token (a Host-header / DNS-rebinding guard was also observed in teardown) |
-| Multi-user | **Yes** — one endpoint, many users | No — one server per developer machine, bound to one ADT session |
-| Connection to SAP | ADT REST (HTTP) everywhere, incl. on-prem via Cloud Connector | **RFC** for on-prem/Private Cloud, **HTTP** for Public Cloud/BTP |
+| Multi-user | **Yes** — one endpoint, many users | No — one server per developer machine, tied to the IDE session |
+| Connection to SAP | ADT REST (HTTP) everywhere, incl. on-prem via Cloud Connector | **Inherits the IDE destination**: RFC (SNC/SSO) on-prem, HTTP (OAuth) cloud |
 | Runtime footprint | Lightweight Node process | Bundled inside the ADT engine (heavier; the price of full ADT fidelity) |
 | Who operates it | You (or your platform team) | SAP's extension; nothing to operate |
-
-**Takeaway:** the SAP server is a *personal* component — there is no notion of "host it for the team."
-ARC-1 is a *shared service* — that is its whole point, and also why it asks more of you to stand up.
 
 ---
 
 ## 5. Authentication & identity
 
-This is one of the sharpest differences and a frequent reason teams choose ARC-1.
+Two distinct questions: **(a) how the AI client authenticates to the MCP server**, and **(b) how the
+server authenticates to SAP.**
 
 | Layer | ARC-1 | SAP ABAP MCP Server |
 |---|---|---|
 | **Auth to the MCP server** | XSUAA OAuth 2.0 · external OIDC JWT (e.g. Entra ID) · API keys (`key:profile`); stdio has none | A single auto-generated **bearer token**, trusted because the server is `localhost`-only |
 | **Per-AI-user identity** | Yes — JWT/`clientId`/`userName` flows through every call | No concept of multiple MCP users |
-| **Auth to SAP** | **Principal propagation**: each AI user → their own SAP user via BTP Destination Service + Cloud Connector; or a shared service user | Reuses **your** ADT logon session / SAP user |
-| **Multiple auth mechanisms at once** | Yes — XSUAA + OIDC + API key can coexist | n/a (single local developer) |
+| **Auth to SAP** | **Principal propagation** — each AI user → their own SAP user via BTP Destination Service + Cloud Connector; or a shared service user | **Inherits the IDE's existing ADT destination** — it does not authenticate to SAP itself |
 | **SAP-side authorizations** | Enforced by SAP (`S_DEVELOP`, `S_ADT_RES`, `S_TRANSPRT`) **and** ARC-1 scopes as defense-in-depth | Enforced by SAP for **your** user |
 
-!!! note "Both share one hard limit"
-    Neither tool can grant SAP rights the backend user doesn't have. **ARC-1 can only restrict
-    further; the SAP backend's own authorizations still decide final access** in both products.
+!!! info "What SSO the SAP server actually uses (it rides the IDE destination)"
+    The ADT MCP Server doesn't log in on its own — it reuses whatever connection the IDE already has, so
+    the available SSO depends on the IDE and release:
 
-!!! tip "What this means in practice"
-    On the SAP server, "who is the AI acting as?" is simply **you** — clean and correct for a single
-    developer on their own system. ARC-1 answers the harder enterprise question: *"a shared agent
-    serves 50 people — how does each call run as the right SAP user, with the right rights, and leave
-    an audit record?"* If you only ever have the first question, the SAP server's model is simpler.
+    - **On-premise / Private Cloud — via RFC.** *ADT for VS Code* v1 initially supported **SNC with SSO**
+      destinations only (plain username/password / non-SNC RFC was on the roadmap for a later release).
+      *ADT for Eclipse* (what this snapshot ran) supports the **full range**: username/password (Basic),
+      **SAP logon / reentrance tickets** (SSO), and **SNC** (Kerberos/SPNEGO, X.509 certificates). RFC
+      ports: **48xx** = RFC with SNC, **33xx** = RFC without SNC.
+    - **Public Cloud / BTP — via HTTP** with **OAuth** (and SAML/IdP-based SSO).
+
+    So "SSO" here means SNC (Kerberos/SPNEGO/X.509) and SAP logon/reentrance tickets for on-prem, OAuth/SAML
+    for cloud — inherited from the IDE. (ARC-1, by contrast, terminates client auth itself via
+    XSUAA/OIDC/API-key, then maps to SAP via principal propagation, Basic, BTP service-key OAuth, or a
+    cookie file for SSO-only systems.)
+
+!!! note "Both share one hard limit"
+    Neither tool can grant SAP rights the backend user doesn't have. **ARC-1 can only restrict further;
+    the SAP backend's own authorizations still decide final access** in both products.
 
 ---
 
 ## 6. Central configuration & governance
 
-The SAP ADT MCP Server **does not provide a central multi-user policy, scope and audit layer
-comparable to ARC-1.** In SAP's model, control is primarily **local IDE configuration plus the
-developer's SAP authorizations and backend workflow controls** such as the human-in-the-loop transport
-selection its tools enforce. That is appropriate for a personal developer tool — there simply is no
-"across users" dimension to govern.
+The SAP ADT MCP Server **does not provide a central multi-user policy, scope and audit layer comparable
+to ARC-1.** Control is **local IDE configuration plus the developer's SAP authorizations and backend
+workflow controls** (e.g. the human-in-the-loop transport selection its tools enforce) — appropriate for
+a personal developer tool with no "across users" dimension. It also has **no rate limiting**.
 
-ARC-1's reason to exist is the opposite: an **admin-controlled safety ceiling** that every call passes
-through, regardless of which user or client made it.
+ARC-1's reason to exist is the opposite: an **admin-controlled safety ceiling** every call passes through.
 
 | Governance control | ARC-1 | SAP ABAP MCP Server |
 |---|---|---|
 | Read-only by default | **Yes** — writes are opt-in (`SAP_ALLOW_WRITES`) | No server-side gate (your SAP authorizations are the limit) |
-| Separate gates for data preview / free SQL / transport writes / git writes | **Yes**, each independent | n/a (those tools aren't exposed) |
-| **Package allowlist** (e.g. `$TMP`, `Z*`, subtree) enforced fail-closed on every mutation | **Yes** | No |
+| Separate gates for data preview / free SQL / transport / git writes | **Yes**, each independent | n/a (those tools aren't exposed) |
+| **Package allowlist** (`$TMP`, `Z*`, subtree) enforced fail-closed on every mutation | **Yes** | No |
 | **Per-action deny** (e.g. block `SAPWrite.delete`) | **Yes** (`SAP_DENY_ACTIONS`) | No |
 | **Scopes** (read / write / data / sql / transports / git / admin) | **Yes**, per user/profile | No |
-| **Rate limiting** (per-IP OAuth, per-user MCP, server-wide SAP semaphore) | **Yes**, three layers | No |
-| **Central audit log** of every call with user identity | **Yes** (stderr / file / **BTP Audit Log**) | No central log; activity is implicit in the SAP system |
-| Local configuration | Central server env/CLI/`.env`, one source of truth | Per-developer IDE settings (enable flag, port) + `~/.adtls/destinations.json` + the developer's SAP auth |
+| **Rate limiting** | **Yes** — per-IP OAuth, per-user MCP, server-wide SAP semaphore | **No** |
+| **Central audit log** with user identity | **Yes** (stderr / file / **BTP Audit Log**) | No central log; activity is implicit in the SAP system |
+| Configuration locus | Central server env/CLI/`.env` | Per-developer IDE settings (enable flag, port) + the developer's SAP auth |
 
 !!! warning "The honest counterpoint"
     For a **single developer on a sandbox / personal dev tier**, ARC-1's governance is overhead they
-    don't need. "It runs as me with my rights" is the *right* amount of control there. ARC-1's
-    governance earns its keep when an AI endpoint is **shared**, **automated**, or **pointed at systems
-    where uncontrolled writes are unacceptable** — not on a lone developer's `$TMP` playground.
+    don't need. ARC-1's controls earn their keep when an AI endpoint is **shared**, **automated**, or
+    **pointed at systems where uncontrolled writes are unacceptable** — not on a lone developer's `$TMP`
+    playground.
 
 ---
 
@@ -238,8 +238,8 @@ through, regardless of which user or client made it.
 
 ### 7.1 The SAP server's tools — 20 tools (SAP Help canonical list)
 
-The table below uses the **exact tool IDs published on the SAP Help "Model Context Protocol Tools"
-page**, including its per-tool **Joule License** column.
+Exact tool IDs from the SAP Help **"Model Context Protocol Tools"** page, including its per-tool **Joule
+License** column.
 
 | Toolset | Tool IDs | Joule licence |
 |---|---|---|
@@ -250,29 +250,22 @@ page**, including its per-tool **Joule License** column.
 | **Execute ABAP Unit Test** | `abap_run_unit_tests` | Not required |
 | **ABAP Repository Object Generation** | `abap_generators-list_generators` · `abap_generators-get_schema` · `abap_generators-generate_objects` | Not required |
 | **ABAP Business Service** | `abap_business_services-fetch_services` · `abap_business_services-fetch_service_information` | Not required |
-| **ABAP Test Cockpit** | `abap_run_atc` · `abap_atc_get_result` · `abap_atc_execute_deterministic_quickfixes` · `abap_atc_apply_ai_fix` · `abap_atc_get_ai_fix_result` | **Required** for the two AI-fix tools (`abap_atc_apply_ai_fix`, `abap_atc_get_ai_fix_result`); others not required |
+| **ABAP Test Cockpit** | `abap_run_atc` · `abap_atc_get_result` · `abap_atc_execute_deterministic_quickfixes` · `abap_atc_apply_ai_fix` · `abap_atc_get_ai_fix_result` | **Required** for the 2 AI-fix tools; others not required |
 
 !!! note "Names: documented vs. tested build"
-    The IDs above are SAP's **published** list. The build tested live on 2026-06-16 returned the **same
-    20 tools** and the same grouping, with **two minor ID variants** — `abap_list_destinations`
-    (vs. documented `abap_lists_destinations`) and `abap_atc_run` (vs. documented `abap_run_atc`).
-    Treat exact separators as build-dependent and trust your client's own `tools/list` over any
-    article. The set is also **backend/version dependent** — newer backends may add tools (SAP's
-    roadmap includes an *ABAP object search* tool).
+    The IDs above are SAP's **published** list. The build tested live returned the **same 20 tools** with
+    **two minor ID variants** — `abap_list_destinations` (vs documented `abap_lists_destinations`) and
+    `abap_atc_run` (vs documented `abap_run_atc`). Trust your client's own `tools/list` over any article;
+    the set is **backend/version dependent** (SAP's roadmap includes an *ABAP object search* tool).
 
-Notable about this surface:
-
-- **No source-read, search, or where-used tool** is in the documented set. **In the IDE this doesn't
-  matter** — the agent reads code through the editor / virtual workspace (Copilot can "find a function
-  and read it" because the *workspace*, not the MCP server, serves the file). **For a non-IDE MCP
-  client, it does matter:** there may be no way to read source via the MCP server alone.
-- On the tested backend the server exposed **only tools** (`resources/list` and `prompts/list`
-  returned *Method not found*) — an observed snapshot, not a documented guarantee.
-- It does **not** expose free SQL, git, transport *release/delete*, or runtime diagnostics (ST22
-  dumps, traces) — none appear in SAP's public examples or the tested server.
-- Its real strengths are the **server-driven creation + generator framework** (e.g. an *OData UI
-  Service from Scratch*) and, **with a Joule licence**, the **AI-fix tools** — neither of which ARC-1
-  has.
+**It does write** — `abap_creation-create_object` creates objects and `abap_generators-generate_objects`
+generates them (tables, CDS views, behavior definitions, service definitions/bindings, even an *OData UI
+Service from Scratch*). What it does **not** expose is an MCP tool to **edit the source of an existing
+object** — that is done in the IDE editor (the agent reads/edits through the editor + virtual workspace,
+not via an MCP tool). Other notable gaps in the documented set: **no source-read / search / where-used
+tool** (matters for non-IDE clients), and **no free SQL, git, transport release/delete, or runtime
+diagnostics (ST22 dumps, traces)**. On the tested backend the server exposed **only tools** (no MCP
+`resources`/`prompts`) — an observed snapshot.
 
 ### 7.2 ARC-1's tools (12 intent tools)
 
@@ -291,25 +284,24 @@ Notable about this surface:
 | `SAPDiagnose` | `syntax` · `atc` · `quickfix`/`apply_quickfix` · ABAP Unit · **ST22 dumps** · **traces** · gateway/system messages · RAP preflight · CDS test-case suggestions |
 | `SAPManage` | Package create/delete/move (DEVC) · FLP catalogs/groups/tiles · feature probe · cache stats |
 
-All gated operations also depend on the target system exposing the needed ADT/OData services and the
-SAP user being authorized.
+All gated operations also depend on the target system exposing the needed ADT/OData services and the SAP
+user being authorized.
 
 ### 7.3 Capability matrix
 
 | Capability | ARC-1 | SAP ABAP MCP Server |
 |---|:---:|:---:|
-| Create objects | ✅ (AFF + classic builders) | ✅ (server-driven, auto-tracks new types) |
-| Update / edit source | ✅ incl. method/section surgery | ⚠️ via IDE editor + LS (no MCP write-source tool in the documented set) |
+| **Create objects** | ✅ | ✅ `create_object` |
+| **Generate objects** (RAP/CDS/Fiori service) | ⚠️ scaffolding + skills | ✅ native generator framework |
+| Edit existing source | ✅ incl. method/section surgery | ⚠️ via IDE editor + LS (no MCP edit-source tool) |
 | Activate | ✅ | ✅ |
 | Run ABAP Unit | ✅ | ✅ |
 | ATC run + results | ✅ | ✅ |
-| ATC **deterministic** quickfix | ✅ (`quickfix`/`apply_quickfix`) | ✅ |
-| ATC **AI** fix (model-generated) | ❌ (use your client LLM manually) | ✅ **Joule** — requires a Joule licence |
-| RAP + repository-object generators | ⚠️ scaffolding + skills, not the backend generator catalog | ✅ native generator framework |
+| ATC **deterministic** quickfix | ✅ | ✅ |
+| ATC **AI** fix | ❌ (use your client LLM manually) | ✅ **Joule** — requires a licence |
 | Read source **over MCP** | ✅ `SAPRead` | ❌ not in the documented toolset (IDE editor reads instead) |
-| Search / where-used **over MCP** | ✅ | ❌ not in the documented toolset (roadmap: object-search tool) |
-| Free SQL | ✅ (gated) | ❌ |
-| Table data preview | ✅ (gated) | ❌ |
+| Search / where-used **over MCP** | ✅ | ❌ not in the documented toolset (roadmap item) |
+| Free SQL · table preview | ✅ (gated) | ❌ |
 | Git (gCTS / abapGit) | ✅ (gated) | ❌ |
 | Transport create / get / diff | ✅ | ✅ |
 | Transport **release / delete** | ✅ (gated) | ❌ |
@@ -317,7 +309,8 @@ SAP user being authorized.
 | Pretty Printer / offline lint | ✅ | ⚠️ formatting via IDE, no abaplint |
 | Integrated **debugger** | ❌ (MCP is RPC) | ✅ (in the IDE) |
 | Inline completion / form editors | ❌ | ✅ (in the IDE) |
-| Server-side AI model | ❌ (bring your own LLM) | ✅ Joule (SAP-ABAP-1), licensed |
+| Server-side AI model | ❌ (bring your own LLM) | ✅ Joule (licensed; model not publicly pinned) |
+| Rate limiting | ✅ (3 layers) | ❌ |
 
 ⚠️ = available but indirectly / partially, or only inside the IDE.
 
@@ -326,32 +319,34 @@ SAP user being authorized.
 ## 8. System & object-type reach
 
 !!! note "Read this as four separate axes — they don't move together"
-    SAP's stack mixes three distinct things the draft must not conflate: **(a) base IDE/backend
-    connectivity**, **(b) which MCP tools a given backend exposes**, and **(c) Joule/ABAP-AI
-    availability + licensing**. ARC-1 adds a fourth: **(d) which ADT REST endpoints a given system
-    actually exposes**, which varies by release and decides per-tool coverage.
+    Don't conflate **(a) IDE/backend connectivity**, **(b) which MCP tools a backend exposes**, **(c)
+    Joule/ABAP-AI availability + licensing** (BTP-hosted), and — for ARC-1 — **(d) which ADT REST
+    endpoints a given system exposes** (varies by release, decides per-tool coverage).
+
+**The SAP server connects to old systems too.** ADT for VS Code is documented to support releases **down
+to NetWeaver 7.3 EHP1 SP04**, and Eclipse ADT reaches further still. What is *not* available on older /
+non-cloud backends is the **ABAP-Cloud-model** workflows (RAP/CDS/generators need newer backends) and the
+**Joule AI** features (BTP-hosted, licensed) — **connectivity is not the limiter**.
 
 | | ARC-1 | SAP ABAP MCP Server |
 |---|---|---|
-| On-prem S/4HANA | ✅ where ADT endpoints exist | ✅ (via RFC; RAP/ABAP-Cloud focus) |
-| **On-prem ECC 7.4+ / NetWeaver** | ⚠️ validate **per tool** — older ECC/NW vary widely in ADT endpoint coverage | ⚠️ extension connects to old releases for basics; AI features need BTP/AI Core |
-| RISE / Private Cloud | ✅ | ✅ |
-| S/4HANA Cloud Public | ✅ | ✅ |
-| BTP ABAP (Steampunk) | ✅ | ✅ |
-| **Classic procedural** (PROG, FUGR/FUNC, includes) | ✅ | ⚠️ creatable on some on-prem backends (observed live on S/4 2023); not the focus |
-| **DDIC** (TABL, STRU) | ✅ | ✅ (TABL/DT, TABL/DS observed live) |
+| On-prem S/4HANA | ✅ where ADT endpoints exist | ✅ (RFC; RAP/ABAP-Cloud focus) |
+| **On-prem ECC 7.4+ / NetWeaver 7.3 EHP1 SP04+** | ⚠️ validate **per tool** — older ECC/NW vary in ADT endpoint coverage | ✅ connects; modern/RAP/AI features gated by backend & BTP/AI Core |
+| RISE / Private Cloud · S/4 Cloud Public · BTP ABAP | ✅ | ✅ |
+| **Classic procedural** (PROG, FUGR/FUNC, includes) | ✅ | ✅ creatable (observed live on S/4 2023); not the marketing focus |
+| **DDIC** (TABL, STRU) | ✅ | ✅ (TABL/DT, TABL/DS) |
 | **DOMA / DTEL / MSAG / SHLP / ENHO / XSLT** | ✅ | ❌ (not in the creatable set observed) |
 | Modern (CLAS, INTF, DDLS, DDLX, DCLS, BDEF, SRVD, SRVB, DRAS…) | ✅ | ✅ |
 | **Dynpro / Web Dynpro / module pools** | ⚠️ limited (ADT itself is thin here) | ❌ not planned (SAP states classic Dynpro/Web Dynpro are not in the current focus) |
 
-!!! note "Live nuance worth knowing (observed on one S/4HANA 2023 on-prem backend)"
-    On the tested system, the SAP server's `abap_creation-get_all_creatable_objects` returned **classic**
-    types too — Program, Function Group/Module/Include, Database Table, Structure, Interface, Lock
-    Object, Type Group — i.e. broader than a strict "modern-only" reading. But it still **omitted** core
-    DDIC types (DOMA, DTEL), message classes (MSAG), search helps (SHLP), and enhancements (ENHO), and
-    there was **no way to read or search** any of them over MCP. This is a backend-driven snapshot, not a
-    product-wide guarantee. ARC-1 covers those types and the read/search path where the backend exposes
-    the endpoints.
+!!! note "The 24 creatable types observed live (one S/4HANA 2023 on-prem backend)"
+    `abap_creation-get_all_creatable_objects` returned **24** types — broader than "modern-only":
+    **CLAS, INTF, FUGR (group/module/include), PROG (program/include), TABL (table/structure), ENQU
+    (lock object), TYPE (type group), DTEB (entity buffer), CHDO, NROB, NONT, RONT** plus the modern
+    **DDLS, DDLX, DCLS, DRAS, DRTY, BDEF, SRVD, SRVB**. **Absent:** DOMA, DTEL, MSAG, SHLP, ENHO, XSLT,
+    and all Dynpro/Web Dynpro. This is a **backend-driven snapshot**, not a product-wide guarantee — and
+    even where *create* is supported there is **no read/search** over MCP. ARC-1 covers the absent types
+    and the read/search path where the backend exposes the endpoints.
 
 ---
 
@@ -361,19 +356,18 @@ SAP user being authorized.
 |---|:---:|:---:|
 | GitHub Copilot (Agent Mode) in VS Code/Eclipse | ✅ | ✅ (the primary client SAP demonstrates) |
 | SAP Joule (in-IDE) | ✅ | ✅ |
-| Claude Desktop | ✅ | ⚠️ technically, if pointed at the localhost URL+token |
+| Claude Desktop / Code | ✅ (`.mcpb` / plugin) | ⚠️ technically, if pointed at the localhost URL+token |
 | **Microsoft Copilot Studio** (remote agents) | ✅ | ❌ (no remote endpoint) |
+| **Automation / CI / scripts** | ✅ | ❌ (localhost, per-developer) |
 | **SAP Joule Studio** (custom agents) | ✅ | ❌ |
-| Cursor / other VS-Code-family editors | ✅ | ⚠️ in-IDE; needs a client that supports the virtual-workspace filesystem |
+| Cursor / other VS-Code-family editors | ✅ | ⚠️ in-IDE; needs virtual-workspace filesystem support |
 | Gemini CLI / custom CLI agents | ✅ | ⚠️ localhost only |
-| JetBrains / web apps / CI | ✅ | ❌ |
+| JetBrains / web apps | ✅ | ❌ |
 
 **SAP's supported/intended scenario is a local IDE agent against a local ADT MCP Server.** A local
-MCP-compatible client *can* technically connect to the `localhost` URL with the token, but the server
-is **not designed as a remote, centrally hosted team endpoint** — so "team server" and "cloud agent
-platform" use cases are off the table. ARC-1 is the one you expose (securely) to remote and automated
-clients. SAP also notes that an agent must support **VS Code's virtual-workspace filesystem** to read
-repository objects in the IDE.
+MCP-compatible client *can* connect to the `localhost` URL with the token, but the server is **not designed
+as a remote, centrally hosted team endpoint**. **ARC-1 is the one you expose (securely) to remote and
+automated clients — Copilot Studio agents, CI pipelines, web apps, scheduled automation.**
 
 ---
 
@@ -385,50 +379,48 @@ repository objects in the IDE.
 | Blast radius if token leaks | Token/JWT scoped + rate-limited; admin can revoke | Anyone *on that machine* who reads the token gets the developer's ADT rights (observed; confirm token storage with SAP docs) |
 | Write safety | Default-deny + allowlists + deny-actions + scopes | The developer's SAP authorizations are the gate; **SAP authorizations remain final** |
 | Auditability | Central, per-user, structured (incl. BTP Audit Log) | The SAP system's own logging |
-| Secrets handling | `.env`/service keys redacted in logs; never committed | Token in IDE settings; destinations in `~/.adtls/` |
+| Secrets handling | `.env`/service keys redacted in logs; never committed | Token in IDE settings; destinations in the IDE config |
 
-Neither is "insecure" — they make **different trust assumptions**. The SAP server assumes a
-**local-machine trust boundary** and relies on the developer's SAP authorizations. ARC-1 assumes a
-shared, possibly hostile-adjacent environment and adds layers accordingly.
+Neither is "insecure" — they make **different trust assumptions**. The SAP server assumes a **local-machine
+trust boundary** and relies on SAP authorizations; ARC-1 assumes a shared, possibly hostile-adjacent
+environment and adds layers accordingly.
 
 ---
 
 ## 11. Setup effort
 
-Both are **easy for the local single-developer case** — that's worth saying plainly, because it's the
-SAP server's home turf and ARC-1 matches it there:
+Both are **easy for the local single-developer case** — that's the SAP server's home turf, and ARC-1
+matches it there:
 
 === "SAP ABAP MCP Server (local)"
 
-    1. Install the *ABAP Development Tools for VS Code* extension (or use Eclipse ADT).
-    2. Create a destination / logon to your SAP system.
-    3. Enable the setting **`adt.mcpServer.enabled`** (UI label "Adt: Enable MCP Server" — labels may
-       vary by release). The server starts at `http://localhost:<port>/mcp` (default port **2236**).
-    4. Your IDE AI agent (Copilot Agent Mode / Joule) discovers the tools.
+    1. Install *ABAP Development Tools for VS Code* (or use Eclipse ADT) and log on to your SAP system.
+    2. Enable the server — Eclipse: *ABAP Development → MCP Server → Enable ADT MCP Server*; VS Code:
+       `adt.mcpServer.enabled`. It starts at `http://localhost:<port>/mcp` (default **2234** here;
+       SAP-samples references 2236) and **auto-generates a bearer token**.
+    3. Point your IDE AI agent (Copilot Agent Mode / Joule) at it.
 
-    **Effort: minutes. Zero infrastructure.** This is the benchmark for frictionless. (Remember SAP
-    marks the MCP server *experimental, not for productive use*.)
+    **Effort: minutes. Zero infrastructure.** (Remember SAP marks it *experimental, not for productive use*.)
 
-=== "ARC-1 (local stdio)"
+=== "ARC-1 (local)"
 
     ```bash
     npx arc-1@latest --url https://your-sap-host:44300 --user YOUR_USER
     ```
 
-    **Effort: minutes.** One command; point your MCP client at it. As easy as the SAP server for a
-    single developer.
+    Or one-click via the **`.mcpb`** bundle in Claude Desktop, or the **Claude Code plugin** (server + 18
+    skills). **Effort: minutes** — as easy as the SAP server for a single developer.
 
 === "ARC-1 (the target architecture)"
 
-    Centrally hosted on **BTP Cloud Foundry** with XSUAA OAuth, BTP Destination Service + Cloud
-    Connector for principal propagation, and the audit-log sink. This unlocks the multi-user/governed
-    story — and it's **more work**: BTP entitlements, destinations, role collections, deployment.
+    Centrally hosted on **BTP Cloud Foundry** with XSUAA OAuth, BTP Destination Service + Cloud Connector
+    for principal propagation, and the audit-log sink. This unlocks the multi-user/governed story — and
+    it's **more work**: BTP entitlements, destinations, role collections, deployment.
 
 !!! important "The key trade-off in one sentence"
-    ARC-1 is *just as easy as the SAP server* when run locally — but running it locally is **not where
-    its value is**. Its design center is the **central, governed deployment**, which costs real setup.
-    The SAP server is purpose-built for the local case and asks for **nothing**. Choose based on which
-    *architecture* you actually need, not on the 5-minute quick-start (both win that).
+    ARC-1 is *just as easy as the SAP server* when run locally — but local isn't where its value is. Its
+    design center is the **central, governed deployment**, which costs real setup. The SAP server is
+    purpose-built for the local case and asks for **nothing**. Choose by the *architecture* you need.
 
 ---
 
@@ -437,74 +429,114 @@ SAP server's home turf and ARC-1 matches it there:
 | | ARC-1 | SAP ABAP MCP Server |
 |---|---|---|
 | The server itself | Free, open source (MIT) | Free (ships with the official extension) |
-| AI model | **Bring your own** (you pay your LLM provider) | Per SAP Help, **only `abap_atc_apply_ai_fix` and `abap_atc_get_ai_fix_result` require a Joule licence**; the other 18 tools do not |
-| Joule / ABAP-AI commercial terms | n/a | SAP/community sources describe consumption-based **AI units** with a promotional free period through **September 2026** — **confirm current SKU / region / terms with SAP** |
+| Non-AI tools | Free | **Free** — 18 of 20 tools need no Joule licence |
+| AI tools | n/a (you bring your own LLM) | **`abap_atc_apply_ai_fix` + `abap_atc_get_ai_fix_result` require a Joule for Developers licence** |
+| AI model | Your choice (Claude/GPT/Gemini/…) | **Not publicly pinned** — SAP GenAI Hub orchestrates a mix of foundation models + an SAP ABAP model (do **not** assume "SAP-ABAP-1") |
+| Licensing model | Your LLM provider's pricing | **Joule Premium** package; separate licence; **consumption-based AI Units** activated via SAP for Me; a valid SAP Build or ABAP licence required |
+| Where the AI runs | Your LLM endpoint | A **BTP-hosted hub** (auth + licence + BTP AI Core) |
 | Infrastructure | Your BTP CF / container / host | Your laptop (none extra) |
-| Vendor lock-in | None (any LLM, any ADT system) | AI-fix tools tie to SAP's GenAI hub / AI Core |
 
-So the SAP server's **18 non-AI tools** (destinations, creation, activation, unit test, ATC run/result,
-deterministic quickfix, transport, generators, business services) carry **no Joule licence**; only the
-**two AI-fix tools** do, and those need BTP/AI Core — so on a pure on-prem system without AI Core they
-won't function even if listed.
-
----
-
-## 13. Using them together
-
-A pattern that works well for a modern team that has adopted VS Code ADT (a **recommended
-architecture**, not a vendor-endorsed one):
-
-- **Per developer, in the IDE:** the SAP server for context-aware editing, debugging, ABAP
-  Unit/ATC, repository-object generation and Joule AI fixes on their **personal dev system**, **and**
-- **Centrally, for everyone & for agents:** ARC-1 as the **governed, audited** endpoint for
-  multi-user access, **non-IDE agents** (Copilot Studio, Joule Studio, CI), **on-prem/classic** reach,
-  and the operations the SAP server omits — **SQL, git, transport release, ST22 dumps/traces**.
-
-They coexist cleanly: distinct tool namespaces (`abap_*` vs `SAPRead`/`SAPWrite`/…), and an agent can
-hold both connections. A reasonable division of labour is *"SAP server writes & generates the modern
-code you're editing; ARC-1 governs access, reaches the rest of the estate, and handles ops."*
+!!! warning "On-premise reality + a commercial caveat"
+    Because Joule for Developers is delivered through a **BTP cloud hub** and licensed separately, a **pure
+    on-premise system with no BTP / Joule-for-Developers entitlement does not get the AI-fix tools** — they
+    won't function there, though the other 18 tools still work. Exact SKUs, AI-Unit pricing, regional terms
+    and any promotional period **change and should be confirmed with SAP** (e.g. via SAP for Me).
 
 ---
 
-## 14. Where each genuinely wins
+## 13. A note on SAP's API policy (unsettled)
+
+Both products ultimately call SAP's **ADT REST endpoints** (`/sap/bc/adt/*`). A fair, honest summary:
+
+- **The official ADT MCP Server is unaffected** — it is SAP's own first-party client of its own APIs.
+- **ARC-1 (and other community tools** like [`abap-adt-api`](https://github.com/marcellourbani/abap-adt-api),
+  abapGit, abaplint) use the **same ADT endpoints**, which SAP has **not published as a released, stable,
+  third-party API contract** (they are the protocol behind the ADT client; see *"Joys and sorrows of the
+  ABAP Developer Tools API"*).
+- The prevailing understanding is that using these endpoints for development tooling is **acceptable**, but
+  there is **no official SAP statement** classifying third-party ADT-API consumption as supported, and
+  SAP's evolving [API Policy](https://community.sap.com/t5/technology-q-a/impacts-of-sap-api-policy-v4-2026-on-existing-customer-integrations/qaq-p/14381879)
+  governs released-vs-internal APIs. **Treat third-party ADT-API use as not-officially-confirmed** — likely
+  fine for dev/test, but watch SAP's guidance, especially for production scenarios.
+
+This is informational, not legal advice — confirm your own situation with SAP.
+
+---
+
+## 14. It's not either/or — the composable MCP ecosystem
+
+You are **not locked into one MCP server**. MCP clients can connect to several at once, and a skills layer
+adds reusable workflows on top. Beyond the two compared here, high-value additions include:
+
+- **SAP docs MCP** (`mcp-sap-docs`) — unified search over SAP developer docs (ABAP/RAP keyword docs, Clean
+  ABAP, BTP, SAP Help, SAP Community). Great for grounding any agent in real documentation.
+- **SAP Notes MCP** — search/retrieve SAP Notes & KBAs.
+- **Official SAP dev-tooling MCP servers** — Fiori elements, CAP, UI5, UI5 Web Components, MDK (npm-distributed).
+- **Skills** — ARC-1 ships **18 SAP skills** (RAP, CDS, ABAP Unit, clean-core, UI5 modernization) usable
+  across agents via `npx skills add`.
+
+A curated, regularly-updated catalog of SAP MCP servers, AI skills and Claude plugins lives at
+**[github.com/marianfoo/sap-ai-mcp-servers](https://github.com/marianfoo/sap-ai-mcp-servers)** — a good
+starting point for assembling the stack that fits you (e.g. *SAP ADT MCP for in-IDE actions + ARC-1 for
+governed/remote reach + SAP docs MCP for grounding + skills for workflows*).
+
+---
+
+## 15. Using them together
+
+A pattern that works well for a modern team on VS Code ADT (a **recommended architecture**, not a
+vendor-endorsed one):
+
+- **Per developer, in the IDE:** the SAP server for context-aware editing, debugging, ABAP Unit/ATC,
+  repository-object generation and Joule AI fixes on their **personal dev system**, **and**
+- **Centrally, for everyone & for agents:** ARC-1 as the **governed, audited** endpoint for multi-user
+  access, **non-IDE agents** (Copilot Studio, automation/CI), on-prem/classic reach, and the operations
+  the SAP server omits — **SQL, git, transport release, ST22 dumps/traces** — plus a **docs/notes MCP and
+  skills** (§14) for grounding and reusable workflows.
+
+Namespaces differ (`abap_*` vs `SAPRead`/`SAPWrite`/…) and an agent can hold several connections at once.
+
+---
+
+## 16. Where each genuinely wins
 
 === "SAP ABAP MCP Server is better at…"
 
     - **Near-zero-config** in-IDE experience; reuses your ADT session.
     - **First-party**, on SAP's roadmap, evolving fast (currently labelled experimental).
-    - **Server-driven creation + repository-object generators** that auto-track backend capabilities.
-    - **Joule AI** (SAP-ABAP-1) ATC fix proposals — a model tuned on ABAP (licensed).
+    - **Server-driven creation + repository-object generators** that auto-track backend capabilities
+      (incl. *OData UI Service from Scratch*).
+    - **Joule AI** ATC fix proposals (licensed, BTP-hosted).
     - The surrounding **IDE**: debugger, completion, navigation, form editors, virtual workspace.
     - **Human-in-the-loop** transport selection baked into the tools.
-    - The same MCP tooling offered across **Eclipse and VS Code** (per SAP/community materials).
+    - The same MCP tooling across **Eclipse and VS Code**.
 
 === "ARC-1 is better at…"
 
-    - **Central, multi-user hosting** with one governed endpoint.
+    - **Central, multi-user hosting** with one governed endpoint; usable **outside any IDE** (Copilot
+      Studio, automation/CI, web).
     - **Enterprise auth**: XSUAA + OIDC + API key, and **per-user principal propagation**.
-    - **Governance**: read-only default, package allowlists, deny-actions, scopes, rate limits, and a
-      **central audit log**.
-    - **Reach**: classic objects (PROG, FUGR, DDIC, MSAG, ENHO…) and **read/search over MCP** wherever
-      the backend exposes the endpoints.
+    - **Governance**: read-only default, package allowlists, deny-actions, scopes, **rate limits**, central
+      audit log.
+    - **Reach**: classic objects (PROG, FUGR, DDIC, MSAG, ENHO…) and **read/search over MCP** wherever the
+      backend exposes the endpoints.
     - **Ops breadth**: free SQL, git, transport release/delete, **ST22 dumps & traces**.
-    - **Any MCP client** (Copilot Studio, Joule Studio, CLI, web, JetBrains) and **any LLM**.
-    - **No cloud/AI-Core dependency and no licence** for any of its tools.
+    - **Any MCP client** and **any LLM**; multiple **distribution** options (`.mcpb`, Claude Code plugin +
+      skills, Docker, npm, BTP connector).
+    - **No cloud/AI-Core dependency and no licence** for any tool.
 
 ### ARC-1's honest limitations
 
-To keep this balanced: ARC-1 is **not** a drop-in replacement for the SAP server's IDE experience.
-
-- It's **community open source** — no SAP support contract or SLA; "production-ready" is the project's
-  own positioning.
+- **Community open source** — no SAP support contract/SLA; "production-ready" is the project's own positioning.
 - **You** operate and secure it (for the central deployment).
-- **No server-side AI model** — output quality is whatever your chosen LLM produces.
+- **No server-side AI model** — quality is whatever your chosen LLM produces.
 - **No IDE UX** — no debugger, no inline completion, no form editors; it's RPC tools.
-- Its ADT layer is **hand-maintained**; new SAP object types/editors may need ARC-1 code, whereas
-  SAP's server-driven framework adapts automatically.
-- Per-tool reach depends on the **backend's ADT/OData endpoints** — older ECC/NetWeaver should be
-  validated per feature.
-- For a **lone developer on a modern dev system living in the IDE**, the SAP server is the
-  better-fitting, lower-friction tool — and ARC-1 doesn't pretend otherwise.
+- Its ADT layer is **hand-maintained**; new SAP object types/editors may need ARC-1 code, whereas SAP's
+  server-driven framework adapts automatically.
+- Per-tool reach depends on the **backend's ADT/OData endpoints** — older ECC/NetWeaver should be validated
+  per feature; and third-party ADT-API use is **not officially confirmed** (§13).
+- For a **lone developer on a modern dev system living in the IDE**, the SAP server is the better-fitting,
+  lower-friction tool — ARC-1 doesn't pretend otherwise.
 
 ---
 
@@ -514,18 +546,20 @@ To keep this balanced: ARC-1 is **not** a drop-in replacement for the SAP server
 
 - [ABAP Development Tools for VS Code — Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=SAPSE.adt-vscode) — official SAP SE extension: free, integrated AI/MCP, debugger, Unit, ATC, transports, RFC/HTTP connectivity, additional licence for certain Joule features.
 - [SAP Help — Model Context Protocol Tools](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/243d050c1be846e788f38f8c23c45d3a.html) — **canonical toolset, exact tool IDs, and per-tool Joule License column** (source for §7.1 and §12).
-- [SAP Help — Configuring ADT MCP Server](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/ed94320814734d97801f51a5b6deb802.html) — URL `http://localhost:<port>/mcp`, port preference, auto-generated bearer token.
-- [SAP Help — Enabling ADT MCP Server](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/6f6e72852b9746ffbe083d5a818fbbec.html) — local HTTP server enablement.
-- [SAP-samples — RAP130 Exercise 1: Enable the ADT MCP Server](https://github.com/SAP-samples/abap-platform-rap130/blob/main/exercises/ex01/README.md) — `adt.mcpServer.enabled`, default port 2236, Copilot Agent mode, and the **experimental / "not intended for productive use"** warning.
-- [SAP News — Agentic AI and ABAP](https://news.sap.com/2026/05/agentic-ai-will-change-the-market/) and [SAP Business AI Release Highlights Q4 2025](https://news.sap.com/2026/01/sap-business-ai-release-highlights-q4-2025/) — SAP-ABAP-1 foundation model availability/training context.
-- [SAP Community — ADT for VS Code: Your Questions Answered](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-your-questions-answered/ba-p/14400848) · [Everything You Need to Know](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-vs-code-everything-you-need-to-know/ba-p/14258129) · [2026 Roadmap for Joule for Developers](https://community.sap.com/t5/technology-blog-posts-by-sap/our-2026-roadmap-for-joule-for-developers-abap-ai-capabilities/ba-p/14360358) — feature scope, classic-model caveats, and the promotional-period context (confirm commercial terms with SAP).
+- [SAP Help — Configuring ADT MCP Server](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/ed94320814734d97801f51a5b6deb802.html) and [Enabling ADT MCP Server](https://help.sap.com/docs/ABAP_AI/c7f5ef43ab274d078baf22f995fd2161/6f6e72852b9746ffbe083d5a818fbbec.html) — URL `http://localhost:<port>/mcp`, port preference, auto-generated bearer token.
+- [SAP-samples — RAP130 Exercise 1: Enable the ADT MCP Server](https://github.com/SAP-samples/abap-platform-rap130/blob/main/exercises/ex01/README.md) — `adt.mcpServer.enabled`, Copilot Agent mode, and the **experimental / "not intended for productive use"** warning.
+- [SAP Joule for Developers — product page](https://www.sap.com/products/artificial-intelligence/joule-for-developers.html) · [GA announcement: ABAP AI capabilities incl. agentic](https://community.sap.com/t5/artificial-intelligence-blogs-posts/sap-joule-for-developers-abap-ai-capabilities-including-agentic/ba-p/14417633) · [Entering the New Era of Agentic AI for ABAP Development](https://community.sap.com/t5/technology-blog-posts-by-sap/entering-the-new-era-of-agentic-ai-for-abap-development/ba-p/14394643) — Joule licensing (Joule Premium / AI Units), BTP-hosted hub, model mix.
+- [SAP Business AI — Release Highlights Q1 2026](https://news.sap.com/2026/04/sap-business-ai-release-highlights-q1-2026/) — Joule model landscape / GenAI Hub.
+- ADT connectivity & SSO: [ADT for VS Code — Everything You Need to Know](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-vs-code-everything-you-need-to-know/ba-p/14258129) · [VS Code now on the Marketplace (Q&A on SNC/SSO, RFC ports)](https://community.sap.com/t5/technology-blog-posts-by-sap/abap-development-tools-for-visual-studio-code-is-now-available-on-the-vs/ba-p/14402120) · [ABAP Tools VS Code Quick Start (software-heroes)](https://software-heroes.com/en/blog/abap-tools-vs-code-quick-start-en) · [Installing ADT for Eclipse — config/SSO/SNC (PDF)](https://help.sap.com/doc/2e9cf4a457d84c7a81f33d8c3fdd9694/Cloud/en-US/inst_guide_abap_development_tools.pdf).
+- API policy: [Impacts of SAP API Policy v4/2026 on existing integrations (SAP Community)](https://community.sap.com/t5/technology-q-a/impacts-of-sap-api-policy-v4-2026-on-existing-customer-integrations/qaq-p/14381879) · [Joys and sorrows of the ABAP Developer Tools API](https://community.sap.com/t5/application-development-and-automation-blog-posts/joys-and-sorrows-of-the-abap-developer-tools-api/ba-p/13409390) · [`marcellourbani/abap-adt-api`](https://github.com/marcellourbani/abap-adt-api).
+- Ecosystem: [github.com/marianfoo/sap-ai-mcp-servers](https://github.com/marianfoo/sap-ai-mcp-servers) — curated catalog of SAP MCP servers, AI skills and Claude plugins (lists ARC-1, MCP SAP Docs, SAP Notes MCP, and the official SAP dev-tooling servers).
 - [Model Context Protocol specification — 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18) — the revision the tested server reported (newer revisions exist).
-- ARC-1: [Architecture](architecture.md) · [Auth overview](enterprise-auth.md) · [Authorization & roles](authorization.md) · [Configuration reference](configuration-reference.md) · [Tools reference](tools.md) · [Security guide](security-guide.md).
+- ARC-1: [Install in Claude](install-in-claude.md) · [Architecture](architecture.md) · [Auth overview](enterprise-auth.md) · [Authorization & roles](authorization.md) · [Configuration reference](configuration-reference.md) · [Tools reference](tools.md) · [Security guide](security-guide.md) · [Skills](skills.md).
 
 ### Author's live snapshot (2026-06-16 — observed, not product-wide)
 
-A running `ADT MCP Server` v1.0.0 in Eclipse on the author's machine (MCP protocol `2025-06-18`, Jetty
-12.1.9), bound to one on-prem **S/4HANA 2023** backend: `tools/list` returned the 20-tool set (with the
-two ID variants noted in §7.1), `resources/list`/`prompts/list` returned *Method not found*, and
-`abap_creation-get_all_creatable_objects` returned the creatable-type list discussed in §8. These exact
-counts/lists are **backend/version dependent** — verify against your own `tools/list`.
+A running `ADT MCP Server` v1.0.0 in **Eclipse** (port **2234**, MCP `2025-06-18`, Jetty 12.1.9), bound to
+one on-prem **S/4HANA 2023** backend: `tools/list` returned the 20-tool set (with the two ID variants noted
+in §7.1), `resources/list`/`prompts/list` returned *Method not found*, and
+`abap_creation-get_all_creatable_objects` returned the **24** creatable types in §8. These exact counts and
+lists are **backend/version dependent** — verify against your own `tools/list`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,12 +55,12 @@ nav:
   - Using ARC-1:
       - Tools Reference: tools.md
       - MCP Usage Guide: mcp-usage.md
-      - vs SAP ABAP MCP Server: arc-1-vs-sap-abap-mcp-server.md
       - Skills: skills.md
       - Blog Series: blog-series.md
   - Reference:
       - Configuration: configuration-reference.md
       - Configuration Precedence: configuration-precedence.md
+      - vs SAP ABAP MCP Server: arc-1-vs-sap-abap-mcp-server.md
       - Security: security-guide.md
       - Caching: caching.md
       - Log Analysis: log-analysis.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Using ARC-1:
       - Tools Reference: tools.md
       - MCP Usage Guide: mcp-usage.md
+      - vs SAP ABAP MCP Server: arc-1-vs-sap-abap-mcp-server.md
       - Skills: skills.md
       - Blog Series: blog-series.md
   - Reference:


### PR DESCRIPTION
## What

Adds a new docs page — [`docs_page/arc-1-vs-sap-abap-mcp-server.md`](https://github.com/marianfoo/arc-1/blob/claude/intelligent-buck-d234b8/docs_page/arc-1-vs-sap-abap-mcp-server.md) — comparing **ARC-1** with **SAP's official ABAP MCP Server** (bundled in *ABAP Development Tools for VS Code* / *ADT for Eclipse*). Wired into the MkDocs nav under **Using ARC-1 → "vs SAP ABAP MCP Server"**.

## Why

Users (and the author) need a single, **neutral** reference to decide **only ARC-1, only the SAP server, or both together**. The page is deliberately balanced: explicit neutrality note, an honest "where each genuinely wins" pair, and an "ARC-1's honest limitations" section — not a sales page.

## Structure

At-a-glance → decision guide + scenario cheat-sheet → product identity → architecture (mermaid) → **auth & identity** → **central config & governance** → tool surface + capability matrix → system/object-type reach → client compatibility → security posture → setup effort → cost & licensing → using both → where each wins → sources.

The three points called out as must-haves are covered head-on: **auth** (§5), **central config/governance "not possible with the SAP server"** (§6), and the **"both easy locally, but local isn't ARC-1's target architecture"** nuance (§11).

## How it was grounded (live + current sources, not memory)

- **Live probe** of the running SAP `ADT MCP Server` v1.0.0 (`localhost`, MCP `2025-06-18`, Jetty 12.1.9) bound to on-prem **S/4HANA 2023**:
  - **20 tools** now (prior internal research said 14) — incl. 5 ATC tools with the **Joule `atc_apply_ai_fix`** AI-fix agent.
  - **Tools-only** server (no `resources`/`prompts`); **no read/search/where-used over MCP** on that backend — reading is the IDE editor's job.
  - `get_all_creatable_objects` returns **classic types too** (PROG/FUGR/TABL/INTF…) on on-prem, but omits DOMA/DTEL/MSAG/SHLP/ENHO.
- **SAP / community sources:** GA at Sapphire 2026, on the Marketplace, "zero-config" MCP, enabled via `ABAP > AI: Enable ADT MCP Server`, same tools in Eclipse + VS Code, RFC on-prem / HTTP cloud, **consumption-based AI-unit pricing (free promo to Sep 2026)** for the Joule features. All linked in the page's Sources section.

## Reviewer notes

- **Docs-only — no release impact** (`docs:` prefix per release-please conventions).
- `mkdocs build` renders the page cleanly (tables, 3 tabbed comparisons, 1 mermaid diagram, 12 admonitions); **zero** build warnings reference the new file.
- `--strict` currently aborts on **91 pre-existing** broken-link warnings in *other* files (`roadmap.md`, `tools.md`, `security-guide.md`) — left untouched as out of scope.
- Placement is under "Using ARC-1"; easy to move to a top-level "Compare" entry if a more vendor-neutral location is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)