### PR TITLE
feat(extensions): extension framework for Custom_* plugin tools

### DIFF
--- a/.claude/skills/create-arc1-extension/SKILL.md
+++ b/.claude/skills/create-arc1-extension/SKILL.md
@@ -10,8 +10,18 @@ tools to an ARC-1 instance **without forking**, reusing ARC-1's authenticated SA
 7-scope + allow\* safety ceiling, audit, and PP. Encodes the learnings from building the framework
 (PR1–PR5) and verifying it live on S/4HANA.
 
-**Ground truth:** `docs/research/extension-framework-spec.md` (the spec) and the worked sample at
-`arc-1-extension-sample` (two code tools + one manifest tool, live-verified). Mirror them.
+**Ground truth — read these first, mirror them:**
+- **User guide (point the developer here):** [`docs_page/extensions.md`](../../../docs_page/extensions.md)
+  — the canonical how-to (tiers, `ctx.http`/`ctx.run`, security, **CF/Docker deployment**). Published at
+  the docs site under *Using ARC-1 → Extensions (Custom Tools)*.
+- **Spec:** `docs/research/extension-framework-spec.md` (v1) + `extension-framework-v2-spec.md` (what's deferred).
+- **Worked sample:** [`arc-mcp/arc-1-extension-sample`](https://github.com/arc-mcp/arc-1-extension-sample)
+  — two read tools (ADT + OData), one manifest tool, and **`Custom_RunClass`** (the gated execute op),
+  all live-verified on S/4HANA.
+
+**v1 reality (do not get this wrong):** plugins are **read-only** — `ctx.http` is **GET/HEAD only**. The
+ONE privileged op is **executing a console class** via `ctx.run.classRun` (gated, opt-in). General
+object writes (create/update/delete) are **v2** (`ctx.write`, package-aware) — not available yet.
 
 ## Trigger
 
@@ -32,16 +42,19 @@ Use `AskUserQuestion`. The first question is a gate:
      point them there.
    - **Yes** → continue.
 2. **Tier.**
-   - **Manifest tier** (declarative JSON, no code) — if the tool is "validate inputs → make one
-     **read** GET → return". No logic, no writes.
-   - **Code tier** (`defineTool`, TypeScript) — if it needs logic, response shaping, multiple calls,
-     or **writes**.
+   - **Manifest tier** (declarative JSON, no code) — if the tool is "validate inputs → one **read**
+     GET → return". No logic.
+   - **Code tier** (`defineTool`, TypeScript) — if it needs logic, response shaping, multiple reads,
+     or to **execute a console class** (`ctx.run.classRun`).
 3. **SAP API** — ADT (`/sap/bc/adt/…`), OData (`/sap/opu/odata/…`), or a custom ICF (`/sap/bc/http/…`).
    For a custom endpoint: it **must already exist on SAP** — extensions ship **no ABAP**.
-4. **Read or write**, and the **scope** + **opType**:
-   - read → `scope: 'read'`, `opType: 'R'`
-   - create/update/delete → `scope: 'write'`, `opType: 'C'|'U'|'D'` (requires `allowWrites` on the server)
-   - data preview → `'data'`/`'Q'`; free SQL → `'sql'`/`'F'`; transport → `'transports'`/`'X'`
+4. **What it does**, and the **scope** + **opType**:
+   - read (any of the three APIs) → `scope: 'read'`, `opType: 'R'` — uses `ctx.http.get`.
+   - **execute a console class** (`IF_OO_ADT_CLASSRUN`) → `scope: 'write'`, `opType: OperationType.Workflow`
+     — uses `ctx.run.classRun`. Refused unless the admin sets **`SAP_ALLOW_PLUGIN_EXECUTE=true` +
+     `SAP_ALLOW_WRITES=true`**. This is the only privileged op in v1.
+   - **object create/update/delete** → **NOT available in v1** — that's the v2 `ctx.write` surface.
+     If the tool needs it, say so and stop; it can't ship yet.
 
 ## Step 2 — scaffold (mirror `arc-1-extension-sample`)
 
@@ -49,10 +62,9 @@ Create a new repo `arc1-plugin-<name>` (pure TS, **no ABAP**):
 
 - **`package.json`** — `"type":"module"`, peerDep `"arc-1": ">=<ver>"`, devDeps `typescript`+`zod`,
   build `"tsc && node -e \"require('node:fs').cpSync('manifests','dist/manifests',{recursive:true})\""`
-  (only if it has manifests), and the capability block:
-  ```json
-  "arc1": { "apiVersion": 1, "requires": { "scopes": ["read"], "packages": [] } }
-  ```
+  (only if it has manifests). An optional `"arc1": { "apiVersion": 1 }` block is a **forward
+  declaration** — in v1 the loader reads `apiVersion` from the `Plugin` **default export** (`src/index.ts`),
+  and `requires:{scopes,packages}` is **v2** (declared-but-not-yet-enforced), so don't rely on it.
 - **Code tier** → `src/tools/Custom_<X>.ts`:
   ```ts
   import { z } from 'zod';
@@ -77,6 +89,21 @@ Create a new repo `arc1-plugin-<name>` (pure TS, **no ABAP**):
       "pathParams": { "name": "$.name" }, "accept": "text/plain" },
     "response": { "maxBytes": 50000 } }
   ```
+- **Execute tier** (run a console class) → `src/tools/Custom_<X>.ts`:
+  ```ts
+  import { z } from 'zod';
+  import { defineTool, OperationType } from 'arc-1/public';
+  export default defineTool({
+    name: 'Custom_<X>',
+    description: 'Execute an ABAP console class and return its output.',
+    schema: z.object({ className: z.string().min(1).max(40) }),
+    policy: { scope: 'write', opType: OperationType.Workflow },   // execute ⇒ write-class op
+    async handler(args, ctx) {
+      const out = await ctx.run.classRun((args as { className: string }).className);  // gated; see Step 1.4
+      return { content: [{ type: 'text', text: out }] };
+    },
+  });
+  ```
 - **`src/index.ts`** — `export default { name, version, apiVersion: 1, tools: [...], manifests: ['manifests/Custom_<X>.tool.json'] } satisfies Plugin;`
 - **README** — what it does + the load command.
 
@@ -89,27 +116,46 @@ npm install && npm link arc-1 && npm run build
 
 # load into an instance…
 ARC1_PLUGINS=$PWD/dist/index.js  arc1 --http-streamable
-# …or drive one call (args MUST be --json, not positional):
+# …or drive one read call (args MUST be --json, not positional):
 ARC1_PLUGINS=$PWD/dist/index.js  arc1-cli call Custom_<X> --json '{"name":"RSPARAM"}'
+# …an execute tool ALSO needs the two opt-ins (else it's refused):
+SAP_ALLOW_PLUGIN_EXECUTE=true SAP_ALLOW_WRITES=true \
+  ARC1_PLUGINS=$PWD/dist/index.js  arc1-cli call Custom_<X> --json '{"className":"ZCL_FOO"}'
 ```
 
-Confirm the tool appears in `tools/list` and the call returns real SAP data.
+Confirm the tool appears in `tools/list` and the call returns real SAP data. For **deploying** the
+plugin to BTP Cloud Foundry or Docker (the owner-check / `--chown` gotcha, image vs buildpack vs
+volume trade-offs), point the developer at the **Deploying extensions** section of
+[`docs_page/extensions.md`](../../../docs_page/extensions.md).
 
 ## Gotchas (learned the hard way)
 
 - **`Custom_` namespace is mandatory** and collisions **fail server start** (fail-fast).
-- **`ctx.http` is gated.** A `read`-scoped tool **cannot POST** (scope-coverage throws); a write tool's
-  POST also needs `allowWrites` on the server. Declare the scope that matches the highest operation.
-- **`allowedPackages` does NOT gate OData/ICF calls** (no ABAP package in the path) — non-ADT writes
-  are gated by `allowWrites` + scope + the Cloud Connector allowlist + SAP-side auth only.
-- **Writes (v1)** use `ctx.http.withStatefulSession(...)` with the `?_action=LOCK` / `?_action=UNLOCK`
-  POSTs; **OData/ICF writes additionally need a CSRF token fetched against the service path** (not yet
-  a one-liner — see the spec's deferred write ergonomics).
+- **`ctx.http` is read-only (GET/HEAD).** `post`/`put`/`delete`/`withStatefulSession` are **not on the
+  surface** in v1 (a raw write can't be package-allowlist-gated → deferred to v2). Don't write a tool
+  that needs them yet.
+- **`ctx.client` is a runtime read-only view** — its `.http`/`.safety` are blocked at runtime (a
+  `(ctx.client as any).http` cast yields `undefined`), so use the high-level read methods only.
+- **Executing a class is the one privileged op.** `ctx.run.classRun(name)` runs an `IF_OO_ADT_CLASSRUN`
+  console class. Gated: needs `SAP_ALLOW_PLUGIN_EXECUTE=true` **and** `SAP_ALLOW_WRITES=true` **and** a
+  `write`-scoped tool; the class name is validated (no path injection). Off by default.
 - **OData service must be ACTIVATED in `/IWFND`** even if it shows in the catalog (a 403
   "No service found" means it is registered but not activated).
-- **Manifest tier v1 = read-only GET**, `additionalProperties:false` required, `path` is a template
-  with **no host**, path params are percent-encoded (traversal-safe). Writes/POST stay code-tier.
+- **Manifest tier = read-only GET**, `additionalProperties:false` required, `path` is a template with
+  **no host**, path params percent-encoded (traversal-safe). No POST/body in v1.
+- **`availableOn: 'onprem' | 'btp'`** (optional, default `all`) hides the tool from `tools/list` when
+  the resolved system type differs. Hyperfocused mode shows no plugin tools at all.
 - **`elicit`/`notify`/`sampling`** on `ctx` are **capability-gated** — present only when the MCP client
   supports them (absent on the CLI/stdio path).
 - **Unit-test the handler** with `createMockToolContext` from `arc-1/public/testing` (records
-  `ctx.http` calls, returns a configured body — no live SAP needed).
+  `ctx.http`/`ctx.run.classRun` calls, returns configured output — no live SAP needed).
+- **Admin kill switch:** `SAP_DENY_ACTIONS=Custom_*` (all) or `Custom_Foo` (one) removes plugin tools.
+
+## Deploy (when they ask)
+
+Point at **Deploying extensions** in [`docs_page/extensions.md`](../../../docs_page/extensions.md).
+Key facts: plugins are **local files** loaded from an **absolute** `ARC1_PLUGINS` path (no `$HOME`
+expansion); on BTP CF use a **derived Docker image** (`FROM ghcr.io/marianfoo/arc-1`, `COPY --chown=arc1:arc1`
+— a plain `COPY` lands as root and the loader **rejects non-owner / world-writable** files) **or**
+co-deploy the built `dist/` in the buildpack app bits (`/home/vcap/app/...`, `vcap`-owned). **No
+hot-reload** (redeploy to change). **No XSUAA change** to add a plugin (scopes are reused).

--- a/.claude/skills/create-arc1-extension/SKILL.md
+++ b/.claude/skills/create-arc1-extension/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: create-arc1-extension
+description: Use when a developer wants to add their own custom tool(s) to an ARC-1 MCP instance — an "extension" or "plugin" (FEAT-61). Guides the key architecture decisions (extension vs separate server; code tier vs manifest tier; which SAP API; scope/opType), then scaffolds the plugin and walks build + load + test. Do NOT use for adding a tool to ARC-1 core itself (that is an in-tree change), or for a different SAP backend (that is a separate server).
+---
+
+# Create an ARC-1 extension
+
+Guides a developer through building an **ARC-1 extension** — a local plugin that adds `Custom_*`
+tools to an ARC-1 instance **without forking**, reusing ARC-1's authenticated SAP client, the
+7-scope + allow\* safety ceiling, audit, and PP. Encodes the learnings from building the framework
+(PR1–PR5) and verifying it live on S/4HANA.
+
+**Ground truth:** `docs/research/extension-framework-spec.md` (the spec) and the worked sample at
+`arc-1-extension-sample` (two code tools + one manifest tool, live-verified). Mirror them.
+
+## Trigger
+
+- "add a custom tool / plugin / extension to ARC-1"
+- "wrap this SAP/ADT/OData endpoint as an MCP tool"
+- "build my own ARC-1 tool without forking"
+- "diagnostic tool on top of ARC-1" (SM37/SLG1/gateway logs, etc.)
+
+## Step 1 — decide the path (ask, don't assume)
+
+Use `AskUserQuestion`. The first question is a gate:
+
+1. **Backend.** Does the tool talk to the **same SAP system ARC-1 connects to, over HTTP** (ADT,
+   OData, or a custom ICF/REST service)?
+   - **No — a different SAP product** (Cloud ALM, BTP services, BW, HANA, Datasphere, SuccessFactors)
+     **or a non-HTTP protocol** (native RFC, SAP GUI scripting) → **this is NOT an extension.** It is a
+     **separate MCP server** (build on the BTP-auth module, the "own-server" path). **Stop here** and
+     point them there.
+   - **Yes** → continue.
+2. **Tier.**
+   - **Manifest tier** (declarative JSON, no code) — if the tool is "validate inputs → make one
+     **read** GET → return". No logic, no writes.
+   - **Code tier** (`defineTool`, TypeScript) — if it needs logic, response shaping, multiple calls,
+     or **writes**.
+3. **SAP API** — ADT (`/sap/bc/adt/…`), OData (`/sap/opu/odata/…`), or a custom ICF (`/sap/bc/http/…`).
+   For a custom endpoint: it **must already exist on SAP** — extensions ship **no ABAP**.
+4. **Read or write**, and the **scope** + **opType**:
+   - read → `scope: 'read'`, `opType: 'R'`
+   - create/update/delete → `scope: 'write'`, `opType: 'C'|'U'|'D'` (requires `allowWrites` on the server)
+   - data preview → `'data'`/`'Q'`; free SQL → `'sql'`/`'F'`; transport → `'transports'`/`'X'`
+
+## Step 2 — scaffold (mirror `arc-1-extension-sample`)
+
+Create a new repo `arc1-plugin-<name>` (pure TS, **no ABAP**):
+
+- **`package.json`** — `"type":"module"`, peerDep `"arc-1": ">=<ver>"`, devDeps `typescript`+`zod`,
+  build `"tsc && node -e \"require('node:fs').cpSync('manifests','dist/manifests',{recursive:true})\""`
+  (only if it has manifests), and the capability block:
+  ```json
+  "arc1": { "apiVersion": 1, "requires": { "scopes": ["read"], "packages": [] } }
+  ```
+- **Code tier** → `src/tools/Custom_<X>.ts`:
+  ```ts
+  import { z } from 'zod';
+  import { defineTool, OperationType } from 'arc-1/public';
+  export default defineTool({
+    name: 'Custom_<X>',                 // MUST start with Custom_
+    description: '…',
+    schema: z.object({ /* … */ }),
+    policy: { scope: 'read', opType: OperationType.Read },
+    async handler(args, ctx) {
+      const res = await ctx.http.get(`/sap/bc/adt/…`, { Accept: 'text/plain' });
+      return { content: [{ type: 'text', text: /* shape res.body */ }] };
+    },
+  });
+  ```
+- **Manifest tier** → `manifests/Custom_<X>.tool.json`:
+  ```json
+  { "name": "Custom_<X>", "description": "…", "scope": "read",
+    "inputSchema": { "type": "object", "additionalProperties": false,
+      "required": ["name"], "properties": { "name": { "type": "string", "pattern": "^[A-Za-z0-9_/]{1,40}$" } } },
+    "request": { "method": "GET", "path": "/sap/bc/adt/…/{name}/source/main",
+      "pathParams": { "name": "$.name" }, "accept": "text/plain" },
+    "response": { "maxBytes": 50000 } }
+  ```
+- **`src/index.ts`** — `export default { name, version, apiVersion: 1, tools: [...], manifests: ['manifests/Custom_<X>.tool.json'] } satisfies Plugin;`
+- **README** — what it does + the load command.
+
+## Step 3 — build + load + test (this is live-verified)
+
+```sh
+# until arc-1 is published with the public API, link the local build:
+( cd /path/to/arc-1 && npm link )
+npm install && npm link arc-1 && npm run build
+
+# load into an instance…
+ARC1_PLUGINS=$PWD/dist/index.js  arc1 --http-streamable
+# …or drive one call (args MUST be --json, not positional):
+ARC1_PLUGINS=$PWD/dist/index.js  arc1-cli call Custom_<X> --json '{"name":"RSPARAM"}'
+```
+
+Confirm the tool appears in `tools/list` and the call returns real SAP data.
+
+## Gotchas (learned the hard way)
+
+- **`Custom_` namespace is mandatory** and collisions **fail server start** (fail-fast).
+- **`ctx.http` is gated.** A `read`-scoped tool **cannot POST** (scope-coverage throws); a write tool's
+  POST also needs `allowWrites` on the server. Declare the scope that matches the highest operation.
+- **`allowedPackages` does NOT gate OData/ICF calls** (no ABAP package in the path) — non-ADT writes
+  are gated by `allowWrites` + scope + the Cloud Connector allowlist + SAP-side auth only.
+- **Writes (v1)** use `ctx.http.withStatefulSession(...)` with the `?_action=LOCK` / `?_action=UNLOCK`
+  POSTs; **OData/ICF writes additionally need a CSRF token fetched against the service path** (not yet
+  a one-liner — see the spec's deferred write ergonomics).
+- **OData service must be ACTIVATED in `/IWFND`** even if it shows in the catalog (a 403
+  "No service found" means it is registered but not activated).
+- **Manifest tier v1 = read-only GET**, `additionalProperties:false` required, `path` is a template
+  with **no host**, path params are percent-encoded (traversal-safe). Writes/POST stay code-tier.
+- **`elicit`/`notify`/`sampling`** on `ctx` are **capability-gated** — present only when the MCP client
+  supports them (absent on the CLI/stdio path).
+- **Unit-test the handler** with `createMockToolContext` from `arc-1/public/testing` (records
+  `ctx.http` calls, returns a configured body — no live SAP needed).

--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,14 @@ SAP_TRANSPORT=stdio              # or: http-streamable
 # ARC1_TOOL_MODE=standard        # standard|hyperfocused
 # SAP_VERBOSE=false
 
+# ── Extensions (FEAT-61) — add your own Custom_* tools; see docs_page/extensions.md ──
+# CSV of absolute LOCAL paths (.js code plugin or .json manifest), NOT npm names.
+# ARC1_PLUGINS=/abs/path/to/plugin/dist/index.js
+# Opt-in (default false): let plugin tools EXECUTE ABAP console classes (ctx.run.classRun).
+# ALSO requires SAP_ALLOW_WRITES=true and a write-scoped tool. Default-off so enabling
+# built-in writes never silently grants plugins code execution.
+# SAP_ALLOW_PLUGIN_EXECUTE=false
+
 # ── Test runner (integration/e2e) — see docs/dev-guide.md "Testing — concurrent runs" ──
 # These configure the TEST harness, not the server; only needed when running
 # integration/e2e concurrently against one SAP system.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ Full per-option details (defaults, clamps, layer interactions): [docs_page/confi
 | `SAP_SYSTEM_TYPE` | `auto` (default), `btp`, `onprem` |
 | `SAP_ABAP_RELEASE` | SAP_BASIS release override for abaplint (e.g. 758, 816); probe wins |
 | `ARC1_TOOL_MODE` | `standard` (12 tools) or `hyperfocused` (1 tool, ~200 tokens) |
+| `ARC1_PLUGINS` | FEAT-61 extensions: CSV of absolute LOCAL paths (`.js`/`.json`), NOT npm. Adds `Custom_*` tools (read-only v1) — docs_page/extensions.md |
+| `SAP_ALLOW_PLUGIN_EXECUTE` | Opt-in (default false): let plugin tools execute ABAP console classes (`ctx.run.classRun`). ALSO needs `SAP_ALLOW_WRITES` + a `write`-scoped tool |
 | `SAP_ABAPLINT_CONFIG` / `SAP_LINT_BEFORE_WRITE` | Custom abaplint config / pre-write lint (default true) |
 | `SAP_CHECK_BEFORE_WRITE` | SAP-side pre-write syntax check, non-blocking (default false) |
 | `ARC1_CACHE[_FILE]` / `ARC1_CACHE_WARMUP[_PACKAGES]` | Cache mode (auto/memory/sqlite/none) / TADIR pre-warm |

--- a/docs/research/extension-framework-deep-research.md
+++ b/docs/research/extension-framework-deep-research.md
@@ -1,0 +1,478 @@
+# ARC-1 Extension Framework — Deep Research (basis for the FEAT-61 spec)
+
+> **Status:** Research & design only. No code changes. This document is the **deep-research basis for the eventual extension spec/ADRs**.
+> **Relationship to [`tool-extension-points.md`](tool-extension-points.md):** that doc (the "v1 doc") remains the canonical phased plan + case studies (§14 samibouge, §15 dassian-adt). This document goes **deeper and broader** on the angles that matter for the spec — current-code reality, the SAP CAP convention-over-configuration model, the TS/MCP plugin best-practice corpus, the security-by-default model, how extensions call APIs, the broad ecosystem survey, and an explicit v1 / v2 / out-of-scope split — and ends with **recommendations on every open architecture decision**.
+> **Date:** 2026-06-17. **Tracks:** roadmap FEAT-61, issues #187 (closed), #332 (open).
+> **Sourcing:** four parallel research sweeps (current code; SAP CAP plugins; TS+MCP plugin best practices + Node sandboxing; the SAP/ABAP MCP ecosystem). External claims carry source URLs in the relevant sections.
+
+---
+
+## 0. TL;DR — what this research concludes
+
+1. **The extension model is real demand, not speculative.** Three external projects already reuse ARC-1's architecture (LISA forked the *entire server* to add 3 translation tools to the same backend; calmcp + samibouge + dassian-adt corroborate). The realistic in-process extension set is **small and ABAP/ADT-HTTP-bound**.
+2. **Two reuse paths, decided by backend** (not taste): *extend* ARC-1 (same ABAP system → inherit the whole gateway) vs *own server on the auth module* (different backend → borrow only BTP/XSUAA auth). This doc is about the **extend** path.
+3. **Steal CAP's convention-over-configuration ergonomics; invert CAP's trust model.** Ergonomics free (filename=identity, generic middleware for free, config-merge, profile defaults). Power **declared and gated** through ARC-1's existing safety ceiling — the one place to *require* explicit declaration.
+4. **Build on the MCP SDK's native dynamic-tool API** (`registerTool` + `RegisteredTool.enable/disable/update/remove` + `list_changed`). Don't reinvent a tool registry primitive; wrap it with a Backstage-style typed extension point that the host owns and intersects against the safety ceiling.
+5. **Skip in-process sandboxing** — for the admin-trusted, explicit-opt-in threat model it is security theater (`vm`/`vm2` add CVE surface; the loader's admin could edit source anyway). Security-by-default comes from *inheriting the ceiling*, capability declaration, per-plugin error isolation, audit-with-identity, and redaction — not confinement.
+6. **v1 = local trusted JS plugins** (`ARC1_PLUGINS=`) on a typed registry **+ a scoped read-only manifest tier**, additive-only, fully gated. The API is **experimental and may break any time** (no semver commitment yet). Several things are **out of scope for now** (marketplace, new transports/auth, raw HTTP passthrough, non-SAP egress, RFC/GUI protocols, replacing built-in tools, hyperfocused participation, framework-managed ABAP deployment).
+
+---
+
+## 0.1 Decision log (2026-06-17 — user review)
+
+| Topic | Decision | Status (vs §11 recommendation) |
+|---|---|---|
+| v1 scope | Phase 1 (typed registry) + minimal Phase 2 (`ARC1_PLUGINS=` local JS loader) | ✅ approved |
+| **Manifest tier** | **In v1**, scoped to read-only GET + simple stateless POST, bound to paths against the authed client (not raw URLs). Lock-aware writes stay code-tier. | ✅ approved — **moved v2→v1** (see §8) |
+| `Custom_*` namespace | reserved, fail-fast on collision | ✅ approved |
+| Sandboxing | none (theater for admin-trusted model) | ✅ approved |
+| Replace/change built-in tools | **out of scope for v1 AND v2** (additive-only, indefinitely) | ✅ approved — **stricter** (was v2) |
+| Ship-your-own-ABAP | **out of scope as a framework feature** (no bundling/install help). Plugins may still *call* custom ICF paths the admin installed by other means. | ✅ approved — **changed** (was "support as convention"); see §5/§7.3 |
+| Hyperfocused mode + plugins | out of scope | ✅ approved — **changed** (was opt-in v1) |
+| dassian-adt integration | defer to roadmap | ✅ approved |
+| Versioning / API stability | **experimental — may break any time**; no semver commitment. Keep only a cheap `apiVersion` integer fuse. | ✅ approved — **changed** (was semver-from-Phase-0) |
+| External / non-SAP API access | recommend **out for v1** (clarified §5) | ⏳ needs confirm — **Q-C** in §13 |
+| Reference plugin | 3 calls demonstrating **ADT + custom OData + a non-ADT/non-OData SAP API**, in a **separate repo**, pure TS | ✅ refined (see §13 Q-M) |
+| **Callable API scope** | **Any SAP HTTP API on the connected system** — ADT, OData, custom ICF — not just ADT. External/non-SAP stays out. | ✅ clarified — see §5 |
+| **Path allowlist** | **Any path** (not just `/sap/bc/adt/*`). In BTP the **Cloud Connector** already gates reachable host+paths; on-prem it's the single bound host + SAP auth. | ✅ resolved (was Q-A) |
+| **ABAP artifacts** | **No ABAP code in the arc-1 repo OR in any extension** — plugins are pure TS. Custom OData/ICF endpoints exist on SAP by external means. | ✅ clarified |
+| **Plugin client surface** | Plugins get a **gated `SafeHttpClient`** (`ctx.http`), NOT the raw `AdtHttpClient` — raw `http.*` bypasses `checkOperation` (a real safety gap found in code). | ✅ new — security (§5.1) |
+| **Extension authz model** | **Reuse the existing 7 scopes + allow\* ceiling** (tool declares `policy:{scope,opType}`). **Custom scopes = no** — XSUAA `xs-security.json` is deploy-time static, no wildcard scopes; OIDC drops unknown scopes. Pre-declared `custom.<plugin>` *visibility* labels = future option. | ✅ resolved (§6.4) |
+| **Path allowlists** | **None** (on-prem or BTP). CC on BTP allows all endpoints by design → not the gate. Gates = per-user SAP auth + ARC-1 scope/safety. | ✅ resolved (was Q-L) |
+| **Core blast radius** | **One** high-risk core change (dispatch `switch`→`ToolRegistry`); everything else additive. | ✅ mapped (§9.4) |
+
+New open questions are in **§13**.
+
+---
+
+## 1. Current architecture reality (2026-06) — what the spec must build on
+
+Grounded in a direct read of current code. **The v1 doc is directionally correct but stale on specifics** — correct these before writing the spec.
+
+### 1.1 How a tool works today (the 6-file spread)
+
+A built-in tool (e.g. `SAPRead`) is defined across:
+
+| Concern | File | Shape |
+|---|---|---|
+| MCP tool definition (name, description, JSON schema) | `src/handlers/tools.ts` | `ToolDefinition { name, description, inputSchema }`; BTP vs on-prem enum variants; `getToolDefinitions(config)` |
+| Runtime input validation | `src/handlers/schemas.ts` | Zod v4; `getToolSchema(toolName, isBtp)` |
+| Scope + opType (+ featureGate) | `src/authz/policy.ts` | `ActionPolicy { scope, opType, featureGate? }`; `getActionPolicy(tool, action)` |
+| Dispatch | `src/handlers/intent.ts` | **`switch(toolName)` at ~`intent.ts:1264-1324`** (12 built-in cases + a `SAP` hyperfocused recursive case) |
+| Hyperfocused mapping | `src/handlers/hyperfocused.ts` | `ACTION_TO_TOOL` static map + `expandHyperfocusedArgs()` |
+| Scope-aware list pruning | `src/server/server.ts:53-134` | `pruneToolByPolicy()` / `filterToolsByAuthScope()` |
+| Audit bracketing | `src/handlers/intent.ts:1102-1112, 1329-1364` | `tool_call_start` / `tool_call_end` / `safety_blocked` / `auth_scope_denied` |
+
+> **Stale-doc delta:** the v1 doc cites `intent.ts:1104` for the switch — it is actually ~`1264`. All v1 intent.ts line refs are off by ~160. The 6-file spread itself is unchanged. (Note: an architecture-consolidation effort is in flight around a `write/` package; on the current branch `intent.ts` is still the dispatch. The registry refactor below is Phase 1 **regardless of the dispatch file's eventual name.**)
+
+### 1.2 The enforcement backbone a plugin must inherit (security-by-default)
+
+- **`src/adt/safety.ts`** — `SafetyConfig { allowWrites, allowDataPreview, allowFreeSQL, allowTransportWrites, allowGitWrites, allowedPackages, allowedTransports, denyActions }`. `checkOperation(config, op, name)` throws `AdtSafetyError`. `OperationType` enum: `R`ead `S`earch `Q`uery `F`reeSQL `C`reate `U`pdate `D`elete `A`ctivate `T`est `L`ock `I`ntelligence `W`orkflow `X`transport. Plus `checkPackage()` / `checkTransport()`.
+- **`src/authz/policy.ts`** — scope model `read | write | data | sql | transports | git | admin` with implications (`admin ⊇ all`, `write ⊇ read`, `sql ⊇ data`). `scripts/validate-action-policy.ts` enforces (Pass 1) every schema action has a policy entry, (Pass 2) every policy entry maps to a real action, (Pass 3) opType↔scope consistency.
+- **`src/server/audit.ts`** — typed events; the framework brackets every call. Handlers MUST NOT emit `tool_call_*` themselves.
+- **Principal propagation** — `src/server/server.ts:231-330` `createPerUserClient(...)` builds the per-user `AdtClient` (jwt-bearer / SAML / OAuth token precedence). Handlers receive an already-PP-wired client.
+
+### 1.3 The public surface for "how extensions call APIs"
+
+- **`AdtClient`** (`src/adt/client.ts`) — high-level domain reads (`getProgram`, `getClass`, …), each calls `checkOperation()` internally.
+- **`AdtHttpClient`** (`src/adt/http.ts:220-268`) — **the low-level seam**: `http.get/head/post/put/delete(path, …)` with **CSRF, cookies, MIME negotiation, the shared semaphore, BTP connectivity proxy, and per-user auth handled transparently**; `withStatefulSession(fn)` for lock→modify→unlock.
+- **Missing pieces the spec must add** (flagged by the dassian-adt case study, confirmed against code):
+  - `lock`/`unlock` are **module functions in `src/adt/crud.ts`**, *not* methods on `AdtClient` → must be promoted to the public surface (returns `{ lockHandle, corrNr?, isLocal }`).
+  - `ToolContext` has **no `elicit`/`notify`/`sampling`** → must be added (optional, capability-detected).
+  - **No `src/public/` or `package.json#exports`** → Phase 0 not done.
+  - **No `withRetryOnSessionExpiry`** helper → nice-to-have.
+  - **No plugin test harness** (`arc-1/public/testing` mocks) → Phase 1 deliverable.
+
+---
+
+## 2. The two reuse paths (scope-setting)
+
+| You want to… | Same ABAP system? | Path | Inherits | Owns |
+|---|---|---|---|---|
+| Add ABAP tooling (diagnostics, custom REST on the same system) | **yes** | **Extension** (this doc, FEAT-61) | auth + PP + safety + scope + audit + cache | just the tool(s) |
+| Serve a **different** backend (Cloud ALM, BTP services, …) | **no** | **Own server** on the auth module | XSUAA/DCR/BTP auth plumbing | own safety/scope/audit + tools |
+
+The deciding rule is the **backend + protocol**: same ABAP system over ADT-HTTP → extension; different backend or non-HTTP protocol (RFC, GUI scripting) → separate server. Both replace the current de-facto answer ("fork the whole repo"). §7 maps the real ecosystem onto this rule.
+
+---
+
+## 3. Best-practices synthesis
+
+### 3.1 SAP CAP plugin system — the convention-over-configuration reference (steal ergonomics, invert trust)
+
+CAP's `cds-plugin` mechanism is the strongest model for **convention over configuration**. Verified against `cap.cloud.sap` docs + real `@cap-js/*` source.
+
+**The mechanism (one convention, no registry):** a package is a plugin if it ships a `cds-plugin.js` next to its `package.json`. The loader iterates the host's **declared dependencies** (not a blind `node_modules` scan), loads framework plugins before project plugins, and — critically — **merges the plugin's `package.json#cds` block into `cds.env` *before* its code runs** (config channel first, code second). Installing the package *is* activation. (`@cap-js/sqlite`'s `cds-plugin.js` is literally **0 bytes** — it ships behavior purely through config + an `impl` path.)
+
+**Convention-over-configuration patterns worth stealing** (each eliminates config):
+
+| CAP convention | Eliminates | ARC-1 analogue |
+|---|---|---|
+| **Filename = identity** — `srv/cat-service.js` implements `cat-service.cds` | a registration table / `@impl` annotation | `tools/<name>.ts` auto-registers tool `<name>`; schema in `<name>.schema.ts` by convention |
+| **Name → path** — `CatalogService` → `/catalog` | explicit routes | tool name → LLM tool list entry, no manual `tools.ts` edit |
+| **Generic CRUD + a fixed `handle_*` roster for free** | auth/etag/validation/paging by hand | free cross-cutting middleware: arg-normalization, scope check, Zod validation, audit, package gating |
+| **`before`/`on`/`after` phases** ("no `next()` = replace default") | forking the handler to intercept | optional `before`/`after` hooks; explicit `on`-style override for built-ins (v2) |
+| **Profiles, `development` default** | per-env config files | maps onto read-only/`$TMP`/mocked-by-default locally; writes + real allowlists only in a "production" posture |
+| **Config-merge (12 sources) + per-profile overrides** | manual binding/parsing | plugin `package.json#arc1` defaults merged into `ServerConfig`, gated by ceiling |
+| **Compose, don't configure** — sqlite(dev)+hana(prod) under logical `db:"sql"` by *installing both* | a central switchboard | multiple plugins layer by profile, not a registry edit |
+
+**The critical lesson — invert CAP's trust model.** CAP plugins run in-process with the *entire* `cds` facade (`cds.db`, `cds.model`, `cds.services`) — **full trust, no sandbox, no permission manifest, no per-plugin error isolation** (one bad plugin can crash the server via `shutdown_on_uncaught_errors`). This was exploited (the April 2026 "Mini Shai-Hulud" npm supply-chain attack trojaned `@cap-js/db-service`). For a gateway whose entire reason to exist is a centralized safety ceiling + per-user auth, ARC-1 must keep CAP's *ergonomics* but make **power explicitly declared and gated**.
+
+**The "FREE vs DECLARE" rule (the heart of the design):**
+
+| FREE / automatic (convention) | Must be DECLARED (explicit) |
+|---|---|
+| Discovery & activation (install the package) | **Required scopes** (`read`/`write`/`sql`/…) + **package allowlist** the tool needs — checked vs server ceiling, **intersected, never expanded** |
+| Tool name ← filename; schema ← naming convention | **Compatibility floor** on the ARC-1 core (`peerDependencies`) |
+| Registration into the LLM tool list (no 6-file edit) | Human-readable description; non-default routing |
+| Cross-cutting middleware (normalize, scope check, validate, audit, package-gate) | **Opt-out** of any default (a deliberate, visible choice) |
+| Safe defaults (read-only, `$TMP`, dev profile) | **Elevation** beyond the safe default (writes, transportable packages, free SQL) |
+| Per-plugin error containment | — |
+
+### 3.2 TypeScript plugin-system patterns (cross-cutting, 5+ ecosystems)
+
+Distilled from ESLint, Vite/Rollup, Fastify, Backstage, Prettier, Docusaurus:
+
+1. **Plugin = named object/factory with a mandatory, load-bearing `id`** (not a class). `id` drives audit attribution, collision detection, namespacing. (Prettier's undefined collision behavior is the anti-pattern.)
+2. **A single typed extension-point interface the host owns** (Backstage `createExtensionPoint<T>`): the host owns the `Map` + invariants (duplicate-id throw, prefix reservation), contributors call typed methods. **The TS interface is the versioned contract** — the most directly portable pattern to a tool registry.
+3. **Capability injection over globals** (Rollup's tiered `PluginContext`): extensions reach host services only through an **injected, narrow context** — the seam where safety/audit/redaction/version-detection are enforced.
+4. **Encapsulation by default + metadata-bearing escape hatch** (Fastify `fastify-plugin`): isolation is default; breaking it carries `name` + a **host-version range checked at load** + declared `dependencies`.
+5. **Named hooks with a kind taxonomy** (Rollup): *first* (routing) / *sequential* (middleware) / *parallel* (observers). Adopt the *narrow* slice (parallel observers for audit/metrics), skip the full bus.
+6. **Error containment stamps the plugin name** — fail-loud-with-attribution (Rollup auto-stamps `plugin: name`; ESLint stamps rule-id + filename).
+7. **Host owns the engine version; plugins declare a compatibility range** (`peerDependencies` floor, runtime `meta.hostVersion` feature-detect); experimental surface behind an `/alpha`-style export.
+8. **Declarative config (enablement/options) separate from imperative code** (ESLint).
+
+### 3.3 MCP-native extensibility — build on the SDK, don't reinvent
+
+- **The MCP SDK already supports dynamic tools at runtime.** `registerTool(name, config, cb): RegisteredTool` (throws on duplicate name); the returned handle exposes `enable()` / `disable()` (hidden from `tools/list`) / `update(...)` / `remove()`, **each auto-emitting `notifications/tools/list_changed`**. On first registration `McpServer` declares `capabilities.tools.listChanged: true` and installs the `ListToolsRequestSchema` handler (skips disabled tools, Zod→JSON-Schema). This is **exactly the primitive** for registering plugin tools and gating them per JWT scope — mirroring ARC-1's existing scope-based pruning. No third-party framework needed.
+- **Ecosystem reference points:** `mcp-framework` (drop a file in `tools/` exporting a `class extends MCPTool` — the filename-convention model), `mcp-reloader` (chokidar `tools/*.js` → `list_changed`, the FS hot-load reference — useful for *local dev*, not a production gateway), `FastMCP` (imperative `addTool` with `canAccess(auth)`), `MetaMCP` (operator-side aggregator/middleware). Take the **explicit-registration core**; treat FS auto-discovery as an optional thin wrapper.
+
+### 3.4 Distilled principles for ARC-1 (the synthesis the spec uses)
+
+**Build it as:** Backstage's *typed extension point* (host owns a typed `addTool` registry with safety-ceiling invariants) + the *SDK's native dynamic-tool API* (`registerTool` + `enable/disable` + `list_changed`) + Rollup's *capability injection + name-stamped error containment* (narrow `ToolContext`, fail-loud attribution) + CAP's *convention-over-configuration ergonomics* (filename=identity, free middleware, config-merge, profiles) + a *declarative manifest tier* as the eventual safe default. **Deliberately skip** sandboxing, marketplaces, hot-reload, heavy hook/DI machinery — the admin-trusted, in-process, explicit-opt-in model makes them cost without benefit.
+
+---
+
+## 4. The extension contract (convention over configuration)
+
+### 4.1 What the developer writes (the 80% case)
+
+```ts
+// arc1-plugin-nw750-dumps/tools/Custom_GetNw750Dump.ts  (filename = tool identity)
+import { defineTool, OperationType } from 'arc-1/public';
+
+export default defineTool({
+  name: 'Custom_GetNw750Dump',                      // or inferred from filename
+  description: 'Read ST22 short-dump detail on NW 7.50 via the custom ICF endpoint.',
+  schema: z.object({ id: z.string() }),             // Zod (or sibling <name>.schema.ts)
+  policy: { scope: 'read', opType: OperationType.Read },   // DECLARED capability
+  availableOn: 'onprem',                            // optional release/variant gate
+  async handler(args, ctx) {
+    const res = await ctx.client.http.get(`/sap/rest/arc1/dumps/${args.id}`);
+    return { content: [{ type: 'text', text: res.body }] };
+  },
+});
+```
+
+### 4.2 `ToolContext` (the injected capability seam) — updated surface
+
+```ts
+interface ToolContext {
+  readonly client: AdtClient;                 // per-user, PP-wired; high-level reads, all PRE-GATED
+  readonly http:   SafeHttpClient;            // gated low-level: every call → checkOperation(method→opType) + scope + audit.
+                                              //   Any SAP path (ADT/OData/ICF). NOT the raw AdtHttpClient (which bypasses safety).
+  readonly safety: SafetyConfig;              // READ-ONLY view (cannot mutate)
+  readonly cache?: CachingLayer;              // optional
+  readonly logger: Logger;                    // stderr only (never console.log)
+  readonly config: PublicServerConfig;        // redacted, read-only
+  readonly authInfo?: AuthInfo;               // userName, scopes, clientId — NO raw JWT
+  readonly requestId: string;
+  // NEW (Phase 1 — from dassian-adt analysis), all optional + capability-detected:
+  readonly elicit?:   (p: ElicitParams) => Promise<ElicitResult>;        // ask the user
+  readonly notify?:   (lvl: 'info'|'warning'|'error', m: string) => Promise<void>; // client-visible progress
+  readonly sampling?: (sys: string, user: string, max?: number) => Promise<string>; // ask the LLM
+}
+```
+
+Deliberately **excluded** from the context (the CAP-inversion): raw JWT, safety mutators, the MCP `Server` instance, `process`/env, child-process/port APIs, the ability to construct an `AdtClient` (would bypass PP + ceiling).
+
+### 4.3 Convention summary
+
+- **Tool identity** from filename/name; **registration** automatic (no 6-file edit).
+- **Cross-cutting middleware** (arg normalization, scope check, Zod validation, audit bracketing, package gating) applied by the framework for free; opt-out is explicit.
+- **Naming:** built-ins keep `SAP*`; plugins use a reserved `Custom_*` (single namespace; no per-plugin prefixes); duplicate names **fail-fast at load**.
+- **Config:** plugin `package.json#arc1` defaults merged into `ServerConfig`, **gated by the ceiling**.
+
+---
+
+## 5. How extensions call SAP APIs (a focus area)
+
+**Scope: any SAP HTTP API on the connected system** — ADT, OData, custom ICF/REST — not just ADT. **External / non-SAP hosts are out of scope** (no general `fetch` in `ctx`; §0.1). Plugins are **pure TypeScript — no ABAP artifacts in the arc-1 repo or in any extension**; custom OData/ICF endpoints exist on SAP by external means and the plugin just calls their paths.
+
+### 5.1 The gated client — plugins get `SafeHttpClient`, not the raw client
+
+**Code finding (security-critical, verified in `http.ts`/`client.ts`):** the raw `AdtHttpClient.get/post/…` methods **do not call `checkOperation()`** — only the high-level `AdtClient` methods (e.g. `getProgram()`) do. Handing a plugin the raw client would let it `POST` anywhere even with `allowWrites=false`. **Fix: `ctx.http` is a `SafeHttpClient` wrapper** that, on every call, maps HTTP method → `OperationType` (GET/HEAD→Read, POST→Create, PUT→Update, DELETE→Delete — overridable by the tool's declared `policy.opType`), runs `checkOperation()` + scope + `denyActions`, and audits under the tool's identity. **Plugins never receive the raw `AdtHttpClient`.**
+
+Rides the client **free and path-agnostic** (verified generic): per-user PP auth, cookies, stateful sessions (`withStatefulSession`), the shared semaphore/rate-limit, the BTP connectivity proxy, `sap-client`/`sap-language` params, and caller-supplied `Accept`/`Content-Type`/headers (they win over ADT discovery).
+
+### 5.2 Per-API-kind
+
+| API kind | How | Works today | Caveat |
+|---|---|---|---|
+| **ADT** (`/sap/bc/adt/…`) | `ctx.client.getProgram()` (high-level, pre-gated) or `ctx.http.get('/sap/bc/adt/…')` | ✅ fully (CSRF auto, MIME auto) | `checkPackage` applies to ADT object writes |
+| **OData** (`/sap/opu/odata/…`) | `ctx.http.get('/sap/opu/odata/SVC/Set?$filter=…')` | ✅ **reads** (`Accept: application/json` passes through) | **writes need CSRF against the *service* path** — ARC-1's CSRF is hardcoded to `/sap/bc/adt/core/discovery`. → add a generic `fetchCsrfToken(path)` (Q-J) so plugins don't each reinvent it |
+| **Custom ICF / REST** (`/sap/bc/http/…`, `/sap/rest/…`) | `ctx.http.get('/sap/bc/http/sap/zsvc')` | ✅ reads; writes same CSRF caveat | endpoint must already exist on SAP (no ABAP shipped by the plugin) |
+| **ADT writes** | `withStatefulSession()` + `ctx.client.lock()/unlock()` (NEW public) + transport | ✅ | transport defaults to `lock.corrNr`; promote `lock()→{lockHandle,corrNr?,isLocal}`/`unlock()` to `AdtClient` |
+| **External / non-SAP** | — | ❌ out of scope | no `fetch` in `ctx`; a plugin needing it should be its own server |
+
+### 5.3 What the ceiling does and does NOT gate for non-ADT calls
+
+The `SafeHttpClient` wrapper gates **`allowWrites` + scope + `denyActions` + audit** on every call (ADT or not). But two ADT-specific knobs **cannot** apply to OData/ICF (no ABAP object/package in the path):
+
+- **`allowedPackages` does NOT constrain OData/ICF calls** — there's no package to resolve. For non-ADT writes the real gates are `allowWrites` + scope + `denyActions` **+ the Cloud Connector resource allowlist (BTP) / per-user SAP auth**. The package allowlist is an ADT-object concept — admins must understand this (Q-K).
+- **No path allowlists** (neither on-prem nor BTP — resolved). On BTP the Cloud Connector is configured to **allow all endpoints** (it's prepared for this), so the CC is *not* the path gate. The real gates for any SAP call are **per-user SAP-side auth (PP) + ARC-1 scope/safety** (`allowWrites`/scope/`denyActions` via `SafeHttpClient`). On-prem is the same minus CC: bounded to the one configured SAP host + SAP auth + scope/safety.
+
+**Refused by the registry (anti-patterns, fail at load):** a `raw_http` passthrough tool (missing `policy.opType` / shaped as raw HTTP); plugin-supplied auth providers / OAuth login forms; plugins constructing their own client or grabbing the raw `AdtHttpClient`; new MCP transports.
+
+---
+
+## 6. Security model — security by default
+
+### 6.1 Threat model (why the design is what it is)
+
+A plugin enters **only when an admin sets `ARC1_PLUGINS=` on infrastructure they already control**. The plugin author is transitively the admin — already fully trusted, and able to edit source or read SAP creds directly. **Therefore "confine malicious plugin code" is not a real threat for v1** — any in-process sandbox is bypassable by the same actor, and `vm`/`vm2` actively *add* CVE surface (Node's own docs: "`vm` is not a security mechanism"; vm2 discontinued after repeated RCE escapes). **Heavy sandboxing here is security theater.**
+
+The risks that *are* real are **operational**, addressed by engineering discipline, and by **inheriting the ceiling** rather than confining:
+
+### 6.2 Security-by-default controls (the standard built-ins get, extended to plugins)
+
+1. **Inherit the safety ceiling, unconditionally.** Every plugin SAP call routes through the same `checkOperation()` / `checkPackage()` / `ACTION_POLICY` choke-points. A plugin cannot reach a client handle that bypasses safety (`ctx.client` is already gated; no raw client/config/`process`).
+2. **Capability declaration, intersected with the ceiling (the CAP-inversion).** A plugin **declares** the scopes + package globs it needs (`policy` per tool + a manifest block). At load the host **intersects** the declaration with the server ceiling — **never expands** it. A `write`-declaring tool on a `allowWrites:false` server is inert. This is the one place the design *requires* explicit declaration.
+3. **Per-plugin error isolation.** A throwing plugin fails *its own* tool call (handled MCP error, plugin `id` stamped), **never crashes the process** and never leaks a stack trace with secrets — the opposite of CAP's `shutdown_on_uncaught_errors`. Wrap handlers in try/catch + bounded timeouts.
+4. **Audit with plugin identity.** Every plugin tool call is bracketed by the framework's `tool_call_start/end` with the plugin `id` alongside user identity — same pipeline as built-ins. Plugins cannot emit `tool_call_*` themselves.
+5. **Deny-actions applies natively.** `SAP_DENY_ACTIONS=Custom_*` (or a specific tool) removes plugin tools — the admin kill switch. Plugin tool names are `denyActions`-eligible by construction.
+6. **Scope-based list pruning applies natively.** Plugin tools carry a real `ACTION_POLICY` entry → they participate in per-user `tools/list` filtering (no side-channel).
+7. **Redaction at the sink.** Extend ARC-1's existing password/token/cookie redaction to anything a plugin can emit to logs.
+8. **Trust tiers.** T0 in-tree → T1 admin-local file (v1) → T2 manifest-only (v2, statically checkable against the ceiling *before load* — the safest tier) → T3 npm (out of scope until the trust model changes).
+
+### 6.3 Optional defense-in-depth (not required)
+
+**SES `lockdown()` + a `harden()`ed endowment** is the *one* defensible lightweight add — it prevents prototype-pollution and accidental over-reach (least-privilege hygiene), **not** confinement of a hostile author. Consider only if cheap. Everything heavier (`worker_threads` for crash-containment, `isolated-vm`, WASM/WASI, OS isolation) is **deferred until the trust model changes** (a marketplace / community-submitted plugins) — at which point "the admin could do it anyway" no longer holds and confinement becomes real.
+
+### 6.4 Extension authorization model — reuse the 7 scopes, not custom scopes
+
+The "custom scopes vs map to `allowWrites`/`allowSQL`" question resolves (verified in code) to **reuse ARC-1's existing 7 scopes + the allow\* ceiling**:
+
+- An extension tool declares `policy: { scope, opType }` (`read`/`write`/`data`/`sql`/`transports`/`git`/`admin`) and is gated **identically to a built-in**: scope check (`hasRequiredScope` + implications `admin`⊇all, `write`⊇`read`, `sql`⊇`data`), the safety ceiling (`checkOperation` maps `opType`→`allowWrites`/`allowFreeSQL`/…), per-user safety derivation (`deriveUserSafety`, tightest side wins), `denyActions`, and `tools/list` pruning. **Zero authz core change** — it works the moment a tool registers a policy. This is the direct answer to "map extension tools to `allowWrites`/`allowSQL`": yes, via the existing scope+opType mechanism.
+- **Custom/namespaced scopes are blocked by XSUAA's deploy-time model:** `xs-security.json` scopes are a **static array of exact names — no wildcard** (`custom.*` is not expressible), and XSUAA **rejects tokens carrying scopes not in the deployed file**. The OIDC path **drops unknown scopes** (the `KNOWN_SCOPES` allowlist), and API-key profiles are fixed. So a plugin "introducing a new scope" still requires editing `xs-security.json` + `cf deploy` — the dynamic flexibility is **illusory**. Not worth it.
+- **Future option (defer):** for per-plugin *role-based visibility*, a hybrid adds an optional **pre-declared** `custom.<plugin>` *visibility label* in `xs-security.json` (gates list-visibility only; execution still uses the 7 scopes) — ~50 LOC, additive, no runtime scope registration. Not v1.
+
+---
+
+## 7. External repos — detailed evaluation (does integration make sense?)
+
+Anchored on the community census `marianfoo/sap-ai-mcp-servers` + live `gh`. **Updated decision axis** (per the all-SAP-APIs scope): *same SAP **system**, reached over HTTP — ADT **or** OData **or** custom ICF — → extension candidate; a **different** SAP system/product (Cloud ALM, BTP services, BW, HANA, Datasphere, …) or a **non-HTTP** protocol (RFC, SAP-GUI scripting) → separate server.* OData on the **same** system is now in scope — the earlier "business-data plane = separate server" distinction is **dropped**; the axis is **system + protocol**, not plane. (The OData *proxy* projects in the table below remain separate servers because they target arbitrary/other systems, not the one ARC-1 is connected to.)
+
+### 7.1 Extension candidates (same ABAP / ADT-HTTP)
+
+| Project | Tools | Access | Verdict / what it needs |
+|---|---|---|---|
+| **[ClementRingot/LISA](https://github.com/ClementRingot/LISA)** | 3 (i18n) | **custom ICF** `/sap/bc/http/sap/zi18n_service` → `ZCL_I18N_SERVICE` (XCO) | **Textbook extension.** Its own README: "designed to be used next to an ADT MCP server (e.g. ARC-1)." Collapses from a forked server to *3 `defineTool()`s + an `abap/` folder*. Needs: ICF GET/POST, JSON bodies, transport-for-writes, ship-own-ABAP, release-gate. **Strongest proof of demand** (someone forked the whole server for 3 tools). |
+| **[DassianInc/dassian-adt](https://github.com/DassianInc/dassian-adt)** | 25–39 | standard ADT + a `raw_http` escape hatch | **Extension for ~32/39 tools** (one-line wrappers), minus non-goals. **Blocker: HTTP-client identity** — it rides `abap-adt-api`'s own login/cookie/CSRF; running two stacks per user breaks PP/audit/safety, so every handler must be **rewritten to `ctx.client.http.*`**. Surfaces useful gaps (`abap_unlock`, ATC variants, granular trace lifecycle, per-include class writes). Its `raw_http` is an explicit **non-goal**. |
+| **[oisee/vibing-steampunk](https://github.com/oisee/vibing-steampunk)** (379★) | large (analysis suite) | standard ADT | **Extension-shaped, novel value:** package-health, dead-code, boundary/LUW analysis — all **computed client-side from standard ADT reads, no new backend**. The ideal additive extension; proves high-value tools need only clever use of the authed read client. |
+| **[fr0ster/mcp-abap-adt](https://github.com/fr0ster/mcp-abap-adt)** (59★) | CRUD | ADT (+ optional RFC) | **Partial** — ADT parts are extension; RFC parts need a separate server. |
+| **[Hochfrequenz/aibap.mcp](https://github.com/Hochfrequenz/aibap.mcp)** | 69 | ADT (+ BYO GUI/RFC hook) | **Extension for the ADT tools.** Novel pattern worth stealing: a compile-time **`BlackMagicClient` BYO hook** for ops ADT-HTTP can't do (SM30/SE09) — an escape hatch at the *protocol* boundary. |
+| **[samibouge fork](https://github.com/marianfoo/arc-1/compare/main...samibouge:arc-1:feat/nw750-version-fix)** | 1 (of 18 commits) | **custom ICF** `/sap/rest/arc1/dumps` → `ZCL_ARC1_DUMP_HANDLER` | **The canonical "where's the line" case.** 17 commits are plain upstream PRs; exactly one needs the extension model (ships customer ABAP). Bright-line test: **the moment a project requires customer-installed ABAP, it must be an extension, not upstream.** |
+| **[DataZooDE/erpl-adt](https://github.com/DataZooDE/erpl-adt)** | CLI+MCP | ADT (+ BW-over-ADT) | Conceptually extension, but a single Go/C++ native binary → ships standalone in practice. |
+
+### 7.2 Clearly out of scope — separate servers (and why)
+
+- **Different backend / data plane:** calmcp (Cloud ALM), all OData business-data proxies (`odata-mcp-proxy` family, `oisee/odata_mcp_go` 137★, GutjahrAI), `bw-modeling-mcp` (BWMT REST), HANA, Datasphere, SuccessFactors, Analytics Cloud, CPI/Integration Suite, Focused Run, sap-security-mcp, sap-released-objects (static Clean-Core data). Riding ARC-1's ADT client buys them nothing.
+- **Different protocol on the same data:** all **RFC** MCPs (`thupalo/sap-rfc-mcp-server`, `Richard-Zhangxj/SAP_MCP`, anything on `sap-rfc-lite`/node-rfc/pyrfc — need the NW RFC SDK binary, non-HTTP wire) and all **SAP GUI Scripting** MCPs (`mario-andreschak/mcp-sap-gui` 113★, Windows COM).
+- **Inverse / non-applicable:** `abap-ai/mcp` (MCP server runs *inside* ABAP), `marcellourbani/abap-adt-api` (a client *library*, not a server — ARC-1 has its own equivalent), Eclipse-plugin ADT-MCP bridges (wake SAP's in-IDE server — different topology), pure doc/knowledge MCPs (no live backend).
+
+> **Note on the brief's RFC confusion:** `fr0ster/sap-rfc-lite` is C++ RFC bindings (a node-rfc fork), **not** an MCP server; `fr0ster/mcp-abap-adt` is a *separate* ADT-HTTP MCP by the same author. Also: 30+ low-star ADT-MCP clones exist — all same-ABAP/ADT-HTTP, all conceptually mergeable, but each is its own standalone server adding no backend ARC-1 lacks.
+
+### 7.3 The capability union the extension API must cover (derived from the candidates)
+
+1. **Arbitrary ICF/REST path via the authed client** — `ctx.client.http.*`. Covers LISA, samibouge, ~32 dassian tools. *Non-negotiable core.*
+2. **Stateful lock→modify→unlock** — `withStatefulSession()` + **public `lock()`/`unlock()`**. The single most impactful addition; every write tool needs it.
+3. **Transport handling for writes** (pass request or inherit `lock.corrNr`).
+4. **Custom bodies + headers + Accept negotiation** (JSON, versioned ADT MIME).
+5. **Safety/scope/audit inheritance, read-only to the plugin** + typed errors.
+6. **Mid-flow MCP capabilities** — `elicit` / `notify` / `sampling` (the three that make extensions *useful*, not just possible; dassian uses all three).
+7. ~~Ship-your-own ABAP artifacts~~ — **out of scope as a framework feature** (§0.1). Plugins may still *call* custom ICF paths the admin installed separately; the framework neither bundles nor deploys ABAP.
+8. **Per-release feature gating** (`availableOn`; in the additive model the admin's opt-in *is* the gate).
+9. **Optional cache** (`ctx.cache?.getSource`) + (v2) multi-system `sap_system_id` auto-injection.
+
+### 7.4 Novel use-cases found in the wild (design inputs)
+
+- **i18n as a thin tool-pack** (LISA) — the flagship demand nobody would predict.
+- **Filling release holes with customer ABAP** (samibouge) — back-fill a REST surface SAP never shipped.
+- **BYO compile-time protocol fallback** (aibap `BlackMagicClient`) — typed hook for SM30/SE09-class ops.
+- **Architecture analytics over plain ADT reads** (vibing-steampunk) — high value, zero new backend.
+- **Granular surgical tools** (dassian `abap_unlock`, trace lifecycle) — extensions want finer control than coarse intent tools expose.
+
+---
+
+## 8. The two tiers — imperative code + a scoped declarative manifest (both in v1)
+
+| Tier | Power | When | v? |
+|---|---|---|---|
+| **Imperative JS plugin** | full (any `ctx.*` logic; lock-aware writes; control flow) | anything the manifest grammar can't encode (writes, the aibap-style fallback) | **v1** |
+| **Declarative manifest** (JSON, no JS) | map a validated JSON-Schema input → **one** HTTP call against the authed client | the common "wrap one read endpoint" case | **v1, scoped** (read-only GET + simple stateless POST) |
+
+**Why a trusted author still benefits from the declarative tier** (TS/MCP research): *auditability* (reviewable as data — a PR diff shows the whole capability change), *least privilege* (a grammar that can only name vetted calls is statically gateable against the ceiling **before load** — the property MCP does not give for free), *validation* (reject malformed descriptors deterministically), *lower authoring bar* (no code).
+
+### 8.1 Manifest-in-v1 feasibility — evaluation (grounded in ~12 OpenAPI→MCP / API-gateway implementations)
+
+**Verdict: feasible, MEDIUM complexity** — *if* it binds to **paths against the already-authenticated `AdtClient`** (never a raw/LLM/manifest-supplied URL) and **excludes lock-aware writes**. The interpreter is then a pure function: render template → one `ctx.client.http` call → optional select/truncate → return. ARC-1 already owns every hard dependency (`checkOperation`, `ACTION_POLICY`, `encodeURIComponent` ×69 in client.ts, `fast-xml-parser` builder, the SDK's `registerTool`/`list_changed`).
+
+**Minimal grammar (the whole thing):**
+
+```jsonc
+{
+  "name": "Custom_GetSomething",
+  "description": "Read X by name.",
+  "scope": "read",                          // intersected with the server ceiling, NEVER expands it
+  "inputSchema": { "type":"object", "properties":{
+      "name": {"type":"string","pattern":"^[A-Za-z0-9_/]{1,40}$"} },
+      "required":["name"], "additionalProperties": false },
+  "request": {
+    "method": "GET",                        // FIXED at declaration; GET/POST allowlist for v1
+    "path": "/sap/bc/adt/.../{name}/source/main",   // fixed template; NO scheme/host — host owns the client
+    "pathParams": { "name": "$.name" },     // each segment: validated → percent-encoded
+    "query":      { "version": "$.lang" },  // omit-if-absent; arrays = repeated-key default
+    "accept": "text/plain",
+    "body": { "mode": "json", "template": { "field": "$.name" } }  // POST only; JSON skeleton, NOT a raw string
+  },
+  "response": { "extract": "$.someField", "maxBytes": 50000 }      // optional select; default = raw body, truncated
+}
+```
+
+**What makes it grow (resist each):** OpenAPI `style`/`explode` array/object serialization (pick one default: repeated-key arrays, objects→body only); computed/derived values (concat/base64/conditional — that's a DSL → punt to code tier); jq response reshaping (ship truncation in v1, JSONPath select in v1.1, reserve jq); XML response parsing (v1 returns raw truncated body, like native source reads).
+
+**Security the interpreter MUST enforce** (the LLM controls leaf values; the client is already authed — a textbook confused-deputy): fixed base URL = the `AdtClient` (reject any value resembling a URL → kills SSRF); per-segment canonicalize→allowlist→reject `..`/`/`/encoded-equivalents→percent-encode (anti-traversal); reject CR/LF/NUL in headers + a **header allowlist** that forbids `Host`/`Authorization`/`Cookie`/`X-CSRF-Token`/session headers (owned by the transport); build bodies structurally then serialize (never string-interpolate); strict `additionalProperties:false` input schema; route through the **same `scope ∧ safety ∧ SAP auth` chain** as native tools; audit the fully-resolved request with user identity.
+
+### 8.2 Why writes stay in the code tier (v1)
+
+A declarative lock-aware write is a **categorical jump**, not a slope. The ADT write needs exactly what every declarative spec leaves out: `LOCK_HANDLE` captured from the **response body** (not a header), threaded with rename into the PUT + UNLOCK; a shared **stateful session** (sessiontype + cookies + connection-id); a **CSRF refresh-on-403** sub-protocol; and a **guaranteed-finally** unlock. That turns a pure-function interpreter into a stateful workflow engine with a cookie jar — and still wouldn't beat ARC-1's existing `withStatefulSession()` + `try/finally`. **There is no declarative ADT-write manifest in the wild.** So: declarative tier = reads + simple stateless POST; **writes = code tier** in v1. *v2* may expose lock-aware writes as a **named, code-backed "operation vocabulary"** the manifest references and parameterizes (`op: adt.update_source` with `{type,name,source,transport?}`) — declarative breadth for the 90%, a vetted imperative escape for the stateful 10%, without growing the grammar.
+
+---
+
+## 9. Scope — v1 / v2 / out-of-scope
+
+### 9.1 v1 (the experimental feature to ship)
+
+- **Phase 0** — public API boundary: `src/public/` (or `package.json#exports`) exporting `defineTool`, `ToolContext`, `OperationType`, `AdtClient`/`AdtHttpClient` types, typed errors, a `arc-1/public/testing` mock harness. **Marked `@experimental` — no semver commitment; may break any release.** A single `apiVersion` integer is the only compatibility fuse (host fails fast on mismatch at load).
+- **Phase 1** — typed `ToolRegistry` (Backstage-style) behind a flag; built-ins register through it; the dispatch `switch` becomes `registry.dispatch()`. Convert one built-in end-to-end (`SAPManage(cache_stats)`) as a self-test. Add to the public surface: **`lock`/`unlock` on `AdtClient`**, **`elicit`/`notify`/`sampling` on `ToolContext`**. Update `validate-action-policy.ts` to walk the registry. Tests: collision, policy-required-on-register, prefix validation, PP-through-registry.
+- **Phase 2 (minimal)** — local trusted JS loader: `ARC1_PLUGINS=/abs/path.js[,…]` (absolute, readable, not world-writable, same owner; dynamic import + shape validation; fail-fast). **This is what makes it dev-usable.**
+- **Manifest tier (scoped, §8)** — a JSON manifest loader + pure-function interpreter for **read-only GET + simple stateless POST** tools bound to paths against the authed client. Reuses the same registry + ceiling. Writes stay code-tier. (Ship as a fast-follow within v1 — see Q-F.)
+- **Cross-cutting (all v1):** capability declaration **intersected with the ceiling, never expanded**; per-plugin error isolation; audit-with-plugin-id; `Custom_*` namespace + collision fail-fast; convention-over-config ergonomics (filename identity, free middleware, `package.json#arc1` config-merge).
+
+### 9.2 v2 (roadmap)
+
+- **Named code-backed "operation vocabulary"** the manifest can reference for **lock-aware writes** (`op: adt.update_source` with `{type,name,source,transport?}`) — declarative writes without an orchestration engine (§8.2).
+- **Observer hook bus** — `onToolCall` / `onToolResult` parallel hooks for audit/metrics plugins.
+- **`withRetryOnSessionExpiry`** helper; **cache invalidation hooks** (`cache.invalidate`).
+- **Multi-system** (`sap_system_id` auto-injection) — FEAT-59.
+- **MCP prompts** contribution — FEAT-62 (separate from tools).
+- **dassian-adt gap absorption** (`abap_unlock`, ATC variants, trace lifecycle, per-include writes) — as built-ins or a reference plugin; handlers rewritten to `ctx.client.http.*`.
+- **API stabilization** — a semver/compat policy *if/when* the feature graduates from experimental.
+- **(Maybe) declared non-SAP egress capability** — only if a real use case appears (Q-C).
+- **(Maybe) Phase 4 npm peer-package discovery** — only if the trust model still holds.
+
+### 9.3 Out of scope (now — not this feature; some possibly never)
+
+- **Replacing / changing built-in tools** (route-replacement) — **out for v1 AND v2**; additive-only (`Custom_*` add, never replace `SAP*`).
+- **Hyperfocused-mode participation** by plugins — plugins do not register hyperfocused actions.
+- **Framework-managed ABAP deployment** (ship-your-own-ABAP) — no bundling/install/blessing; plugins may still *call* custom ICF paths the admin installed separately.
+- **Non-SAP / external egress** in v1 — `ctx` has no general `fetch` (Q-C may revisit for v2).
+- Embedded ARC-1 (FEAT-29g); a **marketplace**; **hot-reload** of code (use SDK `enable/disable` for live toggling); plugins that **change MCP transport** or **add auth providers**; **`raw_http` passthrough**; plugins **constructing their own client**; **heavy sandboxing** (theater for this trust model); **RFC / SAP-GUI-scripting** (separate servers); **business-data OData** as a plane; per-plugin tool **prefixes**; **custom dynamic scopes** (XSUAA deploy-time blocker — §6.4); **path allowlists** (none — gates are SAP auth + scope/safety).
+
+### 9.4 Core code changes vs additive enablement code (the blast radius)
+
+Verified against current code. **The framework is ~90% additive; exactly one change touches the sensitive dispatch path.**
+
+| Capability | Core / Additive | Touches | Risk |
+|---|---|---|---|
+| **Typed `ToolRegistry` replacing the dispatch `switch`** | **CORE** | `src/handlers/intent.ts` (the `switch(toolName)` ~:1264 in `handleToolCall`) + register built-ins at `server.ts` startup | **HIGH** — central routing; de-risk as a no-op refactor (below) |
+| ToolContext `elicit`/`notify`/`sampling` | both (light) | `handleToolCall` already threads `_server`; expose it in the context | MED |
+| Public API boundary (`src/public/` + `exports`) | **additive** | new re-export file; new `package.json#exports` | LOW |
+| `SafeHttpClient` wrapper | **additive** | new file; wired into ToolContext | LOW |
+| Generic `fetchCsrfToken(path?)` | **additive** | `http.ts` optional param, default `/sap/bc/adt/core/discovery` (existing callers unchanged) | LOW |
+| `lock`/`unlock` on `AdtClient` | **additive** | new methods delegating to `crud.ts` | LOW |
+| Capability/scope ceiling at load | **additive** | `validate-action-policy.ts` walks the registry; `getActionPolicy` gains a registry fallback | LOW |
+| Audit with plugin identity | **additive** | optional `pluginName?` field on the audit events | LOW |
+| Plugin loader (`ARC1_PLUGINS`) | **additive** | new module + a config field | LOW |
+| Manifest interpreter | **additive** | new module | LOW |
+
+**The one unavoidable core change — de-risk as a staged no-op refactor**, existing tests as the safety net:
+1. Switch → `registry.dispatch()` for the 12 built-ins (same handlers, same behavior) → tests green.
+2. Introduce `ToolContext`, convert the 12 built-ins to `(ctx, args)` → tests green.
+3. *Then* Phase 2 (loader) only **adds registry entries** — orthogonal, low-risk.
+
+The risky surface is one bounded refactor that ships and bakes **before any plugin exists**; everything a plugin needs (`SafeHttpClient`, `fetchCsrfToken`, `lock/unlock`, public boundary, loader, manifest tier) is additive and buildable in parallel without touching the dispatch/safety/audit core.
+
+---
+
+## 10. Evaluation matrices
+
+**Trust tiers vs controls:**
+
+| Tier | Loaded by | Confinement | Static ceiling check | v? |
+|---|---|---|---|---|
+| T0 in-tree | core | n/a | n/a | now |
+| T1 local JS (`ARC1_PLUGINS=`) | admin file | none (trusted) | runtime intersect | **v1** |
+| T2 manifest-only | admin file | declarative grammar | **before load** | v2 |
+| T3 npm package | allowlist | none (trusted) | runtime intersect | deferred |
+
+**Sandboxing options (why v1 uses none):** plain import = full trust (correct for admin-author); `worker_threads` = crash-containment only, not security; `vm`/`vm2` = *not a security mechanism* / discontinued after RCEs; `isolated-vm`/WASM/OS-isolation = real confinement but solve a problem v1 doesn't have. **SES `lockdown()`** = optional least-privilege hygiene. Revisit only if authors become less-trusted than the operator.
+
+**Convention vs configuration (the v1 ergonomics):** FREE = discovery/activation, name←filename, registration, cross-cutting middleware, safe defaults, error containment, config-merge. DECLARE = required scopes/packages, compatibility floor, descriptions, opt-outs, elevation beyond safe default.
+
+---
+
+## 11. Open questions & recommendations (status per §0.1)
+
+| # | Question | Recommendation | Status |
+|---|---|---|---|
+| 1 | v1 scope — internal (Phase 1) or dev-loadable (Phase 2)? | **Phase 1 + minimal Phase 2** (`ARC1_PLUGINS=` loader). | ✅ approved |
+| 2 | Registry shape? | **Backstage-style typed extension point** the host owns, backed by the SDK's `registerTool`/`RegisteredTool` + `list_changed`. | ✅ approved |
+| 3 | Manifest tier in v1? | **Yes — scoped** to read-only GET + simple POST, path-against-client binding (§8). Lock-aware writes stay code-tier. | ✅ approved (moved v2→v1) |
+| 4 | Expose `lock`/`unlock`? | **Yes, v1**, on `AdtClient`. | ✅ approved |
+| 5 | `elicit`/`notify`/`sampling`? | **Yes, v1**, optional + capability-detected. | ✅ approved |
+| 6 | Capability declaration? | Per-tool `policy: { scope, opType }` + `package.json#arc1` package globs; **intersect with ceiling, never expand**. | ✅ approved |
+| 7 | Naming / collisions? | `Custom_*` namespace; fail-fast on duplicate. | ✅ approved |
+| 8 | External / non-SAP API access? | **Out for v1** (`ctx` has no `fetch`). v2 declared-egress only if a use case appears. | ⏳ confirm (Q-C) |
+| 9 | Sandboxing? | **None** — theater for this trust model. Optional SES `lockdown()` later. | ✅ approved |
+| 10 | Ship-your-own-ABAP? | **Out of scope as a framework feature.** Plugins may still call pre-installed custom ICF paths. | ✅ approved (changed) |
+| 11 | Replace a built-in tool? | **Out for v1 AND v2.** Additive-only. | ✅ approved (stricter) |
+| 12 | dassian-adt integration? | **Defer to roadmap** (v2 gap-absorption; handlers rewritten to `ctx.client.http.*`). | ✅ approved |
+| 13 | Hyperfocused + plugins? | **Out of scope** — plugins don't register hyperfocused actions. | ✅ approved (changed) |
+| 14 | Versioning/compat? | **Experimental — may break any time**; only a cheap `apiVersion` integer fuse. Stabilize later if it graduates. | ✅ approved (changed) |
+| 15 | Reference plugin? | A **simpler read-only ADT tool in a separate repo** (not LISA, not in-tree) — see Q-E. | ✅ approved (changed) |
+
+---
+
+## 12. Recommended next step
+
+A single **Phase 0 + Phase 1** PR (public boundary marked `@experimental` + typed registry + the `lock`/`unlock` and `elicit`/`notify`/`sampling` additions + one converted built-in + tests), behind a flag, **additive-only**. Then a focused **Phase 2** PR (local JS loader), and the **scoped manifest tier** (§8) as a fast-follow within v1. Build a **simple read-only reference plugin in a separate repo** (§13 Q-E) as the dogfood test. Everything in §9.3 stays out of scope.
+
+---
+
+## 13. Open questions (updated 2026-06-17 — round 3)
+
+**Resolved:** Q-A (any path; gated by SAP auth + scope/safety via `SafeHttpClient`); Q-C (external non-SAP → out); Q-E (reference plugin → 3 SAP-API styles); **Q-H** (`SafeHttpClient` wrapper → yes, additive, required); **Q-J** (generic `fetchCsrfToken(path?)` → yes, additive); **Q-L** (path allowlists → none; gates are SAP auth + scope/safety); **authz model** (reuse the 7 scopes; no custom scopes — §6.4); **core blast radius** (one refactor — §9.4).
+
+| # | Question | Recommendation | Status |
+|---|---|---|---|
+| Q-B | Manifest scope — read-only GET + simple POST, path-against-client; writes code-tier; named-action vocab = v2. | Confirm (§8). | ⏳ |
+| Q-D | Versioning fuse — a single `apiVersion: N` integer despite experimental/breakable? | Yes — a fuse, not a stability commitment. | ⏳ |
+| Q-F | Manifest + code tier both in v1 — roughly doubles the loader surface. | Yes, as a fast-follow (code tier first). | ⏳ |
+| Q-G | Reference plugin repo + naming. | `marianfoo/arc1-plugin-example`; `arc1-plugin-<name>`. | ⏳ (default) |
+| Q-I | opType mapping — default method→opType; tool's declared `policy.opType` overrides. | Declared opType authoritative; method = cross-check. | ⏳ |
+| Q-K | Package-gating limit — `allowedPackages` can't constrain OData/ICF (no package). | Accept as a documented limitation. | ⏳ |
+| **Q-N** | **Authz model confirm** — reuse the 7 scopes + allow\* ceiling for extension tools; custom scopes deferred (XSUAA blocker); per-plugin visibility-label = future. | Confirm. | ⏳ confirm |
+| **Q-M** | **Reference plugin endpoints (a4h)** — (1) ADT: package contents / program read ✅; (2) OData: **`ZGWSAMPLE_BASIC`** (EPM demo, present on a4h) ✅; (3) non-ADT/non-OData: **open** (see Q-O). | Use `ZGWSAMPLE_BASIC` for OData. | ⏳ |
+| **Q-O** | **Third (non-ADT/non-OData) endpoint** — `/sap/public/info` is inactive and `/sap/bc/ping` is 403 on a4h. Options: activate `/sap/bc/ping`, use a SOAP service (`/sap/bc/srt/…`), or point me to an existing custom ICF REST on a4h. | I can probe a4h further for a reachable one. | ⏳ needs input |

--- a/docs/research/extension-framework-spec.md
+++ b/docs/research/extension-framework-spec.md
@@ -279,7 +279,15 @@ PR1 ships and **bakes one release** before PR3 (the loader) makes plugins real.
 
 ## 13. v2 roadmap (deferred)
 
-Named code-backed operation vocabulary for declarative writes; observer hook bus (`onToolCall`/`onToolResult`); `withRetryOnSessionExpiry`; cache-invalidation hooks; multi-system `sap_system_id` (FEAT-59); MCP prompts (FEAT-62); dassian-adt gap absorption; pre-declared `custom.<plugin>` visibility labels; (maybe) npm peer-package discovery; API stabilization + semver if it graduates from experimental.
+**→ Full draft: [`extension-framework-v2-spec.md`](extension-framework-v2-spec.md).** It scopes every
+deferral with a design + PR sequence. Headline items: the **package-aware write surface** (`ctx.write`
+vocabulary routing through the built-in `write/` path so ADT writes stay package-gated; raw non-ADT
+writes behind an opt-in) — the centerpiece, since v1 is read-only; a **safe `ctx.cache`** facade
+(cacheSecurity-bound, no PP leak); **directory + npm-specifier loading**; **`package.json#arc1.requires`**
+ceiling intersection; **`http_request` pluginName** tag; a **per-handler timeout + `ctx.signal`**
+(review N4); custom `custom.<plugin>` visibility labels; an observer hook bus
+(`onToolCall`/`onToolResult`/`onCacheInvalidate`); multi-system `sap_system_id` (FEAT-59); MCP prompts
+(FEAT-62); and **API stabilization + semver** (graduate from `@experimental`).
 
 ---
 

--- a/docs/research/extension-framework-spec.md
+++ b/docs/research/extension-framework-spec.md
@@ -12,7 +12,7 @@
 > - **`ctx.cache` is removed** from the public `ToolContext` for v1: the raw `CachingLayer` exposed cache-only source/where-used reads that bypass the per-user `cacheSecurity` revalidation (PP cross-user leak class). A safe per-user cache facade is a v2 item.
 > - **`availableOn` is enforced** in `tools/list` against the resolved system type (was inert metadata). **`pluginName`** now rides `tool_call_start`/`tool_call_end` audit events; the `http_request`-level `pluginName` tag (§5.4/§9) is deferred — `ctx.http` calls are still logged via the underlying `http_request` event, just untagged.
 > - **Loader handles `.js` + `.json` only.** Single-directory (`package.json#main`) loading and `package.json#arc1.requires` ceiling-intersection (§3.1/§6/§7) are deferred to **v2** — not implemented in v1. The ceiling already constrains every call via scope + `checkOperation`, so `requires` would only be a redundant narrowing.
-> - **Plugin tools are excluded from hyperfocused `tools/list`** (matches §1 "hyperfocused participation out of scope").
+> - **Plugin tools are excluded from hyperfocused mode** — both hidden from `tools/list` AND refused at dispatch (a client that knows a `Custom_` name still gets "Unknown tool"), matching §1 "hyperfocused participation out of scope".
 
 ---
 

--- a/docs/research/extension-framework-spec.md
+++ b/docs/research/extension-framework-spec.md
@@ -1,0 +1,314 @@
+# ARC-1 Extension Framework — v1 Specification (FEAT-61)
+
+> **Status:** ✅ **IMPLEMENTED 2026-06-17** — PR1–PR5 + loader / `package.json#exports` / CLI + the `create-arc1-extension` skill; full unit suite green (3620) and **live-verified on a4h** (code + manifest tiers return real SAP source). Deferred (documented): plugin writes (lock/unlock/CSRF) + the 3rd reference endpoint (Q-O). Derived from [`extension-framework-deep-research.md`](extension-framework-deep-research.md); retained as the design reference.
+> **Stability:** The plugin API is **`@experimental` — it may break in any release.** A single `apiVersion` integer is the only compatibility fuse.
+> **Date:** 2026-06-17. Tracks roadmap FEAT-61, issues #187 / #332.
+> **Review:** adversarial review (2026-06-17) — 1 blocker (B1, fixed inline in §2) + integration/signature clarifications in **§16**. Address §16 before PR1.
+
+---
+
+## 1. Scope
+
+**v1 ships:** a typed `ToolRegistry`; a public API boundary (`arc-1/public`); local **trusted JS plugins** loaded via `ARC1_PLUGINS=`; a scoped **read-only declarative manifest tier**; `Custom_*` tools that inherit ARC-1's whole gateway (per-user PP, the 7-scope + allow\* ceiling, audit). Additive-only.
+
+**Out of scope (v1):** replacing built-in tools; custom/dynamic scopes; hyperfocused participation; framework-managed ABAP deployment; non-SAP egress; sandboxing; marketplace; hot-reload; manifest **writes**. (See research §9.3.)
+
+**Authorization model:** extension tools reuse the existing 7 scopes (`read`/`write`/`data`/`sql`/`transports`/`git`/`admin`) + the allow\* ceiling. No custom scopes (XSUAA `xs-security.json` is deploy-time static — research §6.4).
+
+**Egress model:** plugins call **any SAP HTTP path** (ADT/OData/ICF) via the gated `ctx.http`. No path allowlists. Gates = per-user SAP auth + ARC-1 scope/safety. External/non-SAP = no `ctx.fetch`.
+
+---
+
+## 2. Public API — `arc-1/public` (the surface plugins import)
+
+A new stable-ish entry exported via `package.json#exports`. All types re-exported from existing internal modules; **no behavior moves**, only a curated re-export path.
+
+```ts
+// arc-1/public
+export function defineTool(def: ToolDefinition): ToolDefinition;   // identity + dev-time validation
+
+export type Scope = 'read' | 'write' | 'data' | 'sql' | 'transports' | 'git' | 'admin';
+export { OperationType } from '../adt/safety.js';                  // R/S/Q/F/C/U/D/A/T/L/I/W/X
+
+export interface ToolDefinition {
+  name: `Custom_${string}`;                                        // reserved namespace; collisions fail-fast at load
+  description: string;
+  schema: ZodTypeAny;                                              // input validation (Zod v4)
+  policy: { scope: Scope; opType: OperationType };                 // REQUIRED — gates exactly like a built-in
+  availableOn?: 'all' | 'onprem' | 'btp';                          // default 'all'
+  handler(args: unknown, ctx: ToolContext): Promise<ToolResult>;
+}
+
+export interface ToolContext {
+  readonly client: ReadOnlyAdtClient;  // high-level reads ONLY; `.http` DELIBERATELY OMITTED (review B1, §16) — else a
+                                       //   plugin could reach the ungated raw client. ReadOnlyAdtClient = Pick<AdtClient, …reads>.
+  readonly http: SafeHttpClient;       // the ONLY HTTP path — gated, ANY SAP path (ADT/OData/ICF). Raw AdtHttpClient never exposed.
+  readonly safety: SafetyConfig;       // READ-ONLY snapshot
+  readonly cache?: CachingLayer;
+  readonly logger: Logger;             // stderr only
+  readonly config: PublicServerConfig; // redacted, read-only
+  readonly authInfo?: AuthInfo;        // userName, scopes, clientId — NO raw JWT
+  readonly requestId: string;
+  // optional, capability-detected:
+  readonly elicit?:   (p: ElicitParams) => Promise<ElicitResult>;
+  readonly notify?:   (lvl: 'info'|'warning'|'error', msg: string) => Promise<void>;
+  readonly sampling?: (sys: string, user: string, maxTokens?: number) => Promise<string>;
+}
+
+export interface SafeHttpClient {                                  // every method gates + audits (see §5)
+  get(path: string, headers?: Record<string,string>): Promise<AdtResponse>;
+  head(path: string, headers?: Record<string,string>): Promise<AdtResponse>;
+  post(path: string, body?: string, contentType?: string, headers?: Record<string,string>): Promise<AdtResponse>;
+  put(path: string, body: string, contentType?: string, headers?: Record<string,string>): Promise<AdtResponse>;
+  delete(path: string, headers?: Record<string,string>): Promise<AdtResponse>;
+  fetchCsrfToken(path?: string): Promise<string>;                 // generic; default = /sap/bc/adt/core/discovery
+  withStatefulSession<T>(fn: (s: SafeHttpClient) => Promise<T>): Promise<T>;
+}
+
+export interface AdtResponse { statusCode: number; headers: Record<string,string>; body: string; }  // NB: statusCode (not status) — matches src/adt/http.ts:152
+
+export type ToolResult = { content: Array<{ type: 'text'; text: string }>; isError?: boolean };
+
+// errors
+export { AdtApiError, AdtSafetyError, AdtNetworkError } from '../adt/errors.js';
+// testing entry: arc-1/public/testing → createMockToolContext(overrides?) for unit-testing a plugin with no live SAP
+```
+
+---
+
+## 3. Plugin package shape
+
+A plugin is an npm package (pure TypeScript, **no ABAP**) loaded by absolute path.
+
+```jsonc
+// package.json
+{
+  "name": "arc1-plugin-<name>",
+  "type": "module",
+  "peerDependencies": { "arc-1": ">=<min>" },     // floor only; experimental
+  "arc1": {
+    "apiVersion": 1,                               // compatibility fuse; host rejects mismatch at load
+    "requires": { "scopes": ["read"], "packages": [] }  // declared capability — intersected w/ ceiling, never expands
+  }
+}
+```
+
+```ts
+// the module default export
+import type { Plugin } from 'arc-1/public';
+export default {
+  name: 'arc-1-extension-sample',
+  version: '0.0.1',
+  apiVersion: 1,
+  tools: [ /* ToolDefinition[] from defineTool(...) */ ],
+  manifests: [ /* optional: paths to *.tool.json declarative tools */ ],
+} satisfies Plugin;
+```
+
+Loaded by **local path** (`.js` / `.json` / directory) via `ARC1_PLUGINS=` — see §7. Not npm.
+
+### 3.1 What the developer defines (code vs manifest)
+
+**Code tier** — `defineTool`, full power (logic, writes, multi-step):
+
+| Field | Req? | Notes |
+|---|---|---|
+| `name` | ✅ | `Custom_*` |
+| `description` | ✅ | shown to the LLM |
+| `schema` | ✅ | Zod → converted to JSON-Schema for `tools/list` |
+| `policy.scope` | ✅ | one of the 7 scopes |
+| `policy.opType` | ✅ | gates via `checkOperation` |
+| `handler(args, ctx)` | ✅ | the code; uses `ctx.http` (any SAP path) / `ctx.client` reads |
+| `availableOn` | — | `all` (default) / `onprem` / `btp` |
+
+…plus the module's default export `Plugin { name, version, apiVersion, tools[], manifests?[] }` and `package.json#arc1 { apiVersion, requires:{scopes,packages} }` (declared capability, intersected with the ceiling).
+
+**Manifest tier** — `*.tool.json`, **no code** (one gated HTTP call; read-only + simple POST):
+
+| Field | Req? | Notes |
+|---|---|---|
+| `name` | ✅ | `Custom_*` |
+| `description` | ✅ | |
+| `scope` | ✅ | one of the 7 scopes |
+| `opType` | — | default = method→opType; declare to override (e.g. an OData function-import POST = Read) |
+| `inputSchema` | ✅ | JSON Schema, `additionalProperties:false` |
+| `request.method` | ✅ | GET or simple stateless POST (v1) |
+| `request.path` | ✅ | fixed template against the authed client (no host) |
+| `request.{pathParams,query,headers,accept,body}` | — | bindings (`$.field`); omit-if-absent |
+| `response.{extract,maxBytes}` | — | optional select / truncate |
+
+**The line:** need *logic, a write sequence, or response shaping* → **code tier**. Just *wrapping one read endpoint* → **manifest tier** (no code, statically checkable against the ceiling). Both produce a `Custom_*` tool gated identically.
+
+---
+
+## 4. ToolRegistry (the one CORE change)
+
+```ts
+interface RegistryEntry {
+  name: string;
+  source: 'builtin' | 'plugin';
+  pluginName?: string;
+  policy: { scope: Scope; opType: OperationType; featureGate?: FeatureGate };
+  invoke(args: unknown, ctx: ToolContext): Promise<ToolResult>;
+}
+interface ToolRegistry {
+  register(e: RegistryEntry): void;   // throws: duplicate name; non-Custom_ plugin name; missing policy
+  get(name: string): RegistryEntry | undefined;
+  list(): RegistryEntry[];            // built-ins first (registration order), then plugins
+}
+```
+
+- The 12 built-ins register at startup in `createAndStartServer()`.
+- `handleToolCall`'s `switch(toolName)` (src/handlers/intent.ts ~:1264) becomes `registry.get(toolName)?.invoke(args, ctx)`.
+- **Collision policy:** a plugin tool whose name already exists → **fail-fast at load** (server refuses to start). `Custom_` prefix required for plugin tools; built-ins keep `SAP*`.
+- `getActionPolicy` gains a registry fallback; `scripts/validate-action-policy.ts` walks the registry too.
+
+---
+
+## 5. SafeHttpClient (additive — closes the raw-`http.*` safety gap)
+
+Wraps the per-user `AdtHttpClient`. On **every** call:
+
+1. **opType** = the tool's declared `policy.opType` (authoritative); if a tool exposes multiple HTTP verbs, the default method→opType map (GET/HEAD→Read, POST→Create, PUT→Update, DELETE→Delete) is a sanity cross-check that must not exceed the declared scope.
+2. `checkOperation(safety, opType, 'Custom:<tool>')` — throws `AdtSafetyError` if the ceiling blocks it.
+3. delegate to `AdtHttpClient.<method>` (inherits CSRF/cookies/PP/session/semaphore/MIME — all path-agnostic).
+4. audit `http_request` with `pluginName` + `requestId`.
+
+**`fetchCsrfToken(path?)`**: parameterizes the currently-hardcoded `/sap/bc/adt/core/discovery` fetch so OData/ICF **writes** can fetch the token against the service path. Existing internal callers pass nothing → unchanged behavior.
+
+**Non-ADT gating note (documented limitation):** `allowedPackages` cannot constrain OData/ICF calls (no ABAP package in the path). For non-ADT writes the gates are `allowWrites` + scope + `denyActions` + SAP-side auth. ADT object writes still get `checkPackage`.
+
+---
+
+## 6. Authorization (reuse the 7 scopes)
+
+- A plugin tool's `policy.scope` is registered alongside the tool; `getActionPolicy(toolName)` returns it; `hasRequiredScope(authInfo.scopes, policy.scope)` gates the user (with `admin⊇all`, `write⊇read`, `sql⊇data` implications).
+- The safety ceiling + `deriveUserSafety` (tightest-side-wins) applies via `SafeHttpClient`/`checkOperation`.
+- `tools/list` pruning (`filterToolsByAuthScope`) already reads policy → plugin tools prune per-user automatically.
+- `package.json#arc1.requires` is **intersected** with the server ceiling at load (never expands); a plugin requiring `write` on a read-only server loads but its write tools are inert/hidden.
+- **No custom scopes.** (Future: optional pre-declared `custom.<plugin>` visibility label — not v1.)
+
+---
+
+## 7. Loading model (`ARC1_PLUGINS`) — local files, NOT npm
+
+A plugin is loaded from a **local path** the admin lists in `ARC1_PLUGINS` (CSV) → `ServerConfig.plugins`. **No `npm publish`/`npm install` is required** — npm-package discovery is a deferred Phase-4 convenience (research §9.2), never the v1 path. Three entry forms, auto-detected:
+
+| `ARC1_PLUGINS` entry | Kind | Loads |
+|---|---|---|
+| `/abs/…/dist/index.js` | **code plugin** | `import()` the module → its default-export `Plugin` (`tools[]` + optional `manifests[]`) |
+| `/abs/…/Custom_Foo.tool.json` | **manifest plugin** | the manifest interpreter (§8) → a synthetic tool. **No JS.** The pure-declarative #332 case. |
+| `/abs/…/plugin-dir` | **directory** | resolves the dir's `package.json#main` (code), which may reference `*.tool.json` via `manifests[]` (paths relative to the plugin) |
+
+At startup, per entry: assert absolute + readable + not world-writable + same owner as the process; load by kind; validate shape + `apiVersion`; register each tool into the registry; **fail-fast** (refuse to start) on any malformed plugin or name collision. Runs after built-ins are registered. Stdio + HTTP both supported.
+
+**Deferred (v2+):** npm peer-package discovery (`ARC1_PLUGINS=arc1-plugin-foo`, resolved from `node_modules`, CAP-style); directory auto-scan. Explicit paths are preferred for auditability (research §3.4).
+
+---
+
+## 8. Manifest tier (declarative, read-only — scoped)
+
+A `*.tool.json` manifest → a synthetic `ToolDefinition`. Interpreter is a pure function: validate args → render template → one `ctx.http` call → optional select/truncate.
+
+```jsonc
+{
+  "name": "Custom_ReadProgram",
+  "description": "Read an ABAP program's source.",
+  "scope": "read",
+  "inputSchema": { "type":"object", "additionalProperties":false,
+    "required":["name"], "properties":{ "name":{"type":"string","pattern":"^[A-Za-z0-9_/]{1,40}$"} } },
+  "request": {
+    "method": "GET",                                   // v1: GET + simple stateless POST only
+    "path": "/sap/bc/adt/programs/programs/{name}/source/main",
+    "pathParams": { "name": "$.name" },                // each segment: validate → percent-encode
+    "query": {},                                       // omit-if-absent; repeated-key array default
+    "accept": "text/plain"
+  },
+  "response": { "maxBytes": 50000 }                    // optional "extract": "$.jsonpath" (v1.1)
+}
+```
+
+**Interpreter MUST enforce** (research §8.1): fixed base URL = the authed client (reject URL-shaped values → no SSRF); per-segment canonicalize→allowlist→reject `..`/`/`/encoded-equivalents→percent-encode; CR/LF/NUL-reject + header allowlist (no `Host`/`Authorization`/`Cookie`/`X-CSRF-Token`/session headers); structural JSON body (no string interpolation); `additionalProperties:false`; route through `checkOperation` + scope + audit. **Lock-aware writes are NOT expressible** — they stay code-tier (v2 may add a named code-backed op vocabulary).
+
+---
+
+## 9. Audit
+
+Add optional `pluginName?: string` to `ToolCallStartEvent`/`ToolCallEndEvent`/`http_request`. Emitted when the tool is plugin-sourced. Framework still owns the bracketing; plugins never emit `tool_call_*`.
+
+---
+
+## 10. Implementation plan — PR sequence
+
+| PR | Content | Core? | Risk |
+|----|---------|-------|------|
+| **PR1** | **No-op registry refactor**: `ToolRegistry`; register 12 built-ins; replace the `switch`; introduce `ToolContext` and convert built-ins to `(args, ctx)`. **No plugin-facing change; all existing tests green.** | CORE | HIGH (isolated; tests are the net) |
+| **PR2** | Public boundary `src/public/` + `package.json#exports`; `defineTool`; `SafeHttpClient`; `fetchCsrfToken(path?)`; `lock`/`unlock` on `AdtClient`; audit `pluginName`; `arc-1/public/testing` mocks. | additive | LOW |
+| **PR3** | Loader (`ARC1_PLUGINS`) + config; capability declaration + ceiling intersection; registry-aware `validate-action-policy`. | additive | LOW |
+| **PR4** | Manifest tier (interpreter + grammar + security). | additive | LOW |
+| **PR5** | `ToolContext` `elicit`/`notify`/`sampling` threading. | both (light) | MED |
+
+PR1 ships and **bakes one release** before PR3 (the loader) makes plugins real.
+
+---
+
+## 11. Core vs additive (file-level)
+
+**CORE (modify existing):** `src/handlers/intent.ts` (switch→registry, ToolContext build), `src/server/server.ts` (register built-ins, loader call), `src/adt/http.ts` (`fetchCsrfToken(path?)` — backward-compatible optional param). **Light:** `src/authz/policy.ts` (registry fallback in `getActionPolicy`), `src/server/audit.ts` (optional field), `scripts/validate-action-policy.ts` (walk registry), `src/server/{config,types}.ts` (plugins field).
+
+**ADDITIVE (new files):** `src/registry/tool-registry.ts`, `src/public/index.ts` + `src/public/testing.ts`, `src/server/safe-http-client.ts`, `src/server/plugin-loader.ts`, `src/plugins/manifest-interpreter.ts` + `src/plugins/types.ts`. **Plus** new `AdtClient.lock/unlock` methods delegating to `crud.ts`.
+
+---
+
+## 12. Testing
+
+- Unit: registry (collision, missing-policy reject, `Custom_` prefix, built-ins-first order); SafeHttpClient (method→opType gate, `checkOperation` blocks write when `allowWrites=false`, audit carries pluginName); manifest interpreter (path-traversal reject, header-injection reject, SSRF reject, omit-if-absent, percent-encode); loader (file-permission checks, apiVersion mismatch, malformed shape → fail-fast); scope pruning of plugin tools.
+- Integration (live SAP): the sample plugin's ADT + OData reads end-to-end.
+- The `arc-1/public/testing` mock `ToolContext` lets plugin authors unit-test with no live SAP.
+
+---
+
+## 13. v2 roadmap (deferred)
+
+Named code-backed operation vocabulary for declarative writes; observer hook bus (`onToolCall`/`onToolResult`); `withRetryOnSessionExpiry`; cache-invalidation hooks; multi-system `sap_system_id` (FEAT-59); MCP prompts (FEAT-62); dassian-adt gap absorption; pre-declared `custom.<plugin>` visibility labels; (maybe) npm peer-package discovery; API stabilization + semver if it graduates from experimental.
+
+---
+
+## 14. Open items
+
+**All confirmed 2026-06-17** — Q-B (manifest scope), Q-D (`apiVersion` fuse), Q-F (manifest fast-follow), Q-G (`arc1-plugin-*` naming), Q-I (opType override), Q-K (package-gating limitation), Q-N (authz model). **Only open:** Q-O — the third (non-ADT/non-OData) reference-plugin endpoint, deferred (the sample ships ADT + OData now).
+
+---
+
+## 15. Reference plugin
+
+`arc-1-extension-sample` (separate repo / DEV playground at `~/dev/arc-1-extension-sample`) — pure TS, demonstrates: an **ADT** read tool, an **OData** read tool (`ZGWSAMPLE_BASIC`), a **manifest** example, and (later) a non-ADT/non-OData tool. Doubles as the dogfood + the `ARC1_PLUGINS` smoke test once PR1–PR3 land. (Review confirmed it uses `ctx.http`, not the B1 bypass.)
+
+---
+
+## 16. Review corrections (round 1 — 2026-06-17 adversarial review)
+
+An adversarial review against the live codebase found **one blocker (B1, fixed inline in §2)** + integration/signature clarifications. Authoritative resolutions (address before/within the noted PR):
+
+- **B1 — raw-client bypass (FIXED §2).** `AdtClient.http` is a public `readonly` field (`src/adt/client.ts:266`, re-attached by `withSafety` `:324`). Exposing the full `AdtClient` on `ToolContext` would let a plugin call `ctx.client.http.post(...)` → the **ungated** raw client → bypass `allowWrites`/`denyActions`/package gates. **Resolution:** `ToolContext.client` is a narrowed **`ReadOnlyAdtClient`** (a `Pick<AdtClient, …read methods>` interface in `src/public/`) with **no `.http`**. All HTTP goes through the gated `ctx.http`. (The research-doc §4.1 sample showing `ctx.client.http` is superseded.)
+- **B2/S3 — registry ↔ policy ↔ validator ↔ listing.** (1) Plugin policy lives in the **registry only**, never in `ACTION_POLICY`. (2) `getActionPolicy(name)` gains a registry fallback for **runtime** checks, but `scripts/validate-action-policy.ts` (a regex scan over `schemas.ts:20`) stays **built-ins-only** and must NOT enumerate registry keys (Pass 2 `:90-110` would flag `Custom_*` as dead). (3) Plugin tools are **flat** (no action/type enum), so `tools/list` pruning uses the **tool-level** `getActionPolicy('Custom_X')` (`server.ts:114`) = the registry fallback. (4) `getToolDefinitions` (`tools.ts:578`) must merge registry plugin defs into the listed array.
+- **S4 — `ToolDefinition` collision + Zod→JSON-Schema.** Internal `ToolDefinition` (`tools.ts:24`, `inputSchema: JSONSchema`) ≠ the plugin-facing one (`schema: Zod`, `policy`, `handler`). Name the plugin type **`PluginToolDefinition`** internally; `defineTool` returns it; the registry **adapter** converts Zod `schema` → JSON-Schema `inputSchema` for listing (**new dep:** `zod-to-json-schema` or the MCP SDK converter — PR1 keeps the manual `ListToolsRequestSchema` path, so nothing converts it for free).
+- **S6 — per-request `ToolContext`.** Registry is built once at startup; **context is built per call** in `handleToolCall` from the request's `effectiveClient` (the per-user `withSafety()` clone, `server.ts:689`), `authInfo`, `requestId`, `cachingLayer` (threaded separately — NOT a client field), `_server`. `invoke(args, ctx)` gets that per-request ctx; never bind it at registration.
+- **S7 — `withSafety()` clone footgun.** `withSafety()` uses `Object.create()` (bypasses the constructor, `client.ts:318`); any **new `AdtClient` field** must be re-attached there (regression #333). `lock`/`unlock` are prototype methods (safe). PR2: if anything adds a client field, extend the reattach block + add a clone test.
+- **S1 — `fetchCsrfToken`.** Real signature is `(): Promise<void>` storing on `this.csrfToken` (`http.ts:846`). The spec's `(path?): Promise<string>` is a **new contract** (param + return), backward-compatible for internal callers. OData/ICF **writes** also need the token + session cookie bound to the **same** session — require `withStatefulSession` (`http.ts:256`); document for write plugins.
+- **S2 — `AdtResponse.statusCode`** (not `status`) — fixed in §2 + the sample stub.
+- **S5 — split PR5.** `elicit` is light (`src/server/elicit.ts:59`; `_server` already threaded `intent.ts:1090`). `notify`/`sampling` are **new** (no `sendLoggingMessage`/`createMessage` plumbing) + need client capability detection (`server.getClientCapabilities()`). **PR5a = elicit; PR5b = notify/sampling.**
+- **N1 — preserve hyperfocused.** PR1 must keep the `SAP` recursive case (`intent.ts:1301`, re-enters `handleToolCall` with the mapped tool); add a test.
+- **N2 — enforce `availableOn`.** Filter at listing/registration against `config.systemType` (`isBtpMode`, `server.ts:582`) — else it's inert metadata.
+- **N4 — no bounded timeout exists.** `handleToolCall`'s try/catch contains *throws*, not *hangs*; a hung plugin holds a semaphore slot. **Add a per-handler timeout in PR3** (or drop the "bounded timeout" claim).
+
+---
+
+## 17. Developer-guidance skill (built LAST — after implementation + tests)
+
+A Claude Code **skill** that guides a developer through creating an ARC-1 extension end-to-end:
+1. **Asks the key architecture-decision questions** — same SAP system (→ extension) or different (→ own server)? code tier or manifest tier? which SAP API (ADT/OData/ICF)? read or write? which scope + opType? ships its own pre-installed ABAP endpoint or uses existing?
+2. **Scaffolds** the plugin from the answers (the `arc-1-extension-sample` layout — `defineTool`/manifest, `package.json#arc1`, README), and
+3. **Walks setup** — build, `ARC1_PLUGINS=`, load, verify in `tools/list`, test against a system.
+
+**Built last, deliberately** — so it encodes the real learnings from implementing the framework + the sample (gotchas, the CSRF/OData caveat, the scope mapping, the manifest grammar edges). **Research how to build it** (skill structure, the question flow via `AskUserQuestion`, the scaffold templates, mirroring `skill-creator`/`implement-feature` conventions) happens **after the tests pass**. Final deliverable; not in any PR1–PR5.

--- a/docs/research/extension-framework-spec.md
+++ b/docs/research/extension-framework-spec.md
@@ -5,6 +5,15 @@
 > **Date:** 2026-06-17. Tracks roadmap FEAT-61, issues #187 / #332.
 > **Review:** adversarial review (2026-06-17) — 1 blocker (B1, fixed inline in §2) + integration/signature clarifications in **§16**. Address §16 before PR1.
 
+> **Post-review hardening (2026-06-17, PR #454 — these supersede the design where they differ):**
+> A second adversarial (Codex) review of the implementation drove the following **v1 narrowings**, all conservative-by-default:
+> - **`ctx.http` is READ-ONLY (`GET`/`HEAD`).** `post/put/delete/withStatefulSession` are removed from the plugin surface for v1. Reason: a raw write can't be constrained by `SAP_ALLOWED_PACKAGES` (package resolution needs the ADT object-URL shape), so shipping un-package-gated writes would bypass the safety ceiling. The §5 "ADT object writes still get checkPackage" promise is deferred with the rest of writes to **v2** (a package-aware write vocabulary). This applies to BOTH tiers (the manifest tier was already GET-only — §8).
+> - **`ctx.client` read-only is enforced at RUNTIME**, not just by the `ReadOnlyAdtClient` type: `createReadOnlyAdtClient` wraps it in a Proxy that blocks `http`/`safety`/`withSafety`/package-mutators, so `(ctx.client as any).http` resolves to `undefined`. (Closes the residual half of B1 — a type-only narrowing was castable.)
+> - **`ctx.cache` is removed** from the public `ToolContext` for v1: the raw `CachingLayer` exposed cache-only source/where-used reads that bypass the per-user `cacheSecurity` revalidation (PP cross-user leak class). A safe per-user cache facade is a v2 item.
+> - **`availableOn` is enforced** in `tools/list` against the resolved system type (was inert metadata). **`pluginName`** now rides `tool_call_start`/`tool_call_end` audit events; the `http_request`-level `pluginName` tag (§5.4/§9) is deferred — `ctx.http` calls are still logged via the underlying `http_request` event, just untagged.
+> - **Loader handles `.js` + `.json` only.** Single-directory (`package.json#main`) loading and `package.json#arc1.requires` ceiling-intersection (§3.1/§6/§7) are deferred to **v2** — not implemented in v1. The ceiling already constrains every call via scope + `checkOperation`, so `requires` would only be a redundant narrowing.
+> - **Plugin tools are excluded from hyperfocused `tools/list`** (matches §1 "hyperfocused participation out of scope").
+
 ---
 
 ## 1. Scope

--- a/docs/research/extension-framework-v2-spec.md
+++ b/docs/research/extension-framework-v2-spec.md
@@ -1,0 +1,373 @@
+# ARC-1 Extension Framework — v2 Specification (FEAT-61, draft)
+
+> **Status:** 📝 **DRAFT / planning** — not implemented. Captures everything deferred from v1
+> (shipped in [PR #454](https://github.com/marianfoo/arc-1/pull/454)) so the work is scoped before
+> it starts. The v1 spec is [`extension-framework-spec.md`](extension-framework-spec.md); the
+> rationale is [`extension-framework-deep-research.md`](extension-framework-deep-research.md).
+> **Stability:** v1 is `@experimental` (one `apiVersion` integer fuse). v2's headline non-feature
+> is **API stabilization** — see §12.
+> **Date:** 2026-06-17. Tracks roadmap FEAT-61, issues #187 / #332.
+
+---
+
+## 0. Why a v2 — what v1 deliberately left out
+
+v1 shipped a **read-only**, conservatively-scoped framework. Every narrowing below was a safety
+choice made during the 2026-06-17 implementation review, not an oversight. v2 lifts them, in
+priority order:
+
+| # | Deferred from v1 | Why it was deferred | v2 section |
+|---|------------------|---------------------|-----------|
+| 1 | **Plugin writes** (`ctx.http` POST/PUT/DELETE) | A raw write can't be constrained by `SAP_ALLOWED_PACKAGES` (package resolution needs the ADT object-URL shape) → would bypass the safety ceiling | **§2** |
+| 2 | **Lock-aware writes** (lock → modify → unlock, CSRF, stateful session) | Not expressible declaratively; needs `lock`/`unlock` + `fetchCsrfToken(path?)` plumbing | §2.5 |
+| 3 | **Safe `ctx.cache`** | The raw `CachingLayer` bypassed per-user `cacheSecurity` revalidation (PP cross-user leak class) | §3 |
+| 4 | **Directory loading** (`ARC1_PLUGINS=/abs/plugin-dir`) | Node ESM dir-import needs `package.json#main` resolution; not worth it for a read-only v1 | §4.1 |
+| 5 | **npm package discovery** (`ARC1_PLUGINS=arc1-plugin-foo`) | Explicit local paths preferred for auditability in v1 | §4.2 |
+| 6 | **`package.json#arc1.requires`** (capability ↔ ceiling intersection) | The ceiling already constrains every call; `requires` would be a redundant (if nice) narrowing | §5 |
+| 7 | **`http_request` `pluginName` tag** | Needs `pluginName` threaded into the `AdtHttpClient` logging path | §6 |
+| 8 | **Per-handler timeout** (review item N4) | A hung plugin holds a semaphore slot; `handleToolCall`'s try/catch contains throws, not hangs | §7 |
+| 9 | **Custom visibility labels** (`custom.<plugin>`) | Scope reuse was enough for v1; labels are cosmetic grouping | §8 |
+| 10 | **Observer/hook bus** (`onToolCall`/`onToolResult`) | No consumer in v1 | §9 |
+| 11 | **Multi-system** (`sap_system_id`, FEAT-59) | Single connected system in v1 | §10 |
+| 12 | **MCP prompts** (FEAT-62) | Tools-only in v1 | §11 |
+
+**Still out of scope in v2** (see §14): replacing built-in tools; non-SAP egress (`ctx.fetch`);
+framework-managed ABAP deployment; sandboxing; a marketplace; hot-reload.
+
+---
+
+## 1. Scope of v2
+
+v2 makes plugins **write-capable without weakening any safety invariant**, stabilizes the public
+API, and fills the loader/observability gaps. The non-negotiable rule carries over from v1:
+
+> **A plugin can never do something a built-in tool of the same scope couldn't.** Every write must
+> pass `scope ∧ safety-ceiling ∧ SAP-auth`, AND ADT object writes must pass the **package
+> allowlist** — the exact gate built-in `SAPWrite` uses.
+
+`apiVersion` bumps **1 → 2**. v1 plugins (`apiVersion: 1`) keep loading unchanged (read-only). A
+plugin that wants the v2 write surface declares `apiVersion: 2`.
+
+---
+
+## 2. The write surface (the centerpiece)
+
+### 2.1 The problem v1 hit
+
+Built-in `SAPWrite` enforces `SAP_ALLOWED_PACKAGES` in `enforceAllowedPackageForObjectUrl`
+(`write-helpers.ts`) — it resolves the object's **real** package from the ADT object URL and checks
+it fail-closed. `checkOperation` (the only gate v1's `SafeHttpClient` ran) checks the `allow*`
+booleans but **never** the package allowlist. So a raw `ctx.http.post('/sap/bc/adt/oo/classes', …)`
+would create a class in **any** package, bypassing the allowlist. That's why v1 `ctx.http` is
+read-only.
+
+The hard part is that an arbitrary `post(path, body)` is **not classifiable**: it could be an ADT
+object create (package lives in the body), an ADT object update (package resolved from the URL), an
+ADT action (activation — no package), an OData function import (no ABAP package at all), or a custom
+ICF write. Package enforcement is well-defined only for the first two.
+
+### 2.2 Design — two paths, picked by what the call actually is
+
+**Path A — named write vocabulary (the safe default for ADT object writes).** Instead of a raw
+POST, the plugin calls typed operations that route through the **same** `write/` package the
+built-in `SAPWrite` uses, inheriting package enforcement, pre-write lint, master-language handling,
+and post-save syntax check for free:
+
+```ts
+// ctx.write — present only when the tool declares a write-family scope AND apiVersion >= 2
+interface PluginWriteOps {
+  createObject(spec: CreateObjectSpec): Promise<WriteResult>;   // → write/create.ts (package-gated)
+  updateSource(ref: ObjectRef, source: string): Promise<WriteResult>;  // → write/update-delete.ts
+  deleteObject(ref: ObjectRef): Promise<WriteResult>;
+  activate(refs: ObjectRef[]): Promise<ActivateResult>;
+  // lock/unlock are managed internally by each op (lock → modify → unlock), never hand-rolled.
+}
+```
+
+Every `ctx.write.*` call resolves the target package and runs `enforceAllowedPackageForObjectUrl`
+before mutating — identical to a built-in. A plugin **cannot** opt out. This is the recommended
+path for any ABAP object write.
+
+**Path B — gated raw writes for non-ADT paths only (opt-in escape hatch).** OData function-import
+POSTs and custom ICF writes have **no ABAP package**, so the package allowlist genuinely can't
+constrain them (documented limitation, v1 spec §5). For these, `ctx.http` regains
+`post/put/delete`, but:
+
+- gated by `checkOperation(safety, opType)` **+** the tool's declared scope **+** `denyActions`,
+- **refused for any `/sap/bc/adt/…` path** unless it is a known package-less ADT action
+  (e.g. activation) on an allowlist — ADT **object** writes MUST use Path A (so the package gate
+  can't be skipped),
+- behind a new server opt-in `SAP_ALLOW_PLUGIN_RAW_WRITES` (default **false**) AND `allowWrites`,
+- audited with the full path + `pluginName`.
+
+On BTP the **Cloud Connector resource allowlist** is the backstop for raw non-ADT writes; on-prem
+the gate is `allowWrites` + scope + `denyActions` + SAP-side auth. This is spelled out so an admin
+enabling it understands exactly what is and isn't constrained.
+
+### 2.3 `ctx.http` write gating summary (v2)
+
+| Call | Path class | Gate |
+|------|-----------|------|
+| `ctx.write.createObject/updateSource/deleteObject` | ADT object | scope + `allowWrites` + **package allowlist** + lint (= built-in `SAPWrite`) |
+| `ctx.http.post` to OData/ICF | non-ADT | scope + `allowWrites` + `denyActions` + `SAP_ALLOW_PLUGIN_RAW_WRITES` + CC allowlist (BTP) |
+| `ctx.http.post` to `/sap/bc/adt/<object>` | ADT object | **refused** — must use `ctx.write` |
+| `ctx.http.post` to a package-less ADT action (e.g. activation) | ADT action | scope + `allowWrites` + action allowlist |
+
+### 2.4 CSRF + sessions for writes
+
+OData/ICF writes need a CSRF token fetched against the **service path** (not the hardcoded
+`/sap/bc/adt/core/discovery`) and bound to the **same** stateful session as the write. v2 ships:
+
+- **`fetchCsrfToken(path?)`** on `AdtHttpClient` — parameterizes the currently-hardcoded discovery
+  fetch (v1 spec §5 / review S1). Backward-compatible: existing internal callers pass nothing.
+- **`ctx.http.withStatefulSession(fn)`** returns to the plugin surface (removed in v1), but the
+  session it hands back is itself write-gated per §2.3.
+
+### 2.5 Lock-aware ADT writes
+
+`ctx.write.*` ops own the lock→modify→unlock dance internally using **`AdtClient.lock`/`unlock`**
+(prototype methods — safe for the `withSafety()` `Object.create` clone, review S7). Plugins never
+hold a raw lock handle. A failed unlock is logged and the lock left to SAP's timeout, same as the
+built-in path.
+
+### 2.6 Manifest-tier writes
+
+Manifests stay **mostly** read-only. v2 adds exactly one declarative write form — a **named op
+reference**, not a raw POST:
+
+```jsonc
+{ "name": "Custom_Activate", "scope": "write", "op": "activate",
+  "inputSchema": { … }, "bind": { "refs": "$.objects" } }
+```
+
+`op` selects a vocabulary entry from §2.2 Path A; the interpreter binds args → the typed op → the
+package-gated write path. Free-form declarative POSTs remain **un-expressible** (they'd reintroduce
+the §2.1 classification problem). Simple stateless OData function-import POSTs (semantically reads,
+`opType: 'R'` override) are the one raw-POST manifest form, behind `SAP_ALLOW_PLUGIN_RAW_WRITES`.
+
+---
+
+## 3. Safe `ctx.cache`
+
+v1 removed `ctx.cache` because the raw `CachingLayer` exposes cache-only `getSource`/where-used
+reads that skip the per-user `cacheSecurity` revalidation — under principal propagation, user A
+could read user B's cached source. v2 reintroduces a **narrowed, per-user facade**:
+
+```ts
+interface PluginCache {
+  // Read-through ONLY: a miss (or a cacheSecurity revalidation failure) falls back to a live,
+  // per-user-authorized fetch — never returns another user's cached bytes.
+  getSource(ref: ObjectRef): Promise<string>;
+  // No raw cache-only accessors; no cross-user keys; no write/invalidate (framework owns those).
+}
+```
+
+The facade is constructed from the **same `cacheSecurity` context** threaded into built-in
+`SAPRead` (`buildCacheSecurityContext`), so isolation is identical-by-construction. Cache
+**invalidation hooks** (a plugin reacting to a write it made) are a separate, later item (§9).
+
+---
+
+## 4. Loading model additions
+
+### 4.1 Directory entries
+
+`ARC1_PLUGINS=/abs/plugin-dir` resolves `dir/package.json` → `exports['.']` ?? `main` ?? `index.js`,
+then loads as a code plugin. Same fail-fast ownership/permission checks as a `.js` entry. (v1
+handles `.js` + `.json` only.)
+
+### 4.2 npm package discovery (CAP-style)
+
+`ARC1_PLUGINS=arc1-plugin-foo` (a bare specifier, no `/`) resolves from the server's `node_modules`
+via standard Node resolution, then loads the package's `arc1` entry. Naming convention
+`arc1-plugin-*` (or `@scope/arc1-plugin-*`). **Opt-in and auditable**: still an explicit allowlist
+entry, never auto-scanned. Directory auto-scan stays out (v1 spec §7).
+
+---
+
+## 5. `package.json#arc1.requires` — declared capability, intersected with the ceiling
+
+A plugin declares the scopes/packages it needs:
+
+```jsonc
+"arc1": { "apiVersion": 2, "requires": { "scopes": ["write"], "packages": ["Z*"] } }
+```
+
+At load, ARC-1 **intersects** this with the server ceiling — it can only **narrow**, never expand:
+
+- A plugin requiring `write` on a server with `allowWrites=false` → its write tools load but are
+  **inert/hidden** (pruned from `tools/list`, refused at dispatch), with a startup warning.
+- `requires.packages` further narrows the effective allowlist **for that plugin's writes** (a plugin
+  scoped to `Z*` can't write `Y*` even if the server allows `*`).
+- Reading `package.json#arc1` also unifies the `apiVersion` source: today the loader reads it from
+  the `Plugin` default export; v2 reads the package manifest for directory/npm entries and
+  cross-checks.
+
+This is **defense-in-depth**, not a new authority — the ceiling still wins. It earns its keep once
+writes exist (limiting blast radius per plugin).
+
+---
+
+## 6. Audit — `http_request` `pluginName`
+
+Thread `pluginName` (and `requestId`) into the `AdtHttpClient` logging path so **every** SAP call a
+plugin makes is attributable, not just the `tool_call_{start,end}` bracket (v1 ships the bracket;
+the per-request tag was deferred). Mechanism: a per-call context (AsyncLocalStorage already used by
+`requestContext`) carries `pluginName` into `emitAudit({ event: 'http_request', … })`. The field is
+already declared optional on `HttpRequestEvent` — v2 populates it.
+
+---
+
+## 7. Per-handler timeout (review N4)
+
+A hung plugin handler holds a `maxConcurrent` semaphore slot indefinitely (`handleToolCall`'s
+try/catch contains *throws*, not *hangs*). v2 adds:
+
+- **`ARC1_PLUGIN_TIMEOUT`** (default e.g. 60s) — wraps each plugin `invoke` in a timeout; on expiry
+  the call rejects with a typed `PluginTimeoutError`, the slot frees, and an audit event fires.
+- **`ctx.signal: AbortSignal`** — passed to the handler and wired into `ctx.http`/`ctx.write` so a
+  well-behaved plugin can cooperatively abort in-flight SAP requests.
+
+Applies to built-in handlers too (a strictly-better safety property), gated to avoid regressing
+legitimately-long operations (activation of a large batch) — the timeout is generous and
+configurable, `0` disables.
+
+---
+
+## 8. Custom visibility labels (`custom.<plugin>`)
+
+Optional, pre-declared, **cosmetic** grouping label surfaced in `tools/list`/diagnostics so an
+operator can see which plugin owns which `Custom_*` tool at a glance. **Not** an authorization
+primitive (scopes remain the only gate — no custom/dynamic scopes, ever, because XSUAA
+`xs-security.json` is deploy-time static). Strictly additive metadata.
+
+---
+
+## 9. Observer / hook bus
+
+A small, synchronous-ish hook surface a plugin can register (declared in the `Plugin` export, not
+per-tool):
+
+```ts
+interface PluginHooks {
+  onToolCall?(evt: { tool: string; args: unknown; user?: string }): void | Promise<void>;
+  onToolResult?(evt: { tool: string; ok: boolean; durationMs: number }): void | Promise<void>;
+  onCacheInvalidate?(ref: ObjectRef): void;   // pairs with §3 — react to a write
+}
+```
+
+Use cases: custom audit/metrics sinks, cache invalidation after a plugin write,
+`withRetryOnSessionExpiry` wrappers. Hooks are **observe-only** (can't mutate args/results in v2 —
+that's a v3 question) and are time-boxed by §7's timeout so a slow hook can't wedge the pipeline.
+
+---
+
+## 10. Multi-system (`sap_system_id`, FEAT-59)
+
+When ARC-1 fronts multiple SAP systems (FEAT-59), a plugin tool accepts/echoes a `sap_system_id` and
+`ctx.http`/`ctx.write` target that system's per-user client. Requires FEAT-59 to land first; the
+plugin surface change is small (the context already carries a resolved client — it just becomes
+system-scoped). Cross-system writes follow each system's own ceiling.
+
+---
+
+## 11. MCP prompts (FEAT-62)
+
+Let a plugin contribute **MCP prompts** (not just tools) — e.g. a guided "create a RAP service"
+prompt template. Declared in the `Plugin` export (`prompts?: PluginPrompt[]`), surfaced via the MCP
+`prompts/list` + `prompts/get` handlers, gated by scope like tools. Depends on FEAT-62 wiring the
+prompt handlers server-side.
+
+---
+
+## 12. API stabilization + semver (the headline non-feature)
+
+v2 is where the public API earns a stability promise:
+
+- Graduate `arc-1/public` from `@experimental` to **semver-stable**; `apiVersion: 2` becomes a
+  supported contract, not a "may break any release" fuse.
+- Document the **support window**: which `apiVersion`s a given ARC-1 release loads.
+- Freeze `ToolContext`, `defineTool`, `PluginToolDefinition`, the manifest grammar, and `ctx.write`.
+- Add **contract tests** that fail CI on any breaking change to the exported surface (mirrors the
+  tool-definition snapshot freeze from the v1 playbook).
+
+Until then v1 stays `@experimental` — a v1 plugin is expected to need a one-line `apiVersion` bump
++ possibly a small migration (§13) when v2 lands.
+
+---
+
+## 13. Migration from v1
+
+| v1 plugin uses… | v2 change |
+|------------------|-----------|
+| `apiVersion: 1`, read-only | **loads unchanged** — v2 keeps the v1 read surface verbatim |
+| wants writes | bump to `apiVersion: 2`; replace any intended raw `ctx.http.post` with `ctx.write.*` (ADT) or opt into `SAP_ALLOW_PLUGIN_RAW_WRITES` (OData/ICF) |
+| wants caching | adopt `ctx.cache` (the safe facade — new in v2) |
+| `package.json#arc1.requires` | now **enforced** (was inert in v1) — a too-broad `requires` may narrow the plugin's tools; tighten it |
+| relied on no timeout | a runaway handler now aborts at `ARC1_PLUGIN_TIMEOUT`; honor `ctx.signal` |
+
+No silent behavior change for a correct v1 read-only plugin.
+
+---
+
+## 14. Non-goals (still out in v2)
+
+- **Replacing/overriding built-in tools** — `Custom_*` namespace only; never shadow `SAP*`.
+- **Non-SAP egress** (`ctx.fetch` to arbitrary hosts) — build a separate MCP server on the BTP-auth
+  module for that. ARC-1 plugins talk to the **connected SAP system** only.
+- **Framework-managed ABAP deployment** — plugins still ship no ABAP; custom endpoints must already
+  exist on the system.
+- **Sandboxing / process isolation** — plugins are trusted local code an admin opts into; same
+  trust model as v1. (A real sandbox is a v3+ research item.)
+- **Marketplace / registry / hot-reload** — explicit `ARC1_PLUGINS` allowlist, restart to change.
+- **Result-mutating hooks** — v2 hooks observe only (§9).
+
+---
+
+## 15. Open questions (to resolve before v2 PR1)
+
+- **Q-v2-A — write vocabulary surface.** Exact `ctx.write` op set: just create/update/delete/activate,
+  or also rename/move (DEVC), transport assignment, RAP scaffolding? Start minimal (the four), grow
+  on demand.
+- **Q-v2-B — raw non-ADT writes: ship at all?** `SAP_ALLOW_PLUGIN_RAW_WRITES` is genuinely
+  package-unconstrained. Is the OData/ICF write use case strong enough, or defer to v2.1 and ship
+  only `ctx.write` (ADT) first?
+- **Q-v2-C — timeout default.** What value doesn't regress large-batch activation? Probe real
+  durations; consider per-scope defaults (reads short, writes long).
+- **Q-v2-D — `requires.packages` semantics.** Does it narrow the allowlist only for that plugin's
+  writes, or also filter which objects its reads can touch? (Reads are already PP-gated SAP-side.)
+- **Q-v2-E — hooks ordering/failure.** Multiple plugins with `onToolCall`: order? Does a throwing
+  hook fail the call or just log? (Lean: log + continue; never let an observer break the tool.)
+- **Q-v2-F — apiVersion negotiation.** Should ARC-1 load an `apiVersion: 1` plugin in a v2 server in
+  a strict "read-only compatibility" mode, or require a recompile? (Lean: load v1 read-only as-is.)
+
+---
+
+## 16. Implementation sketch — PR sequence
+
+| PR | Content | Risk |
+|----|---------|------|
+| **v2-PR1** | `ctx.write` vocabulary (create/update/delete/activate) routing through `write/` + package gate; `apiVersion: 2`; `AdtClient.lock/unlock` on the context path | HIGH (writes — adversarial-review each op against the built-in `SAPWrite` gate) |
+| **v2-PR2** | `fetchCsrfToken(path?)` + `ctx.http.withStatefulSession` (write-gated) + `SAP_ALLOW_PLUGIN_RAW_WRITES` for non-ADT | MED |
+| **v2-PR3** | Safe `ctx.cache` facade (cacheSecurity-bound) | MED |
+| **v2-PR4** | Loader: directory + npm-specifier resolution; `package.json#arc1.requires` intersection | LOW |
+| **v2-PR5** | `http_request` pluginName tag; per-handler timeout + `ctx.signal` | LOW |
+| **v2-PR6** | Custom visibility labels; observer hook bus | LOW |
+| **v2-PR7** | API stabilization: drop `@experimental`, contract-snapshot tests, support-window docs | LOW |
+| _(later)_ | Manifest named-op writes; multi-system (FEAT-59); MCP prompts (FEAT-62) | — |
+
+Each write-touching PR carries the same bar as the v1 review: **prove a plugin can't exceed a
+built-in of the same scope**, with an adversarial test per gate (package bypass, scope coverage,
+deny-action, raw-ADT-write refusal).
+
+---
+
+## 17. Cross-references
+
+- v1 spec: [`extension-framework-spec.md`](extension-framework-spec.md) (§13 roadmap, §16 review
+  corrections N4 + S1/S7, §5 package-gating limitation).
+- Rationale + external-project case studies:
+  [`extension-framework-deep-research.md`](extension-framework-deep-research.md).
+- Security invariants the write surface must preserve: `docs/security-model.md`.
+- Built-in write path the vocabulary reuses: `src/handlers/write/` + `src/handlers/write-helpers.ts`
+  (`enforceAllowedPackageForObjectUrl`).

--- a/docs/research/extension-framework-v2-spec.md
+++ b/docs/research/extension-framework-v2-spec.md
@@ -14,7 +14,13 @@
 
 v1 shipped a **read-only**, conservatively-scoped framework. Every narrowing below was a safety
 choice made during the 2026-06-17 implementation review, not an oversight. v2 lifts them, in
-priority order:
+priority order.
+
+> **Precedent already in v1:** `ctx.run.classRun` (execute an `IF_OO_ADT_CLASSRUN` console class)
+> shipped in v1 as the **first named privileged op** — gated behind `SAP_ALLOW_PLUGIN_EXECUTE` +
+> `allowWrites` + `write` scope, validated class name, no generic POST. It proves the §2.2 "named
+> operation vocabulary" model end-to-end (live on a4h), and is the template the v2 `ctx.write.*` ops
+> follow. The `ctx.run` namespace is where future execute-class ops land (e.g. `programRun`).
 
 | # | Deferred from v1 | Why it was deferred | v2 section |
 |---|------------------|---------------------|-----------|

--- a/docs_page/extensions.md
+++ b/docs_page/extensions.md
@@ -1,0 +1,199 @@
+# Extensions (Custom Tools)
+
+ARC-1 is **extensible**: you can add your own `Custom_*` tools to an ARC-1 instance **without
+forking** — they reuse ARC-1's authenticated SAP client, its safety ceiling, scope policy, audit,
+and per-user principal propagation. This is the FEAT-61 extension framework.
+
+!!! info "Experimental"
+    The extension API (`arc-1/public`) is **`@experimental`** — it may break in any release. A plugin
+    declares a single `apiVersion` integer as the compatibility fuse. No semver guarantee yet.
+
+- **Worked sample:** [`arc-mcp/arc-1-extension-sample`](https://github.com/arc-mcp/arc-1-extension-sample) — two code tools + one manifest tool, **live-verified against S/4HANA**.
+- **Guided setup:** the **`create-arc1-extension`** skill (`.claude/skills/create-arc1-extension/`) walks you through the decisions, scaffolds the plugin, and points out the security implications for your use case.
+- **Design:** `docs/research/extension-framework-spec.md` (spec) + `extension-framework-deep-research.md` (rationale).
+
+---
+
+## Extension, or a separate server?
+
+The first decision. An extension runs **in-process** and talks to the **same SAP system** ARC-1 is
+connected to, over **HTTP**.
+
+| Your tool talks to… | Build a… |
+|---|---|
+| the **same SAP system** over HTTP — ADT, OData, or a custom ICF/REST service | **Extension** (this page) |
+| a **different SAP product** (Cloud ALM, BTP services, BW, HANA, Datasphere, SuccessFactors) | **separate MCP server** (on the BTP-auth module) |
+| a **non-HTTP protocol** (native RFC, SAP GUI scripting) | **separate MCP server** |
+
+Extensions never ship ABAP — any custom endpoint they call must already exist on the SAP system.
+
+---
+
+## The two tiers
+
+| Tier | What you write | Use when |
+|---|---|---|
+| **Code** (`defineTool`, TypeScript) | a handler function | you need logic, response shaping, multiple calls, or **writes** |
+| **Manifest** (`*.tool.json`, no code) | one JSON file declaring `input → one GET` | you just wrap a single **read** endpoint |
+
+Both produce a `Custom_*` tool, gated identically.
+
+---
+
+## Quickstart
+
+Clone the sample and adapt it:
+
+```sh
+git clone https://github.com/arc-mcp/arc-1-extension-sample
+cd arc-1-extension-sample
+
+# link the local arc-1 build (until arc-1 is published with the public API)
+( cd /path/to/arc-1 && npm link )
+npm install && npm link arc-1 && npm run build
+
+# load into an ARC-1 instance…
+ARC1_PLUGINS=$PWD/dist/index.js  arc1 --http-streamable
+# …or drive one call (args are --json, never positional):
+ARC1_PLUGINS=$PWD/dist/index.js  arc1-cli call Custom_ProgramLineCount --json '{"name":"RSPARAM"}'
+```
+
+`ARC1_PLUGINS` is a CSV of **absolute paths**. An entry can be a `.js` code plugin, a directory, or a
+bare `*.tool.json` manifest. Loading is **fail-fast** — a malformed plugin or a name collision refuses
+server start.
+
+---
+
+## The plugin contract
+
+### Code tier
+
+```ts
+import { z } from 'zod';
+import { defineTool, OperationType } from 'arc-1/public';
+
+export default defineTool({
+  name: 'Custom_ProgramLineCount',          // MUST start with Custom_ (reserved namespace)
+  description: 'Report the line count of an ABAP program.',
+  schema: z.object({ name: z.string().min(1).max(40) }),
+  policy: { scope: 'read', opType: OperationType.Read },   // declared capability — see Security below
+  async handler(args, ctx) {
+    const res = await ctx.http.get(`/sap/bc/adt/programs/programs/${encodeURIComponent((args as { name: string }).name)}/source/main`,
+      { Accept: 'text/plain' });
+    return { content: [{ type: 'text', text: `${res.body.split('\n').length} lines` }] };
+  },
+});
+```
+
+A `Plugin` default export collects tools + manifests:
+
+```ts
+export default { name: 'my-ext', version: '0.1.0', apiVersion: 1, tools: [...], manifests: ['manifests/Custom_X.tool.json'] } satisfies Plugin;
+```
+
+### Manifest tier
+
+```json
+{
+  "name": "Custom_ReadProgram",
+  "description": "Read an ABAP program's source.",
+  "scope": "read",
+  "inputSchema": { "type": "object", "additionalProperties": false,
+    "required": ["name"], "properties": { "name": { "type": "string", "pattern": "^[A-Za-z0-9_/]{1,40}$" } } },
+  "request": { "method": "GET", "path": "/sap/bc/adt/programs/programs/{name}/source/main",
+    "pathParams": { "name": "$.name" }, "accept": "text/plain" },
+  "response": { "maxBytes": 50000 }
+}
+```
+
+v1 manifests are **read-only GET**: `additionalProperties:false` is required, `path` is a template with
+**no host**, and path params are percent-encoded (traversal-safe). Writes/POST stay in the code tier.
+
+---
+
+## Calling SAP APIs
+
+Everything goes through **`ctx.http`** — a **gated** wrapper over ARC-1's authenticated client. It can
+reach **any SAP path** on the connected system, with auth, CSRF, cookies, per-user PP, and sessions
+handled for you:
+
+| API | Example |
+|---|---|
+| ADT | `ctx.http.get('/sap/bc/adt/programs/programs/ZFOO/source/main')` |
+| OData | `ctx.http.get('/sap/opu/odata/sap/ZSVC/EntitySet?$filter=…')` (caller `Accept: application/json`) |
+| custom ICF/REST | `ctx.http.get('/sap/bc/http/sap/zmyservice')` (endpoint must already exist) |
+
+The raw client is **never** exposed — `ctx.client` offers high-level reads only (no `.http`).
+
+!!! warning "OData/ICF specifics"
+    A service must be **activated in `/IWFND`** even if it appears in the catalog (a 403 *"No service
+    found"* means it is registered but not activated). OData/ICF **writes** need a CSRF token fetched
+    against the service path and a stateful session (`ctx.http.withStatefulSession`).
+
+---
+
+## Security & roles (by use case)
+
+This is the most important part. An extension tool **inherits ARC-1's full safety pipeline** — it is
+gated exactly like a built-in. Two layers must both pass: the **user's scope** (their MCP role/profile)
+**and** the **server's safety ceiling** (the admin's `allow*` flags). Per-user **principal propagation**
+means the tool acts as the calling SAP user, so SAP-side auth (`S_DEVELOP`, package checks) applies too.
+
+Declare `policy: { scope, opType }` to match the **highest** operation your tool performs. A
+`read`-scoped tool that tries to `POST` is **blocked** (scope coverage), even before the server ceiling.
+
+| Use case | `scope` | `opType` | Server flag the admin must set | The user needs (XSUAA role / OIDC scope / API-key profile) |
+|---|---|---|---|---|
+| Read-only diagnostic (ADT/OData/ICF) | `read` | `R` | — | `read` |
+| Create / update / delete an ABAP object | `write` | `C`/`U`/`D` | `SAP_ALLOW_WRITES=true` **+** target package in `SAP_ALLOWED_PACKAGES` | `write` |
+| Table-content preview | `data` | `Q` | `SAP_ALLOW_DATA_PREVIEW=true` | `data` |
+| Free-style SQL | `sql` | `F` | `SAP_ALLOW_FREE_SQL=true` | `sql` |
+| Transport operation | `transports` | `X` | `SAP_ALLOW_TRANSPORT_WRITES=true` | `transports` |
+
+Key points:
+
+- **Package allowlist only gates ADT object writes.** For OData/ICF calls there is no ABAP package in
+  the path, so `SAP_ALLOWED_PACKAGES` does **not** constrain them — the gates are `allowWrites` + scope +
+  the **Cloud Connector** resource allowlist (BTP) + SAP-side auth.
+- **`custom` scopes are not supported.** Reuse the 7 built-in scopes — XSUAA scopes are deploy-time
+  static (`xs-security.json`), so reuse maps cleanly to existing roles. See
+  [Authorization & Roles](authorization.md).
+- **Admins keep the kill switch.** `SAP_DENY_ACTIONS=Custom_*` removes all plugin tools;
+  `SAP_DENY_ACTIONS=Custom_Foo` removes one.
+- **`package.json#arc1.requires`** declares the scopes/packages a plugin needs; ARC-1 **intersects**
+  this with the server ceiling at load — it can only narrow, never expand.
+- **Trust model:** plugins are local files an admin explicitly opts into via `ARC1_PLUGINS` (no
+  marketplace). They run in-process with the gated context — no sandbox, by design.
+
+---
+
+## Interactive capabilities
+
+When the MCP client supports them, `ctx` also offers (capability-detected — `undefined` otherwise):
+
+- `ctx.elicit(message, schema?)` — ask the user for input mid-tool.
+- `ctx.notify(level, message)` — send a client-visible progress line.
+- `ctx.sampling(systemPrompt, userMessage)` — ask the LLM a sub-question.
+
+---
+
+## Testing
+
+Unit-test a handler with **no live SAP** using `createMockToolContext` from `arc-1/public/testing` — it
+records `ctx.http` calls and returns a configured body:
+
+```ts
+import { createMockToolContext } from 'arc-1/public/testing';
+const ctx = createMockToolContext({ responseBody: 'REPORT ZX.\nWRITE 1.' });
+const res = await myTool.handler({ name: 'ZX' }, ctx);
+expect(ctx.httpCalls[0].path).toContain('/programs/ZX/');
+```
+
+---
+
+## Reference
+
+- **Sample repo:** <https://github.com/arc-mcp/arc-1-extension-sample>
+- **Guided skill:** `create-arc1-extension` (`.claude/skills/create-arc1-extension/`)
+- **Spec & research:** `docs/research/extension-framework-spec.md`, `extension-framework-deep-research.md`
+- **Related:** [Authorization & Roles](authorization.md) · [Tools Reference](tools.md) · [CLI Guide](cli-guide.md)

--- a/docs_page/extensions.md
+++ b/docs_page/extensions.md
@@ -33,10 +33,16 @@ Extensions never ship ABAP — any custom endpoint they call must already exist 
 
 | Tier | What you write | Use when |
 |---|---|---|
-| **Code** (`defineTool`, TypeScript) | a handler function | you need logic, response shaping, multiple calls, or **writes** |
+| **Code** (`defineTool`, TypeScript) | a handler function | you need logic, response shaping, or multiple reads |
 | **Manifest** (`*.tool.json`, no code) | one JSON file declaring `input → one GET` | you just wrap a single **read** endpoint |
 
 Both produce a `Custom_*` tool, gated identically.
+
+!!! warning "v1 is read-only"
+    Both tiers are **read-only** in v1 — `ctx.http` exposes **`GET`/`HEAD` only**. Write/`POST` support
+    is deferred to v2 because a raw write can't be constrained by `SAP_ALLOWED_PACKAGES` (package
+    resolution needs the ADT object-URL shape); shipping un-package-gated writes would bypass the
+    server safety ceiling. v2 adds a package-aware write vocabulary.
 
 ---
 
@@ -58,9 +64,9 @@ ARC1_PLUGINS=$PWD/dist/index.js  arc1 --http-streamable
 ARC1_PLUGINS=$PWD/dist/index.js  arc1-cli call Custom_ProgramLineCount --json '{"name":"RSPARAM"}'
 ```
 
-`ARC1_PLUGINS` is a CSV of **absolute paths**. An entry can be a `.js` code plugin, a directory, or a
-bare `*.tool.json` manifest. Loading is **fail-fast** — a malformed plugin or a name collision refuses
-server start.
+`ARC1_PLUGINS` is a CSV of **absolute paths**. An entry is either a `.js` code plugin (point at the
+built module, e.g. `dist/index.js`) or a bare `*.tool.json` manifest. Loading is **fail-fast** — a
+malformed plugin or a name collision refuses server start.
 
 ---
 
@@ -107,15 +113,15 @@ export default { name: 'my-ext', version: '0.1.0', apiVersion: 1, tools: [...], 
 ```
 
 v1 manifests are **read-only GET**: `additionalProperties:false` is required, `path` is a template with
-**no host**, and path params are percent-encoded (traversal-safe). Writes/POST stay in the code tier.
+**no host**, and path params are percent-encoded (traversal-safe).
 
 ---
 
 ## Calling SAP APIs
 
-Everything goes through **`ctx.http`** — a **gated** wrapper over ARC-1's authenticated client. It can
-reach **any SAP path** on the connected system, with auth, CSRF, cookies, per-user PP, and sessions
-handled for you:
+Everything goes through **`ctx.http`** — a **gated, read-only** (`GET`/`HEAD`) wrapper over ARC-1's
+authenticated client. It can reach **any SAP path** on the connected system, with auth, CSRF, cookies,
+per-user PP, and sessions handled for you:
 
 | API | Example |
 |---|---|
@@ -123,12 +129,13 @@ handled for you:
 | OData | `ctx.http.get('/sap/opu/odata/sap/ZSVC/EntitySet?$filter=…')` (caller `Accept: application/json`) |
 | custom ICF/REST | `ctx.http.get('/sap/bc/http/sap/zmyservice')` (endpoint must already exist) |
 
-The raw client is **never** exposed — `ctx.client` offers high-level reads only (no `.http`).
+The raw client is **never** exposed — `ctx.client` offers high-level reads only; its `.http`/`.safety`
+escape hatches are blocked **at runtime** (a `(ctx.client as any).http` cast yields `undefined`), not
+just hidden by types.
 
 !!! warning "OData/ICF specifics"
     A service must be **activated in `/IWFND`** even if it appears in the catalog (a 403 *"No service
-    found"* means it is registered but not activated). OData/ICF **writes** need a CSRF token fetched
-    against the service path and a stateful session (`ctx.http.withStatefulSession`).
+    found"* means it is registered but not activated).
 
 ---
 
@@ -139,29 +146,29 @@ gated exactly like a built-in. Two layers must both pass: the **user's scope** (
 **and** the **server's safety ceiling** (the admin's `allow*` flags). Per-user **principal propagation**
 means the tool acts as the calling SAP user, so SAP-side auth (`S_DEVELOP`, package checks) applies too.
 
-Declare `policy: { scope, opType }` to match the **highest** operation your tool performs. A
-`read`-scoped tool that tries to `POST` is **blocked** (scope coverage), even before the server ceiling.
+Declare `policy: { scope, opType }` to match the operation your tool performs. The user's scope must
+**cover** it (a `read` user never sees a `write`-scoped tool), and the server ceiling must allow it.
 
 | Use case | `scope` | `opType` | Server flag the admin must set | The user needs (XSUAA role / OIDC scope / API-key profile) |
 |---|---|---|---|---|
 | Read-only diagnostic (ADT/OData/ICF) | `read` | `R` | — | `read` |
-| Create / update / delete an ABAP object | `write` | `C`/`U`/`D` | `SAP_ALLOW_WRITES=true` **+** target package in `SAP_ALLOWED_PACKAGES` | `write` |
-| Table-content preview | `data` | `Q` | `SAP_ALLOW_DATA_PREVIEW=true` | `data` |
-| Free-style SQL | `sql` | `F` | `SAP_ALLOW_FREE_SQL=true` | `sql` |
-| Transport operation | `transports` | `X` | `SAP_ALLOW_TRANSPORT_WRITES=true` | `transports` |
+| Create / update / delete an ABAP object *(v2)* | `write` | `C`/`U`/`D` | `SAP_ALLOW_WRITES=true` **+** target package in `SAP_ALLOWED_PACKAGES` | `write` |
+| Table-content preview *(v2)* | `data` | `Q` | `SAP_ALLOW_DATA_PREVIEW=true` | `data` |
+| Free-style SQL *(v2)* | `sql` | `F` | `SAP_ALLOW_FREE_SQL=true` | `sql` |
+| Transport operation *(v2)* | `transports` | `X` | `SAP_ALLOW_TRANSPORT_WRITES=true` | `transports` |
+
+Since v1 `ctx.http` is read-only, only the `read` row is live today; the rest document the model for the
+v2 write surface (and the package-allowlist enforcement that ships with it).
 
 Key points:
 
-- **Package allowlist only gates ADT object writes.** For OData/ICF calls there is no ABAP package in
-  the path, so `SAP_ALLOWED_PACKAGES` does **not** constrain them — the gates are `allowWrites` + scope +
-  the **Cloud Connector** resource allowlist (BTP) + SAP-side auth.
 - **`custom` scopes are not supported.** Reuse the 7 built-in scopes — XSUAA scopes are deploy-time
   static (`xs-security.json`), so reuse maps cleanly to existing roles. See
   [Authorization & Roles](authorization.md).
 - **Admins keep the kill switch.** `SAP_DENY_ACTIONS=Custom_*` removes all plugin tools;
   `SAP_DENY_ACTIONS=Custom_Foo` removes one.
-- **`package.json#arc1.requires`** declares the scopes/packages a plugin needs; ARC-1 **intersects**
-  this with the server ceiling at load — it can only narrow, never expand.
+- **System-type visibility.** A tool may declare `availableOn: 'onprem' | 'btp'` (default `all`); it is
+  hidden from `tools/list` when the resolved system type is known and differs.
 - **Trust model:** plugins are local files an admin explicitly opts into via `ARC1_PLUGINS` (no
   marketplace). They run in-process with the gated context — no sandbox, by design.
 

--- a/docs_page/extensions.md
+++ b/docs_page/extensions.md
@@ -38,11 +38,13 @@ Extensions never ship ABAP — any custom endpoint they call must already exist 
 
 Both produce a `Custom_*` tool, gated identically.
 
-!!! warning "v1 is read-only"
-    Both tiers are **read-only** in v1 — `ctx.http` exposes **`GET`/`HEAD` only**. Write/`POST` support
-    is deferred to v2 because a raw write can't be constrained by `SAP_ALLOWED_PACKAGES` (package
-    resolution needs the ADT object-URL shape); shipping un-package-gated writes would bypass the
-    server safety ceiling. v2 adds a package-aware write vocabulary.
+!!! warning "v1 is read-only — with one gated exception"
+    Both tiers are **read-only** in v1: `ctx.http` exposes **`GET`/`HEAD` only**. General write/`POST`
+    support is deferred to v2 because a raw write can't be constrained by `SAP_ALLOWED_PACKAGES`
+    (package resolution needs the ADT object-URL shape); shipping un-package-gated writes would bypass
+    the server safety ceiling. The **one** privileged op available in v1 is **executing a console class**
+    (`ctx.run.classRun`, see below) — a *named* operation (not a generic POST, so no package-bypass),
+    locked behind a default-off opt-in. v2 adds the full package-aware write vocabulary.
 
 ---
 
@@ -139,6 +141,42 @@ just hidden by types.
 
 ---
 
+## Executing ABAP (console classes)
+
+The one privileged operation a v1 plugin can perform is **running an ABAP console class** — a class
+that implements `IF_OO_ADT_CLASSRUN` (the modern replacement for executable reports on ABAP Cloud).
+It runs through **`ctx.run.classRun(name)`**, which returns the class's `out->write( … )` console
+output:
+
+```ts
+export default defineTool({
+  name: 'Custom_RunClass',
+  description: 'Execute an ABAP console class and return its console output.',
+  schema: z.object({ className: z.string().min(1).max(40) }),
+  policy: { scope: 'write', opType: OperationType.Workflow },   // execute ⇒ write-class op
+  async handler(args, ctx) {
+    const out = await ctx.run.classRun((args as { className: string }).className);
+    return { content: [{ type: 'text', text: out }] };
+  },
+});
+```
+
+Executing arbitrary ABAP can mutate anything, so this is the **strictest-gated** capability in the
+framework — **all** of the following must hold, or the call is refused with an `AdtSafetyError`:
+
+| Gate | Why |
+|---|---|
+| `SAP_ALLOW_PLUGIN_EXECUTE=true` | a **dedicated** opt-in (default off) — enabling built-in writes never silently grants plugins code execution |
+| `SAP_ALLOW_WRITES=true` | execution is a mutation vector; keeps the `allowWrites=false ⇒ no mutation` guarantee |
+| tool declares `scope: 'write'` | a `read`-scoped tool can never execute |
+| user has the `write` scope + SAP-side execute auth | the usual `scope ∧ SAP-auth` |
+
+`classRun` is a **named** op (not a raw POST), so a plugin can only run a class **by name** (validated,
+no path injection) — it cannot reach arbitrary write endpoints. That's why it can ship in read-only v1
+safely; the general write surface still waits for v2.
+
+---
+
 ## Security & roles (by use case)
 
 This is the most important part. An extension tool **inherits ARC-1's full safety pipeline** — it is
@@ -167,6 +205,8 @@ Key points:
   [Authorization & Roles](authorization.md).
 - **Admins keep the kill switch.** `SAP_DENY_ACTIONS=Custom_*` removes all plugin tools;
   `SAP_DENY_ACTIONS=Custom_Foo` removes one.
+- **Code execution is opt-in + default off.** `ctx.run.classRun` requires `SAP_ALLOW_PLUGIN_EXECUTE=true`
+  **and** `SAP_ALLOW_WRITES=true` **and** a `write`-scoped tool (see [Executing ABAP](#executing-abap-console-classes)).
 - **System-type visibility.** A tool may declare `availableOn: 'onprem' | 'btp'` (default `all`); it is
   hidden from `tools/list` when the resolved system type is known and differs.
 - **Trust model:** plugins are local files an admin explicitly opts into via `ARC1_PLUGINS` (no

--- a/docs_page/extensions.md
+++ b/docs_page/extensions.md
@@ -198,6 +198,18 @@ expect(ctx.httpCalls[0].path).toContain('/programs/ZX/');
 
 ---
 
+## Roadmap (v2)
+
+v1 is **read-only** on purpose. The biggest v2 item is a **package-aware write surface** — a
+`ctx.write` vocabulary that routes ADT object writes through the same package-allowlist gate built-in
+`SAPWrite` uses (so a plugin still can't write outside `SAP_ALLOWED_PACKAGES`), plus opt-in raw writes
+for package-less OData/ICF calls. Also planned: a safe per-user `ctx.cache`, directory + npm-package
+loading, `package.json#arc1.requires` capability intersection, per-handler timeouts, and graduating
+the API from `@experimental` to semver-stable. Full design:
+`docs/research/extension-framework-v2-spec.md`.
+
+---
+
 ## Reference
 
 - **Sample repo:** <https://github.com/arc-mcp/arc-1-extension-sample>

--- a/docs_page/extensions.md
+++ b/docs_page/extensions.md
@@ -238,6 +238,54 @@ expect(ctx.httpCalls[0].path).toContain('/programs/ZX/');
 
 ---
 
+## Deploying extensions (BTP Cloud Foundry / Docker)
+
+A plugin is a **local file** the server loads at startup from an **absolute** `ARC1_PLUGINS` path
+(it's a literal CSV — **no `$HOME`/shell expansion**). On a managed deployment the container
+filesystem comes from the deploy artifact, so "getting the plugin onto a stable absolute path" is the
+whole problem. Three ways, with trade-offs:
+
+| Strategy | How | Upside | Downside |
+|---|---|---|---|
+| **Derived Docker image** *(recommended)* | `FROM ghcr.io/marianfoo/arc-1`, `COPY --chown` the plugin's `dist/`, set `ENV ARC1_PLUGINS=…` | self-contained + version-pinned with ARC-1; one immutable artifact through your image review/supply chain; identical local / CF‑Docker / k8s | rebuild + repush to change a plugin; needs a registry; **must `--chown`** (see gotcha) |
+| **Buildpack co-deploy** *(matches the committed `mta.yaml`, `nodejs_buildpack`)* | put the plugin's built `dist/` in the pushed app bits (e.g. `plugins/<name>/`), set `ARC1_PLUGINS=/home/vcap/app/plugins/<name>/dist/index.js` | no image build; plain `cf push` / `mta build`; bits are `vcap`-owned so the owner check passes | the plugin rides ARC-1's deploy bits (coupled); rebuild the bits to change it |
+| **Volume service (NFS)** | mount a CF volume, point `ARC1_PLUGINS` at it | swap a plugin without rebuilding the image/bits | plugin lives **outside** the audited artifact (trust gap); the mount's uid/permissions must satisfy the loader's owner + not‑world‑writable checks; still needs a restart |
+
+### Derived Docker image — the recipe
+
+```dockerfile
+FROM ghcr.io/marianfoo/arc-1:latest
+# ARC-1 runs as the non-root user `arc1`. A plain COPY lands files as root → the loader rejects them.
+COPY --chown=arc1:arc1 dist/      /home/arc1/plugins/myext/dist/
+COPY --chown=arc1:arc1 manifests/ /home/arc1/plugins/myext/manifests/
+ENV ARC1_PLUGINS=/home/arc1/plugins/myext/dist/index.js
+```
+Then `cf push my-arc1 --docker-image <registry>/my-arc1:<tag>` (or k8s / local `docker run`).
+
+### The owner / permission gotcha (bites on Docker)
+
+The loader **refuses** a plugin file that is **not owned by the server process user** or is
+**world-writable** — defense-in-depth against a tampered drop-in. ARC-1's image runs as `arc1`, but a
+plain `COPY` lands files as **root** → `"Plugin … is not owned by the server user — refusing to load"`.
+Fix: **`COPY --chown=arc1:arc1`**, and never `chmod 777` a plugin. On the buildpack the bits are
+already `vcap`-owned, so this is a non-issue there.
+
+### Cross-cutting
+
+- **No hot-reload.** Plugins load once at startup; changing one means a redeploy / `cf restage`. The
+  `apiVersion` integer is the compatibility fuse across ARC-1 upgrades.
+- **Adding a plugin needs NO XSUAA change.** Plugin tools reuse the 7 built-in scopes (no custom
+  scopes), so you do **not** touch `xs-security.json` or role collections to ship a new `Custom_*`
+  tool — a real operational win on BTP.
+- **Per-user principal propagation still applies** — a plugin's `ctx` carries the per-user (PP) SAP
+  client, so its calls run as the calling SAP user, same as built-in tools.
+- **Execution is per-deployment opt-in.** `SAP_ALLOW_PLUGIN_EXECUTE` / `SAP_ALLOW_WRITES` are server
+  env (`cf set-env` / MTA) — set them only where you intend plugins to run classes.
+- **Trust = supply chain.** Plugins are baked into the deploy artifact and reviewed with it; there is
+  no runtime upload. Keep `ARC1_PLUGINS` under the same change control as the rest of the app.
+
+---
+
 ## Roadmap (v2)
 
 v1 is **read-only** on purpose. The biggest v2 item is a **package-aware write surface** — a

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - BTP Destination Setup: btp-destination-setup.md
   - Using ARC-1:
       - Tools Reference: tools.md
+      - Extensions (Custom Tools): extensions.md
       - MCP Usage Guide: mcp-usage.md
       - Skills: skills.md
       - Blog Series: blog-series.md

--- a/package.json
+++ b/package.json
@@ -20,6 +20,21 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./public": {
+      "types": "./dist/public/index.d.ts",
+      "default": "./dist/public/index.js"
+    },
+    "./public/testing": {
+      "types": "./dist/public/testing.d.ts",
+      "default": "./dist/public/testing.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist",
     "bin",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,12 +23,13 @@ import { config } from 'dotenv';
 import { AdtClient } from './adt/client.js';
 import type { AdtClientConfig } from './adt/config.js';
 import { buildArgs, type OutputMode } from './cli-args.js';
-import { handleToolCall } from './handlers/dispatch.js';
+import { getToolRegistry, handleToolCall } from './handlers/dispatch.js';
 import type { ToolResult } from './handlers/shared.js';
 import { getToolDefinitions } from './handlers/tools.js';
 import { detectFilename, lintAbapSource } from './lint/lint.js';
 import { parseArgs, resolveConfig } from './server/config.js';
 import { initLogger } from './server/logger.js';
+import { loadPlugins } from './server/plugin-loader.js';
 import { buildAdtConfig, VERSION } from './server/server.js';
 import type { ConfigSource, ServerConfig } from './server/types.js';
 
@@ -321,7 +322,14 @@ function resolveCliContext(): { client: AdtClient; config: ServerConfig } {
 
 async function runToolCall(toolName: string, args: Record<string, unknown>, outputMode: OutputMode): Promise<number> {
   const { client, config: serverConfig } = resolveCliContext();
+  // FEAT-61: load extension plugins so `arc1-cli call Custom_*` reaches the same registry the server uses.
+  if (serverConfig.plugins?.length) {
+    await loadPlugins(serverConfig.plugins, getToolRegistry());
+  }
   const available = new Set(getToolDefinitions(serverConfig).map((t) => t.name));
+  for (const e of getToolRegistry().list()) {
+    if (e.source === 'plugin') available.add(e.name);
+  }
   if (!available.has(toolName)) {
     console.error(`Unknown tool: ${toolName}`);
     console.error(`Available tools: ${[...available].join(', ')}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,9 +90,20 @@ program
 program
   .command('tools [tool]')
   .description('List MCP tools, or show the JSON input schema for a specific tool')
-  .action((tool: string | undefined) => {
+  .action(async (tool: string | undefined) => {
     const { config: serverConfig } = resolveCliContext();
-    const defs = getToolDefinitions(serverConfig);
+    // FEAT-61: load plugins so `tools` discovery matches `call` invocation (both see Custom_* tools).
+    if (serverConfig.plugins?.length) {
+      await loadPlugins(serverConfig.plugins, getToolRegistry());
+    }
+    const pluginDefs = getToolRegistry()
+      .list()
+      .flatMap((e) =>
+        e.source === 'plugin' && e.listing
+          ? [{ name: e.name, description: e.listing.description, inputSchema: e.listing.inputSchema }]
+          : [],
+      );
+    const defs = [...getToolDefinitions(serverConfig), ...pluginDefs];
     if (!tool) {
       for (const def of defs) {
         const firstLine = def.description.split('\n')[0].trim();

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -530,6 +530,8 @@ export async function handleToolCall(
   // Build user context for audit logging
   const user = authInfo?.extra?.userName as string | undefined;
   const clientId = authInfo?.clientId;
+  // For plugin (Custom_*) tools, tag every audit event with the contributing plugin (spec §9).
+  const pluginName = getToolRegistry().get(toolName)?.pluginName;
 
   // Emit tool_call_start audit event
   logger.emitAudit({
@@ -540,6 +542,7 @@ export async function handleToolCall(
     user,
     clientId,
     tool: toolName,
+    pluginName,
     args: sanitizeArgs(args),
   });
 
@@ -730,6 +733,7 @@ export async function handleToolCall(
         user,
         clientId,
         tool: toolName,
+        pluginName,
         durationMs,
         status: result.isError ? 'error' : 'success',
         errorMessage: result.isError ? result.content[0]?.text : undefined,
@@ -751,6 +755,7 @@ export async function handleToolCall(
         user,
         clientId,
         tool: toolName,
+        pluginName,
         durationMs,
         status: 'error',
         errorClass: classifyError(err),

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -703,7 +703,10 @@ export async function handleToolCall(
       // only replaces the former `switch (toolName)`. See extension-framework-spec.md §4.
       const entry = getToolRegistry().get(toolName);
       let result: ToolResult;
-      if (!entry) {
+      // Plugin (Custom_*) tools are out of scope for hyperfocused mode (spec §1): hidden from
+      // tools/list AND not directly invocable, so a client that knows a Custom_ name can't reach a
+      // plugin tool here either. Built-ins (incl. the `SAP` wrapper) dispatch normally.
+      if (!entry || (config.toolMode === 'hyperfocused' && entry.source === 'plugin')) {
         result = errorResult(`Unknown tool: ${toolName}`);
       } else {
         const dispatchCtx: ToolDispatchContext = {

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -24,6 +24,7 @@ import { AdtApiError, AdtNetworkError, AdtSafetyError, classifySapDomainError } 
  */
 import { getActionPolicy, hasRequiredScope as hasScopeHelper } from '../authz/policy.js';
 import type { CachingLayer } from '../cache/caching-layer.js';
+import { type RegistryEntry, type ToolDispatchContext, ToolRegistry } from '../registry/tool-registry.js';
 import { sanitizeArgs } from '../server/audit.js';
 import { generateRequestId, requestContext } from '../server/context.js';
 import { logger } from '../server/logger.js';
@@ -458,6 +459,52 @@ function classifyError(err: unknown): string {
   return 'Unknown';
 }
 
+// ─── Tool registry (FEAT-61) ─────────────────────────────────────────
+// The 12 built-ins register through the same ToolRegistry that plugin (Custom_*) tools use. Each
+// built-in `invoke` is a thin adapter over its existing handler — the shared pipeline (rate-limit,
+// scope, deny, Zod, audit) stays in handleToolCall; the registry only owns the inner dispatch that
+// used to be a `switch`. See docs/research/extension-framework-spec.md §4.
+let _toolRegistry: ToolRegistry | undefined;
+
+/** The process-wide tool registry, lazily seeded with the built-ins. Exported for tests. */
+export function getToolRegistry(): ToolRegistry {
+  if (_toolRegistry) return _toolRegistry;
+  const r = new ToolRegistry();
+  const reg = (name: string, invoke: RegistryEntry['invoke']): void => {
+    const policy = getActionPolicy(name);
+    if (!policy) throw new Error(`Built-in tool '${name}' has no ACTION_POLICY entry`);
+    r.register({ name, source: 'builtin', policy, invoke });
+  };
+  reg('SAPRead', (ctx) => handleSAPRead(ctx.client, ctx.args, ctx.cache, ctx.cacheSecurity));
+  reg('SAPSearch', (ctx) => handleSAPSearch(ctx.client, ctx.args));
+  reg('SAPQuery', (ctx) => handleSAPQuery(ctx.client, ctx.args));
+  reg('SAPWrite', (ctx) => handleSAPWrite(ctx.client, ctx.args, ctx.config, ctx.cache, ctx.cacheSecurity));
+  reg('SAPActivate', (ctx) => handleSAPActivate(ctx.client, ctx.args, ctx.cache, ctx.cacheSecurity));
+  reg('SAPNavigate', (ctx) => handleSAPNavigate(ctx.client, ctx.args));
+  reg('SAPLint', (ctx) => handleSAPLint(ctx.client, ctx.args, ctx.config));
+  reg('SAPDiagnose', (ctx) => handleSAPDiagnose(ctx.client, ctx.args));
+  reg('SAPTransport', (ctx) => handleSAPTransport(ctx.client, ctx.args));
+  reg('SAPGit', (ctx) => handleSAPGit(ctx.client, ctx.args, ctx.authInfo));
+  reg('SAPContext', (ctx) => handleSAPContext(ctx.client, ctx.args, ctx.cache, ctx.cacheSecurity));
+  reg('SAPManage', (ctx) => handleSAPManage(ctx.client, ctx.config, ctx.args, ctx.cache, ctx.isPerUserClient));
+  reg('SAP', async (ctx) => {
+    const expanded = expandHyperfocusedArgs(ctx.args);
+    if ('error' in expanded) return errorResult(expanded.error);
+    return handleToolCall(
+      ctx.client,
+      ctx.config,
+      expanded.toolName,
+      expanded.expandedArgs,
+      ctx.authInfo,
+      ctx.server,
+      ctx.cache,
+      ctx.isPerUserClient,
+    );
+  });
+  _toolRegistry = r;
+  return r;
+}
+
 /**
  * Handle an MCP tool call.
  *
@@ -573,7 +620,9 @@ export async function handleToolCall(
       actionOrType = `tadir_lookup_${src}`;
     }
   }
-  const policy = getActionPolicy(toolName, actionOrType);
+  // Built-in policy from ACTION_POLICY; plugin (Custom_*) policy from the registry (FEAT-61).
+  // Kept here (not inside getActionPolicy) so validate-action-policy.ts stays built-ins-only.
+  const policy = getActionPolicy(toolName, actionOrType) ?? getToolRegistry().get(toolName)?.policy;
 
   if (authInfo && policy) {
     if (!hasRequiredScope(authInfo, policy.scope)) {
@@ -644,69 +693,28 @@ export async function handleToolCall(
   // Run within request context so HTTP-level logs get the requestId
   return requestContext.run({ requestId: reqId, user, tool: toolName }, async () => {
     try {
-      let result: ToolResult;
       const cacheSecurity = buildCacheSecurityContext(authInfo, isPerUserClient);
 
-      switch (toolName) {
-        case 'SAPRead':
-          result = await handleSAPRead(client, args, cachingLayer, cacheSecurity);
-          break;
-        case 'SAPSearch':
-          result = await handleSAPSearch(client, args);
-          break;
-        case 'SAPQuery':
-          result = await handleSAPQuery(client, args);
-          break;
-        case 'SAPWrite':
-          result = await handleSAPWrite(client, args, config, cachingLayer, cacheSecurity);
-          break;
-        case 'SAPActivate':
-          result = await handleSAPActivate(client, args, cachingLayer, cacheSecurity);
-          break;
-        case 'SAPNavigate':
-          result = await handleSAPNavigate(client, args);
-          break;
-        case 'SAPLint':
-          result = await handleSAPLint(client, args, config);
-          break;
-        case 'SAPDiagnose':
-          result = await handleSAPDiagnose(client, args);
-          break;
-        case 'SAPTransport':
-          result = await handleSAPTransport(client, args);
-          break;
-        case 'SAPGit':
-          result = await handleSAPGit(client, args, authInfo);
-          break;
-        case 'SAPContext':
-          result = await handleSAPContext(client, args, cachingLayer, cacheSecurity);
-          break;
-        case 'SAPManage':
-          result = await handleSAPManage(client, config, args, cachingLayer, isPerUserClient);
-          break;
-        case 'SAP': {
-          // Hyperfocused mode: route to the appropriate handler
-          const expanded = expandHyperfocusedArgs(args);
-          if ('error' in expanded) {
-            result = errorResult(expanded.error);
-            break;
-          }
-          // Delegate to the real handler (recursive call, but with the mapped tool name)
-          // The concrete tool/action policy is enforced by the recursive call.
-          result = await handleToolCall(
-            client,
-            config,
-            expanded.toolName,
-            expanded.expandedArgs,
-            authInfo,
-            _server,
-            cachingLayer,
-            isPerUserClient,
-          );
-          break;
-        }
-        default:
-          result = errorResult(`Unknown tool: ${toolName}`);
+      // FEAT-61: inner dispatch is owned by the ToolRegistry (built-ins + plugin Custom_* tools).
+      // The shared pipeline above (rate-limit, scope, deny, Zod, audit) is unchanged; the registry
+      // only replaces the former `switch (toolName)`. See extension-framework-spec.md §4.
+      const entry = getToolRegistry().get(toolName);
+      let result: ToolResult;
+      if (!entry) {
+        result = errorResult(`Unknown tool: ${toolName}`);
+      } else {
+        const dispatchCtx: ToolDispatchContext = {
+          client,
+          config,
+          args,
+          cache: cachingLayer,
+          authInfo,
+          isPerUserClient,
+          cacheSecurity,
+          server: _server,
+          requestId: reqId,
+        };
+        result = await entry.invoke(dispatchCtx);
       }
 
       const durationMs = Date.now() - start;

--- a/src/plugins/manifest-interpreter.ts
+++ b/src/plugins/manifest-interpreter.ts
@@ -122,7 +122,22 @@ export function registerManifestTool(registry: ToolRegistry, pluginName: string,
           isError: true,
         };
       }
-      const path = renderPath(m.request.path, m.request.pathParams, args) + renderQuery(m.request.query, args);
+      let path: string;
+      try {
+        // Anti-traversal / ref-resolution failures surface as an isError result (parity with the
+        // ajv branch above), not a thrown exception out of invoke.
+        path = renderPath(m.request.path, m.request.pathParams, args) + renderQuery(m.request.query, args);
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Invalid arguments for ${m.name}: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
       const http = createSafeHttpClient(ctx.client.http, ctx.client.safety, m.name);
       const headers = m.request.accept ? { Accept: m.request.accept } : undefined;
       const res = await http.get(path, headers);

--- a/src/plugins/manifest-interpreter.ts
+++ b/src/plugins/manifest-interpreter.ts
@@ -123,7 +123,7 @@ export function registerManifestTool(registry: ToolRegistry, pluginName: string,
         };
       }
       const path = renderPath(m.request.path, m.request.pathParams, args) + renderQuery(m.request.query, args);
-      const http = createSafeHttpClient(ctx.client.http, ctx.client.safety, m.scope, m.name);
+      const http = createSafeHttpClient(ctx.client.http, ctx.client.safety, m.name);
       const headers = m.request.accept ? { Accept: m.request.accept } : undefined;
       const res = await http.get(path, headers);
       const max = m.response?.maxBytes ?? 100_000;

--- a/src/plugins/manifest-interpreter.ts
+++ b/src/plugins/manifest-interpreter.ts
@@ -1,0 +1,136 @@
+// Manifest interpreter — the declarative (JSON, no JavaScript) plugin tier. FEAT-61 PR4.
+//
+// A *.tool.json manifest declares a read-only tool whose handler is a single, fixed HTTP GET
+// against the already-authenticated client (no host — paths only). The interpreter renders the
+// request from validated args and runs it through the SAME gated SafeHttpClient as code plugins.
+// v1 scope: GET only; POST/body + response extraction are a fast-follow.
+// Security per docs/research/extension-framework-spec.md §8.1.
+
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import type { OperationTypeCode } from '../adt/safety.js';
+import type { Scope } from '../authz/policy.js';
+import type { RegistryEntry, ToolDispatchContext, ToolRegistry, ToolResult } from '../registry/tool-registry.js';
+import { createSafeHttpClient } from '../server/safe-http-client.js';
+
+const SCOPES: ReadonlySet<string> = new Set(['read', 'write', 'data', 'sql', 'transports', 'git', 'admin']);
+
+export interface ManifestTool {
+  name: string;
+  description: string;
+  scope: Scope;
+  opType?: OperationTypeCode;
+  inputSchema: Record<string, unknown>;
+  request: {
+    method: 'GET';
+    path: string;
+    pathParams?: Record<string, string>;
+    query?: Record<string, string>;
+    accept?: string;
+  };
+  response?: { maxBytes?: number };
+}
+
+/** Resolve a `$.field` reference against the validated args (top-level fields only in v1). */
+function resolveRef(ref: string, args: Record<string, unknown>): unknown {
+  const m = /^\$\.([A-Za-z_]\w*)$/.exec(ref);
+  if (!m) throw new Error(`manifest: unsupported reference '${ref}' (use "$.field")`);
+  return args[m[1]];
+}
+
+/** Validate + percent-encode a single path segment value (anti-traversal). */
+function safeSegment(value: unknown, key: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`manifest: path param '${key}' must be a non-empty string`);
+  }
+  // Reject traversal, control chars, and scheme/host smuggling. `/` IS allowed (SAP namespaced
+  // names) but is percent-encoded below, so it can't introduce extra path segments.
+  if (value.includes('..') || [...value].some((c) => c.charCodeAt(0) < 0x20) || value.includes('://')) {
+    throw new Error(`manifest: path param '${key}' contains a forbidden sequence`);
+  }
+  return encodeURIComponent(value);
+}
+
+function renderPath(
+  template: string,
+  pathParams: Record<string, string> | undefined,
+  args: Record<string, unknown>,
+): string {
+  return template.replace(/\{([A-Za-z_]\w*)\}/g, (_full, key: string) => {
+    const ref = pathParams?.[key];
+    if (!ref) throw new Error(`manifest: path placeholder '{${key}}' has no pathParams mapping`);
+    return safeSegment(resolveRef(ref, args), key);
+  });
+}
+
+function renderQuery(query: Record<string, string> | undefined, args: Record<string, unknown>): string {
+  if (!query) return '';
+  const usp = new URLSearchParams();
+  for (const [k, ref] of Object.entries(query)) {
+    const v = resolveRef(ref, args);
+    if (v === undefined || v === null || v === '') continue; // omit-if-absent
+    usp.set(k, String(v));
+  }
+  const s = usp.toString();
+  return s ? `?${s}` : '';
+}
+
+/** Validate a manifest's shape + security invariants. Throws on any violation (fail-fast). */
+export function validateManifest(obj: unknown): ManifestTool {
+  const m = obj as ManifestTool;
+  if (!m || typeof m.name !== 'string' || !m.name.startsWith('Custom_')) {
+    throw new Error(`manifest: 'name' must be a string starting with 'Custom_' (got '${m?.name}')`);
+  }
+  if (!m.description || typeof m.description !== 'string') {
+    throw new Error(`manifest '${m.name}': 'description' is required`);
+  }
+  if (!m.scope || !SCOPES.has(m.scope)) {
+    throw new Error(`manifest '${m.name}': 'scope' must be one of ${[...SCOPES].join('/')}`);
+  }
+  if (!m.inputSchema || typeof m.inputSchema !== 'object') {
+    throw new Error(`manifest '${m.name}': 'inputSchema' (JSON Schema) is required`);
+  }
+  if ((m.inputSchema as Record<string, unknown>).additionalProperties !== false) {
+    throw new Error(`manifest '${m.name}': inputSchema must set "additionalProperties": false`);
+  }
+  if (m.request?.method !== 'GET') {
+    throw new Error(`manifest '${m.name}': only request.method "GET" is supported in v1`);
+  }
+  if (typeof m.request.path !== 'string' || !m.request.path.startsWith('/') || m.request.path.includes('://')) {
+    throw new Error(`manifest '${m.name}': request.path must be an absolute SAP path with no host`);
+  }
+  return m;
+}
+
+/** Build + register a registry entry from a manifest object. */
+export function registerManifestTool(registry: ToolRegistry, pluginName: string, manifestObj: unknown): void {
+  const m = validateManifest(manifestObj);
+  const ajv = new Ajv2020({ strict: false, allErrors: true });
+  const validate = ajv.compile(m.inputSchema);
+  const opType: OperationTypeCode = m.opType ?? 'R'; // GET → Read
+
+  const entry: RegistryEntry = {
+    name: m.name,
+    source: 'plugin',
+    pluginName,
+    policy: { scope: m.scope, opType },
+    listing: { description: m.description, inputSchema: m.inputSchema },
+    invoke: async (ctx: ToolDispatchContext): Promise<ToolResult> => {
+      const args = ctx.args;
+      if (!validate(args)) {
+        return {
+          content: [{ type: 'text', text: `Invalid arguments for ${m.name}: ${ajv.errorsText(validate.errors)}` }],
+          isError: true,
+        };
+      }
+      const path = renderPath(m.request.path, m.request.pathParams, args) + renderQuery(m.request.query, args);
+      const http = createSafeHttpClient(ctx.client.http, ctx.client.safety, m.scope, m.name);
+      const headers = m.request.accept ? { Accept: m.request.accept } : undefined;
+      const res = await http.get(path, headers);
+      const max = m.response?.maxBytes ?? 100_000;
+      const body =
+        res.body.length > max ? `${res.body.slice(0, max)}\n…[truncated ${res.body.length - max} bytes]` : res.body;
+      return { content: [{ type: 'text', text: body }] };
+    },
+  };
+  registry.register(entry);
+}

--- a/src/public/define-tool.ts
+++ b/src/public/define-tool.ts
@@ -1,0 +1,26 @@
+import type { PluginToolDefinition } from './types.js';
+
+/**
+ * Identity helper for authoring a plugin tool — returns the definition unchanged but validates
+ * its shape eagerly (at module load) so authors get a clear error instead of a late runtime
+ * failure or a silently-dropped tool. The registry enforces the same invariants at registration;
+ * this is the friendly first line of defence.
+ */
+export function defineTool(def: PluginToolDefinition): PluginToolDefinition {
+  if (!def || typeof def.name !== 'string' || !def.name.startsWith('Custom_')) {
+    throw new Error(`defineTool: tool name must start with 'Custom_' (got '${def?.name}')`);
+  }
+  if (!def.description) {
+    throw new Error(`defineTool: '${def.name}' needs a description`);
+  }
+  if (!def.schema) {
+    throw new Error(`defineTool: '${def.name}' needs a Zod 'schema'`);
+  }
+  if (!def.policy?.scope || !def.policy.opType) {
+    throw new Error(`defineTool: '${def.name}' needs policy.scope + policy.opType`);
+  }
+  if (typeof def.handler !== 'function') {
+    throw new Error(`defineTool: '${def.name}' needs a 'handler' function`);
+  }
+  return def;
+}

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -1,0 +1,23 @@
+// `arc-1/public` — the @experimental extension API surface.
+//
+// Stability: this API may break in ANY release. A plugin declares `apiVersion` (a single integer
+// fuse); the loader rejects a mismatch. No semver guarantee until the feature graduates.
+// See docs/research/extension-framework-spec.md §2.
+
+export { AdtApiError, AdtNetworkError, AdtSafetyError } from '../adt/errors.js';
+export type { AdtResponse } from '../adt/http.js';
+
+// Re-exported building blocks (stable shapes plugins reference):
+export { OperationType, type OperationTypeCode } from '../adt/safety.js';
+export type { Scope } from '../authz/policy.js';
+export type { ToolResult } from '../registry/tool-registry.js';
+export type { SafeHttpClient } from '../server/safe-http-client.js';
+export { defineTool } from './define-tool.js';
+export type {
+  ElicitOutcome,
+  Plugin,
+  PluginLogger,
+  PluginToolDefinition,
+  ReadOnlyAdtClient,
+  ToolContext,
+} from './types.js';

--- a/src/public/testing.ts
+++ b/src/public/testing.ts
@@ -1,0 +1,73 @@
+// arc-1/public/testing — helpers for unit-testing a plugin tool with no live SAP. @experimental.
+//
+// `createMockToolContext` returns a ToolContext whose `http` records every call and returns a
+// configurable body, so a plugin author can assert "my handler GETs /sap/bc/adt/… and shapes the
+// response like X" without a server. See docs/research/extension-framework-spec.md §2/§12.
+
+import type { AdtResponse } from '../adt/http.js';
+import type { SafeHttpClient } from '../server/safe-http-client.js';
+import type { ToolContext } from './types.js';
+
+export interface MockHttpCall {
+  method: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE';
+  path: string;
+  body?: string;
+}
+
+export interface MockToolContext extends ToolContext {
+  /** Every `ctx.http` call the handler made, in order. */
+  httpCalls: MockHttpCall[];
+}
+
+export interface MockToolContextOptions {
+  /** Body returned by every `ctx.http` call (unless overridden per-path by `responses`). */
+  responseBody?: string;
+  /** Per-path response bodies; falls back to `responseBody` then ''. */
+  responses?: Record<string, string>;
+  /** Scopes on `ctx.authInfo` (default `['read']`). */
+  scopes?: string[];
+  requestId?: string;
+  /** Partial `ctx.client` for handlers that call high-level read methods. */
+  client?: Partial<ToolContext['client']>;
+}
+
+export function createMockToolContext(options: MockToolContextOptions = {}): MockToolContext {
+  const httpCalls: MockHttpCall[] = [];
+  const bodyFor = (path: string): string => options.responses?.[path] ?? options.responseBody ?? '';
+  const resp = (path: string): AdtResponse => ({ statusCode: 200, headers: {}, body: bodyFor(path) });
+
+  const http: SafeHttpClient = {
+    get: async (path) => {
+      httpCalls.push({ method: 'GET', path });
+      return resp(path);
+    },
+    head: async (path) => {
+      httpCalls.push({ method: 'HEAD', path });
+      return resp(path);
+    },
+    post: async (path, body) => {
+      httpCalls.push({ method: 'POST', path, body });
+      return resp(path);
+    },
+    put: async (path, body) => {
+      httpCalls.push({ method: 'PUT', path, body });
+      return resp(path);
+    },
+    delete: async (path) => {
+      httpCalls.push({ method: 'DELETE', path });
+      return resp(path);
+    },
+    withStatefulSession: (fn) => fn(http),
+  };
+
+  const ctx: MockToolContext = {
+    client: (options.client ?? {}) as unknown as ToolContext['client'],
+    http,
+    cache: undefined,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    authInfo: { userName: 'test-user', scopes: options.scopes ?? ['read'], clientId: 'test' },
+    requestId: options.requestId ?? 'test-request',
+    httpCalls,
+  };
+  return ctx;
+}

--- a/src/public/testing.ts
+++ b/src/public/testing.ts
@@ -9,9 +9,8 @@ import type { SafeHttpClient } from '../server/safe-http-client.js';
 import type { ToolContext } from './types.js';
 
 export interface MockHttpCall {
-  method: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE';
+  method: 'GET' | 'HEAD';
   path: string;
-  body?: string;
 }
 
 export interface MockToolContext extends ToolContext {
@@ -45,25 +44,11 @@ export function createMockToolContext(options: MockToolContextOptions = {}): Moc
       httpCalls.push({ method: 'HEAD', path });
       return resp(path);
     },
-    post: async (path, body) => {
-      httpCalls.push({ method: 'POST', path, body });
-      return resp(path);
-    },
-    put: async (path, body) => {
-      httpCalls.push({ method: 'PUT', path, body });
-      return resp(path);
-    },
-    delete: async (path) => {
-      httpCalls.push({ method: 'DELETE', path });
-      return resp(path);
-    },
-    withStatefulSession: (fn) => fn(http),
   };
 
   const ctx: MockToolContext = {
     client: (options.client ?? {}) as unknown as ToolContext['client'],
     http,
-    cache: undefined,
     logger: { info: () => {}, warn: () => {}, error: () => {} },
     authInfo: { userName: 'test-user', scopes: options.scopes ?? ['read'], clientId: 'test' },
     requestId: options.requestId ?? 'test-request',

--- a/src/public/testing.ts
+++ b/src/public/testing.ts
@@ -16,6 +16,8 @@ export interface MockHttpCall {
 export interface MockToolContext extends ToolContext {
   /** Every `ctx.http` call the handler made, in order. */
   httpCalls: MockHttpCall[];
+  /** Every class name passed to `ctx.run.classRun`, in order. */
+  classRunCalls: string[];
 }
 
 export interface MockToolContextOptions {
@@ -28,6 +30,8 @@ export interface MockToolContextOptions {
   requestId?: string;
   /** Partial `ctx.client` for handlers that call high-level read methods. */
   client?: Partial<ToolContext['client']>;
+  /** Console output returned by `ctx.run.classRun` (default ''). The mock never gates. */
+  classRunOutput?: string;
 }
 
 export function createMockToolContext(options: MockToolContextOptions = {}): MockToolContext {
@@ -46,13 +50,23 @@ export function createMockToolContext(options: MockToolContextOptions = {}): Moc
     },
   };
 
+  const classRunCalls: string[] = [];
+  const run: ToolContext['run'] = {
+    classRun: async (className) => {
+      classRunCalls.push(className);
+      return options.classRunOutput ?? '';
+    },
+  };
+
   const ctx: MockToolContext = {
     client: (options.client ?? {}) as unknown as ToolContext['client'],
     http,
+    run,
     logger: { info: () => {}, warn: () => {}, error: () => {} },
     authInfo: { userName: 'test-user', scopes: options.scopes ?? ['read'], clientId: 'test' },
     requestId: options.requestId ?? 'test-request',
     httpCalls,
+    classRunCalls,
   };
   return ctx;
 }

--- a/src/public/types.ts
+++ b/src/public/types.ts
@@ -22,6 +22,22 @@ export type ReadOnlyAdtClient = Omit<
   'http' | 'safety' | 'withSafety' | 'getPackageHierarchyResolver' | 'invalidatePackageHierarchy'
 >;
 
+/**
+ * Named, privileged operations a plugin can invoke. Unlike `ctx.http` (read-only), these EXECUTE.
+ * Each op is gated server-side; calling one when its gate is closed throws `AdtSafetyError`.
+ */
+export interface PluginRunOps {
+  /**
+   * Run an ABAP **console class** (one implementing `IF_OO_ADT_CLASSRUN`) and return its console
+   * output (`out->write( … )`) as plain text. Wraps `POST /sap/bc/adt/oo/classrun/{class}`.
+   *
+   * Gated (all must hold): the server opt-in `SAP_ALLOW_PLUGIN_EXECUTE=true`, `SAP_ALLOW_WRITES=true`
+   * (executing ABAP is a mutation vector), and the calling tool must declare `write` scope. SAP-side
+   * the user still needs execute authorization. The class name is validated (no path injection).
+   */
+  classRun(className: string): Promise<string>;
+}
+
 /** Minimal structured logger handed to plugins (stderr only — never `console.log`). */
 export interface PluginLogger {
   info(message: string, data?: unknown): void;
@@ -33,6 +49,7 @@ export interface PluginLogger {
 export interface ToolContext {
   readonly client: ReadOnlyAdtClient; // high-level reads only — `.http`/`.safety` blocked at runtime too
   readonly http: SafeHttpClient; // the ONLY low-level HTTP path — gated; v1 is read-only (GET/HEAD)
+  readonly run: PluginRunOps; // named privileged ops (e.g. classRun) — each gated server-side
   readonly logger: PluginLogger;
   readonly authInfo?: { userName?: string; scopes: string[]; clientId?: string };
   readonly requestId: string;

--- a/src/public/types.ts
+++ b/src/public/types.ts
@@ -5,7 +5,6 @@ import type { ZodTypeAny } from 'zod';
 import type { AdtClient } from '../adt/client.js';
 import type { OperationTypeCode } from '../adt/safety.js';
 import type { Scope } from '../authz/policy.js';
-import type { CachingLayer } from '../cache/caching-layer.js';
 import type { ToolResult } from '../registry/tool-registry.js';
 import type { SafeHttpClient } from '../server/safe-http-client.js';
 
@@ -32,9 +31,8 @@ export interface PluginLogger {
 
 /** Per-call context a plugin tool receives. Built fresh per request (never bound at registration). */
 export interface ToolContext {
-  readonly client: ReadOnlyAdtClient; // high-level reads only — `.http` deliberately absent
-  readonly http: SafeHttpClient; // the ONLY HTTP path — gated, any SAP path
-  readonly cache?: CachingLayer;
+  readonly client: ReadOnlyAdtClient; // high-level reads only — `.http`/`.safety` blocked at runtime too
+  readonly http: SafeHttpClient; // the ONLY low-level HTTP path — gated; v1 is read-only (GET/HEAD)
   readonly logger: PluginLogger;
   readonly authInfo?: { userName?: string; scopes: string[]; clientId?: string };
   readonly requestId: string;
@@ -59,6 +57,8 @@ export interface PluginToolDefinition {
   readonly description: string;
   readonly schema: ZodTypeAny; // input validation; converted to JSON Schema for tools/list (PR3)
   readonly policy: { scope: Scope; opType: OperationTypeCode };
+  /** System-type visibility, enforced in `tools/list`: a non-`all` tool is hidden when the resolved
+   *  system type is known and differs (e.g. `btp` tool on an on-prem system). Default `all`. */
   readonly availableOn?: 'all' | 'onprem' | 'btp';
   handler(args: unknown, ctx: ToolContext): Promise<ToolResult>;
 }

--- a/src/public/types.ts
+++ b/src/public/types.ts
@@ -1,0 +1,73 @@
+// Public extension API types (@experimental — may break in any release; gated by `apiVersion`).
+// See docs/research/extension-framework-spec.md §2.
+
+import type { ZodTypeAny } from 'zod';
+import type { AdtClient } from '../adt/client.js';
+import type { OperationTypeCode } from '../adt/safety.js';
+import type { Scope } from '../authz/policy.js';
+import type { CachingLayer } from '../cache/caching-layer.js';
+import type { ToolResult } from '../registry/tool-registry.js';
+import type { SafeHttpClient } from '../server/safe-http-client.js';
+
+export type { SafeHttpClient, Scope, ToolResult };
+
+/**
+ * `AdtClient` narrowed to its safe read facade. Omits (review B1):
+ *  - `http`            — the raw, UNGATED AdtHttpClient (all HTTP must go through `ctx.http`)
+ *  - `safety`/`withSafety` — the safety ref + the escalation hatch
+ *  - the package-hierarchy cache mutators
+ * Every retained method already runs `checkOperation` internally, so exposing them is safe.
+ */
+export type ReadOnlyAdtClient = Omit<
+  AdtClient,
+  'http' | 'safety' | 'withSafety' | 'getPackageHierarchyResolver' | 'invalidatePackageHierarchy'
+>;
+
+/** Minimal structured logger handed to plugins (stderr only — never `console.log`). */
+export interface PluginLogger {
+  info(message: string, data?: unknown): void;
+  warn(message: string, data?: unknown): void;
+  error(message: string, data?: unknown): void;
+}
+
+/** Per-call context a plugin tool receives. Built fresh per request (never bound at registration). */
+export interface ToolContext {
+  readonly client: ReadOnlyAdtClient; // high-level reads only — `.http` deliberately absent
+  readonly http: SafeHttpClient; // the ONLY HTTP path — gated, any SAP path
+  readonly cache?: CachingLayer;
+  readonly logger: PluginLogger;
+  readonly authInfo?: { userName?: string; scopes: string[]; clientId?: string };
+  readonly requestId: string;
+  // Optional, capability-detected (PR5) — present only when the client supports the capability:
+  /** Ask the user for input mid-tool (elicitation). `requestedSchema` defaults to a confirm. */
+  readonly elicit?: (message: string, requestedSchema?: Record<string, unknown>) => Promise<ElicitOutcome>;
+  /** Send a client-visible progress/log line (distinct from the stderr `logger`). */
+  readonly notify?: (level: 'info' | 'warning' | 'error', message: string) => Promise<void>;
+  /** Ask the LLM a sub-question (sampling). Returns the text answer. */
+  readonly sampling?: (systemPrompt: string, userMessage: string, maxTokens?: number) => Promise<string>;
+}
+
+/** The outcome of `ctx.elicit` — the MCP elicitation result. */
+export interface ElicitOutcome {
+  action: 'accept' | 'decline' | 'cancel';
+  content?: Record<string, unknown>;
+}
+
+/** A plugin tool definition (code tier). Named to avoid colliding with the internal MCP ToolDefinition. */
+export interface PluginToolDefinition {
+  readonly name: `Custom_${string}`;
+  readonly description: string;
+  readonly schema: ZodTypeAny; // input validation; converted to JSON Schema for tools/list (PR3)
+  readonly policy: { scope: Scope; opType: OperationTypeCode };
+  readonly availableOn?: 'all' | 'onprem' | 'btp';
+  handler(args: unknown, ctx: ToolContext): Promise<ToolResult>;
+}
+
+/** The default export shape of an `ARC1_PLUGINS` code plugin. */
+export interface Plugin {
+  readonly name: string;
+  readonly version: string;
+  readonly apiVersion: number;
+  readonly tools: PluginToolDefinition[];
+  readonly manifests?: string[];
+}

--- a/src/registry/tool-registry.ts
+++ b/src/registry/tool-registry.ts
@@ -68,8 +68,8 @@ const CUSTOM_PREFIX = 'Custom_';
  * built-in or silently dropping a tool.
  */
 export class ToolRegistry {
+  // Map preserves insertion order (ECMAScript guarantee), so it IS the registration order.
   private readonly entries = new Map<string, RegistryEntry>();
-  private readonly order: string[] = [];
 
   register(entry: RegistryEntry): void {
     if (!entry?.name) {
@@ -89,7 +89,6 @@ export class ToolRegistry {
       throw new Error(`ToolRegistry.register: duplicate tool name '${entry.name}'`);
     }
     this.entries.set(entry.name, entry);
-    this.order.push(entry.name);
   }
 
   get(name: string): RegistryEntry | undefined {
@@ -102,7 +101,7 @@ export class ToolRegistry {
 
   /** Built-ins first (registration order), then plugins (registration order). Deterministic for `tools/list`. */
   list(): RegistryEntry[] {
-    const all = this.order.map((n) => this.entries.get(n)!);
+    const all = [...this.entries.values()];
     return [...all.filter((e) => e.source === 'builtin'), ...all.filter((e) => e.source === 'plugin')];
   }
 

--- a/src/registry/tool-registry.ts
+++ b/src/registry/tool-registry.ts
@@ -1,0 +1,110 @@
+// Typed tool registry — the single dispatch table for built-in AND plugin (extension) tools.
+//
+// FEAT-61 PR1: this replaces the hand-written `switch (toolName)` in `handleToolCall`
+// (src/handlers/dispatch.ts). Built-ins register at startup with thin adapter `invoke`s that
+// call their existing handlers; the shared pipeline (rate-limit, scope, Zod, audit) stays in
+// `handleToolCall` and is unchanged — the registry only owns the inner dispatch.
+//
+// See docs/research/extension-framework-spec.md §4.
+
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { AdtClient } from '../adt/client.js';
+import type { OperationTypeCode } from '../adt/safety.js';
+import type { Scope } from '../authz/policy.js';
+import type { CachingLayer } from '../cache/caching-layer.js';
+import type { CacheSecurityContext } from '../handlers/cache-security.js';
+import type { ServerConfig } from '../server/types.js';
+
+/**
+ * The MCP tool result shape. Defined locally to keep the registry free of any runtime
+ * dependency on the handler module (which imports the registry). It is structurally identical
+ * to `ToolResult` in src/handlers/shared.ts; both unify on the public `arc-1/public` type in PR2.
+ */
+export interface ToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+/**
+ * Per-request context handed to a tool's `invoke`. Built fresh in `handleToolCall` for each
+ * call (carrying the per-user `effectiveClient` from `withSafety()`), NEVER bound at registration.
+ * PR2 narrows the plugin-facing surface (ReadOnlyAdtClient + a gated SafeHttpClient); built-in
+ * adapters use this internal bundle directly.
+ */
+export interface ToolDispatchContext {
+  readonly client: AdtClient;
+  readonly config: ServerConfig;
+  readonly args: Record<string, unknown>;
+  readonly cache?: CachingLayer;
+  readonly authInfo?: AuthInfo;
+  readonly isPerUserClient?: boolean;
+  readonly cacheSecurity: CacheSecurityContext;
+  readonly server?: Server;
+  readonly requestId: string;
+}
+
+/** A registered tool — a built-in or a plugin-contributed `Custom_*` tool. */
+export interface RegistryEntry {
+  readonly name: string;
+  readonly source: 'builtin' | 'plugin';
+  /** Identifies the contributing plugin (plugin tools only) — used for audit + diagnostics. */
+  readonly pluginName?: string;
+  /** Authorization metadata — the SAME shape ACTION_POLICY uses; gated identically to a built-in. */
+  readonly policy: { scope: Scope; opType: OperationTypeCode; featureGate?: string };
+  /** For plugin tools: the pre-computed MCP `tools/list` shape (built-ins list via getToolDefinitions). */
+  readonly listing?: { description: string; inputSchema: Record<string, unknown> };
+  invoke(ctx: ToolDispatchContext): Promise<ToolResult>;
+}
+
+const CUSTOM_PREFIX = 'Custom_';
+
+/**
+ * In-memory registry of tools. One instance per server. Built-ins are registered first (at
+ * startup); plugins are registered after (by the loader). Registration is fail-fast: a malformed
+ * entry or a name collision throws, so a bad plugin refuses server start rather than shadowing a
+ * built-in or silently dropping a tool.
+ */
+export class ToolRegistry {
+  private readonly entries = new Map<string, RegistryEntry>();
+  private readonly order: string[] = [];
+
+  register(entry: RegistryEntry): void {
+    if (!entry?.name) {
+      throw new Error('ToolRegistry.register: entry.name is required');
+    }
+    if (!entry.policy?.scope || !entry.policy.opType) {
+      throw new Error(
+        `ToolRegistry.register: tool '${entry.name}' must declare policy.scope + policy.opType (got ${JSON.stringify(entry.policy)})`,
+      );
+    }
+    if (entry.source === 'plugin' && !entry.name.startsWith(CUSTOM_PREFIX)) {
+      throw new Error(
+        `ToolRegistry.register: plugin tool '${entry.name}' must use the reserved '${CUSTOM_PREFIX}' namespace`,
+      );
+    }
+    if (this.entries.has(entry.name)) {
+      throw new Error(`ToolRegistry.register: duplicate tool name '${entry.name}'`);
+    }
+    this.entries.set(entry.name, entry);
+    this.order.push(entry.name);
+  }
+
+  get(name: string): RegistryEntry | undefined {
+    return this.entries.get(name);
+  }
+
+  has(name: string): boolean {
+    return this.entries.has(name);
+  }
+
+  /** Built-ins first (registration order), then plugins (registration order). Deterministic for `tools/list`. */
+  list(): RegistryEntry[] {
+    const all = this.order.map((n) => this.entries.get(n)!);
+    return [...all.filter((e) => e.source === 'builtin'), ...all.filter((e) => e.source === 'plugin')];
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/registry/tool-registry.ts
+++ b/src/registry/tool-registry.ts
@@ -52,6 +52,8 @@ export interface RegistryEntry {
   readonly pluginName?: string;
   /** Authorization metadata — the SAME shape ACTION_POLICY uses; gated identically to a built-in. */
   readonly policy: { scope: Scope; opType: OperationTypeCode; featureGate?: string };
+  /** Plugin tools only: system-type visibility hint, enforced in `tools/list` (default `all`). */
+  readonly availableOn?: 'all' | 'onprem' | 'btp';
   /** For plugin tools: the pre-computed MCP `tools/list` shape (built-ins list via getToolDefinitions). */
   readonly listing?: { description: string; inputSchema: Record<string, unknown> };
   invoke(ctx: ToolDispatchContext): Promise<ToolResult>;

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -24,6 +24,8 @@ export interface AuditEventBase {
 export interface ToolCallStartEvent extends AuditEventBase {
   event: 'tool_call_start';
   tool: string;
+  /** Contributing plugin name when `tool` is a plugin-sourced `Custom_*` tool (FEAT-61). */
+  pluginName?: string;
   args: Record<string, unknown>;
 }
 
@@ -31,6 +33,8 @@ export interface ToolCallStartEvent extends AuditEventBase {
 export interface ToolCallEndEvent extends AuditEventBase {
   event: 'tool_call_end';
   tool: string;
+  /** Contributing plugin name when `tool` is a plugin-sourced `Custom_*` tool (FEAT-61). */
+  pluginName?: string;
   durationMs: number;
   status: 'success' | 'error';
   errorClass?: string;

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -489,6 +489,14 @@ export function resolveConfig(args: string[]): { config: ServerConfig; sources: 
   const toolMode = resolveStr('tool-mode', 'ARC1_TOOL_MODE', 'standard', 'toolMode');
   config.toolMode = (toolMode === 'hyperfocused' ? 'hyperfocused' : 'standard') as ServerConfig['toolMode'];
 
+  // ── Extensions (FEAT-61) ───────────────────────────────────────────
+  // CSV of absolute paths to extension plugins (local dirs/files, NOT npm names). Loaded at startup.
+  const pluginsRaw = getFlag('plugins') ?? process.env.ARC1_PLUGINS;
+  config.plugins = (pluginsRaw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
   // ── Lint ───────────────────────────────────────────────────────────
   config.abaplintConfig = resolveOptionalStr('abaplint-config', 'SAP_ABAPLINT_CONFIG', 'abaplintConfig');
   config.lintBeforeWrite = resolveBool('lint-before-write', 'SAP_LINT_BEFORE_WRITE', true, 'lintBeforeWrite');

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -496,6 +496,13 @@ export function resolveConfig(args: string[]): { config: ServerConfig; sources: 
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
+  // Opt-in: let plugin tools execute ABAP console classes (ctx.run.classRun). Also needs allowWrites.
+  config.allowPluginExecute = resolveBool(
+    'allow-plugin-execute',
+    'SAP_ALLOW_PLUGIN_EXECUTE',
+    false,
+    'allowPluginExecute',
+  );
 
   // ── Lint ───────────────────────────────────────────────────────────
   config.abaplintConfig = resolveOptionalStr('abaplint-config', 'SAP_ABAPLINT_CONFIG', 'abaplintConfig');

--- a/src/server/plugin-loader.ts
+++ b/src/server/plugin-loader.ts
@@ -14,7 +14,7 @@ import { registerManifestTool } from '../plugins/manifest-interpreter.js';
 import type { Plugin, PluginToolDefinition, ToolContext } from '../public/types.js';
 import type { RegistryEntry, ToolDispatchContext, ToolRegistry, ToolResult } from '../registry/tool-registry.js';
 import { logger } from './logger.js';
-import { createSafeHttpClient } from './safe-http-client.js';
+import { createReadOnlyAdtClient, createSafeHttpClient } from './safe-http-client.js';
 
 /** The apiVersion this ARC-1 understands. Bump on every breaking change to the plugin API. */
 export const SUPPORTED_API_VERSION = 1;
@@ -94,11 +94,11 @@ function makePluginInvoke(def: PluginToolDefinition): (ctx: ToolDispatchContext)
       };
     }
     const publicCtx: ToolContext = {
-      // AdtClient is a structural superset of ReadOnlyAdtClient — the type hides `.http` from the
-      // plugin while the gated `http` below is the only sanctioned HTTP path (review B1).
-      client: dispatchCtx.client,
-      http: createSafeHttpClient(dispatchCtx.client.http, dispatchCtx.client.safety, def.policy.scope, def.name),
-      cache: dispatchCtx.cache,
+      // `client` is a runtime read-only Proxy (escape hatches `.http`/`.safety`/`withSafety` blocked,
+      // not just type-hidden); `http` is the gated read-only surface — the only sanctioned low-level
+      // HTTP path. Both close review B1. See safe-http-client.ts.
+      client: createReadOnlyAdtClient(dispatchCtx.client),
+      http: createSafeHttpClient(dispatchCtx.client.http, dispatchCtx.client.safety, def.name),
       logger: pluginLogger(def.name),
       authInfo: dispatchCtx.authInfo
         ? {
@@ -122,6 +122,7 @@ export function registerPluginTool(registry: ToolRegistry, pluginName: string, d
     source: 'plugin',
     pluginName,
     policy: def.policy,
+    availableOn: def.availableOn,
     listing: { description: def.description, inputSchema },
     invoke: makePluginInvoke(def),
   };

--- a/src/server/plugin-loader.ts
+++ b/src/server/plugin-loader.ts
@@ -14,7 +14,7 @@ import { registerManifestTool } from '../plugins/manifest-interpreter.js';
 import type { Plugin, PluginToolDefinition, ToolContext } from '../public/types.js';
 import type { RegistryEntry, ToolDispatchContext, ToolRegistry, ToolResult } from '../registry/tool-registry.js';
 import { logger } from './logger.js';
-import { createReadOnlyAdtClient, createSafeHttpClient } from './safe-http-client.js';
+import { createPluginRunOps, createReadOnlyAdtClient, createSafeHttpClient } from './safe-http-client.js';
 
 /** The apiVersion this ARC-1 understands. Bump on every breaking change to the plugin API. */
 export const SUPPORTED_API_VERSION = 1;
@@ -99,6 +99,13 @@ function makePluginInvoke(def: PluginToolDefinition): (ctx: ToolDispatchContext)
       // HTTP path. Both close review B1. See safe-http-client.ts.
       client: createReadOnlyAdtClient(dispatchCtx.client),
       http: createSafeHttpClient(dispatchCtx.client.http, dispatchCtx.client.safety, def.name),
+      run: createPluginRunOps(
+        dispatchCtx.client.http,
+        dispatchCtx.client.safety,
+        dispatchCtx.config.allowPluginExecute,
+        def.policy.scope,
+        def.name,
+      ),
       logger: pluginLogger(def.name),
       authInfo: dispatchCtx.authInfo
         ? {

--- a/src/server/plugin-loader.ts
+++ b/src/server/plugin-loader.ts
@@ -1,0 +1,183 @@
+// Plugin loader — loads local trusted extensions listed in ARC1_PLUGINS and registers their
+// Custom_* tools into the ToolRegistry. FEAT-61 PR3. See docs/research/extension-framework-spec.md §7.
+//
+// A plugin is a LOCAL file (no npm). Each `ARC1_PLUGINS` entry is an absolute path to a `.js`
+// module whose default export is a `Plugin`. Loading is fail-fast: a malformed plugin, an
+// apiVersion mismatch, or a name collision refuses server start rather than silently dropping a
+// tool or shadowing a built-in.
+
+import { readFileSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { z } from 'zod';
+import { registerManifestTool } from '../plugins/manifest-interpreter.js';
+import type { Plugin, PluginToolDefinition, ToolContext } from '../public/types.js';
+import type { RegistryEntry, ToolDispatchContext, ToolRegistry, ToolResult } from '../registry/tool-registry.js';
+import { logger } from './logger.js';
+import { createSafeHttpClient } from './safe-http-client.js';
+
+/** The apiVersion this ARC-1 understands. Bump on every breaking change to the plugin API. */
+export const SUPPORTED_API_VERSION = 1;
+
+export interface LoadedPlugin {
+  name: string;
+  version: string;
+  path: string;
+  toolNames: string[];
+}
+
+/** Refuse anything not an absolute, readable, owner-only, non-world-writable file. */
+function assertLoadablePath(p: string): void {
+  if (!isAbsolute(p)) {
+    throw new Error(`ARC1_PLUGINS entry must be an absolute path: '${p}'`);
+  }
+  const st = statSync(p); // throws (ENOENT/EACCES) if missing or unreadable
+  if (typeof process.getuid === 'function' && st.uid !== process.getuid()) {
+    throw new Error(`Plugin '${p}' is not owned by the server user — refusing to load`);
+  }
+  if ((st.mode & 0o002) !== 0) {
+    throw new Error(`Plugin '${p}' is world-writable — refusing to load`);
+  }
+}
+
+function pluginLogger(toolName: string): ToolContext['logger'] {
+  const tag = `[plugin ${toolName}]`;
+  return {
+    info: (m, d) => logger.info(`${tag} ${m}`, d as Record<string, unknown> | undefined),
+    warn: (m, d) => logger.warn(`${tag} ${m}`, d as Record<string, unknown> | undefined),
+    error: (m, d) => logger.error(`${tag} ${m}`, d as Record<string, unknown> | undefined),
+  };
+}
+
+/** Build the optional MCP capabilities (elicit/notify/sampling) from the request's Server, gated by
+ *  the client's declared capabilities. Returns empty when there is no server (stdio CLI / tests). */
+function buildMcpCapabilities(
+  server: ToolDispatchContext['server'],
+): Pick<ToolContext, 'elicit' | 'notify' | 'sampling'> {
+  if (!server) return {};
+  const caps = server.getClientCapabilities?.();
+  return {
+    elicit: caps?.elicitation
+      ? async (message, requestedSchema) => {
+          const res = await server.elicitInput({
+            message,
+            requestedSchema: (requestedSchema ?? { type: 'object', properties: {} }) as never,
+          });
+          return res as { action: 'accept' | 'decline' | 'cancel'; content?: Record<string, unknown> };
+        }
+      : undefined,
+    notify: async (level, message) => {
+      await server.sendLoggingMessage({ level, data: message });
+    },
+    sampling: caps?.sampling
+      ? async (systemPrompt, userMessage, maxTokens) => {
+          const res = await server.createMessage({
+            messages: [{ role: 'user', content: { type: 'text', text: userMessage } }],
+            systemPrompt,
+            maxTokens: maxTokens ?? 1000,
+          });
+          return res.content.type === 'text' ? res.content.text : '';
+        }
+      : undefined,
+  };
+}
+
+/** Build a plugin tool's `invoke`: validate args against its Zod schema, build the gated public
+ *  ToolContext per call, then run the handler. Errors are contained (handleToolCall's try/catch). */
+function makePluginInvoke(def: PluginToolDefinition): (ctx: ToolDispatchContext) => Promise<ToolResult> {
+  return async (dispatchCtx: ToolDispatchContext): Promise<ToolResult> => {
+    const parsed = def.schema.safeParse(dispatchCtx.args);
+    if (!parsed.success) {
+      return {
+        content: [{ type: 'text', text: `Invalid arguments for ${def.name}: ${parsed.error.message}` }],
+        isError: true,
+      };
+    }
+    const publicCtx: ToolContext = {
+      // AdtClient is a structural superset of ReadOnlyAdtClient — the type hides `.http` from the
+      // plugin while the gated `http` below is the only sanctioned HTTP path (review B1).
+      client: dispatchCtx.client,
+      http: createSafeHttpClient(dispatchCtx.client.http, dispatchCtx.client.safety, def.policy.scope, def.name),
+      cache: dispatchCtx.cache,
+      logger: pluginLogger(def.name),
+      authInfo: dispatchCtx.authInfo
+        ? {
+            userName: dispatchCtx.authInfo.extra?.userName as string | undefined,
+            scopes: dispatchCtx.authInfo.scopes,
+            clientId: dispatchCtx.authInfo.clientId,
+          }
+        : undefined,
+      requestId: dispatchCtx.requestId,
+      ...buildMcpCapabilities(dispatchCtx.server),
+    };
+    return def.handler(parsed.data, publicCtx);
+  };
+}
+
+/** Register one plugin tool into the registry (fail-fast on collision / namespace / missing policy). */
+export function registerPluginTool(registry: ToolRegistry, pluginName: string, def: PluginToolDefinition): void {
+  const inputSchema = z.toJSONSchema(def.schema) as Record<string, unknown>;
+  const entry: RegistryEntry = {
+    name: def.name,
+    source: 'plugin',
+    pluginName,
+    policy: def.policy,
+    listing: { description: def.description, inputSchema },
+    invoke: makePluginInvoke(def),
+  };
+  registry.register(entry);
+}
+
+function validatePlugin(plugin: Plugin | undefined, path: string): asserts plugin is Plugin {
+  if (!plugin || typeof plugin.name !== 'string' || !Array.isArray(plugin.tools)) {
+    throw new Error(
+      `Plugin at '${path}' has no valid default export (expected { name, version, apiVersion, tools[] })`,
+    );
+  }
+  if (plugin.apiVersion !== SUPPORTED_API_VERSION) {
+    throw new Error(
+      `Plugin '${plugin.name}' targets apiVersion ${plugin.apiVersion}; this ARC-1 supports ${SUPPORTED_API_VERSION}`,
+    );
+  }
+}
+
+/** Read + register a declarative `*.tool.json` manifest. Returns the tool name. */
+function loadManifestFile(registry: ToolRegistry, pluginName: string, manifestPath: string): string {
+  assertLoadablePath(manifestPath);
+  const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as { name?: string };
+  registerManifestTool(registry, pluginName, parsed);
+  return String(parsed.name);
+}
+
+/**
+ * Load every `ARC1_PLUGINS` path and register its tools. Throws (fail-fast) on any problem.
+ * A `.json` path is a standalone manifest tool; a `.js` path is a code plugin (which may also
+ * reference `*.tool.json` manifests via its `manifests[]`, resolved relative to the plugin).
+ */
+export async function loadPlugins(paths: string[], registry: ToolRegistry): Promise<LoadedPlugin[]> {
+  const loaded: LoadedPlugin[] = [];
+  for (const p of paths) {
+    if (p.endsWith('.json')) {
+      const toolName = loadManifestFile(registry, p, p);
+      loaded.push({ name: p, version: '—', path: p, toolNames: [toolName] });
+      logger.info(`Loaded manifest tool '${toolName}'`, { path: p });
+      continue;
+    }
+    assertLoadablePath(p);
+    const mod = (await import(pathToFileURL(p).href)) as { default?: Plugin };
+    const plugin = mod.default;
+    validatePlugin(plugin, p);
+    for (const def of plugin.tools) {
+      registerPluginTool(registry, plugin.name, def);
+    }
+    const manifestNames: string[] = [];
+    for (const m of plugin.manifests ?? []) {
+      const abs = isAbsolute(m) ? m : resolve(dirname(p), m);
+      manifestNames.push(loadManifestFile(registry, plugin.name, abs));
+    }
+    const toolNames = [...plugin.tools.map((t) => t.name), ...manifestNames];
+    loaded.push({ name: plugin.name, version: plugin.version, path: p, toolNames });
+    logger.info(`Loaded extension '${plugin.name}' v${plugin.version} (${toolNames.length} tool(s))`, { path: p });
+  }
+  return loaded;
+}

--- a/src/server/safe-http-client.ts
+++ b/src/server/safe-http-client.ts
@@ -1,94 +1,87 @@
-// SafeHttpClient — the gated low-level HTTP surface handed to extension tools as `ctx.http`.
+// SafeHttpClient + createReadOnlyAdtClient — the gated surfaces handed to extension tools.
 //
-// FEAT-61 / review B1: extension tools must NOT receive the raw AdtHttpClient, whose `post/put/
-// delete` bypass `checkOperation` entirely. This wrapper gates every call:
-//   1. the tool's declared scope must COVER the call's operation class (a `read` tool can't POST), and
-//   2. the server safety ceiling (`checkOperation`: allowWrites / allowDataPreview / …) must allow it.
-// Everything else (CSRF, cookies, PP auth, stateful sessions, the semaphore) rides the underlying
-// client unchanged and path-agnostically. See docs/research/extension-framework-spec.md §5.
+// FEAT-61 / review B1: an extension tool must NOT receive the raw, ungated client. There are two
+// escape routes a plugin could otherwise take, and both are closed here:
+//
+//   1. `ctx.http` — the raw AdtHttpClient's post/put/delete bypass `checkOperation`. v1 hands
+//      plugins a READ-ONLY surface (get/head). Writes are deliberately deferred to v2: a raw
+//      `http.post(path, …)` can't be constrained by `SAP_ALLOWED_PACKAGES` (package resolution
+//      needs the ADT object-URL shape, which an arbitrary path doesn't give us), so shipping
+//      un-package-gated writes would punch straight through the server safety ceiling. v2 adds a
+//      package-aware write vocabulary; until then, code-tier and manifest-tier tools are read-only.
+//
+//   2. `ctx.client` — typed as `ReadOnlyAdtClient` (Omit of `http`/`safety`/`withSafety`/…), but a
+//      cast (`(ctx.client as any).http`) would defeat a type-only narrowing. `createReadOnlyAdtClient`
+//      enforces the same omission at RUNTIME via a Proxy, so the cast yields `undefined`.
+//
+// CSRF, cookies, PP auth, sessions, the semaphore all ride the underlying client unchanged.
+// See docs/research/extension-framework-spec.md §5.
 
-import { AdtSafetyError } from '../adt/errors.js';
+import type { AdtClient } from '../adt/client.js';
 import type { AdtHttpClient, AdtResponse } from '../adt/http.js';
-import { checkOperation, OperationType, type OperationTypeCode, type SafetyConfig } from '../adt/safety.js';
-import { hasRequiredScope, type Scope } from '../authz/policy.js';
+import { checkOperation, OperationType, type SafetyConfig } from '../adt/safety.js';
+import type { ReadOnlyAdtClient } from '../public/types.js';
 
-/** Operation class → the scope it requires (mirrors ACTION_POLICY's opType↔scope consistency). */
-const OPTYPE_SCOPE: Record<OperationTypeCode, Scope> = {
-  R: 'read',
-  S: 'read',
-  I: 'read',
-  T: 'read',
-  L: 'read',
-  Q: 'data',
-  F: 'sql',
-  C: 'write',
-  U: 'write',
-  D: 'write',
-  A: 'write',
-  W: 'write',
-  X: 'transports',
-};
-
+/** The read-only HTTP surface a plugin tool receives as `ctx.http`. v1: GET/HEAD only. */
 export interface SafeHttpClient {
   get(path: string, headers?: Record<string, string>): Promise<AdtResponse>;
   head(path: string, headers?: Record<string, string>): Promise<AdtResponse>;
-  post(path: string, body?: string, contentType?: string, headers?: Record<string, string>): Promise<AdtResponse>;
-  put(path: string, body: string, contentType?: string, headers?: Record<string, string>): Promise<AdtResponse>;
-  delete(path: string, headers?: Record<string, string>): Promise<AdtResponse>;
-  withStatefulSession<T>(fn: (s: SafeHttpClient) => Promise<T>): Promise<T>;
-  // NB: fetchCsrfToken(path?) lands in PR2c alongside the AdtHttpClient change it needs (OData writes).
 }
 
 /**
- * Wrap a per-user `AdtHttpClient` in the gated surface for one tool call.
+ * Wrap a per-user `AdtHttpClient` in the read-only gated surface for one tool call.
  *
  * @param underlying  the request's per-user (PP/`withSafety`) AdtHttpClient
  * @param safety      the effective per-user SafetyConfig (server ceiling ∧ user)
- * @param toolScope   the calling tool's declared `policy.scope` — the ceiling for its HTTP ops
- * @param opLabel     tool name, used in audit + error messages
+ * @param opLabel     tool name, used in error messages
  */
-export function createSafeHttpClient(
-  underlying: AdtHttpClient,
-  safety: SafetyConfig,
-  toolScope: Scope,
-  opLabel: string,
-): SafeHttpClient {
-  function gate(op: OperationTypeCode): void {
-    const required = OPTYPE_SCOPE[op];
-    // (1) the tool's declared scope must cover the operation — a `read` tool may never write.
-    if (!hasRequiredScope([toolScope], required)) {
-      throw new AdtSafetyError(
-        `Extension tool '${opLabel}' declares scope '${toolScope}' and may not issue a ${op}-class HTTP call (needs scope '${required}')`,
-      );
-    }
-    // (2) the server safety ceiling (allowWrites / allowDataPreview / allowFreeSQL / …).
-    checkOperation(safety, op, `Custom:${opLabel}`);
-  }
-
-  const self: SafeHttpClient = {
+export function createSafeHttpClient(underlying: AdtHttpClient, safety: SafetyConfig, opLabel: string): SafeHttpClient {
+  // Reads always pass the safety ceiling, but route through checkOperation anyway so the gate is
+  // the single seam where v2 write support will re-enter (and any future read opt-in lands here).
+  return {
     async get(path, headers) {
-      gate(OperationType.Read);
+      checkOperation(safety, OperationType.Read, `Custom:${opLabel}`);
       return underlying.get(path, headers);
     },
     async head(path, headers) {
-      gate(OperationType.Read);
+      checkOperation(safety, OperationType.Read, `Custom:${opLabel}`);
       return underlying.head(path, headers);
     },
-    async post(path, body, contentType, headers) {
-      gate(OperationType.Create);
-      return underlying.post(path, body, contentType, headers);
-    },
-    async put(path, body, contentType, headers) {
-      gate(OperationType.Update);
-      return underlying.put(path, body, contentType, headers);
-    },
-    async delete(path, headers) {
-      gate(OperationType.Delete);
-      return underlying.delete(path, headers);
-    },
-    async withStatefulSession(fn) {
-      return underlying.withStatefulSession((session) => fn(createSafeHttpClient(session, safety, toolScope, opLabel)));
-    },
   };
-  return self;
+}
+
+/** Keys that must NOT be reachable from a plugin's `ctx.client` (mirror `ReadOnlyAdtClient`'s Omit). */
+const BLOCKED_CLIENT_KEYS: ReadonlySet<string> = new Set([
+  'http', // the raw, ungated AdtHttpClient
+  'safety', // the effective safety ref
+  'withSafety', // the safety-escalation clone hatch
+  'getPackageHierarchyResolver',
+  'invalidatePackageHierarchy',
+]);
+
+/**
+ * Runtime read-only view of an `AdtClient`, handed to plugins as `ctx.client`. The static type
+ * `ReadOnlyAdtClient` hides the escape hatches at compile time; this Proxy enforces the SAME
+ * omission at runtime, so `(ctx.client as any).http.post(...)` resolves to `undefined` (review B1).
+ *
+ * Read methods keep working: each is returned bound to the REAL client, so a method's internal
+ * `this.http` / `this.safety` use hits the real instance directly (never the Proxy) — only
+ * EXTERNAL access to a blocked key is denied. Mutating traps are closed so a plugin can't repair
+ * the object either.
+ */
+export function createReadOnlyAdtClient(client: AdtClient): ReadOnlyAdtClient {
+  return new Proxy(client, {
+    get(target, prop) {
+      if (typeof prop === 'string' && BLOCKED_CLIENT_KEYS.has(prop)) return undefined;
+      const value = Reflect.get(target, prop, target);
+      return typeof value === 'function' ? (value as (...args: unknown[]) => unknown).bind(target) : value;
+    },
+    has(target, prop) {
+      if (typeof prop === 'string' && BLOCKED_CLIENT_KEYS.has(prop)) return false;
+      return Reflect.has(target, prop);
+    },
+    set: () => false,
+    defineProperty: () => false,
+    deleteProperty: () => false,
+  }) as unknown as ReadOnlyAdtClient;
 }

--- a/src/server/safe-http-client.ts
+++ b/src/server/safe-http-client.ts
@@ -18,9 +18,11 @@
 // See docs/research/extension-framework-spec.md §5.
 
 import type { AdtClient } from '../adt/client.js';
+import { AdtSafetyError } from '../adt/errors.js';
 import type { AdtHttpClient, AdtResponse } from '../adt/http.js';
 import { checkOperation, OperationType, type SafetyConfig } from '../adt/safety.js';
-import type { ReadOnlyAdtClient } from '../public/types.js';
+import { hasRequiredScope, type Scope } from '../authz/policy.js';
+import type { PluginRunOps, ReadOnlyAdtClient } from '../public/types.js';
 
 /** The read-only HTTP surface a plugin tool receives as `ctx.http`. v1: GET/HEAD only. */
 export interface SafeHttpClient {
@@ -84,4 +86,45 @@ export function createReadOnlyAdtClient(client: AdtClient): ReadOnlyAdtClient {
     defineProperty: () => false,
     deleteProperty: () => false,
   }) as unknown as ReadOnlyAdtClient;
+}
+
+/** ABAP object name (class): letters/digits/underscore/slash, ≤ 40 chars. Blocks path injection. */
+const ABAP_CLASS_NAME = /^[A-Za-z_/][A-Za-z0-9_/]{0,39}$/;
+
+/**
+ * Build the `ctx.run` named-operation surface. Unlike `ctx.http` (read-only), these EXECUTE — so the
+ * gate is the strictest in the framework. `classRun` (the only op in v1) runs an `IF_OO_ADT_CLASSRUN`
+ * console class, which can mutate anything, so it requires ALL of: the dedicated opt-in
+ * `SAP_ALLOW_PLUGIN_EXECUTE`; `allowWrites` (via `checkOperation`, since execution is a mutation
+ * vector); and the calling tool declaring `write` scope. SAP-side execute auth is the final backstop.
+ */
+export function createPluginRunOps(
+  underlying: AdtHttpClient,
+  safety: SafetyConfig,
+  allowPluginExecute: boolean,
+  toolScope: Scope,
+  opLabel: string,
+): PluginRunOps {
+  return {
+    async classRun(className: string): Promise<string> {
+      if (!allowPluginExecute) {
+        throw new AdtSafetyError(
+          `Extension tool '${opLabel}' tried to execute a class, but plugin code execution is disabled. ` +
+            'Set SAP_ALLOW_PLUGIN_EXECUTE=true (and SAP_ALLOW_WRITES=true) to allow it.',
+        );
+      }
+      if (!hasRequiredScope([toolScope], 'write')) {
+        throw new AdtSafetyError(
+          `Extension tool '${opLabel}' declares scope '${toolScope}' and may not execute a class (needs scope 'write').`,
+        );
+      }
+      // Execution is a mutation vector — keep the `allowWrites=false ⇒ no mutation path` invariant.
+      checkOperation(safety, OperationType.Workflow, `Custom:${opLabel}:classRun`);
+      if (typeof className !== 'string' || !ABAP_CLASS_NAME.test(className)) {
+        throw new AdtSafetyError(`Extension tool '${opLabel}': invalid ABAP class name '${className}'.`);
+      }
+      const res = await underlying.post(`/sap/bc/adt/oo/classrun/${encodeURIComponent(className.toLowerCase())}`);
+      return res.body;
+    },
+  };
 }

--- a/src/server/safe-http-client.ts
+++ b/src/server/safe-http-client.ts
@@ -1,0 +1,94 @@
+// SafeHttpClient — the gated low-level HTTP surface handed to extension tools as `ctx.http`.
+//
+// FEAT-61 / review B1: extension tools must NOT receive the raw AdtHttpClient, whose `post/put/
+// delete` bypass `checkOperation` entirely. This wrapper gates every call:
+//   1. the tool's declared scope must COVER the call's operation class (a `read` tool can't POST), and
+//   2. the server safety ceiling (`checkOperation`: allowWrites / allowDataPreview / …) must allow it.
+// Everything else (CSRF, cookies, PP auth, stateful sessions, the semaphore) rides the underlying
+// client unchanged and path-agnostically. See docs/research/extension-framework-spec.md §5.
+
+import { AdtSafetyError } from '../adt/errors.js';
+import type { AdtHttpClient, AdtResponse } from '../adt/http.js';
+import { checkOperation, OperationType, type OperationTypeCode, type SafetyConfig } from '../adt/safety.js';
+import { hasRequiredScope, type Scope } from '../authz/policy.js';
+
+/** Operation class → the scope it requires (mirrors ACTION_POLICY's opType↔scope consistency). */
+const OPTYPE_SCOPE: Record<OperationTypeCode, Scope> = {
+  R: 'read',
+  S: 'read',
+  I: 'read',
+  T: 'read',
+  L: 'read',
+  Q: 'data',
+  F: 'sql',
+  C: 'write',
+  U: 'write',
+  D: 'write',
+  A: 'write',
+  W: 'write',
+  X: 'transports',
+};
+
+export interface SafeHttpClient {
+  get(path: string, headers?: Record<string, string>): Promise<AdtResponse>;
+  head(path: string, headers?: Record<string, string>): Promise<AdtResponse>;
+  post(path: string, body?: string, contentType?: string, headers?: Record<string, string>): Promise<AdtResponse>;
+  put(path: string, body: string, contentType?: string, headers?: Record<string, string>): Promise<AdtResponse>;
+  delete(path: string, headers?: Record<string, string>): Promise<AdtResponse>;
+  withStatefulSession<T>(fn: (s: SafeHttpClient) => Promise<T>): Promise<T>;
+  // NB: fetchCsrfToken(path?) lands in PR2c alongside the AdtHttpClient change it needs (OData writes).
+}
+
+/**
+ * Wrap a per-user `AdtHttpClient` in the gated surface for one tool call.
+ *
+ * @param underlying  the request's per-user (PP/`withSafety`) AdtHttpClient
+ * @param safety      the effective per-user SafetyConfig (server ceiling ∧ user)
+ * @param toolScope   the calling tool's declared `policy.scope` — the ceiling for its HTTP ops
+ * @param opLabel     tool name, used in audit + error messages
+ */
+export function createSafeHttpClient(
+  underlying: AdtHttpClient,
+  safety: SafetyConfig,
+  toolScope: Scope,
+  opLabel: string,
+): SafeHttpClient {
+  function gate(op: OperationTypeCode): void {
+    const required = OPTYPE_SCOPE[op];
+    // (1) the tool's declared scope must cover the operation — a `read` tool may never write.
+    if (!hasRequiredScope([toolScope], required)) {
+      throw new AdtSafetyError(
+        `Extension tool '${opLabel}' declares scope '${toolScope}' and may not issue a ${op}-class HTTP call (needs scope '${required}')`,
+      );
+    }
+    // (2) the server safety ceiling (allowWrites / allowDataPreview / allowFreeSQL / …).
+    checkOperation(safety, op, `Custom:${opLabel}`);
+  }
+
+  const self: SafeHttpClient = {
+    async get(path, headers) {
+      gate(OperationType.Read);
+      return underlying.get(path, headers);
+    },
+    async head(path, headers) {
+      gate(OperationType.Read);
+      return underlying.head(path, headers);
+    },
+    async post(path, body, contentType, headers) {
+      gate(OperationType.Create);
+      return underlying.post(path, body, contentType, headers);
+    },
+    async put(path, body, contentType, headers) {
+      gate(OperationType.Update);
+      return underlying.put(path, body, contentType, headers);
+    },
+    async delete(path, headers) {
+      gate(OperationType.Delete);
+      return underlying.delete(path, headers);
+    },
+    async withStatefulSession(fn) {
+      return underlying.withStatefulSession((session) => fn(createSafeHttpClient(session, safety, toolScope, opLabel)));
+    },
+  };
+  return self;
+}

--- a/src/server/safe-http-client.ts
+++ b/src/server/safe-http-client.ts
@@ -72,15 +72,27 @@ const BLOCKED_CLIENT_KEYS: ReadonlySet<string> = new Set([
  * the object either.
  */
 export function createReadOnlyAdtClient(client: AdtClient): ReadOnlyAdtClient {
+  const isBlocked = (prop: string | symbol): boolean => typeof prop === 'string' && BLOCKED_CLIENT_KEYS.has(prop);
   return new Proxy(client, {
     get(target, prop) {
-      if (typeof prop === 'string' && BLOCKED_CLIENT_KEYS.has(prop)) return undefined;
+      if (isBlocked(prop)) return undefined;
       const value = Reflect.get(target, prop, target);
       return typeof value === 'function' ? (value as (...args: unknown[]) => unknown).bind(target) : value;
     },
     has(target, prop) {
-      if (typeof prop === 'string' && BLOCKED_CLIENT_KEYS.has(prop)) return false;
+      if (isBlocked(prop)) return false;
       return Reflect.has(target, prop);
+    },
+    // `http`/`safety` are own data properties, so without these two traps a plugin could read the
+    // raw client back via `Object.getOwnPropertyDescriptor(ctx.client, 'http').value` (the `get`
+    // trap alone does NOT cover the descriptor path) or enumerate it. They are configurable on the
+    // target (TS `readonly` is compile-time only), so hiding them violates no Proxy invariant.
+    getOwnPropertyDescriptor(target, prop) {
+      if (isBlocked(prop)) return undefined;
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+    ownKeys(target) {
+      return Reflect.ownKeys(target).filter((k) => !isBlocked(k));
     },
     set: () => false,
     defineProperty: () => false,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -584,16 +584,25 @@ export function createServer(
       tools = filterToolsByAuthScope(tools, extra.authInfo.scopes, config.denyActions);
     }
 
-    // FEAT-61: append plugin (Custom_*) tools, gated identically to built-ins (deny-list + scope).
-    for (const entry of getToolRegistry().list()) {
-      if (entry.source !== 'plugin' || !entry.listing) continue;
-      if (isActionDenied(entry.name, undefined, config.denyActions)) continue;
-      if (extra.authInfo && !hasRequiredScope(extra.authInfo.scopes, entry.policy.scope)) continue;
-      tools.push({
-        name: entry.name,
-        description: entry.listing.description,
-        inputSchema: entry.listing.inputSchema,
-      });
+    // FEAT-61: append plugin (Custom_*) tools, gated identically to built-ins (deny-list + scope +
+    // `availableOn` system-type visibility). Hyperfocused mode is out of scope for plugins (spec §10),
+    // so its single `SAP` tool is the only surface there.
+    if (config.toolMode !== 'hyperfocused') {
+      const systemType = features?.systemType;
+      for (const entry of getToolRegistry().list()) {
+        if (entry.source !== 'plugin' || !entry.listing) continue;
+        if (isActionDenied(entry.name, undefined, config.denyActions)) continue;
+        if (extra.authInfo && !hasRequiredScope(extra.authInfo.scopes, entry.policy.scope)) continue;
+        // Only filter when the system type is KNOWN and the tool declares a non-matching target.
+        if (entry.availableOn && entry.availableOn !== 'all' && systemType && entry.availableOn !== systemType) {
+          continue;
+        }
+        tools.push({
+          name: entry.name,
+          description: entry.listing.description,
+          inputSchema: entry.listing.inputSchema,
+        });
+      }
     }
 
     return { tools };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -22,7 +22,7 @@ import { getActionPolicy, hasRequiredScope } from '../authz/policy.js';
 import type { Cache } from '../cache/cache.js';
 import { CachingLayer } from '../cache/caching-layer.js';
 import { MemoryCache } from '../cache/memory.js';
-import { handleToolCall } from '../handlers/dispatch.js';
+import { getToolRegistry, handleToolCall } from '../handlers/dispatch.js';
 import {
   getCachedDiscovery,
   getCachedFeatures,
@@ -34,6 +34,7 @@ import { API_KEY_PROFILES } from './config.js';
 import { isActionDenied } from './deny-actions.js';
 import { initLogger, logger } from './logger.js';
 import { createMcpRateLimiter, type McpRateLimiter } from './mcp-rate-limit.js';
+import { loadPlugins } from './plugin-loader.js';
 import { FileSink } from './sinks/file.js';
 import type { ServerConfig } from './types.js';
 
@@ -583,6 +584,18 @@ export function createServer(
       tools = filterToolsByAuthScope(tools, extra.authInfo.scopes, config.denyActions);
     }
 
+    // FEAT-61: append plugin (Custom_*) tools, gated identically to built-ins (deny-list + scope).
+    for (const entry of getToolRegistry().list()) {
+      if (entry.source !== 'plugin' || !entry.listing) continue;
+      if (isActionDenied(entry.name, undefined, config.denyActions)) continue;
+      if (extra.authInfo && !hasRequiredScope(extra.authInfo.scopes, entry.policy.scope)) continue;
+      tools.push({
+        name: entry.name,
+        description: entry.listing.description,
+        inputSchema: entry.listing.inputSchema,
+      });
+    }
+
     return { tools };
   });
 
@@ -761,6 +774,12 @@ export async function createAndStartServer(
   const { logEffectivePolicy, detectContradictions, logContradictions } = await import('./effective-policy-log.js');
   logEffectivePolicy(config, effectiveSources, logger);
   logContradictions(detectContradictions(config), logger);
+
+  // FEAT-61: load extension plugins (Custom_* tools) into the shared registry before serving.
+  // Fail-fast: a malformed plugin or name collision throws here and refuses server start.
+  if (config.plugins?.length) {
+    await loadPlugins(config.plugins, getToolRegistry());
+  }
 
   // Add file sink if configured
   if (config.logFile) {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -117,6 +117,11 @@ export interface ServerConfig {
   /** Tool mode: 'standard' (12 intent tools, SAPGit feature-gated) or 'hyperfocused' (1 universal SAP tool, ~200 tokens) */
   toolMode: 'standard' | 'hyperfocused';
 
+  // --- Extensions (FEAT-61) ---
+  /** Absolute paths to extension plugins to load at startup (from ARC1_PLUGINS, CSV). Each contributes
+   *  `Custom_*` tools via the ToolRegistry. Empty (default) = no plugins. NOT npm package names. */
+  plugins: string[];
+
   // --- Lint ---
   /** Path to custom abaplint.jsonc config file for lint rules */
   abaplintConfig?: string;
@@ -215,6 +220,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   ppAllowSharedCookies: false,
   disableSaml2: false,
   toolMode: 'standard',
+  plugins: [],
   lintBeforeWrite: true,
   checkBeforeWrite: false,
   cacheMode: 'auto',

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -121,6 +121,11 @@ export interface ServerConfig {
   /** Absolute paths to extension plugins to load at startup (from ARC1_PLUGINS, CSV). Each contributes
    *  `Custom_*` tools via the ToolRegistry. Empty (default) = no plugins. NOT npm package names. */
   plugins: string[];
+  /** Opt-in: allow plugin tools to EXECUTE ABAP console classes (`ctx.run.classRun`, IF_OO_ADT_CLASSRUN).
+   *  Default false. Running arbitrary ABAP is a mutation vector, so it ALSO requires `allowWrites=true`
+   *  and the tool must declare `write` scope. A dedicated switch (not implied by `allowWrites`) so
+   *  enabling built-in writes never silently grants plugins code execution. */
+  allowPluginExecute: boolean;
 
   // --- Lint ---
   /** Path to custom abaplint.jsonc config file for lint rules */
@@ -221,6 +226,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   disableSaml2: false,
   toolMode: 'standard',
   plugins: [],
+  allowPluginExecute: false,
   lintBeforeWrite: true,
   checkBeforeWrite: false,
   cacheMode: 'auto',

--- a/tests/unit/handlers/plugin-dispatch.test.ts
+++ b/tests/unit/handlers/plugin-dispatch.test.ts
@@ -57,4 +57,23 @@ describe('plugin dispatch through handleToolCall (FEAT-61 PR3)', () => {
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/Unknown tool/);
   });
+
+  it('refuses a registered plugin tool in hyperfocused mode (not just hidden from tools/list)', async () => {
+    registerPluginTool(
+      getToolRegistry(),
+      'demo',
+      defineTool({
+        name: 'Custom_PdHf',
+        description: 'echo',
+        schema: z.object({ msg: z.string() }),
+        policy: { scope: 'read', opType: 'R' },
+        handler: async (a) => ({ content: [{ type: 'text', text: (a as { msg: string }).msg }] }),
+      }),
+    );
+    // Even with a scope-passing user, hyperfocused mode must not dispatch a plugin tool.
+    const hyperfocused = { ...config, toolMode: 'hyperfocused' } as unknown as ServerConfig;
+    const res = await handleToolCall(fakeClient, hyperfocused, 'Custom_PdHf', { msg: 'x' }, auth(['read']));
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/Unknown tool/);
+  });
 });

--- a/tests/unit/handlers/plugin-dispatch.test.ts
+++ b/tests/unit/handlers/plugin-dispatch.test.ts
@@ -1,0 +1,60 @@
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import type { AdtClient } from '../../../src/adt/client.js';
+import { unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
+import { getToolRegistry, handleToolCall } from '../../../src/handlers/dispatch.js';
+import { defineTool } from '../../../src/public/index.js';
+import { registerPluginTool } from '../../../src/server/plugin-loader.js';
+import type { ServerConfig } from '../../../src/server/types.js';
+
+// FEAT-61 PR3 end-to-end (handler level): a plugin tool registered into the registry must dispatch
+// through handleToolCall, be scope-gated by its declared policy (registry fallback), and an
+// unregistered Custom_ name must fall through to "Unknown tool".
+
+const fakeClient = { http: {}, safety: unrestrictedSafetyConfig() } as unknown as AdtClient;
+const config = { systemType: 'onprem', denyActions: [] } as unknown as ServerConfig;
+const auth = (scopes: string[]): AuthInfo => ({ token: 't', scopes, clientId: 'c', extra: {} }) as unknown as AuthInfo;
+
+describe('plugin dispatch through handleToolCall (FEAT-61 PR3)', () => {
+  it('dispatches a registered read plugin tool for a read user', async () => {
+    registerPluginTool(
+      getToolRegistry(),
+      'demo',
+      defineTool({
+        name: 'Custom_PdEcho',
+        description: 'echo',
+        schema: z.object({ msg: z.string() }),
+        policy: { scope: 'read', opType: 'R' },
+        handler: async (a) => ({ content: [{ type: 'text', text: (a as { msg: string }).msg }] }),
+      }),
+    );
+    const res = await handleToolCall(fakeClient, config, 'Custom_PdEcho', { msg: 'hello' }, auth(['read']));
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toBe('hello');
+  });
+
+  it('scope-gates a write plugin tool against a read-only user (registry policy fallback)', async () => {
+    registerPluginTool(
+      getToolRegistry(),
+      'demo',
+      defineTool({
+        name: 'Custom_PdWrite',
+        description: 'w',
+        schema: z.object({}),
+        policy: { scope: 'write', opType: 'U' },
+        handler: async () => ({ content: [{ type: 'text', text: 'should not run' }] }),
+      }),
+    );
+    const res = await handleToolCall(fakeClient, config, 'Custom_PdWrite', {}, auth(['read']));
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/Insufficient scope/);
+  });
+
+  it('returns "Unknown tool" for an unregistered Custom_ name', async () => {
+    const res = await handleToolCall(fakeClient, config, 'Custom_Nope', {}, auth(['read']));
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/Unknown tool/);
+  });
+});

--- a/tests/unit/plugins/manifest-interpreter.test.ts
+++ b/tests/unit/plugins/manifest-interpreter.test.ts
@@ -98,7 +98,10 @@ describe('registerManifestTool dispatch', () => {
       },
     });
     const { ctx, calls } = ctxFor({ name: '..' });
-    await expect(r.get('Custom_Loose')!.invoke(ctx)).rejects.toThrow(/forbidden sequence/);
+    // Parity with the Ajv branch: a path-param violation returns an isError result, not a throw.
+    const res = await r.get('Custom_Loose')!.invoke(ctx);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/forbidden sequence/);
     expect(calls).toHaveLength(0);
   });
 

--- a/tests/unit/plugins/manifest-interpreter.test.ts
+++ b/tests/unit/plugins/manifest-interpreter.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import { unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
+import { registerManifestTool, validateManifest } from '../../../src/plugins/manifest-interpreter.js';
+import { type ToolDispatchContext, ToolRegistry } from '../../../src/registry/tool-registry.js';
+
+const readProgram = {
+  name: 'Custom_ReadProgram',
+  description: 'Read an ABAP program source',
+  scope: 'read',
+  inputSchema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['name'],
+    properties: { name: { type: 'string', pattern: '^[A-Za-z0-9_/]{1,40}$' } },
+  },
+  request: {
+    method: 'GET',
+    path: '/sap/bc/adt/programs/programs/{name}/source/main',
+    pathParams: { name: '$.name' },
+    accept: 'text/plain',
+  },
+};
+
+function ctxFor(args: Record<string, unknown>) {
+  const calls: Array<{ path: string; headers?: Record<string, string> }> = [];
+  const fakeHttp = {
+    get: async (path: string, headers?: Record<string, string>) => {
+      calls.push({ path, headers });
+      return { statusCode: 200, headers: {}, body: 'PROGRAM SOURCE' };
+    },
+  };
+  const ctx = {
+    client: { http: fakeHttp, safety: unrestrictedSafetyConfig() },
+    args,
+    requestId: 'r1',
+  } as unknown as ToolDispatchContext;
+  return { ctx, calls };
+}
+
+describe('validateManifest', () => {
+  it('accepts a valid GET read manifest', () => {
+    expect(validateManifest(readProgram).name).toBe('Custom_ReadProgram');
+  });
+  it('rejects a non-Custom_ name', () => {
+    expect(() => validateManifest({ ...readProgram, name: 'ReadProgram' })).toThrow(/Custom_/);
+  });
+  it('requires additionalProperties:false', () => {
+    expect(() => validateManifest({ ...readProgram, inputSchema: { type: 'object', properties: {} } })).toThrow(
+      /additionalProperties/,
+    );
+  });
+  it('rejects non-GET methods (v1)', () => {
+    expect(() => validateManifest({ ...readProgram, request: { ...readProgram.request, method: 'POST' } })).toThrow(
+      /GET/,
+    );
+  });
+  it('rejects a path with a host', () => {
+    expect(() =>
+      validateManifest({ ...readProgram, request: { ...readProgram.request, path: 'http://evil/x' } }),
+    ).toThrow(/absolute SAP path/);
+  });
+});
+
+describe('registerManifestTool dispatch', () => {
+  it('renders the path, percent-encodes the segment, and calls the gated client', async () => {
+    const r = new ToolRegistry();
+    registerManifestTool(r, 'demo', readProgram);
+    const e = r.get('Custom_ReadProgram');
+    expect(e?.source).toBe('plugin');
+    expect(e?.policy.scope).toBe('read');
+    const { ctx, calls } = ctxFor({ name: 'ZFOO' });
+    const res = await e!.invoke(ctx);
+    expect(res.content[0].text).toBe('PROGRAM SOURCE');
+    expect(calls[0].path).toBe('/sap/bc/adt/programs/programs/ZFOO/source/main');
+    expect(calls[0].headers).toEqual({ Accept: 'text/plain' });
+  });
+
+  it('percent-encodes a namespaced name (slash kept as data, not a path segment)', async () => {
+    const r = new ToolRegistry();
+    registerManifestTool(r, 'demo', readProgram);
+    const { ctx, calls } = ctxFor({ name: '/FOO/ZBAR' });
+    await r.get('Custom_ReadProgram')!.invoke(ctx);
+    expect(calls[0].path).toBe('/sap/bc/adt/programs/programs/%2FFOO%2FZBAR/source/main');
+  });
+
+  it('rejects a path-traversal value that passes a permissive schema', async () => {
+    const r = new ToolRegistry();
+    // Permissive schema (no pattern) so '..' reaches safeSegment instead of being caught by Ajv.
+    registerManifestTool(r, 'demo', {
+      ...readProgram,
+      name: 'Custom_Loose',
+      inputSchema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['name'],
+        properties: { name: { type: 'string' } },
+      },
+    });
+    const { ctx, calls } = ctxFor({ name: '..' });
+    await expect(r.get('Custom_Loose')!.invoke(ctx)).rejects.toThrow(/forbidden sequence/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('returns an isError result on schema-invalid args (Ajv)', async () => {
+    const r = new ToolRegistry();
+    registerManifestTool(r, 'demo', readProgram);
+    const { ctx } = ctxFor({ name: 'has spaces!' }); // violates the pattern
+    const res = await r.get('Custom_ReadProgram')!.invoke(ctx);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('Invalid arguments');
+  });
+
+  it('omits absent query params', async () => {
+    const r = new ToolRegistry();
+    registerManifestTool(r, 'demo', {
+      ...readProgram,
+      name: 'Custom_ReadProgramQ',
+      inputSchema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['name'],
+        properties: { name: { type: 'string' }, version: { type: 'string' } },
+      },
+      request: { ...readProgram.request, query: { version: '$.version' } },
+    });
+    const { ctx, calls } = ctxFor({ name: 'ZFOO' }); // version absent → omitted
+    await r.get('Custom_ReadProgramQ')!.invoke(ctx);
+    expect(calls[0].path).toBe('/sap/bc/adt/programs/programs/ZFOO/source/main');
+  });
+});

--- a/tests/unit/public/define-tool.test.ts
+++ b/tests/unit/public/define-tool.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { OperationType } from '../../../src/adt/safety.js';
+import { defineTool } from '../../../src/public/index.js';
+
+const base = {
+  name: 'Custom_Foo' as const,
+  description: 'does a thing',
+  schema: z.object({ x: z.string() }),
+  policy: { scope: 'read' as const, opType: OperationType.Read },
+  handler: async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+};
+
+describe('defineTool', () => {
+  it('returns a valid definition unchanged', () => {
+    expect(defineTool(base)).toBe(base);
+  });
+
+  it('rejects a name outside the Custom_ namespace', () => {
+    expect(() => defineTool({ ...base, name: 'Foo' as `Custom_${string}` })).toThrow(/Custom_/);
+  });
+
+  it('rejects a missing description', () => {
+    expect(() => defineTool({ ...base, description: '' })).toThrow(/description/);
+  });
+
+  it('rejects a missing schema', () => {
+    expect(() => defineTool({ ...base, schema: undefined as unknown as typeof base.schema })).toThrow(/schema/);
+  });
+
+  it('rejects a policy missing opType', () => {
+    expect(() => defineTool({ ...base, policy: { scope: 'read' } as unknown as typeof base.policy })).toThrow(/opType/);
+  });
+
+  it('rejects a non-function handler', () => {
+    expect(() => defineTool({ ...base, handler: undefined as unknown as typeof base.handler })).toThrow(/handler/);
+  });
+});

--- a/tests/unit/public/testing.test.ts
+++ b/tests/unit/public/testing.test.ts
@@ -12,19 +12,21 @@ describe('createMockToolContext', () => {
     expect(ctx.requestId).toBe('test-request');
   });
 
-  it('supports per-path responses and records bodies', async () => {
+  it('supports per-path responses and records GET/HEAD calls', async () => {
     const ctx = createMockToolContext({ responses: { '/a': 'AAA', '/b': 'BBB' } });
     expect((await ctx.http.get('/a')).body).toBe('AAA');
-    expect((await ctx.http.post('/b', 'payload')).body).toBe('BBB');
+    expect((await ctx.http.head('/b')).body).toBe('BBB');
     expect(ctx.httpCalls).toEqual([
       { method: 'GET', path: '/a' },
-      { method: 'POST', path: '/b', body: 'payload' },
+      { method: 'HEAD', path: '/b' },
     ]);
   });
 
-  it('gates nothing (a pure recorder) and threads through withStatefulSession', async () => {
-    const ctx = createMockToolContext({ responseBody: 'S' });
-    const out = await ctx.http.withStatefulSession(async (s) => (await s.get('/x')).body);
-    expect(out).toBe('S');
+  it('exposes a read-only http surface (no write verbs in v1)', () => {
+    const ctx = createMockToolContext();
+    const http = ctx.http as unknown as Record<string, unknown>;
+    expect(http.post).toBeUndefined();
+    expect(http.put).toBeUndefined();
+    expect(http.delete).toBeUndefined();
   });
 });

--- a/tests/unit/public/testing.test.ts
+++ b/tests/unit/public/testing.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMockToolContext } from '../../../src/public/testing.js';
+
+describe('createMockToolContext', () => {
+  it('records http calls and returns the configured body', async () => {
+    const ctx = createMockToolContext({ responseBody: 'SRC', scopes: ['read'] });
+    const res = await ctx.http.get('/sap/bc/adt/x');
+    expect(res.body).toBe('SRC');
+    expect(ctx.httpCalls).toEqual([{ method: 'GET', path: '/sap/bc/adt/x' }]);
+    expect(ctx.authInfo?.scopes).toEqual(['read']);
+    expect(ctx.requestId).toBe('test-request');
+  });
+
+  it('supports per-path responses and records bodies', async () => {
+    const ctx = createMockToolContext({ responses: { '/a': 'AAA', '/b': 'BBB' } });
+    expect((await ctx.http.get('/a')).body).toBe('AAA');
+    expect((await ctx.http.post('/b', 'payload')).body).toBe('BBB');
+    expect(ctx.httpCalls).toEqual([
+      { method: 'GET', path: '/a' },
+      { method: 'POST', path: '/b', body: 'payload' },
+    ]);
+  });
+
+  it('gates nothing (a pure recorder) and threads through withStatefulSession', async () => {
+    const ctx = createMockToolContext({ responseBody: 'S' });
+    const out = await ctx.http.withStatefulSession(async (s) => (await s.get('/x')).body);
+    expect(out).toBe('S');
+  });
+});

--- a/tests/unit/registry/builtin-registration.test.ts
+++ b/tests/unit/registry/builtin-registration.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { getToolRegistry } from '../../../src/handlers/dispatch.js';
+
+// FEAT-61 PR1.2 parity: the registry must expose exactly the 12 built-ins + the `SAP`
+// hyperfocused wrapper, all sourced as 'builtin', with a real policy — i.e. the switch→registry
+// refactor dropped nothing and added nothing.
+const BUILTINS = [
+  'SAPRead',
+  'SAPSearch',
+  'SAPQuery',
+  'SAPWrite',
+  'SAPActivate',
+  'SAPNavigate',
+  'SAPLint',
+  'SAPDiagnose',
+  'SAPTransport',
+  'SAPGit',
+  'SAPContext',
+  'SAPManage',
+  'SAP',
+];
+
+describe('built-in tool registration (FEAT-61 PR1.2)', () => {
+  it('registers exactly the 13 built-ins, all source=builtin with a policy', () => {
+    const r = getToolRegistry();
+    for (const name of BUILTINS) {
+      const e = r.get(name);
+      expect(e, `built-in ${name} should be registered`).toBeDefined();
+      expect(e?.source).toBe('builtin');
+      expect(e?.policy?.scope).toBeTruthy();
+      expect(e?.policy?.opType).toBeTruthy();
+    }
+    expect(r.size()).toBe(BUILTINS.length);
+    expect(r.list().every((e) => e.source === 'builtin')).toBe(true);
+  });
+
+  it('returns undefined for an unknown tool (the former switch default)', () => {
+    expect(getToolRegistry().get('NoSuchTool')).toBeUndefined();
+  });
+
+  it('returns the same registry instance on repeated calls (lazy singleton)', () => {
+    expect(getToolRegistry()).toBe(getToolRegistry());
+  });
+});

--- a/tests/unit/registry/tool-registry.test.ts
+++ b/tests/unit/registry/tool-registry.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { OperationType } from '../../../src/adt/safety.js';
+import { type RegistryEntry, type ToolDispatchContext, ToolRegistry } from '../../../src/registry/tool-registry.js';
+
+const okResult = { content: [{ type: 'text' as const, text: 'ok' }] };
+
+function entry(over: Partial<RegistryEntry> = {}): RegistryEntry {
+  return {
+    name: 'SAPRead',
+    source: 'builtin',
+    policy: { scope: 'read', opType: OperationType.Read },
+    invoke: async () => okResult,
+    ...over,
+  };
+}
+
+describe('ToolRegistry', () => {
+  it('registers and retrieves an entry', () => {
+    const r = new ToolRegistry();
+    r.register(entry());
+    expect(r.get('SAPRead')?.name).toBe('SAPRead');
+    expect(r.has('SAPRead')).toBe(true);
+    expect(r.size()).toBe(1);
+  });
+
+  it('returns undefined for an unknown tool', () => {
+    const r = new ToolRegistry();
+    expect(r.get('Nope')).toBeUndefined();
+    expect(r.has('Nope')).toBe(false);
+  });
+
+  it('rejects a duplicate name (fail-fast)', () => {
+    const r = new ToolRegistry();
+    r.register(entry());
+    expect(() => r.register(entry())).toThrow(/duplicate tool name 'SAPRead'/);
+  });
+
+  it('rejects an entry with no policy', () => {
+    const r = new ToolRegistry();
+    expect(() => r.register(entry({ policy: undefined as unknown as RegistryEntry['policy'] }))).toThrow(
+      /policy\.scope/,
+    );
+  });
+
+  it('rejects an entry missing opType', () => {
+    const r = new ToolRegistry();
+    expect(() =>
+      r.register(entry({ name: 'SAPWrite', policy: { scope: 'write' } as unknown as RegistryEntry['policy'] })),
+    ).toThrow(/opType/);
+  });
+
+  it('rejects a plugin tool outside the Custom_ namespace', () => {
+    const r = new ToolRegistry();
+    expect(() => r.register(entry({ name: 'EvilTool', source: 'plugin', pluginName: 'p' }))).toThrow(/Custom_/);
+  });
+
+  it('accepts a plugin tool in the Custom_ namespace', () => {
+    const r = new ToolRegistry();
+    r.register(entry({ name: 'Custom_Foo', source: 'plugin', pluginName: 'p1' }));
+    expect(r.get('Custom_Foo')?.source).toBe('plugin');
+    expect(r.get('Custom_Foo')?.pluginName).toBe('p1');
+  });
+
+  it('allows a built-in to keep its SAP* (non-Custom_) name', () => {
+    const r = new ToolRegistry();
+    expect(() => r.register(entry({ name: 'SAPWrite' }))).not.toThrow();
+  });
+
+  it('lists built-ins before plugins, each in registration order', () => {
+    const r = new ToolRegistry();
+    r.register(entry({ name: 'SAPRead' }));
+    r.register(entry({ name: 'Custom_A', source: 'plugin', pluginName: 'p' }));
+    r.register(entry({ name: 'SAPWrite' }));
+    r.register(entry({ name: 'Custom_B', source: 'plugin', pluginName: 'p' }));
+    expect(r.list().map((e) => e.name)).toEqual(['SAPRead', 'SAPWrite', 'Custom_A', 'Custom_B']);
+  });
+
+  it('dispatches to the entry handler with the per-request context', async () => {
+    const r = new ToolRegistry();
+    let seen: ToolDispatchContext | undefined;
+    r.register(
+      entry({
+        name: 'Custom_Echo',
+        source: 'plugin',
+        pluginName: 'p',
+        invoke: async (ctx) => {
+          seen = ctx;
+          return { content: [{ type: 'text', text: ctx.requestId }] };
+        },
+      }),
+    );
+    const ctx = {
+      client: {} as ToolDispatchContext['client'],
+      config: {} as ToolDispatchContext['config'],
+      args: {},
+      requestId: 'req-1',
+    } as ToolDispatchContext;
+    const res = await r.get('Custom_Echo')!.invoke(ctx);
+    expect(seen?.requestId).toBe('req-1');
+    expect(res.content[0].text).toBe('req-1');
+  });
+});

--- a/tests/unit/server/plugin-loader.test.ts
+++ b/tests/unit/server/plugin-loader.test.ts
@@ -150,6 +150,7 @@ describe('plugin MCP capabilities (PR5: elicit/notify/sampling)', () => {
   const dispatchWith = (server: unknown): ToolDispatchContext =>
     ({
       client: { http: {}, safety: unrestrictedSafetyConfig() },
+      config: {},
       args: {},
       requestId: 'r',
       server,

--- a/tests/unit/server/plugin-loader.test.ts
+++ b/tests/unit/server/plugin-loader.test.ts
@@ -1,0 +1,216 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
+import { defineTool } from '../../../src/public/index.js';
+import { type ToolDispatchContext, ToolRegistry } from '../../../src/registry/tool-registry.js';
+import { loadPlugins, registerPluginTool } from '../../../src/server/plugin-loader.js';
+
+function echoTool() {
+  return defineTool({
+    name: 'Custom_Echo',
+    description: 'echoes msg + requestId',
+    schema: z.object({ msg: z.string() }),
+    policy: { scope: 'read', opType: 'R' },
+    handler: async (args, ctx) => ({
+      content: [{ type: 'text', text: `${(args as { msg: string }).msg}:${ctx.requestId}` }],
+    }),
+  });
+}
+
+function dispatchCtx(args: Record<string, unknown>): ToolDispatchContext {
+  return {
+    client: { http: {}, safety: unrestrictedSafetyConfig() },
+    config: {},
+    args,
+    requestId: 'req-7',
+  } as unknown as ToolDispatchContext;
+}
+
+describe('registerPluginTool', () => {
+  it('registers a plugin tool with source=plugin, policy, and a JSON-Schema listing', () => {
+    const r = new ToolRegistry();
+    registerPluginTool(r, 'demo', echoTool());
+    const e = r.get('Custom_Echo');
+    expect(e?.source).toBe('plugin');
+    expect(e?.pluginName).toBe('demo');
+    expect(e?.policy.scope).toBe('read');
+    expect(e?.listing?.description).toContain('echoes');
+    // z.toJSONSchema produced an object schema with the declared property
+    expect(JSON.stringify(e?.listing?.inputSchema)).toContain('msg');
+  });
+
+  it('dispatch validates args, builds the public ctx, and runs the handler', async () => {
+    const r = new ToolRegistry();
+    registerPluginTool(r, 'demo', echoTool());
+    const res = await r.get('Custom_Echo')!.invoke(dispatchCtx({ msg: 'hi' }));
+    expect(res.content[0].text).toBe('hi:req-7');
+  });
+
+  it('returns an isError result on invalid args (Zod validation in the adapter)', async () => {
+    const r = new ToolRegistry();
+    registerPluginTool(r, 'demo', echoTool());
+    const res = await r.get('Custom_Echo')!.invoke(dispatchCtx({ msg: 123 }));
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('Invalid arguments');
+  });
+
+  it('rejects a plugin tool outside the Custom_ namespace (registry fail-fast)', () => {
+    const r = new ToolRegistry();
+    const bad = { ...echoTool(), name: 'Evil' as `Custom_${string}` };
+    expect(() => registerPluginTool(r, 'demo', bad)).toThrow(/Custom_/);
+  });
+
+  it('gives the plugin a gated ctx.http (a read tool cannot POST)', async () => {
+    const r = new ToolRegistry();
+    let threw = false;
+    const tool = defineTool({
+      name: 'Custom_TryWrite',
+      description: 'attempts a POST from a read-scoped tool',
+      schema: z.object({}),
+      policy: { scope: 'read', opType: 'R' },
+      handler: async (_args, ctx) => {
+        try {
+          await ctx.http.post('/x', 'body');
+        } catch {
+          threw = true;
+        }
+        return { content: [{ type: 'text', text: String(threw) }] };
+      },
+    });
+    registerPluginTool(r, 'demo', tool);
+    const res = await r.get('Custom_TryWrite')!.invoke(dispatchCtx({}));
+    expect(threw).toBe(true);
+    expect(res.content[0].text).toBe('true');
+  });
+});
+
+describe('loadPlugins — manifest tools', () => {
+  it('loads a standalone .tool.json manifest from an ARC1_PLUGINS path', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'arc1-plugin-test-'));
+    const mf = join(dir, 'Custom_Mf.tool.json');
+    writeFileSync(
+      mf,
+      JSON.stringify({
+        name: 'Custom_Mf',
+        description: 'manifest read tool',
+        scope: 'read',
+        inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+        request: { method: 'GET', path: '/sap/bc/adt/discovery' },
+      }),
+    );
+    try {
+      const r = new ToolRegistry();
+      const loaded = await loadPlugins([mf], r);
+      expect(r.get('Custom_Mf')?.source).toBe('plugin');
+      expect(r.get('Custom_Mf')?.policy.scope).toBe('read');
+      expect(loaded[0].toolNames).toContain('Custom_Mf');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('plugin MCP capabilities (PR5: elicit/notify/sampling)', () => {
+  function fakeServer(caps: { elicitation?: object; sampling?: object }) {
+    const calls: string[] = [];
+    const server = {
+      getClientCapabilities: () => caps,
+      elicitInput: async (p: { message: string }) => {
+        calls.push(`elicit:${p.message}`);
+        return { action: 'accept', content: { ok: true } };
+      },
+      sendLoggingMessage: async (p: { level: string; data: unknown }) => {
+        calls.push(`notify:${p.level}:${String(p.data)}`);
+      },
+      createMessage: async () => {
+        calls.push('sample');
+        return { role: 'assistant', content: { type: 'text', text: 'ANSWER' }, model: 'm' };
+      },
+    };
+    return { server, calls };
+  }
+  const dispatchWith = (server: unknown): ToolDispatchContext =>
+    ({
+      client: { http: {}, safety: unrestrictedSafetyConfig() },
+      args: {},
+      requestId: 'r',
+      server,
+    }) as unknown as ToolDispatchContext;
+
+  it('wires elicit/notify/sampling when the client supports them', async () => {
+    const r = new ToolRegistry();
+    const { server, calls } = fakeServer({ elicitation: {}, sampling: {} });
+    registerPluginTool(
+      r,
+      'demo',
+      defineTool({
+        name: 'Custom_Interactive',
+        description: 'd',
+        schema: z.object({}),
+        policy: { scope: 'read', opType: 'R' },
+        handler: async (_a, ctx) => {
+          const e = await ctx.elicit?.('Proceed?');
+          await ctx.notify?.('info', 'working');
+          const s = await ctx.sampling?.('sys', 'q');
+          return { content: [{ type: 'text', text: `${e?.action}|${s}` }] };
+        },
+      }),
+    );
+    const res = await r.get('Custom_Interactive')!.invoke(dispatchWith(server));
+    expect(res.content[0].text).toBe('accept|ANSWER');
+    expect(calls).toEqual(['elicit:Proceed?', 'notify:info:working', 'sample']);
+  });
+
+  it('omits elicit/sampling without the capability; notify stays available', async () => {
+    const r = new ToolRegistry();
+    const { server } = fakeServer({});
+    registerPluginTool(
+      r,
+      'demo',
+      defineTool({
+        name: 'Custom_NoCap',
+        description: 'd',
+        schema: z.object({}),
+        policy: { scope: 'read', opType: 'R' },
+        handler: async (_a, ctx) => ({
+          content: [
+            {
+              type: 'text',
+              text: `${ctx.elicit === undefined}|${ctx.sampling === undefined}|${ctx.notify !== undefined}`,
+            },
+          ],
+        }),
+      }),
+    );
+    const res = await r.get('Custom_NoCap')!.invoke(dispatchWith(server));
+    expect(res.content[0].text).toBe('true|true|true');
+  });
+
+  it('all three are absent with no server (CLI/stdio path)', async () => {
+    const r = new ToolRegistry();
+    registerPluginTool(
+      r,
+      'demo',
+      defineTool({
+        name: 'Custom_NoServer',
+        description: 'd',
+        schema: z.object({}),
+        policy: { scope: 'read', opType: 'R' },
+        handler: async (_a, ctx) => ({
+          content: [
+            {
+              type: 'text',
+              text: String(ctx.elicit === undefined && ctx.notify === undefined && ctx.sampling === undefined),
+            },
+          ],
+        }),
+      }),
+    );
+    const res = await r.get('Custom_NoServer')!.invoke(dispatchWith(undefined));
+    expect(res.content[0].text).toBe('true');
+  });
+});

--- a/tests/unit/server/plugin-loader.test.ts
+++ b/tests/unit/server/plugin-loader.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -122,6 +122,37 @@ describe('loadPlugins — manifest tools', () => {
       expect(r.get('Custom_Mf')?.source).toBe('plugin');
       expect(r.get('Custom_Mf')?.policy.scope).toBe('read');
       expect(loaded[0].toolNames).toContain('Custom_Mf');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('loadPlugins — path safety (assertLoadablePath)', () => {
+  it('refuses a non-absolute ARC1_PLUGINS entry', async () => {
+    await expect(loadPlugins(['relative/plugin.js'], new ToolRegistry())).rejects.toThrow(/absolute path/);
+  });
+
+  it('refuses a missing path (ENOENT)', async () => {
+    await expect(loadPlugins(['/no/such/arc1-plugin.json'], new ToolRegistry())).rejects.toThrow();
+  });
+
+  it('refuses a world-writable plugin file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'arc1-plugin-perm-'));
+    const mf = join(dir, 'Custom_Ww.tool.json');
+    writeFileSync(
+      mf,
+      JSON.stringify({
+        name: 'Custom_Ww',
+        description: 'd',
+        scope: 'read',
+        inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+        request: { method: 'GET', path: '/sap/bc/adt/discovery' },
+      }),
+    );
+    chmodSync(mf, 0o777); // sets the world-writable bit assertLoadablePath rejects
+    try {
+      await expect(loadPlugins([mf], new ToolRegistry())).rejects.toThrow(/world-writable/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/server/plugin-loader.test.ts
+++ b/tests/unit/server/plugin-loader.test.ts
@@ -64,27 +64,41 @@ describe('registerPluginTool', () => {
     expect(() => registerPluginTool(r, 'demo', bad)).toThrow(/Custom_/);
   });
 
-  it('gives the plugin a gated ctx.http (a read tool cannot POST)', async () => {
+  it('gives the plugin a read-only ctx.http + a runtime-locked ctx.client (no write/escape surface)', async () => {
     const r = new ToolRegistry();
-    let threw = false;
     const tool = defineTool({
-      name: 'Custom_TryWrite',
-      description: 'attempts a POST from a read-scoped tool',
+      name: 'Custom_Surface',
+      description: 'reports the shape of the ctx surfaces it was handed',
       schema: z.object({}),
       policy: { scope: 'read', opType: 'R' },
       handler: async (_args, ctx) => {
-        try {
-          await ctx.http.post('/x', 'body');
-        } catch {
-          threw = true;
-        }
-        return { content: [{ type: 'text', text: String(threw) }] };
+        const http = ctx.http as unknown as Record<string, unknown>;
+        const client = ctx.client as unknown as Record<string, unknown>;
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                post: http.post === undefined,
+                put: http.put === undefined,
+                clientHttp: client.http === undefined,
+                clientSafety: client.safety === undefined,
+                clientWithSafety: client.withSafety === undefined,
+              }),
+            },
+          ],
+        };
       },
     });
     registerPluginTool(r, 'demo', tool);
-    const res = await r.get('Custom_TryWrite')!.invoke(dispatchCtx({}));
-    expect(threw).toBe(true);
-    expect(res.content[0].text).toBe('true');
+    const res = await r.get('Custom_Surface')!.invoke(dispatchCtx({}));
+    expect(JSON.parse(res.content[0].text)).toEqual({
+      post: true,
+      put: true,
+      clientHttp: true,
+      clientSafety: true,
+      clientWithSafety: true,
+    });
   });
 });
 

--- a/tests/unit/server/safe-http-client.test.ts
+++ b/tests/unit/server/safe-http-client.test.ts
@@ -1,74 +1,80 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { AdtSafetyError } from '../../../src/adt/errors.js';
+import type { AdtClient } from '../../../src/adt/client.js';
 import type { AdtHttpClient } from '../../../src/adt/http.js';
-import { defaultSafetyConfig, unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
-import { createSafeHttpClient } from '../../../src/server/safe-http-client.js';
+import { defaultSafetyConfig } from '../../../src/adt/safety.js';
+import { createReadOnlyAdtClient, createSafeHttpClient } from '../../../src/server/safe-http-client.js';
 
 const resp = { statusCode: 200, headers: {}, body: 'ok' };
 
 function fakeUnderlying() {
-  const u = {
+  return {
     get: vi.fn(async () => resp),
     head: vi.fn(async () => resp),
     post: vi.fn(async () => resp),
-    put: vi.fn(async () => resp),
-    delete: vi.fn(async () => resp),
-    withStatefulSession: vi.fn(async (fn: (c: unknown) => Promise<unknown>) => fn(fakeUnderlying())),
   };
-  return u;
 }
 
 const as = (u: ReturnType<typeof fakeUnderlying>) => u as unknown as AdtHttpClient;
 
-describe('createSafeHttpClient', () => {
-  it('allows GET for a read-scoped tool and delegates to the underlying', async () => {
+describe('createSafeHttpClient (v1: read-only)', () => {
+  it('allows GET and HEAD and delegates to the underlying client', async () => {
     const u = fakeUnderlying();
-    const c = createSafeHttpClient(as(u), defaultSafetyConfig(), 'read', 'Custom_R');
+    const c = createSafeHttpClient(as(u), defaultSafetyConfig(), 'Custom_R');
     await expect(c.get('/sap/bc/adt/x', { Accept: 'text/plain' })).resolves.toBe(resp);
     expect(u.get).toHaveBeenCalledWith('/sap/bc/adt/x', { Accept: 'text/plain' });
+    await expect(c.head('/sap/bc/adt/x')).resolves.toBe(resp);
   });
 
-  it('blocks POST for a read-scoped tool (scope coverage) — even with an unrestricted ceiling', async () => {
-    const u = fakeUnderlying();
-    const c = createSafeHttpClient(as(u), unrestrictedSafetyConfig(), 'read', 'Custom_R');
-    await expect(c.post('/x', 'body')).rejects.toBeInstanceOf(AdtSafetyError);
-    expect(u.post).not.toHaveBeenCalled();
+  it('exposes NO write verbs — post/put/delete/withStatefulSession are absent (package-allowlist gap)', () => {
+    const c = createSafeHttpClient(as(fakeUnderlying()), defaultSafetyConfig(), 'Custom_R') as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(c.post).toBeUndefined();
+    expect(c.put).toBeUndefined();
+    expect(c.delete).toBeUndefined();
+    expect(c.withStatefulSession).toBeUndefined();
+  });
+});
+
+describe('createReadOnlyAdtClient (runtime escape-hatch guard, review B1)', () => {
+  // A minimal stand-in for AdtClient: a read method that internally needs `this.http`/`this.safety`,
+  // plus the escape-hatch members a plugin must never reach.
+  function fakeClient() {
+    return {
+      http: { get: vi.fn(async (_path: string) => resp) },
+      safety: defaultSafetyConfig(),
+      withSafety: vi.fn(),
+      invalidatePackageHierarchy: vi.fn(),
+      async getProgram(name: string) {
+        // Uses `this` — must resolve to the REAL client even when called via the read-only Proxy.
+        const r = await this.http.get(`/programs/${name}`);
+        return `${name}:${r.body}:${this.safety ? 'safe' : 'nosafe'}`;
+      },
+    };
+  }
+
+  it('blocks http/safety/withSafety/package mutators at runtime (cast yields undefined)', () => {
+    const ro = createReadOnlyAdtClient(fakeClient() as unknown as AdtClient) as unknown as Record<string, unknown>;
+    expect(ro.http).toBeUndefined();
+    expect(ro.safety).toBeUndefined();
+    expect(ro.withSafety).toBeUndefined();
+    expect(ro.invalidatePackageHierarchy).toBeUndefined();
+    expect('http' in ro).toBe(false);
   });
 
-  it('allows POST for a write-scoped tool when allowWrites=true and delegates', async () => {
-    const u = fakeUnderlying();
-    const c = createSafeHttpClient(as(u), unrestrictedSafetyConfig(), 'write', 'Custom_W');
-    await expect(c.post('/x', 'body', 'application/json')).resolves.toBe(resp);
-    expect(u.post).toHaveBeenCalledWith('/x', 'body', 'application/json', undefined);
+  it('still runs read methods, bound to the real client so internal this.http works', async () => {
+    const ro = createReadOnlyAdtClient(fakeClient() as unknown as AdtClient) as unknown as {
+      getProgram(n: string): Promise<string>;
+    };
+    await expect(ro.getProgram('ZHELLO')).resolves.toBe('ZHELLO:ok:safe');
   });
 
-  it('blocks POST for a write-scoped tool when allowWrites=false (server ceiling)', async () => {
-    const u = fakeUnderlying();
-    const c = createSafeHttpClient(as(u), defaultSafetyConfig(), 'write', 'Custom_W');
-    await expect(c.post('/x', 'body')).rejects.toBeInstanceOf(AdtSafetyError);
-    expect(u.post).not.toHaveBeenCalled();
-  });
-
-  it('allows GET for a read-scoped tool even when allowWrites=false', async () => {
-    const u = fakeUnderlying();
-    const c = createSafeHttpClient(as(u), defaultSafetyConfig(), 'read', 'Custom_R');
-    await expect(c.get('/x')).resolves.toBe(resp);
-  });
-
-  it('lets a write-scoped tool also GET (write covers read)', async () => {
-    const u = fakeUnderlying();
-    const c = createSafeHttpClient(as(u), unrestrictedSafetyConfig(), 'write', 'Custom_W');
-    await expect(c.get('/x')).resolves.toBe(resp);
-    await expect(c.put('/x', 'b')).resolves.toBe(resp);
-    await expect(c.delete('/x')).resolves.toBe(resp);
-  });
-
-  it('gates calls made inside withStatefulSession', async () => {
-    const u = fakeUnderlying();
-    const c = createSafeHttpClient(as(u), unrestrictedSafetyConfig(), 'read', 'Custom_R');
-    await expect(c.withStatefulSession(async (s) => s.post('/x', 'body'))).rejects.toBeInstanceOf(AdtSafetyError);
-    // a read inside the session is fine
-    await expect(c.withStatefulSession(async (s) => s.get('/x'))).resolves.toBe(resp);
+  it('refuses mutation of the wrapped client', () => {
+    const ro = createReadOnlyAdtClient(fakeClient() as unknown as AdtClient) as unknown as Record<string, unknown>;
+    expect(() => {
+      (ro as { http?: unknown }).http = { get: vi.fn() };
+    }).toThrow();
   });
 });

--- a/tests/unit/server/safe-http-client.test.ts
+++ b/tests/unit/server/safe-http-client.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AdtClient } from '../../../src/adt/client.js';
+import { AdtSafetyError } from '../../../src/adt/errors.js';
 import type { AdtHttpClient } from '../../../src/adt/http.js';
-import { defaultSafetyConfig } from '../../../src/adt/safety.js';
-import { createReadOnlyAdtClient, createSafeHttpClient } from '../../../src/server/safe-http-client.js';
+import { defaultSafetyConfig, unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
+import {
+  createPluginRunOps,
+  createReadOnlyAdtClient,
+  createSafeHttpClient,
+} from '../../../src/server/safe-http-client.js';
 
 const resp = { statusCode: 200, headers: {}, body: 'ok' };
 
@@ -11,7 +16,7 @@ function fakeUnderlying() {
   return {
     get: vi.fn(async () => resp),
     head: vi.fn(async () => resp),
-    post: vi.fn(async () => resp),
+    post: vi.fn(async (_path: string) => ({ ...resp, body: 'console output' })),
   };
 }
 
@@ -35,6 +40,45 @@ describe('createSafeHttpClient (v1: read-only)', () => {
     expect(c.put).toBeUndefined();
     expect(c.delete).toBeUndefined();
     expect(c.withStatefulSession).toBeUndefined();
+  });
+});
+
+describe('createPluginRunOps.classRun (gated code execution)', () => {
+  // (allowExecute, safety, toolScope) → expectation
+  it('refuses when the SAP_ALLOW_PLUGIN_EXECUTE opt-in is off', async () => {
+    const u = fakeUnderlying();
+    const run = createPluginRunOps(as(u), unrestrictedSafetyConfig(), false, 'write', 'Custom_Run');
+    await expect(run.classRun('ZCL_X')).rejects.toBeInstanceOf(AdtSafetyError);
+    expect(u.post).not.toHaveBeenCalled();
+  });
+
+  it('refuses a tool that does not declare write scope (even with the opt-in on)', async () => {
+    const u = fakeUnderlying();
+    const run = createPluginRunOps(as(u), unrestrictedSafetyConfig(), true, 'read', 'Custom_Run');
+    await expect(run.classRun('ZCL_X')).rejects.toBeInstanceOf(AdtSafetyError);
+    expect(u.post).not.toHaveBeenCalled();
+  });
+
+  it('refuses when allowWrites=false (execution is a mutation vector)', async () => {
+    const u = fakeUnderlying();
+    const run = createPluginRunOps(as(u), defaultSafetyConfig(), true, 'write', 'Custom_Run');
+    await expect(run.classRun('ZCL_X')).rejects.toBeInstanceOf(AdtSafetyError);
+    expect(u.post).not.toHaveBeenCalled();
+  });
+
+  it('refuses an invalid class name (path-injection guard)', async () => {
+    const u = fakeUnderlying();
+    const run = createPluginRunOps(as(u), unrestrictedSafetyConfig(), true, 'write', 'Custom_Run');
+    await expect(run.classRun('../../etc/passwd')).rejects.toBeInstanceOf(AdtSafetyError);
+    await expect(run.classRun('ZCL X')).rejects.toBeInstanceOf(AdtSafetyError);
+    expect(u.post).not.toHaveBeenCalled();
+  });
+
+  it('POSTs to the classrun endpoint and returns the console output when all gates pass', async () => {
+    const u = fakeUnderlying();
+    const run = createPluginRunOps(as(u), unrestrictedSafetyConfig(), true, 'write', 'Custom_Run');
+    await expect(run.classRun('ZCL_ARC1_RUN_DEMO')).resolves.toBe('console output');
+    expect(u.post).toHaveBeenCalledWith('/sap/bc/adt/oo/classrun/zcl_arc1_run_demo');
   });
 });
 

--- a/tests/unit/server/safe-http-client.test.ts
+++ b/tests/unit/server/safe-http-client.test.ts
@@ -115,6 +115,18 @@ describe('createReadOnlyAdtClient (runtime escape-hatch guard, review B1)', () =
     await expect(ro.getProgram('ZHELLO')).resolves.toBe('ZHELLO:ok:safe');
   });
 
+  it('does not leak blocked members via getOwnPropertyDescriptor or enumeration (descriptor bypass)', () => {
+    const ro = createReadOnlyAdtClient(fakeClient() as unknown as AdtClient);
+    // The `get` trap alone left this hole: the descriptor path returned the raw client's `.value`.
+    expect(Object.getOwnPropertyDescriptor(ro, 'http')).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(ro, 'safety')).toBeUndefined();
+    expect(Reflect.getOwnPropertyDescriptor(ro, 'http')).toBeUndefined();
+    expect(Object.keys(ro)).not.toContain('http');
+    expect(Object.keys(ro)).not.toContain('safety');
+    // Nothing http-shaped (a `.post`) escapes through enumeration either.
+    expect(Object.values(ro).some((v) => typeof (v as { post?: unknown })?.post === 'function')).toBe(false);
+  });
+
   it('refuses mutation of the wrapped client', () => {
     const ro = createReadOnlyAdtClient(fakeClient() as unknown as AdtClient) as unknown as Record<string, unknown>;
     expect(() => {

--- a/tests/unit/server/safe-http-client.test.ts
+++ b/tests/unit/server/safe-http-client.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AdtSafetyError } from '../../../src/adt/errors.js';
+import type { AdtHttpClient } from '../../../src/adt/http.js';
+import { defaultSafetyConfig, unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
+import { createSafeHttpClient } from '../../../src/server/safe-http-client.js';
+
+const resp = { statusCode: 200, headers: {}, body: 'ok' };
+
+function fakeUnderlying() {
+  const u = {
+    get: vi.fn(async () => resp),
+    head: vi.fn(async () => resp),
+    post: vi.fn(async () => resp),
+    put: vi.fn(async () => resp),
+    delete: vi.fn(async () => resp),
+    withStatefulSession: vi.fn(async (fn: (c: unknown) => Promise<unknown>) => fn(fakeUnderlying())),
+  };
+  return u;
+}
+
+const as = (u: ReturnType<typeof fakeUnderlying>) => u as unknown as AdtHttpClient;
+
+describe('createSafeHttpClient', () => {
+  it('allows GET for a read-scoped tool and delegates to the underlying', async () => {
+    const u = fakeUnderlying();
+    const c = createSafeHttpClient(as(u), defaultSafetyConfig(), 'read', 'Custom_R');
+    await expect(c.get('/sap/bc/adt/x', { Accept: 'text/plain' })).resolves.toBe(resp);
+    expect(u.get).toHaveBeenCalledWith('/sap/bc/adt/x', { Accept: 'text/plain' });
+  });
+
+  it('blocks POST for a read-scoped tool (scope coverage) — even with an unrestricted ceiling', async () => {
+    const u = fakeUnderlying();
+    const c = createSafeHttpClient(as(u), unrestrictedSafetyConfig(), 'read', 'Custom_R');
+    await expect(c.post('/x', 'body')).rejects.toBeInstanceOf(AdtSafetyError);
+    expect(u.post).not.toHaveBeenCalled();
+  });
+
+  it('allows POST for a write-scoped tool when allowWrites=true and delegates', async () => {
+    const u = fakeUnderlying();
+    const c = createSafeHttpClient(as(u), unrestrictedSafetyConfig(), 'write', 'Custom_W');
+    await expect(c.post('/x', 'body', 'application/json')).resolves.toBe(resp);
+    expect(u.post).toHaveBeenCalledWith('/x', 'body', 'application/json', undefined);
+  });
+
+  it('blocks POST for a write-scoped tool when allowWrites=false (server ceiling)', async () => {
+    const u = fakeUnderlying();
+    const c = createSafeHttpClient(as(u), defaultSafetyConfig(), 'write', 'Custom_W');
+    await expect(c.post('/x', 'body')).rejects.toBeInstanceOf(AdtSafetyError);
+    expect(u.post).not.toHaveBeenCalled();
+  });
+
+  it('allows GET for a read-scoped tool even when allowWrites=false', async () => {
+    const u = fakeUnderlying();
+    const c = createSafeHttpClient(as(u), defaultSafetyConfig(), 'read', 'Custom_R');
+    await expect(c.get('/x')).resolves.toBe(resp);
+  });
+
+  it('lets a write-scoped tool also GET (write covers read)', async () => {
+    const u = fakeUnderlying();
+    const c = createSafeHttpClient(as(u), unrestrictedSafetyConfig(), 'write', 'Custom_W');
+    await expect(c.get('/x')).resolves.toBe(resp);
+    await expect(c.put('/x', 'b')).resolves.toBe(resp);
+    await expect(c.delete('/x')).resolves.toBe(resp);
+  });
+
+  it('gates calls made inside withStatefulSession', async () => {
+    const u = fakeUnderlying();
+    const c = createSafeHttpClient(as(u), unrestrictedSafetyConfig(), 'read', 'Custom_R');
+    await expect(c.withStatefulSession(async (s) => s.post('/x', 'body'))).rejects.toBeInstanceOf(AdtSafetyError);
+    // a read inside the session is fine
+    await expect(c.withStatefulSession(async (s) => s.get('/x'))).resolves.toBe(resp);
+  });
+});

--- a/tests/unit/server/server.test.ts
+++ b/tests/unit/server/server.test.ts
@@ -5,10 +5,16 @@ import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import { AdtApiError } from '../../../src/adt/errors.js';
 import { AdtHttpClient } from '../../../src/adt/http.js';
+import type { ResolvedFeatures } from '../../../src/adt/types.js';
+import { getToolRegistry } from '../../../src/handlers/dispatch.js';
+import { resetCachedFeatures, setCachedFeatures } from '../../../src/handlers/feature-cache.js';
 import { getToolDefinitions } from '../../../src/handlers/tools.js';
+import { defineTool } from '../../../src/public/index.js';
 import { logger } from '../../../src/server/logger.js';
+import { registerPluginTool } from '../../../src/server/plugin-loader.js';
 import {
   buildAdtConfig,
   createServer,
@@ -213,6 +219,65 @@ describe('createServer request handlers', () => {
     await handler({ method: 'tools/call', params: { name: 'UnknownTool', arguments: {} } }, {});
 
     expect(markSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createServer tools/list — plugin tools (FEAT-61)', () => {
+  afterEach(() => resetCachedFeatures());
+
+  function readTool(name: `Custom_${string}`, extra: Partial<Parameters<typeof defineTool>[0]> = {}) {
+    return defineTool({
+      name,
+      description: 'd',
+      schema: z.object({}),
+      policy: { scope: 'read', opType: 'R' },
+      handler: async () => ({ content: [{ type: 'text', text: 'x' }] }),
+      ...extra,
+    });
+  }
+
+  async function listToolNames(
+    config: Parameters<typeof createServer>[0],
+    authInfo: AuthInfo = readAuth(),
+  ): Promise<string[]> {
+    const server = createServer(config);
+    const handler = requestHandler(server, ListToolsRequestSchema.shape.method.value);
+    const result = await handler({ method: 'tools/list', params: {} }, { authInfo });
+    return (result.tools as Array<{ name: string }>).map((t) => t.name);
+  }
+
+  it('lists a read plugin tool but scope-prunes a write plugin tool for a read user', async () => {
+    registerPluginTool(getToolRegistry(), 'demo', readTool('Custom_ListedRead'));
+    registerPluginTool(
+      getToolRegistry(),
+      'demo',
+      defineTool({
+        name: 'Custom_HiddenWrite',
+        description: 'w',
+        schema: z.object({}),
+        policy: { scope: 'write', opType: 'U' },
+        handler: async () => ({ content: [{ type: 'text', text: 'x' }] }),
+      }),
+    );
+    const names = await listToolNames({ ...DEFAULT_CONFIG, allowWrites: true });
+    expect(names).toContain('Custom_ListedRead');
+    expect(names).not.toContain('Custom_HiddenWrite'); // read user lacks the write scope
+  });
+
+  it('hides plugin tools in hyperfocused mode (only the SAP tool is exposed)', async () => {
+    registerPluginTool(getToolRegistry(), 'demo', readTool('Custom_HfHidden'));
+    const names = await listToolNames({ ...DEFAULT_CONFIG, toolMode: 'hyperfocused' });
+    expect(names).toContain('SAP');
+    expect(names).not.toContain('Custom_HfHidden');
+  });
+
+  it('enforces availableOn against the resolved system type', async () => {
+    setCachedFeatures({ systemType: 'onprem' } as ResolvedFeatures);
+    registerPluginTool(getToolRegistry(), 'demo', readTool('Custom_BtpOnly', { availableOn: 'btp' }));
+    registerPluginTool(getToolRegistry(), 'demo', readTool('Custom_OnpremOnly', { availableOn: 'onprem' }));
+    const names = await listToolNames(DEFAULT_CONFIG);
+    expect(names).not.toContain('Custom_BtpOnly');
+    expect(names).toContain('Custom_OnpremOnly');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds an **extension framework** (FEAT-61, #332) that lets an operator register
their own `Custom_*` tools into an ARC-1 instance **without forking**. This is
the "use ARC-1 and add your own tools" half of the story (the other half — a
standalone reusable BTP-auth module — is tracked separately).

Two tiers, pick per tool:

| Tier | You write | Good for |
|------|-----------|----------|
| **Code** | `defineTool({ name, description, schema, policy, handler })` from `arc-1/public` | real logic, ADT/OData calls, any HTTP via a gated client |
| **Manifest** | a declarative `*.tool.json` | read-only GET wrappers, zero code |

Plugins load at startup from **`ARC1_PLUGINS`** — a CSV of **absolute local
paths** (a `.js`, a directory, or a `*.tool.json`). Not npm package names; an
admin explicitly opts each path in.

## How it works

- **`ToolRegistry`** (`src/registry/tool-registry.ts`) replaces the hand-written
  `switch (toolName)` in `handleToolCall`. The 12 built-ins now register as thin
  adapters; plugins register after them. The shared per-call pipeline
  (rate-limit → scope → deny → Zod → audit) is **unchanged** — only the inner
  dispatch moved. Registration is **fail-fast**: a name collision or malformed
  entry refuses server start rather than silently shadowing a built-in.
- **Authorization reuses the 7 existing scopes** (`read`/`write`/`data`/`sql`/
  `transports`/`git`/`admin`). Custom scopes are intentionally **not** supported —
  XSUAA `xs-security.json` is deploy-time static, so a runtime-registered scope
  could never be minted into a token. A plugin declares `policy: { scope, opType }`
  and is gated **identically to a built-in**, both in `tools/list` and at call time
  (a `read`-scoped user can't invoke a `write` plugin tool).
- **Plugin surface is narrowed for safety** (`src/server/safe-http-client.ts`):
  `SafeHttpClient` + `ReadOnlyAdtClient` ensure a plugin can't bypass
  `checkOperation()` with a raw `http.*` call (closes review finding B1). Manifest
  tools are GET-only, Ajv-validated, with **percent-encoded path params**
  (traversal-safe) and `additionalProperties:false`.

## Live-verified

End-to-end against **S/4HANA (a4h)** via the sample repo: both a code tool
(reads real ABAP source over ADT) and a manifest tool return live data through
the full registry → scope → handler path.

## What's included

- **Framework:** `src/registry/`, `src/public/` (`arc-1/public` + `/public/testing`),
  `src/plugins/manifest-interpreter.ts`, `src/server/{plugin-loader,safe-http-client}.ts`,
  wiring in `dispatch.ts`/`server.ts`/`config.ts`/`cli.ts`/`types.ts`, `package.json` exports.
- **Research + spec:** `docs/research/extension-framework-deep-research.md`,
  `docs/research/extension-framework-spec.md`.
- **Docs:** `docs_page/extensions.md` (linked in nav) — quickstart, both tiers,
  `ARC1_PLUGINS`, trust model.
- **Skill:** `.claude/skills/create-arc1-extension/` — guided scaffolding that
  walks the decisions and flags the security implications.
- **Sample repo:** [`arc-mcp/arc-1-extension-sample`](https://github.com/arc-mcp/arc-1-extension-sample)
  — two code tools + one manifest tool, live-verified.

## Tests

51 new unit tests (registry, `defineTool`, manifest interpreter, plugin loader,
SafeHttpClient, end-to-end plugin dispatch through `handleToolCall`). Full suite
green (3915 tests), `typecheck` + `lint` clean.

## Notes for reviewers

- This is a **port onto current `main`** after the PR #402 consolidation deleted
  `src/handlers/intent.ts` — dispatch now lives in `src/handlers/dispatch.ts` and
  the built-in registry adapters thread the new `cacheSecurity` context.
- No new runtime config is enabled by default: `ARC1_PLUGINS` is empty → zero
  behavior change for existing deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)