### PR TITLE
docs: announcement bar for the arc-mcp / docs.arc-1-mcp.com move

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'docs_page/**'
+      - 'overrides/**'
       - 'README.md'
       - 'mkdocs.yml'
   workflow_dispatch:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ docs_dir: docs_page
 
 theme:
   name: material
+  custom_dir: overrides
   palette:
     - scheme: default
       primary: deep orange
@@ -31,6 +32,7 @@ theme:
     - search.highlight
     - content.code.copy
     - content.code.annotate
+    - announce.dismiss
   icon:
     repo: fontawesome/brands/github
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+<!-- Site-wide announcement bar (dismissible via the `announce.dismiss` feature).
+     Informs returning visitors that ARC-1 moved to the arc-mcp org + docs.arc-1-mcp.com. -->
+{% block announce %}
+  📢 ARC-1 has moved — these docs now live at
+  <a href="https://docs.arc-1-mcp.com/"><strong>docs.arc-1-mcp.com</strong></a>
+  and the project at
+  <a href="https://github.com/arc-mcp/arc-1"><strong>github.com/arc-mcp/arc-1</strong></a>.
+  Please update your bookmarks.
+{% endblock %}


### PR DESCRIPTION
Adds a site-wide, **dismissible** announcement bar (mkdocs-material `announce` block) so returning visitors know the project moved.

> 📢 ARC-1 has moved — these docs now live at **docs.arc-1-mcp.com** and the project at **github.com/arc-mcp/arc-1**. Please update your bookmarks.

## Changes
- `mkdocs.yml`: `theme.custom_dir: overrides` + `announce.dismiss` feature
- `overrides/main.html`: the `{% block announce %}` banner

## Notes
- Dismissible — Material remembers dismissal in localStorage (re-shows if the text changes), so it's not naggy.
- Appears on **every** page, top of viewport.
- Verified locally with `mkdocs build` — banner renders on `index`, `architecture`, `tools`; `CNAME` still emitted. (Build warnings are pre-existing broken links in `roadmap.md`/`security-guide.md`, untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
