### PR TITLE
chore(github): add issue-form templates (bug, feature) + config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,6 +12,41 @@ body:
 
         Before filing, please skim the [documentation](https://marianfoo.github.io/arc-1/) ([quickstart](https://marianfoo.github.io/arc-1/quickstart/) · [tool reference](https://marianfoo.github.io/arc-1/tools/)) and [search existing issues](https://github.com/marianfoo/arc-1/issues?q=is%3Aissue).
 
+  - type: markdown
+    attributes:
+      value: |
+        <details><summary>🤖 <b>Using an AI assistant (Claude, Copilot, Cursor, …)? Let it fill this out for you — click to expand.</b></summary>
+
+        ARC-1 runs through an assistant, so the assistant that hit the problem already has the exact tool call and error in context. Paste the prompt below to it, then drop its answer into the fields here.
+
+        ```text
+        I hit a problem using ARC-1 (the SAP ADT MCP server). Help me file a precise bug report.
+
+        1. Summarize the problem in 2–3 sentences: what I asked for, what ARC-1 actually did, and what I expected.
+        2. Recover from THIS session, verbatim — do not paraphrase or invent:
+           - the exact failing tool call: tool name, action, and full JSON arguments
+           - the exact response/error: message, HTTP status code, and ADT URL if present
+        3. Determine what you can about the environment; write "unknown" for anything you can't (do NOT guess):
+           ARC-1 version, SAP system type, SAP_BASIS release, how ARC-1 is deployed, which MCP client this is, the ABAP object type involved.
+        4. Sanity-check first: ARC-1 is read-only and $TMP-only by default. If this is a write that failed, it may just need
+           SAP_ALLOW_WRITES=true and the target package added to SAP_ALLOWED_PACKAGES — if that's the likely cause, tell me that
+           instead of writing a bug report.
+        5. Then output the filled-in fields below, ready for me to paste into the GitHub bug form:
+
+        Version:
+        SAP system:
+        SAP_BASIS release:
+        Deployment:
+        MCP client:
+        Tool(s):
+        Object type:
+        What happened:
+        Steps to reproduce (the exact call):
+        Expected:
+        Error / HTTP status / ADT response:
+        ```
+        </details>
+
   - type: checkboxes
     id: preflight
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,202 @@
+name: 🐞 Bug report
+description: A tool call fails, returns wrong data, or a connection / auth problem.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! 🙏
+
+        A few seconds of context saves a round-trip. The most useful things are your **SAP release**, the **exact tool call** you made, and the **exact error / HTTP status** you got back.
+
+        Before filing, please skim the [documentation](https://marianfoo.github.io/arc-1/) ([quickstart](https://marianfoo.github.io/arc-1/quickstart/) · [tool reference](https://marianfoo.github.io/arc-1/tools/)) and [search existing issues](https://github.com/marianfoo/arc-1/issues?q=is%3Aissue).
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checks
+      options:
+        - label: I searched [existing issues](https://github.com/marianfoo/arc-1/issues?q=is%3Aissue) (open and closed) and this isn't a duplicate.
+          required: true
+        - label: I checked the [documentation](https://marianfoo.github.io/arc-1/) (quickstart, tool reference, configuration).
+          required: false
+        - label: Writes failing? I confirmed `SAP_ALLOW_WRITES=true` and my target package is covered by `SAP_ALLOWED_PACKAGES` — ARC-1 is read-only and `$TMP`-only by default.
+          required: false
+
+  - type: markdown
+    attributes:
+      value: "### Environment"
+
+  - type: input
+    id: version
+    attributes:
+      label: ARC-1 version
+      description: "Run `arc1-cli --version`, or check the installed `arc-1` package version / Docker image tag."
+      placeholder: "e.g. 0.9.17"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: system
+    attributes:
+      label: SAP system
+      description: Which kind of SAP backend are you connecting to?
+      options:
+        - SAP S/4HANA (on-premise or private cloud)
+        - SAP S/4HANA Cloud Public Edition
+        - SAP BTP ABAP Environment (Steampunk / embedded)
+        - SAP NetWeaver AS ABAP (7.0x – 7.5x)
+        - SAP ERP / ECC
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: sap-basis
+    attributes:
+      label: SAP_BASIS release
+      description: "ARC-1 gates tools and behavior by release, so this matters a lot. Find it via System → Status in SAP GUI (component SAP_BASIS), or in ARC-1's startup log (the feature probe prints the detected release)."
+      placeholder: "e.g. 750, 758, 816, or 'ECC EHP8 / 740'"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: How are you running ARC-1?
+      options:
+        - Local — npx / npm (stdio)
+        - Docker (ghcr.io/marianfoo/arc-1)
+        - SAP BTP Cloud Foundry
+        - Self-hosted HTTP Streamable server
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: client
+    attributes:
+      label: MCP client
+      description: Which assistant / client is calling ARC-1?
+      options:
+        - Claude Desktop
+        - Claude Code
+        - VS Code (GitHub Copilot / Continue / Cline)
+        - Cursor
+        - Eclipse (GitHub Copilot)
+        - Microsoft Copilot Studio
+        - Gemini CLI
+        - Windsurf
+        - Other / N/A
+    validations:
+      required: false
+
+  - type: dropdown
+    id: auth
+    attributes:
+      label: Authentication mode
+      options:
+        - Basic (SAP_USER / SAP_PASSWORD)
+        - API key
+        - XSUAA OAuth (BTP)
+        - OIDC / Entra ID
+        - BTP Destination + Principal Propagation
+        - Cookies
+        - Not sure
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: "### What went wrong"
+
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Which ARC-1 tool(s)?
+      description: Select all that apply.
+      multiple: true
+      options:
+        - SAPRead
+        - SAPSearch
+        - SAPWrite
+        - SAPActivate
+        - SAPNavigate
+        - SAPQuery
+        - SAPTransport
+        - SAPGit
+        - SAPContext
+        - SAPLint
+        - SAPDiagnose
+        - SAPManage
+        - Not sure / not tool-specific (connection, setup, auth)
+    validations:
+      required: false
+
+  - type: input
+    id: object-type
+    attributes:
+      label: ABAP object type(s) involved
+      description: If the bug is about a specific object kind.
+      placeholder: "e.g. TABL, TTYP (table type), FUGR include, DTEL, CLAS, DDLS"
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear, concise description of the bug.
+      placeholder: "SAPWrite create of a table type (TTYP) returns ... / the function-group include is never written ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: "Include the **exact** tool call — the `arc1-cli call …` command, or the JSON arguments your client sent. This is the single most helpful thing you can provide."
+      placeholder: |
+        1. ...
+        2. Call the tool, e.g.:
+           {
+             "action": "create",
+             "type": "TTYP",
+             "name": "ZTT_DEMO",
+             "package": "$TMP"
+           }
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "The table type should be created and activate cleanly."
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Exact error / HTTP status / ADT response
+      description: "Copy the full message, including the HTTP status code and ADT URL if present (e.g. `status 423 at /sap/bc/adt/...`)."
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs & relevant configuration
+      description: "Set `ARC1_LOG_HTTP_DEBUG=true` for full ADT request/response logging. Paste relevant env vars (e.g. `SAP_ALLOW_WRITES`, `SAP_ALLOWED_PACKAGES`, `SAP_LANGUAGE`, `SAP_SYSTEM_TYPE`, `ARC1_TOOL_MODE`). ⚠️ Redact `SAP_PASSWORD`, API keys, service keys, and cookies."
+      render: shell
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        💡 Many "write doesn't work" reports turn out to be configuration: ARC-1 is **read-only by default** and only allows the `$TMP` package until you set `SAP_ALLOW_WRITES=true` and add your package to `SAP_ALLOWED_PACKAGES`. See the [configuration reference](https://marianfoo.github.io/arc-1/).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -88,6 +88,14 @@ body:
       required: true
 
   - type: input
+    id: system-other
+    attributes:
+      label: Other SAP system — please specify
+      description: Only if you selected "Other / not sure" above.
+    validations:
+      required: false
+
+  - type: input
     id: sap-basis
     attributes:
       label: SAP_BASIS release
@@ -109,6 +117,14 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: deployment-other
+    attributes:
+      label: Other deployment — please specify
+      description: Only if you selected "Other" above.
+    validations:
+      required: false
+
   - type: dropdown
     id: client
     attributes:
@@ -124,6 +140,14 @@ body:
         - Gemini CLI
         - Windsurf
         - Other / N/A
+    validations:
+      required: false
+
+  - type: input
+    id: client-other
+    attributes:
+      label: Other MCP client — please specify
+      description: Only if you selected "Other / N/A" above.
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://marianfoo.github.io/arc-1/
+    about: Setup, configuration, authentication, and the full tool reference — most "how do I…" questions are answered here.
+  - name: 🔐 Report a security vulnerability
+    url: https://github.com/marianfoo/arc-1/blob/main/SECURITY.md
+    about: Please report security issues privately per our security policy — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -59,6 +59,14 @@ body:
       required: false
 
   - type: input
+    id: area-other
+    attributes:
+      label: Other area — please specify
+      description: Only if you selected "Other" above.
+    validations:
+      required: false
+
+  - type: input
     id: release
     attributes:
       label: Release-specific?

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,76 @@
+name: 💡 Feature request
+description: Suggest a new capability, a new object type / tool action, or an improvement to existing behavior.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: "Thanks for the idea! Please [search existing issues](https://github.com/marianfoo/arc-1/issues?q=is%3Aissue) first — many requests are already tracked."
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues (open and closed) and this isn't already requested.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what's blocking you today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should ARC-1 do? If it's a tool change, name the tool, the action, and the object type.
+      placeholder: "e.g. SAPWrite should support creating table types (TTYP) and writing function-group includes."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Select all that apply.
+      multiple: true
+      options:
+        - SAPRead
+        - SAPSearch
+        - SAPWrite
+        - SAPActivate
+        - SAPNavigate
+        - SAPQuery
+        - SAPTransport
+        - SAPGit
+        - SAPContext
+        - SAPLint
+        - SAPDiagnose
+        - SAPManage
+        - Connection / auth / deployment
+        - Caching / performance
+        - Documentation
+        - Other
+    validations:
+      required: false
+
+  - type: input
+    id: release
+    attributes:
+      label: Release-specific?
+      description: If this only applies to certain SAP releases, which ones?
+      placeholder: "e.g. only 8.16+, or NW 7.50"
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives / workarounds
+      description: Anything you've tried, or other tools that already do this (e.g. fr0ster/mcp-abap-adt).
+    validations:
+      required: false


### PR DESCRIPTION
## What & why

The repo had **no issue templates**, so reports arrive without the facts needed to act on them. The trigger was [#451](https://github.com/marianfoo/arc-1/issues/451) (*"Arc 1 cant write Table type and Function group include"*) — one sentence, no release, no repro, no error.

This adds GitHub **issue forms** (the modern dropdown-based framework) under `.github/ISSUE_TEMPLATE/`.

## Grounded in the real corpus

I went over **all 31 issues** (every one community-filed) + external PRs and pulled the fields maintainers repeatedly need and reporters repeatedly omit:

| Field | Why (issues) |
|-------|--------------|
| SAP system flavor + `SAP_BASIS` release | Release-gating is central — #162, #218, #285; incl. **ECC** (#293) and **NW 7.50** (#285) |
| Exact tool call (repro) | #343, #379 |
| Exact error + HTTP status + ADT URL | #293 (423), #379 (400 `[?/049]`), #385 |
| Object type | #218, #250, #285, #451 |
| Deployment + MCP client + auth mode | Connection cluster: #208, #214, #221, #301, #377, #434 |
| arc-1 version | #333 |

## Files

- **`bug_report.yml`** — dropdowns for system / deployment / MCP client / auth / tool; required version, system, release, repro, expected; a "read-only & `$TMP`-only by default" hint to deflect config-not-bug write reports.
- **`feature_request.yml`** — short form; covers the ~7 feature/improvement requests so disabling blank issues doesn't trap them.
- **`config.yml`** — `blank_issues_enabled: false` (forces a form — this is what actually stops #451-style bare issues), contact links to the docs site and `SECURITY.md`. Discussions is disabled, so Issues is the only channel.

## Notes

- Auto-applied labels (`bug`, `enhancement`) already exist in the repo.
- All three files validated as YAML and against the issue-form schema (unique ids, valid field types, `render: shell`).
- `arc1-cli --version` / SAP GUI System → Status hints verified against the code (the `arc1` server bin has no `--version`; `SAPDiagnose` does not report the release).

Closes #451 in spirit (turns it into the motivating example); doesn't change any runtime behavior — `chore`, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
