### PR TITLE
docs(auth): research + spec for extracting XSUAA/BTP auth into @arc-mcp/xsuaa-auth

### DIFF
--- a/docs/research/auth-module/RESEARCH.md
+++ b/docs/research/auth-module/RESEARCH.md
@@ -1,0 +1,244 @@
+# Auth Module — Extraction Research & Decisions
+
+> ⚠️ **`SPEC.md` is the authoritative contract** (frozen deps, API, scope). Where this research doc differs, the SPEC wins — notably: `express` resolved to **`^5.0.1`** (Express 4 is moot; the MCP SDK hard-depends on express 5), SDK floor **`>=1.18.2`**, rate-limit **out of v1**, PP **in v1** (`./btp`), and the verifier chain order **frozen as XSUAA→OIDC→api-key**. This doc is retained for rationale/history.
+
+> **Status:** Research / pre-spec. **Date:** 2026-06-17. **Workstream:** Fork A (auth module).
+> **Org:** `github.com/arc-mcp` (standalone repo). **Maintenance:** solo. **npm:** `@arc-mcp/xsuaa-auth` (scoped — published under the `arc-mcp` npm org; never `marianfoo`). **Repo:** `arc-mcp/xsuaa-auth`.
+> **End goal:** a frozen SPEC. This doc gathers evidence and proposes ADRs (each with a recommendation) to confirm *before* the spec.
+
+Grounded in three investigations (2026-06-17): (1) ARC-1 auth current-state (exact signatures + coupling), (2) calmcp + LISA auth teardown (3-way diff), (3) external best-practice research (ESM packaging, MCP SDK auth, @sap/xssec, release/publish). Versions below were verified against primary sources, not recalled.
+
+---
+
+## 1. Goals & constraints (ranked)
+
+1. **PRIMARY — minimal change for ARC-1.** The package API must let ARC-1 adopt it with an import-swap + tiny glue, not a rewrite. ARC-1 keeps `startHttpServer` (its orchestrator); the package provides the building blocks it already calls.
+2. **Replace calmcp + LISA custom code via PRs.** After ARC-1 adopts, ship PRs to both external repos that delete their copied auth and depend on the package — smallest possible diff each.
+3. **Plug-and-play initial usage.** A near-zero-config happy path; special config only when the use case needs it.
+4. **ARC-1-grade repo quality.** Superb docs, release-please, tests, issue templates, samples, CI — security-sensitive-library posture.
+
+Tension to resolve up front: (1) "minimal ARC-1 diff" wants the **low-level building blocks** ARC-1 already calls; (3) "plug-and-play" wants a **high-level one-liner**; (2) calmcp already uses a high-level facade while LISA hand-wires building blocks. → resolved by **ADR-003 (two-layer API)**.
+
+---
+
+## 2. Current state — ARC-1 auth anatomy
+
+Files in scope (`src/server/` unless noted), with exact public surface:
+
+| Module | LOC | Public surface (abbrev.) | ARC-1 coupling |
+|---|---|---|---|
+| `stateless-client-store.ts` | ~590 | `class StatelessDcrClientStore(xsuaaClientId, xsuaaClientSecret, signingSecret, opts?)` impl `OAuthRegisteredClientsStore`; `matchesXsuaaRedirectPattern`, `validateRedirectUri`, `XSUAA_REDIRECT_URI_PATTERNS` | `logger` singleton; const `ID_PREFIX='arc1-'`, `KDF_LABEL='arc1-dcr/v1'` |
+| `oauth-state.ts` | ~150 | `class OAuthStateCodec(signingSecret, {ttlSeconds?})` → `encode/decode`; `type DecodeResult` | **none** (pure crypto codec); const `KDF_LABEL='arc1-oauth-state/v1'` |
+| `xsuaa.ts` | ~590 | `createXsuaaTokenVerifier(creds)`, `createChainedTokenVerifier(cfg, xsuaaV?, oidcV?)`, `createXsuaaOAuthProvider(creds, appUrl, opts?) → {provider, clientStore, stateCodec}`, `class XsuaaProxyOAuthProvider`, `qualifyXsuaaScopes`, `interface XsuaaCredentials`, `CreateXsuaaOAuthProviderOptions` | `expandScopes` ← `authz/policy`; `API_KEY_PROFILES` ← `config`; `logger`; hardcoded scope list `[read,write,data,sql,transports,git,admin]` |
+| `auth-rate-limit.ts` | ~124 | `createAuthRateLimiter(endpoint, perMinute, opts?) → RequestHandler`, `isCopilotJsonRpc(req)` | `logger` (audit) |
+| `mcp-rate-limit.ts` | ~113 | `createMcpRateLimiter(perMinute) → McpRateLimiter`, `resolveRateLimitUserKey(authInfo)`, types | **none** |
+| `adt/btp.ts` | ~571 | `parseVCAPServices`, `lookupDestination(WithUserToken)`, `createConnectivityProxy`, `resolveBTPDestination`, `getAppUrl` | `logger`; reads `VCAP_*`/`SAP_BTP_*` env directly |
+| `http.ts` (auth slice only) | ~300 of 972 | `createOAuthCallbackHandler(stateCodec, clientStore?)`, `createStandardVerifier(config)`, `extractOidcScopes(payload)`; the wiring in `startHttpServer` | `ServerConfig`, `expandScopes`, `API_KEY_PROFILES`, `logger`, `VERSION`, `getAppUrl` |
+
+**Wiring sequence** (in `startHttpServer`, XSUAA branch): resolve `appUrl` (`getAppUrl()`) → `createXsuaaOAuthProvider(creds, appUrl, {dcrTtlSeconds, dcrSigningSecret, callbackUrl})` → `createXsuaaTokenVerifier` + optional `createOidcVerifier` → `createChainedTokenVerifier(config, xsuaaV, oidcV)` → `requireBearerAuth({verifier, resourceMetadataUrl})` → mount Layer-1 rate limiters on `/register|/authorize|/token|/revoke|/oauth/callback` → `/authorize` shim (`ensureRedirectUri` + Copilot JSON-RPC bypass) → `GET /oauth/callback` (the #214 proxy) → optional base-path metadata overrides → `mcpAuthRouter({provider, issuerUrl, baseUrl, resourceServerUrl, scopesSupported, resourceName})` → `/mcp` rate-limit → `app.all('/mcp', bearerAuth, mcpHandler)`.
+
+**Coupling seams to cut (from the deep read):** ① logger singleton → inject; ② hardcoded scope names → param; ③ `expandScopes` (policy) → inject/optional; ④ `API_KEY_PROFILES` → accept `keys→scopes` directly; ⑤ `ServerConfig` → small options object; ⑥ `ID_PREFIX`/`KDF_LABEL`×2 → params; ⑦ redirect patterns → param (defaults shipped); ⑧ `resourceName` → param; ⑨ btp env reads → keep out of package; ⑩ error-page HTML → optional override.
+
+**Auth-layer npm deps today:** `@modelcontextprotocol/sdk ^1.28`, `@sap/xssec ^4.13`, `@sap-cloud-sdk/connectivity ^4.7` (btp only), `jose ^6.2` (OIDC, lazy), `express ^5.2`, `express-rate-limit ^8.5`, `rate-limiter-flexible ^11.1`, `helmet`, `cors`, `node:crypto`.
+
+---
+
+## 3. Three-way reality check (arc-1 / calmcp / LISA)
+
+The crypto core (`stateless-client-store`, `oauth-state`, `XsuaaProxyOAuthProvider`) is **verbatim-identical** across all three. All divergence is in the **wiring/entry layer** — which is exactly what the package must get right.
+
+| Dimension | arc-1 | calmcp | LISA |
+|---|---|---|---|
+| **Entry shape** | building blocks, wired in `startHttpServer` | **facade** `setupHttpAuth(app, opts, logger)` | **building blocks**, hand-wired in `http.ts` (doesn't even use SDK `requireBearerAuth`) |
+| **Config model** | full `ServerConfig` | **small** `HttpAuthOptions` (2 fields) | full app `Config` (~20 fields) injected |
+| **Logger** | singleton `(msg, data)` + `emitAudit` | **pino**, injected `(obj, msg)` ⚠ arg-order | custom class singleton `(msg, data)` + `emitAudit` |
+| **@sap/xssec** | ^4.13 | ^4.13 | ^4.2 |
+| **MCP SDK** | ^1.28 | ^1.28 | **^1.12** |
+| **express** | ^5.2 | **^5** | **^4.21** |
+| **rate-limit** | 2 layers | 1 (in transport) | 2 (in transport) |
+| **OIDC** | yes (jose) | **no** | yes (jose ^5.9) |
+| **api-key** | multi, profile→scopes | **single** static key | multi `key:profile` |
+| **local scope check** | full policy | one (`Viewer`) | **none** (auth-only) |
+| **PP / btp** | full | **none** | full (threads user JWT itself) |
+| **prefix / kdf** | `arc1-` / `arc1-dcr,oauth-state` | `calmcp-` / `calmcp-*` | `sapt-` / `lisa-*` |
+
+**Migration verdicts:** calmcp → expose its exact `setupHttpAuth(app, opts, logger)` facade ⇒ ~3-line diff. LISA → expose the granular building blocks it already calls (`createChainedTokenVerifier`, `createXsuaaOAuthProvider`, `createOAuthCallbackHandler`, `StatelessDcrClientStore`, …) ⇒ small diff, **its blocker is logger injection** (currently imports a singleton). arc-1 → building blocks + keep `startHttpServer`.
+
+**Hard divergences the API must absorb:** logger contract incl. **pino arg-order** (`(obj,msg)` vs `(msg,obj)`); **MCP SDK 1.12↔1.28** spread; **Express 4↔5**; small-vs-big config; scope opt-in vs none; OIDC present/absent; api-key single/list; PP out entirely.
+
+---
+
+## 4. Scope — in / out
+
+**IN (the package):**
+- Stateless DCR client store (RFC 7591, HMAC-signed client_ids).
+- OAuth state codec (the #214 `+`-bug callback proxy).
+- XSUAA OAuth proxy provider + token verifier (`@sap/xssec`).
+- Chained bearer verifier (api-key → XSUAA → OIDC), each optional.
+- Optional OIDC verifier (jose).
+- API-key verifier (single string **or** `{key, scopes}[]`).
+- OAuth callback handler + `/authorize` redirect-uri shim helper.
+- Redirect-uri validation + default patterns (the shared vendored lists).
+- **Optional sub-module:** the two rate-limit helpers (per-IP + per-user) — generic, all three use them (ADR-015).
+- A thin `setupHttpAuth` facade (plug-and-play) over the above.
+
+**OUT (stays per-consumer):**
+- **Principal propagation / BTP destination/connectivity** (`btp.ts`). It's the SAP-*client* layer, not client→server auth; the package's job ends at producing `AuthInfo` + the raw bearer token. LISA threads the token to SAP itself; calmcp has no PP. (Reconsider as a *separate* future package, never bundled here.)
+- **Scope/tool policy** (`ACTION_POLICY`, `expandScopes` as arc-1 defines it) — injectable, not owned.
+- **Safety ceiling, ServerConfig, MCP tools, the SAP backend client.**
+- **MCP transport ownership** (the host owns `stdio`/`http-streamable`; the package contributes middleware + a router).
+
+---
+
+## 5. Architecture Decision Records (proposed — confirm before spec)
+
+> These graduate to individual `docs/adr/NNNN-*.md` once confirmed.
+
+### ADR-001 — Repo, org, naming
+**Context:** New org `arc-mcp`; solo; no `marianfoo` scope; name deferrable.
+**Options:** `@arc-mcp/auth` · `@arc-mcp/xsuaa-auth` · `@arc-mcp/mcp-btp-auth`.
+**Recommendation:** repo `arc-mcp/auth`; npm **`@arc-mcp/xsuaa-auth`** (most descriptive — XSUAA-centric MCP auth; leaves room for a sibling `@arc-mcp/*` later). Confirm name at scaffold.
+**Consequences:** Org scope decouples from personal identity; scoped packages publish fine under OIDC trusted publishing.
+
+### ADR-002 — Package contents / module boundary
+**Context:** §4 in/out.
+**Recommendation:** Ship the transport-auth layer (§4 IN). **Exclude `btp.ts`/PP** and policy/safety/config. Rate-limit helpers go in an **optional sub-export** (ADR-015), not the core.
+**Consequences:** Smaller, security-focused surface; PP stays where identity-threading lives; no consumer inherits arc-1's policy engine.
+
+### ADR-003 — Two-layer public API (the key decision)
+**Context:** minimal-arc-1-diff + LISA want building blocks; calmcp + plug-and-play want a facade.
+**Recommendation:** Expose **both**: (a) **building blocks** — `StatelessDcrClientStore`, `OAuthStateCodec`, `createXsuaaOAuthProvider`, `createXsuaaTokenVerifier`, `createOidcVerifier`, `createApiKeyVerifier`, `createChainedTokenVerifier`, `createOAuthCallbackHandler`, `validateRedirectUri`; (b) a thin **`setupHttpAuth(app, options, logger?)`** facade composing them (calmcp's existing signature).
+**Consequences:** All three migrate with minimal diff; new users get the one-liner. Slightly larger API surface to maintain — acceptable, it's the whole point.
+
+### ADR-004 — Build on the MCP "resource-server" model + insulate from SDK v2
+**Context:** MCP SDK **v2 monorepo split is in active alpha (Apr 2026)** — auth moves out of core, **Express becomes a separate `@modelcontextprotocol/express` adapter**, import paths change. Even 1.x minors shifted auth defaults. The 2025-06-18 spec treats the MCP server as an OAuth **resource server** with XSUAA as the separate AS.
+**Recommendation:** Center the design on `OAuthTokenVerifier` + `requireBearerAuth` + protected-resource metadata (spec direction, cleanest XSUAA fit). **Wrap the SDK's auth types behind our own thin interface** so the v2 relocation is a one-file change. Keep `ProxyOAuthServerProvider`/`mcpAuthRouter` for the full-flow path we already need.
+**Consequences:** One internal adapter file absorbs SDK churn; consumers never see SDK path changes.
+
+### ADR-005 — Logger: injected structural interface (no pino dep)
+**Context:** calmcp=pino `(obj,msg)`, arc-1/LISA=custom singleton `(msg,data)` + `emitAudit`. LISA's migration blocker is that it imports a logger singleton.
+**Recommendation:** Define a minimal **structural** interface `Logger { debug/info/warn/error(msg: string, data?: object): void; emitAudit?(e): void }`, **injected everywhere, optional, default no-op.** Standardize on `(message, data?)` (matches the source). calmcp passes a ~3-line pino adapter; arc-1/LISA inject directly.
+**Consequences:** Zero logging dep in the package; plug-and-play needs no logger; calmcp eats a trivial adapter (documented).
+
+### ADR-006 — Config: small `AuthOptions`, consumers adapt
+**Context:** calmcp small options vs LISA whole-config injection.
+**Recommendation:** Package owns a small `AuthOptions` (calmcp's shape, extended — see §6). **Never depend on a consumer's config type**; each writes a one-function `theirConfig → AuthOptions` adapter (LISA already effectively does).
+**Consequences:** Clean boundary; consumers keep their own config philosophy.
+
+### ADR-007 — Dependency strategy
+**Context:** Best-practice rule = peer the *host frameworks* whose identity must be shared; depend on leaf validators. Express 4↔5 and SDK 1.12↔1.28 spread across consumers. `@sap/xssec` is pure CJS.
+**Recommendation:**
+- **peerDependencies:** `@modelcontextprotocol/sdk` (**`>=1.12 <2`**, tested at both floor & ceiling in CI), `express` (**`>=4.21 <6`** — building blocks are express-version-agnostic; only the facade/middleware touch express types, tested on 5).
+- **optional peer:** `jose` (`>=5 <7`, `peerDependenciesMeta.optional`, lazy-imported) — OIDC-only, so calmcp needn't install it.
+- **dependencies:** `@sap/xssec` (`^4`).
+- **Not surfaced:** `zod` (skip unless we expose Zod types).
+**Consequences:** No duplicate Express/SDK instances (which would break `req.auth`); LISA stays on Express 4 via building blocks; calmcp skips jose. Wide SDK range needs CI matrix.
+
+### ADR-008 — Parameterization knobs + defaults
+**Recommendation:** Options (all defaulted except secrets): `clientIdPrefix` (default `'mcp-'`), `dcrKdfLabel` (`'mcp-dcr/v1'`), `stateKdfLabel` (`'mcp-oauth-state/v1'`), `redirectUriPatterns` + `defaultRedirectUris` (ship the shared vendored lists as defaults), `resourceName` (default `'MCP Server'`), `scopesSupported` (default `[]`), `requiredScope` (default none), `dcrTtlSeconds` (30d), `stateTtlSeconds` (600s), `dcrSigningSecret` (required for stable client_ids; document falling back to xsuaa `clientsecret`).
+**Consequences:** Every consumer overrides `clientIdPrefix`/`kdfLabel` per-deployment (the revocation/domain-separation knob — must be documented as such).
+
+### ADR-009 — Scope/policy out; single-scope opt-in
+**Recommendation:** Authentication only + an **optional** `requiredScope` check (calmcp's `Viewer` case). Ship `qualifyXsuaaScopes` (generic). **Inject `expandScopes`** (optional, default identity) — arc-1 passes its policy fn; others omit. API-keys are `{key, scopes: string[]}[]` — the consumer maps its own "profiles" to scopes; the package has no profile concept.
+**Consequences:** No policy engine leaks into the package; arc-1's richer policy stays in arc-1.
+
+### ADR-010 — OIDC + API-key shape
+**Recommendation:** `createOidcVerifier(issuer, audience, opts?)` exported, jose optional/lazy. `createApiKeyVerifier(keys: string | {key, scopes?}[])` collapses calmcp-single + LISA-list.
+**Consequences:** One verifier covers both consumers; OIDC is pay-for-what-you-use.
+
+### ADR-011 — Ship the #214 oauth-state codec; document removal trigger
+**Context:** XSUAA echoes `+` in `state` un-encoded; the callback proxy works around it. Load-bearing today.
+**Recommendation:** Ship it (internal to `createXsuaaOAuthProvider` + the exported callback handler). Document the removal trigger (when XSUAA fixes the bug) in code + a roadmap note.
+**Consequences:** All consumers stop re-carrying the workaround; one place to delete it later.
+
+### ADR-012 — ESM-only packaging
+**Context:** `require(esm)` is stable on Node 20.19+/22.12+, so dual builds are unjustified for a Node-22+ target. `@sap/xssec` is pure CJS.
+**Recommendation:** ESM-only. `"type":"module"`, `"sideEffects":false`, `"engines":{"node":">=22"}`, an **`exports` map** (types-first, `default` last, sub-paths `./rate-limit`, `./package.json`). Build with **plain `tsc`** (`NodeNext`, `declaration`, `isolatedDeclarations`). Consume `@sap/xssec` via default-import + destructure (`esModuleInterop`); **document the CJS interop sharp edge** in the README. CI gate: `publint && attw --pack . --profile esm-only`.
+**Consequences:** Modern, tree-shakeable, no dual-build complexity; one documented interop caveat.
+
+### ADR-013 — Release & publish
+**Recommendation:** **release-please** (`release-type: node`, single `"."` package, **no `extra-files`** — no source VERSION constant). **npm OIDC trusted publishing** (automatic provenance, no `NPM_TOKEN`, `id-token: write`, Node ≥22.14/npm ≥11.5.1). Start **`0.1.0`** (0.x while the API settles across 3 consumers). Treat option/knob changes as semver-relevant.
+**Consequences:** Same posture as arc-1 minus the VERSION marker; conventional-commits drive versioning.
+
+### ADR-014 — Repo quality stack
+**Recommendation:** Mirror arc-1 (biome, vitest, husky/lint-staged, dependabot npm+actions, SHA-pinned third-party actions, `npm audit --audit-level=high`, dependency-review, SECURITY.md). **Add for a security-sensitive auth lib:** GitHub **Private Vulnerability Reporting**, **CodeQL** (`security-extended`), **OpenSSF Scorecard** (required check), YAML issue forms + PR template, **CODEOWNERS on `/.github/workflows/`** + auth source, an **`examples/`** dir (runnable per-scenario TS apps), and a docs site = **TypeDoc + typedoc-plugin-markdown → VitePress** (TS-native API ref + guides; VitePress over Docusaurus unless versioned docs are needed; over mkdocs because TS-native). **Port the triplicate tests** (arc-1 + calmcp + LISA all have them) into one suite.
+**Consequences:** Best-in-class OSS auth-lib hygiene; tests consolidated.
+
+### ADR-015 — Rate limiting as an optional sub-module
+**Context:** All three rate-limit, but wire it in their transport, not the auth core; shapes differ (1 vs 2 layers).
+**Recommendation:** Ship `createAuthRateLimiter` (per-IP) + `createMcpRateLimiter` (per-user) under **`@arc-mcp/xsuaa-auth/rate-limit`**, deps `express-rate-limit` + `rate-limiter-flexible`. Not part of the facade; host mounts them.
+**Consequences:** Core stays focused; rate-limit is opt-in and independently versioned-in.
+
+---
+
+## 6. Proposed public API surface (illustrative — not frozen)
+
+```ts
+// @arc-mcp/xsuaa-auth
+export interface Logger { debug(m,d?):void; info(m,d?):void; warn(m,d?):void; error(m,d?):void; emitAudit?(e):void }
+
+export interface AuthOptions {
+  apiKeys?: string | { key: string; scopes?: string[] }[];
+  xsuaa?: { credentials: XsuaaCredentials; appUrl: string;
+            clientIdPrefix?: string; dcrKdfLabel?: string; stateKdfLabel?: string;
+            resourceName?: string; scopesSupported?: string[]; requiredScope?: string;
+            redirectUriPatterns?: string[]; defaultRedirectUris?: string[];
+            dcrTtlSeconds?: number; stateTtlSeconds?: number; dcrSigningSecret?: string };
+  oidc?: { issuer: string; audience: string; clockToleranceSec?: number };
+  expandScopes?: (scopes: string[]) => string[];   // injected policy hook (default: identity)
+}
+
+// Facade (plug-and-play; calmcp):
+export function setupHttpAuth(app, options: AuthOptions, logger?: Logger): RequestHandler | undefined;
+
+// Building blocks (minimal-diff; arc-1, LISA):
+export class StatelessDcrClientStore { /* … */ }
+export class OAuthStateCodec { /* … */ }
+export function createXsuaaOAuthProvider(creds, appUrl, opts?, logger?): { provider; clientStore; stateCodec };
+export function createXsuaaTokenVerifier(creds, opts?): Verifier;
+export function createOidcVerifier(issuer, audience, opts?): Verifier;          // jose, lazy
+export function createApiKeyVerifier(keys): Verifier;
+export function createChainedTokenVerifier(opts, xsuaaV?, oidcV?): Verifier;
+export function createOAuthCallbackHandler(stateCodec, clientStore?, logger?): RequestHandler;
+export function validateRedirectUri(uri, patterns?): void;
+export type { XsuaaCredentials, AuthInfo };
+
+// Sub-module: @arc-mcp/xsuaa-auth/rate-limit
+export function createAuthRateLimiter(endpoint, perMinute, opts?): RequestHandler;
+export function createMcpRateLimiter(perMinute): McpRateLimiter;
+```
+
+**Minimal ARC-1 diff** (validates the primary goal): swap 5 imports `./server/*` → `@arc-mcp/xsuaa-auth`; pass `config.logger` into the factories; map the handful of `ServerConfig` fields → `AuthOptions`; inject `expandScopes` from `authz/policy`. `startHttpServer` keeps orchestrating. No behavior change.
+
+---
+
+## 7. Deliverables & phasing
+
+1. **This research doc** → confirm ADRs.
+2. **SPEC** — freeze the public API (§6), the `AuthOptions`, the Logger contract, the exports map, peer ranges. The gate before any code.
+3. **Repo scaffold** (`arc-mcp/auth`) — ADR-012/013/014 stack: tsc/ESM, exports map, vitest, biome, release-please, OIDC publish CI, CodeQL, Scorecard, dependabot, SECURITY + private vuln reporting, issue forms, CODEOWNERS, `examples/`, TypeDoc→VitePress.
+4. **Port code + tests** — lift the modules, parameterize the knobs, inject logger, consolidate the triplicate test suites; `publint`/`attw` green.
+5. **ARC-1 integration PR** — import-swap + glue; delete the moved files; lower `check:sizes`; full gate green.
+6. **calmcp PR** — delete `src/httpAuth/`, adopt `setupHttpAuth` (+ pino adapter); ~3-line call site.
+7. **LISA PR** — adopt building blocks; inject logger; bump SDK to the peer range; Express-4 path verified.
+
+---
+
+## 8. Open decisions (need confirmation)
+
+- **npm name:** RESOLVED → `@arc-mcp/xsuaa-auth` (scoped, under the `arc-mcp` npm org; GitHub repo `arc-mcp/xsuaa-auth`).
+- **MCP SDK peer floor:** `>=1.12` (covers LISA as-is, wider risk) vs `>=1.28` (forces LISA to bump in its PR, tighter). *Recommend `>=1.12 <2` + CI matrix*, since LISA bumps anyway in its migration PR — confirm appetite for the matrix.
+- **Rate-limit sub-module in v1?** Recommended yes (ADR-015); could defer if we want the smallest first release.
+- **Docs site:** VitePress (recommended, lean) vs Docusaurus (if versioned docs matter early).
+- **`btp.ts`/PP:** confirmed OUT of this package — future separate `@arc-mcp/*` package or left per-consumer? (Recommend: leave per-consumer for now; revisit only if a 2nd PP consumer with the same shape appears.)
+- **Express peer:** `>=4.21 <6` (covers LISA) vs `^5` only (forces LISA to Express 5). *Recommend the wide range* — building blocks are version-agnostic.
+
+## 9. Risks
+- **MCP SDK v2 churn** (highest) — mitigated by ADR-004 (wrap types, pin `<2`).
+- **Wide peer ranges** (SDK 1.12–1.x, Express 4–5) → real test-matrix cost; the facade is the riskiest cross-version surface, building blocks are safe.
+- **`@sap/xssec` CJS interop** in an ESM-only package — mitigated by default-import+destructure + documented caveat.
+- **Logger arg-order** (pino vs source) — mitigated by standardizing `(msg, data)` + a calmcp adapter.
+- **Solo maintenance of a security-sensitive public package** — mitigated by Scorecard/CodeQL/private-reporting and keeping the surface small.
+
+## 10. Key sources (verified 2026-06-17)
+nodejs.org/api/packages.html · joyeecheung.github.io (require(esm) stability) · publint.dev · arethetypeswrong · github.com/modelcontextprotocol/typescript-sdk (v1.29.0 `src/server/auth/*`, v2 alpha tags 2026-04-01, issue #440) · modelcontextprotocol.io/specification/2025-06-18/basic/authorization · registry.npmjs.org (@modelcontextprotocol/sdk 1.29.0, express 5.2.1/4.22.2, @sap/xssec 4.13.0) · @sap/xssec README · docs.npmjs.com/trusted-publishers · github.com/googleapis/release-please · npmjs.com/package/express-oauth2-jwt-bearer · ossf/scorecard-action · github/codeql-action.

--- a/docs/research/auth-module/SPEC.md
+++ b/docs/research/auth-module/SPEC.md
@@ -1,0 +1,341 @@
+# Auth Module — SPEC (API-freeze candidate, v0)
+
+> **Status:** Draft spec — the API-freeze gate before any code. **Date:** 2026-06-17. **Companion:** [`RESEARCH.md`](./RESEARCH.md) (rationale + ADRs).
+> **Decisions locked this round:** rate-limit **OUT** of v1 · principal propagation **IN** v1 (`./btp` sub-module) · SDK floor **`>=1.18.2`** · `express ^5.0.1` (Express 4 is moot — SDK hard-forces 5).
+
+This spec freezes: scope, entrypoints, dependency ranges, the logger contract, every public signature, the auth↔PP coupling contract, and the minimal-diff adoption path for each of the three consumers (arc-1, calmcp, LISA). Rationale and the version evidence live in `RESEARCH.md`; this document is the contract.
+
+---
+
+## 1. Package identity
+
+| | |
+|---|---|
+| Org / repo | `github.com/arc-mcp/xsuaa-auth` (working) |
+| npm | `@arc-mcp/xsuaa-auth` (working name — final at scaffold; never `marianfoo` scope) |
+| Module system | **ESM-only**, `"type": "module"`, `engines.node >= 22` |
+| Maintenance | solo |
+| Release | release-please (`node`, single package, no `extra-files`) + npm OIDC trusted publishing (automatic provenance) |
+| First version | `0.1.0` (0.x while the API settles across the 3 consumers) |
+
+---
+
+## 2. Scope
+
+**IN (v1):**
+- **Core auth (`.`)** — MCP client→server authentication: XSUAA OAuth proxy provider, stateless RFC 7591 DCR client store, the `#214` OAuth-state callback codec, chained bearer verifier (**XSUAA → OIDC → api-key**, each optional; order frozen to match arc-1 — correctness-immaterial since token types are disjoint), and a thin `setupHttpAuth` facade.
+- **Principal propagation (`./btp`)** — BTP destination lookup, per-user PP token exchange, and the Cloud Connector connectivity-proxy descriptor.
+
+**OUT (v1) — deliberately deferred or consumer-owned:**
+- **Rate limiting** — deferred post-v1 (consumers keep their own; see §14).
+- **Scope/tool policy** (`ACTION_POLICY`, arc-1's `expandScopes` semantics) — injected as an optional hook, never owned.
+- **Safety ceiling, `ServerConfig`, the MCP tools, the SAP HTTP client** — consumer-owned.
+- **`getAppUrl` / OAuth-metadata URL resolution** — stays in each consumer's transport (it's not a PP concern; LISA already inlines its own).
+- **The Copilot Studio `/authorize` JSON-RPC bypass and reverse-proxy base-path metadata overrides** — arc-1 specials, kept in arc-1 via the building blocks.
+
+---
+
+## 3. Entrypoints (`exports` map)
+
+```jsonc
+"exports": {
+  ".":            { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+  "./btp":        { "types": "./dist/btp.d.ts",   "default": "./dist/btp.js" },
+  "./package.json": "./package.json"
+}
+```
+- `.` — core auth. Deps it needs: `@modelcontextprotocol/sdk` (peer), `express` (peer), `@sap/xssec`, `jose` (optional/lazy).
+- `./btp` — PP. Deps it needs: `@sap-cloud-sdk/connectivity`. (Originally also `undici`; dropped in v0.1 — the code uses Node's global `fetch`, and the `proxyFetch` forward-proxy helper that would have needed `undici.ProxyAgent` is deferred, §14.)
+- **No `./rate-limit` in v1.** `./testing` (mock verifiers/clients) is a v1.1 stretch (§14).
+
+---
+
+## 4. Dependencies (FROZEN ranges)
+
+```jsonc
+"peerDependencies": {
+  "@modelcontextprotocol/sdk": ">=1.18.2 <2",
+  "express": "^5.0.1",
+  "jose": ">=5 <7"
+},
+"peerDependenciesMeta": {
+  "jose": { "optional": true }   // OIDC-only, lazy-imported; non-OIDC consumers (calmcp) skip it
+},
+"dependencies": {
+  "@sap/xssec": "^4",
+  "@sap-cloud-sdk/connectivity": "^4.7.0"
+}
+```
+> **Drift note (v0.1):** `undici ^8` was dropped from `dependencies`. The original plan kept it for a `proxyFetch` forward-proxy helper, but that helper is deferred (§14) and every call site uses Node's global `fetch`, so the dependency was dead weight. Re-add it if/when `proxyFetch` lands.
+- **`@modelcontextprotocol/sdk` peer `>=1.18.2 <2`** — `1.18.2` is the first version exposing `mcpAuthRouter({ resourceServerUrl })` (PR #858); all other primitives exist since 1.12, no breaking override changes 1.12→1.29. `<2` because a v2 monorepo split (auth relocates, Express becomes a separate adapter) is alpha — opt in only after it's GA + tested.
+- **`express` peer `^5.0.1`** — the SDK hard-depends on `express ^5.0.1` (since 1.6.0) / `^5.2.1` (since 1.26). Express 4 cannot coexist with the SDK's router. Don't tighten to `^5.2.1` (needlessly excludes SDK < 1.26 resolvers; the facade only uses stable 5.0 `RequestHandler`/`Router` types).
+- **`@sap/xssec` dependency `^4`** — leaf token validator; not a shared instance. **Pure CommonJS** (no ESM entry) → consume via `import xssec from '@sap/xssec'; const { createSecurityContext, XsuaaService } = xssec;` with `esModuleInterop`; documented as a known interop edge (§12).
+- **`@sap-cloud-sdk/connectivity ^4.7.0` dependency** — used only by `./btp`. All three consumers already pin this exact major, so no friction; a core-only consumer (calmcp) installs it unused (acceptable; calmcp has it already). (`undici` was originally listed here too but is dropped in v0.1 — see the drift note above.) `jose` is an **optional peer** (range `>=5 <7`, covers arc-1's 6.x and LISA's 5.x), lazy-imported so non-OIDC consumers (calmcp) need not install it.
+
+**CI peer test-matrix:** `1.18.2 + 5.0.1` (floor), `1.25.3 + 5.0.1` (last pre-1.26), `1.28 + 5.2.1` (arc-1/calmcp prod), `1.29 + 5.2.1` (latest). Node **22 + 24** (the package's `engines.node >= 22` floor — matches arc-1). A `tsc --noEmit` typecheck pinned at the `1.18.2 + 5.0.1` floor (excess-property errors surface only there).
+
+---
+
+## 5. Logger contract
+
+```ts
+export interface Logger {
+  debug(message: string, data?: Record<string, unknown>): void;
+  info(message: string, data?: Record<string, unknown>): void;
+  warn(message: string, data?: Record<string, unknown>): void;
+  error(message: string, data?: Record<string, unknown>): void;
+  emitAudit?(event: Record<string, unknown>): void;
+}
+```
+- **Injected, optional, default no-op.** Argument order is `(message, data)` — matches arc-1 + LISA (the source). `emitAudit` is optional (arc-1/LISA have it; the package calls it only when present).
+- **calmcp uses pino**, whose order is `(obj, msg)`. calmcp passes a ~3-line adapter: `{ debug:(m,d)=>pino.debug(d??{},m), ... }`. Documented in the migration guide.
+
+---
+
+## 6. Core auth API (`.`) — FROZEN
+
+```ts
+// ─── Re-exported SDK types (behind the insulation layer, §8) ───
+export type { AuthInfo, OAuthClientInformationFull } from './internal/sdk.js';
+export type Verifier = (token: string) => Promise<AuthInfo>;
+
+// ─── XSUAA binding ───
+export interface XsuaaCredentials {
+  url: string; clientid: string; clientsecret: string;
+  xsappname: string; uaadomain: string; verificationkey?: string;
+}
+
+// ─── API keys ───
+export interface ApiKeyEntry { key: string; scopes?: string[]; clientId?: string }
+
+// ─── Scope hook (injected policy; default identity) ───
+export type ExpandScopes = (scopes: string[]) => string[];
+
+// ─── Config-loading helpers (Layer-0 plug-and-play) ───
+export function loadXsuaaCredentials(env?: NodeJS.ProcessEnv): XsuaaCredentials;   // reads + validates the bound XSUAA service (VCAP_SERVICES / service binding)
+export function resolveAppUrl(env?: NodeJS.ProcessEnv, options?: { publicUrlEnvVar?: string; port?: number }): string;   // VCAP_APPLICATION route, overridable by a configurable public-URL env var (e.g. ARC1_PUBLIC_URL)
+
+// ─── Stateless DCR client store ───
+export interface StatelessDcrClientStoreOptions {
+  clientIdPrefix?: string;            // default 'mcp-'
+  kdfLabel?: string;                  // default 'mcp-dcr/v1'  (domain-separation / revocation knob)
+  ttlSeconds?: number;                // default 30d; 0 disables expiry
+  redirectUriPatterns?: readonly string[]; // default XSUAA_DEFAULT_REDIRECT_URI_PATTERNS
+  defaultRedirectUris?: readonly string[];  // default XSUAA_DEFAULT_REDIRECT_URIS
+  now?: () => number;
+  logger?: Logger;
+}
+export class StatelessDcrClientStore /* implements OAuthRegisteredClientsStore */ {
+  constructor(xsuaaClientId: string, xsuaaClientSecret: string, signingSecret: string, options?: StatelessDcrClientStoreOptions);
+  getClient(clientId: string): Promise<OAuthClientInformationFull | undefined>;
+  registerClient(client: Omit<OAuthClientInformationFull, 'client_id' | 'client_id_issued_at'>): Promise<OAuthClientInformationFull>;
+  ensureRedirectUri(clientId: string, uri: string): void;
+  checkRedirectUri(clientId: string, uri: string): Promise<'ok' | 'unknown_client' | 'unregistered'>;
+}
+export const XSUAA_DEFAULT_REDIRECT_URI_PATTERNS: readonly string[];
+export const XSUAA_DEFAULT_REDIRECT_URIS: readonly string[];
+export function validateRedirectUri(uri: string, patterns?: readonly string[]): void;
+export function matchesRedirectPattern(uri: string, patterns?: readonly string[]): boolean;
+
+// ─── OAuth-state codec (the #214 `+`-bug callback proxy) ───
+export interface OAuthStateCodecOptions { kdfLabel?: string /* 'mcp-oauth-state/v1' */; ttlSeconds?: number /* 600 */ }
+export class OAuthStateCodec {
+  constructor(signingSecret: string, options?: OAuthStateCodecOptions);
+  encode(input: { clientState?: string; clientRedirectUri: string; clientId: string; now?: number }): string;
+  decode(token: string, now?: number): DecodeResult;
+}
+export type DecodeResult =
+  | { kind: 'ok'; clientState?: string; clientRedirectUri: string; clientId: string }
+  | { kind: 'error'; reason: 'malformed' | 'bad_signature' | 'invalid_payload' | 'expired' };
+
+// ─── XSUAA OAuth provider ───
+export interface CreateXsuaaOAuthProviderOptions {
+  clientIdPrefix?: string; dcrKdfLabel?: string; stateKdfLabel?: string;
+  dcrTtlSeconds?: number; stateTtlSeconds?: number; dcrSigningSecret?: string;
+  redirectUriPatterns?: readonly string[]; defaultRedirectUris?: readonly string[];
+  callbackUrl?: string; logger?: Logger;
+}
+export function createXsuaaOAuthProvider(
+  credentials: XsuaaCredentials, appUrl: string, options?: CreateXsuaaOAuthProviderOptions,
+): { provider: XsuaaProxyOAuthProvider; clientStore: StatelessDcrClientStore; stateCodec: OAuthStateCodec };
+export class XsuaaProxyOAuthProvider { /* extends the SDK ProxyOAuthServerProvider via the §8 insulation layer */ }
+
+// ─── Verifiers ───
+// `acceptedScopes` (default DEFAULT_ACCEPTED_SCOPES = the arc-1 set
+// ['read','write','data','sql','transports','git','admin']) is the set of scope
+// names kept from the token; a consumer with different names (e.g. calmcp's
+// 'Viewer') overrides it so its scopes aren't silently dropped. `expandScopes` is
+// applied EXACTLY once by each sub-verifier (the chain does NOT re-apply it).
+export function createXsuaaTokenVerifier(
+  credentials: XsuaaCredentials, options?: { expandScopes?: ExpandScopes; acceptedScopes?: string[]; logger?: Logger },
+): Verifier;
+export function createOidcVerifier(   // lazy-imports jose
+  issuer: string, audience: string,
+  options?: { clockToleranceSec?: number; scopeClaim?: string; algorithms?: string[]; acceptedScopes?: string[]; fallbackScopes?: string[]; expandScopes?: ExpandScopes; logger?: Logger },
+): Verifier;   // algorithms default ['RS256','ES256','PS256'] — pins allowed JWT algs (closes alg:none / algorithm-confusion). fallbackScopes default [] — fail closed when a verified token carries no accepted scope; set ['read'] for legacy read-only fallback
+export function createApiKeyVerifier(keys: string | ApiKeyEntry[], options?: { expandScopes?: ExpandScopes; logger?: Logger }): Verifier;
+export function createChainedTokenVerifier(   // does NOT re-apply expandScopes — the sub-verifiers own it (applied once)
+  config: { apiKeys?: string | ApiKeyEntry[] },
+  xsuaaVerifier?: Verifier, oidcVerifier?: Verifier,
+  options?: { expandScopes?: ExpandScopes; logger?: Logger },
+): Verifier;
+export function qualifyXsuaaScopes(scopes: string[], xsappname: string): string[];
+
+// ─── OAuth callback handler (the #214 proxy second half) ───
+export function createOAuthCallbackHandler(
+  stateCodec: OAuthStateCodec, clientStore?: StatelessDcrClientStore, options?: { logger?: Logger },
+): import('express').RequestHandler;
+
+// ─── Facade (plug-and-play; covers the standard XSUAA+DCR+callback+bearer flow) ───
+export interface AuthOptions {
+  apiKeys?: string | ApiKeyEntry[];
+  xsuaa?: {
+    credentials: XsuaaCredentials; appUrl: string;
+    clientIdPrefix?: string; dcrKdfLabel?: string; stateKdfLabel?: string;
+    resourceName?: string; scopesSupported?: string[]; requiredScopes?: string[];
+    redirectUriPatterns?: readonly string[]; defaultRedirectUris?: readonly string[];
+    dcrTtlSeconds?: number; stateTtlSeconds?: number; dcrSigningSecret?: string;
+    callbackUrl?: string;   // this server's own /oauth/callback sent to XSUAA (#214); default `${appUrl}/oauth/callback`
+  };
+  oidc?: { issuer: string; audience: string; clockToleranceSec?: number; algorithms?: string[]; scopeClaim?: string; fallbackScopes?: string[] };   // fallbackScopes default [] (fail closed); ['read'] = legacy read-only fallback
+  allowedOrigins?: string[];   // CORS allowlist for browser MCP clients (e.g. https://claude.ai); facade applies exact-match CORS + credentials. Unset = no CORS.
+  required?: boolean;          // default false → returns undefined (open) with a loud warn; true → throws if no auth method configured
+  expandScopes?: ExpandScopes;
+}
+export function setupHttpAuth(
+  app: import('express').Express, options: AuthOptions, logger?: Logger,
+): import('express').RequestHandler | undefined;   // bearer middleware for /mcp; undefined when no method configured
+```
+
+Notes:
+- **`requiredScopes`** is enforced by the facade via the SDK's `requireBearerAuth({ requiredScopes })`; building-block users enforce scopes themselves. (calmcp sets `requiredScopes: ['Viewer']`; LISA/arc-1 leave it unset.) The facade derives `issuerUrl`/`baseUrl`/`resourceServerUrl` from `xsuaa.appUrl` and mounts the standard `/authorize` `ensureRedirectUri` (pattern-gated) + `/oauth/callback` + `mcpAuthRouter`.
+- **`expandScopes`** is the injected policy seam (default identity), applied **exactly once** — by each sub-verifier (XSUAA/OIDC/api-key) to the scopes it extracts before returning `AuthInfo`. `createChainedTokenVerifier` does **NOT** re-apply it (re-application would double a non-idempotent expander); it only builds its internal api-key verifier with the same hook so the api-key path expands once too. arc-1 passes its `authz/policy` fn so AuthInfo carries expanded scopes exactly as today; calmcp/LISA omit it. The facade threads it into every verifier uniformly; building-block users pass it per verifier.
+- **`acceptedScopes`** (verifier option; default `DEFAULT_ACCEPTED_SCOPES` = the arc-1 set) is the scope-name allowlist applied to the token's claims. The facade threads `xsuaa.scopesSupported` (when set) into both the XSUAA and OIDC verifiers as `acceptedScopes`, so a consumer that advertises non-arc-1 scopes (calmcp: `scopesSupported:['Viewer']`) keeps them instead of having them filtered out.
+- **`fallbackScopes`** (OIDC verifier option; default `[]`) is the **fail-closed** scope set returned when a *verified* OIDC token carries no accepted scope — either it has no `scope`/`scp` claims at all, or its claims survive verification but none match `acceptedScopes`. The default `[]` grants **no** privileges, so an IdP that is misconfigured to drop scope claims cannot silently hand out access. A consumer that wants the historical read-only fallback opts in explicitly with `fallbackScopes: ['read']` (arc-1 does this to preserve its prior default). `fallbackScopes` is **not** run through `expandScopes` — it is an already-final grant chosen by the consumer, not a token-derived scope set. The facade exposes it as `oidc.fallbackScopes`.
+- **api-key profiles** are not a package concept: arc-1 maps its `API_KEY_PROFILES` → `ApiKeyEntry[]` (`{key, scopes}`) before passing.
+- The facade does **not** include arc-1's Copilot `/authorize` bypass or reverse-proxy base-path overrides — those stay in arc-1's `startHttpServer` using the building blocks.
+- When `options.xsuaa` is omitted (api-key/OIDC only), the facade builds the chained verifier and returns bearer middleware **without** mounting the OAuth router/callback — mirroring arc-1's non-XSUAA path (`createStandardVerifier`).
+- **Verifier chain order is frozen as `XSUAA → OIDC → api-key`** (matches arc-1). Correctness-immaterial (token types are disjoint — an api-key never validates as a JWT; an XSUAA JWT never validates against the OIDC issuer), but pinned for determinism + test stability. calmcp's PR adapts from its current api-key-first order (called out in its PR description).
+- **CORS + COOP (browser / popup OAuth):** when `allowedOrigins` is set the facade applies a built-in exact-match CORS handler (`credentials:true` + MCP headers; no `cors` dep). The facade sets **no restrictive `Cross-Origin-Opener-Policy`** — popup OAuth (Copilot Studio, claude.ai) breaks under `COOP: same-origin`. Broad hardening (helmet CSP/HSTS) stays consumer-owned; a consumer adding helmet must disable COOP. arc-1 keeps its own `applySecurityMiddleware` via the building-block path.
+- **Redirect-URI validation is fail-closed (normative):** `validateRedirectUri` throws on malformed/disallowed input; `matchesRedirectPattern` returns `false` on parse failure. The DCR store's `redirectUriPatterns` MUST stay in sync with the XSUAA service's `xs-security.json` `oauth2-configuration.redirect-uris`.
+- **`emitAudit` is always null-guarded** (`logger.emitAudit?.(…)`); the package never assumes it exists.
+- **Layer-0 plug-and-play:** `loadXsuaaCredentials()` + `resolveAppUrl()` let a consumer write `setupHttpAuth(app, { xsuaa: { credentials: loadXsuaaCredentials(), appUrl: resolveAppUrl() }, apiKeys }, logger)` with no hand-parsed binding.
+
+---
+
+## 7. Principal-propagation API (`./btp`) — FROZEN
+
+Lifted near-verbatim from arc-1 `src/adt/btp.ts` (LISA's copy is byte-identical). The **only** refactor is the logger seam (optional trailing `logger?` param; default no-op).
+
+```ts
+export interface BTPConfig {
+  xsuaaUrl: string; xsuaaClientId: string; xsuaaSecret: string;
+  destinationUrl: string; destinationClientId: string; destinationSecret: string; destinationTokenUrl: string;
+  connectivityProxyHost: string; connectivityProxyPort: string; connectivityClientId: string;
+  connectivitySecret: string; connectivityTokenUrl: string;
+}
+export interface Destination {
+  Name: string; URL: string; Authentication: string; ProxyType: string; User: string; Password: string;
+  'sap-client'?: string; CloudConnectorLocationId?: string;
+}
+export interface BTPProxyConfig { host: string; port: number; protocol: string; getProxyToken: () => Promise<string>; locationId?: string }
+export interface PerUserAuthTokens { sapConnectivityAuth?: string; bearerToken?: string; ppProxyAuth?: string }
+
+export function parseVCAPServices(env?: NodeJS.ProcessEnv): BTPConfig | null;   // env defaults to process.env
+export function lookupDestination(btpConfig: BTPConfig, name: string, logger?: Logger): Promise<Destination>;
+export function lookupDestinationWithUserToken(            // ← the PP primitive
+  btpConfig: BTPConfig, name: string, userJwt: string, logger?: Logger,
+): Promise<{ destination: Destination; authTokens: PerUserAuthTokens }>;
+export function createConnectivityProxy(btpConfig: BTPConfig, locationId?: string, logger?: Logger): BTPProxyConfig | null;
+export function resolveBTPDestination(name: string, logger?: Logger): Promise<{
+  url: string; username: string; password: string; client: string; proxy: BTPProxyConfig | null;
+}>;
+```
+
+- **`@sap-cloud-sdk/connectivity`** does the destination-service call + `X-User-Token` + per-user cache; the jwt-bearer "Option 2" fallback is a raw global-`fetch` call that validates the JWT then re-sends the **original** user JWT as `SAP-Connectivity-Authentication`. (Behavior preserved exactly from arc-1.)
+- **Not in v1, optional/future:** a shared `proxyFetch(proxy, target, logger?)` forward-proxy helper. arc-1 + LISA reimplement it identically inside their HTTP clients, but ripping it out of arc-1's `AdtHttpClient` (CSRF/cookies/stateful sessions) is a non-trivial edit that conflicts with the minimal-diff goal. Ship the `BTPProxyConfig` descriptor only; consumers keep their own proxy-request code. Revisit once arc-1's HTTP client is otherwise touched.
+- **The package returns credentials + a proxy descriptor; it never applies them.** What to do when no PP token is produced (arc-1 throws; LISA falls back to BasicAuth) is **consumer policy** — `lookupDestinationWithUserToken` returns a possibly-empty `PerUserAuthTokens` and the consumer decides.
+- **`lookupDestinationWithUserToken` is JWT-only (anti-footgun):** it validates `userJwt` is a 3-segment JWT and throws a typed error otherwise — PP needs a per-user user token, not an API key. (arc-1 guards this at its call site today; the package now guards it for every consumer.)
+- **`parseVCAPServices` is a helper, not policy:** destination/connectivity *names* and env semantics stay consumer-owned (passed as params). `ttlSeconds <= 0` normalizes to "no expiry" consistently in both the DCR store and `OAuthStateCodec`.
+
+---
+
+## 8. SDK-insulation requirement (v2-proofing)
+
+All `@modelcontextprotocol/sdk/server/auth/*` imports are confined to **one internal module** (`src/internal/sdk.ts`) that re-exports the symbols and types the package uses (`ProxyOAuthServerProvider`, `mcpAuthRouter`, `requireBearerAuth`, `OAuthRegisteredClientsStore`, `AuthInfo`, `OAuthClientInformationFull`) behind package-owned names. The SDK v2 monorepo split (auth → `@modelcontextprotocol/server`, Express → `@modelcontextprotocol/express`, path changes) then becomes a **one-file migration**. No other source file imports the SDK directly.
+
+---
+
+## 9. Coupling contract
+
+- **auth → PP:** the sole handoff is the **raw, already-verified bearer JWT (string)**. The verifier produces `AuthInfo` (with `.token`); the consumer passes `authInfo.token` to `lookupDestinationWithUserToken(btpConfig, name, token)`. PP touches no scopes/clientId/AuthInfo shape. The package does **not** wire this — the consumer does (arc-1: `extra.authInfo.token` → `createPerUserClient`; LISA: `token` → `I18nClient`).
+- **PP → SAP request:** the package returns `{ destination, authTokens, proxy }`; the consumer's SAP HTTP client applies them (`Authorization`/`SAP-Connectivity-Authentication`/proxy). That client stays consumer-owned.
+- **`dcrSigningSecret`** stabilizes DCR client_ids across restarts; defaults to the XSUAA `clientsecret` when omitted (documented; rotating it or bumping `kdfLabel` is the revocation knob).
+
+---
+
+## 10. What stays in each consumer
+
+The SAP HTTP client (arc-1 `AdtHttpClient`, LISA `I18nClient`, calmcp `CalmHttpClient`); `applyPerUserAuthTokens` / header assembly; the proxy-request code (until `proxyFetch` lands); `getAppUrl`; the scope/tool policy (`expandScopes` source, `ACTION_POLICY`); the safety ceiling + `ServerConfig`; arc-1's Copilot `/authorize` bypass and base-path metadata; the MCP transport itself (`startHttpServer`).
+
+---
+
+## 11. Minimal-diff adoption
+
+**arc-1 (primary goal — import-swap + glue, no logic change):**
+- `.`: in `http.ts`, swap 5 imports `./server/*` → `@arc-mcp/xsuaa-auth`; map the ~10 `ServerConfig` fields → `AuthOptions`; pass `config.logger`; pass `authz/policy.expandScopes` as the `expandScopes` hook; build `ApiKeyEntry[]` from `API_KEY_PROFILES`. `startHttpServer` (incl. Copilot bypass + base-path) stays.
+- `./btp`: delete `src/adt/btp.ts`; repoint ~5 call sites + the `BTPConfig`/`BTPProxyConfig`/`PerUserAuthTokens` type imports to `@arc-mcp/xsuaa-auth/btp`; pass `logger` to the btp calls. `AdtHttpClient`/`applyPerUserAuthTokens`/`createPerUserClient` unchanged.
+- Net: import repoints + logger injection + config mapping. Delete ~1,160 LOC (auth modules + btp). Lower `check:sizes`.
+
+**calmcp (near-zero diff):** delete `src/httpAuth/`; `setupHttpAuth(app, authOptions, pinoAdapter(logger))` at the existing call site; set `clientIdPrefix:'calmcp-'`, `requiredScopes:['Viewer']`, `scopesSupported:['Viewer']`, `resourceName`. No PP (doesn't import `./btp`). Its PR also notes the chain-order change (api-key-first → frozen XSUAA→OIDC→api-key; outcome-identical).
+
+**LISA (small diff):** adopt building blocks it already calls (`createChainedTokenVerifier`, `createXsuaaOAuthProvider`, `createOidcVerifier`, `createOAuthCallbackHandler`, `StatelessDcrClientStore`); inject its logger; **bump SDK `^1.12` → `>=1.18.2`** and **align `express → ^5`** (it declares `^4.21` but already resolves 5 transitively via the SDK); delete its `src/server/*` auth + `src/sap/btp.ts`, import `./btp`; set `clientIdPrefix:'sapt-'`.
+
+**Live-deployment coverage (verified via CF — `arc1-mcp-joule2` + `arc1-mcp-test`, org Marian_Zeis_joule2/space dev):** every auth-relevant deployed param maps to a v1 config knob —
+
+| Deployed param | v1 config |
+|---|---|
+| `SAP_XSUAA_AUTH=true` | `AuthOptions.xsuaa` present |
+| `ARC1_API_KEYS` | `AuthOptions.apiKeys` |
+| `ARC1_ALLOWED_ORIGINS` (`https://claude.ai`) | `AuthOptions.allowedOrigins` |
+| `ARC1_PUBLIC_URL` (API-Management reverse proxy) | `xsuaa.appUrl` / `resolveAppUrl({ publicUrlEnvVar:'ARC1_PUBLIC_URL' })` |
+| `SAP_BTP_DESTINATION=SAP_TRIAL` (technical) | `./btp` `resolveBTPDestination(name)` |
+| `ARC1_OAUTH_DCR_TTL_SECONDS` (unset→30d; `0` for Copilot CLI/Cursor) | `xsuaa.dcrTtlSeconds` |
+| `ARC1_DCR_SIGNING_SECRET` | `xsuaa.dcrSigningSecret` |
+| XSUAA scopes + redirect-uris (`xs-security.json`, incl. `…azure-apim.net/redirect/**` for MS Copilot) | `scopesSupported` + `redirectUriPatterns` (shipped defaults already include the azure-apim pattern) |
+
+Out of module scope (stays consumer env): `SAP_ALLOW_*` / `SAP_ALLOWED_PACKAGES` (safety ceiling), `SAP_INSECURE` / `SAP_SYSTEM_TYPE` / `SAP_TRANSPORT` / `SAP_LANGUAGE` (SAP connection). **Note:** the live apps do **not** set `SAP_PP_ENABLED` — they use a shared technical destination, so the current MS Copilot path is XSUAA-OAuth/API-key client auth → technical SAP identity. PP ships in v1 for per-user deployments but is not exercised by the current Copilot test.
+
+---
+
+## 12. Packaging, build, publish
+
+- ESM-only; `exports` map (types-first, `default` last); `sideEffects:false`; `engines.node>=22`.
+- Build: plain `tsc` (`NodeNext`, `declaration:true`). **`isolatedDeclarations` is deferred** (not enabled in `tsconfig.json` as of v0.1): turning it on surfaces a small number of `TS9010`/`TS9017` "needs an explicit type annotation" errors (e.g. the `RESERVED_OAUTH_SCOPES` `Set` literal). The build is correct without it, and the perf/parallelism payoff `isolatedDeclarations` buys only matters at much larger scale, so it's a deliberate post-v1 cleanup (annotate the flagged exports, then flip the flag) rather than a blocker. New code SHOULD still be written isolatedDeclarations-clean (explicit annotations on exported `const`s) to keep the eventual flip a no-op.
+- `@sap/xssec` is **pure CJS** → default-import + destructure, `esModuleInterop`; README calls out this interop edge.
+- Publish gate: `publint && attw --pack . --profile esm-only` green; `npm test`; `tsc --noEmit` at the peer floor.
+- release-please (`node`, no `extra-files`) → `release_created`-gated npm publish via OIDC (Node ≥22.14 / npm ≥11.5.1, `id-token: write`, automatic provenance, no `NPM_TOKEN`).
+
+---
+
+## 13. Versioning & quality gates
+
+- Start `0.1.0`; option/knob changes are semver-relevant.
+- Repo quality (mirror arc-1 + auth-lib hardening): biome, vitest (consolidate the triplicate test suites), husky/lint-staged, dependabot (npm+actions), SHA-pinned third-party actions, `npm audit --audit-level=high`, dependency-review, SECURITY.md + **GitHub Private Vulnerability Reporting**, **CodeQL** (`security-extended`), **OpenSSF Scorecard** (required check), YAML issue forms + PR template, CODEOWNERS on `/.github/workflows/` + auth source, `examples/` (runnable per-scenario TS apps), docs = TypeDoc + typedoc-plugin-markdown → VitePress.
+
+---
+
+## 14. Deferred / open
+
+- **Rate limiting** — post-v1. (arc-1's `auth-rate-limit` + `mcp-rate-limit` are generic; revisit as a `./rate-limit` sub-module once core ships and a consumer asks. Until then all three keep their own.)
+- **`proxyFetch` shared forward-proxy helper** — once arc-1's `AdtHttpClient` is otherwise touched (§7).
+- **`./testing` mocks** — mock `Verifier`/`Destination` for consumers' tests; v1.1 stretch.
+- **npm final name** (`@arc-mcp/xsuaa-auth` recommended), **docs-site choice** (VitePress recommended).
+- **SDK v2 path** — adopt only after v2 GA + tested; the §8 insulation makes it a one-file change.
+- **IAS / SAP Cloud Identity Services** (`@sap/xssec` `IdentityService`) — the package is XSUAA-specific by name; SAP is steering new apps toward IAS, so a sibling `IdentityService` verifier is a roadmap candidate, not v1.
+
+---
+
+## 15. Non-goals
+
+A generic "any OAuth provider" framework (this is XSUAA-centric); embedding arc-1 as a library (that's FEAT-29g, separate); owning the MCP transport; owning scope/tool policy or the SAP HTTP client; per-client DCR revocation (only TTL / signing-key rotation).


### PR DESCRIPTION
Research, ADRs, and a freeze-candidate spec for carving ARC-1's XSUAA OAuth + RFC 7591 dynamic client registration + BTP principal-propagation layer into a standalone npm package (`@arc-mcp/xsuaa-auth`, now published `0.1.0`), so other SAP MCP servers (consetto/calmcp, ClementRingot/LISA) can depend on it instead of copy-pasting.

**Docs only — no code change.** Adds `docs/research/auth-module/{RESEARCH,SPEC}.md`.

Validated locally before writing this up (not in this PR):
- Module built + 209 tests green (tsc / biome / publint / attw clean); published as `@arc-mcp/xsuaa-auth@0.1.0`.
- Dropped into an arc-1 worktree: 3756 arc-1 tests green, −3621 LOC, behaviour unchanged, `arc1-` client-id/KDF identifiers preserved.
- Live XSUAA token validation proven against a real XSUAA-issued token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)