### PR TITLE
fix(auth): adopt @arc-mcp/xsuaa-auth hardened OIDC + constant-time api-key verifiers

### DIFF
--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -255,43 +255,17 @@ export function createOAuthCallbackHandler(stateCodec: OAuthStateCodec, clientSt
   };
 }
 
-// ─── API Key Matching Helper ─────────────────────────────────────────
-
-/**
- * Match a token against configured API keys (multi-key with profiles).
- * Returns the matched entry's profile and scopes, or undefined if no match.
- */
-function matchApiKey(
-  token: string,
-  config: ServerConfig,
-): { profile: string; scopes: string[]; clientId: string } | undefined {
-  // Multi-key: each API key has a named profile that maps to a scope set + partial SafetyConfig
-  if (config.apiKeys) {
-    for (const entry of config.apiKeys) {
-      if (token === entry.key) {
-        const profile = API_KEY_PROFILES[entry.profile];
-        if (!profile) {
-          // Should have been caught at config parse; defense in depth
-          return undefined;
-        }
-        const scopes = expandScopes(profile.scopes);
-        return { profile: entry.profile, scopes, clientId: `api-key:${entry.profile}` };
-      }
-    }
-  }
-  return undefined;
-}
+// ─── API Key Entry Mapping ───────────────────────────────────────────
 
 /**
  * Map ARC-1's `config.apiKeys` (`{key, profile}[]`) to the package's
- * `ApiKeyEntry[]` (`{key, scopes, clientId}`) so the package's chained verifier
- * resolves them identically to ARC-1's legacy `matchApiKey`:
- *   - scopes come from `API_KEY_PROFILES[profile]` after `expandScopes` (same as
- *     `matchApiKey`),
- *   - clientId is `api-key:<profile>` (same string `matchApiKey` returned, so
- *     audit/identity output is unchanged).
- * Entries whose profile is unknown are dropped (matching `matchApiKey`'s
- * defense-in-depth `undefined`); profiles are validated at config-parse time.
+ * `ApiKeyEntry[]` (`{key, scopes, clientId}`) so the package's constant-time
+ * api-key verifier resolves them identically to ARC-1's previous profile-based
+ * matching:
+ *   - scopes come from `API_KEY_PROFILES[profile]` after `expandScopes`,
+ *   - clientId is `api-key:<profile>` (same audit/identity string as before).
+ * Entries whose profile is unknown are dropped (defense in depth — profiles are
+ * already validated at config-parse time). Used by BOTH XSUAA and standard mode.
  */
 function toApiKeyEntries(config: ServerConfig): ApiKeyEntry[] {
   if (!config.apiKeys) return [];
@@ -303,11 +277,6 @@ function toApiKeyEntries(config: ServerConfig): ApiKeyEntry[] {
   }
   return entries;
 }
-
-// ─── JWKS / JWT types (lazy-loaded from jose) ────────────────────────
-
-let joseModule: typeof import('jose') | null = null;
-let jwksClient: ReturnType<typeof import('jose').createRemoteJWKSet> | null = null;
 
 // ─── Security Middleware (helmet + opt-in CORS) ──────────────────────
 
@@ -504,9 +473,8 @@ export async function startHttpServer(
   if (config.xsuaaAuth && xsuaaCredentials) {
     const { mcpAuthRouter } = await import('@modelcontextprotocol/sdk/server/auth/router.js');
     const { requireBearerAuth } = await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');
-    const { createXsuaaOAuthProvider, createChainedTokenVerifier, createXsuaaTokenVerifier } = await import(
-      '@arc-mcp/xsuaa-auth'
-    );
+    const { createXsuaaOAuthProvider, createChainedTokenVerifier, createXsuaaTokenVerifier, createOidcVerifier } =
+      await import('@arc-mcp/xsuaa-auth');
     const { getAppUrl } = await import('./app-url.js');
 
     // Determine app URL for OAuth metadata
@@ -545,9 +513,12 @@ export async function startHttpServer(
     // Inject ARC-1's scope-expansion policy + logger so the verifier emits the
     // same expanded AuthInfo.scopes ARC-1 produced before the extraction.
     const xsuaaVerifier = createXsuaaTokenVerifier(xsuaaCredentials, { expandScopes, logger: authLibLogger });
-    // ARC-1 keeps its OWN inline createOidcVerifier (jose + ServerConfig-driven);
-    // it does not depend on a moved module, so it stays as-is.
-    const oidcVerifier = config.oidcIssuer ? await createOidcVerifier(config) : undefined;
+    // OIDC verifier comes from the package (hardened: pinned `algorithms`
+    // allowlist, no `sub` in debug logs). `buildPackageOidcVerifier` threads
+    // ARC-1's historical contract (accepted scopes, `expandScopes`, the
+    // `['read']` fallback, clock tolerance). Construction is SYNC — the package
+    // lazy-imports jose + memoizes the JWKS on first verify.
+    const oidcVerifier = config.oidcIssuer ? buildPackageOidcVerifier(config, createOidcVerifier) : undefined;
     const chainedVerifier = createChainedTokenVerifier(
       { apiKeys: toApiKeyEntries(config) },
       xsuaaVerifier,
@@ -775,9 +746,9 @@ export async function startHttpServer(
     });
   } else {
     // ─── Standard Auth Mode (API key / OIDC) ─────────────────
-    if (config.oidcIssuer) {
-      await initJwks(config.oidcIssuer);
-    }
+    // No JWKS pre-warm needed: the package's OIDC verifier lazy-imports jose and
+    // memoizes the remote JWKS on the first verify (and retries on a transient
+    // discovery failure instead of caching the rejection).
 
     // Layer 1 on /mcp also applies outside XSUAA mode — API-key / OIDC / no-auth
     // deployments get the same anonymous-probing protection. OAuth endpoints don't
@@ -790,7 +761,7 @@ export async function startHttpServer(
       // Use requireBearerAuth so that authInfo is populated on the MCP request context.
       // This enables scope enforcement, per-request safety, and principal propagation.
       const { requireBearerAuth } = await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');
-      const verifier = createStandardVerifier(config);
+      const verifier = await createStandardVerifier(config);
       const bearerAuth = requireBearerAuth({ verifier: { verifyAccessToken: verifier } });
       app.all('/mcp', bearerAuth, mcpHandler);
     } else {
@@ -836,177 +807,76 @@ export async function startHttpServer(
   });
 }
 
+// ─── OIDC Verifier (package-backed) ─────────────────────────────────
+
+/**
+ * ARC-1's recognised scope names — the `acceptedScopes` allowlist threaded into
+ * the package's OIDC verifier so non-ARC-1 claims (e.g. Entra's `User.Read`) are
+ * filtered out, exactly as ARC-1's removed inline `extractOidcScopes` did.
+ */
+const KNOWN_SCOPES = ['read', 'write', 'data', 'sql', 'transports', 'git', 'admin'];
+
+/**
+ * Build the package's OIDC verifier from `ServerConfig`, threading ARC-1's
+ * historical contract so adopting it changes nothing observable except the two
+ * intended hardening wins (pinned `algorithms` allowlist + no `sub` in the debug
+ * log — both live inside the package now):
+ *   - `acceptedScopes = KNOWN_SCOPES` (same filter as the old inline code),
+ *   - `expandScopes` = ARC-1's policy expander (implied scopes: write⊇read, …),
+ *   - `fallbackScopes: ['read']` = ARC-1's legacy default — a verified token with
+ *     no scope claims, OR scope claims none of which are accepted, grants `['read']`
+ *     (the package defaults this to `[]`; ARC-1 opts back into read-only),
+ *   - `scopeClaim` left default (`'scope'`, preferred over `scp`),
+ *   - `clockToleranceSec` only when `config.oidcClockTolerance` is set.
+ *
+ * `config.oidcAudience` is optional in ARC-1 and was historically forwarded to
+ * jose verbatim (jose treats `undefined` as "skip the audience check"); the
+ * package forwards it the same way, so we pass it through unchanged. The package
+ * signature types `audience` as `string`; the cast preserves the
+ * undefined-passthrough without an empty-string audience that would force a
+ * (failing) audience check. `config.oidcIssuer` is asserted non-null — every
+ * call site is gated on `config.oidcIssuer`.
+ *
+ * Construction is synchronous: the package lazy-imports jose and memoizes the
+ * remote JWKS on the first verify.
+ */
+function buildPackageOidcVerifier(
+  config: ServerConfig,
+  createOidcVerifier: typeof import('@arc-mcp/xsuaa-auth').createOidcVerifier,
+): import('@arc-mcp/xsuaa-auth').Verifier {
+  return createOidcVerifier(config.oidcIssuer as string, config.oidcAudience as string, {
+    acceptedScopes: KNOWN_SCOPES,
+    expandScopes,
+    fallbackScopes: ['read'],
+    ...(config.oidcClockTolerance != null ? { clockToleranceSec: config.oidcClockTolerance } : {}),
+    logger: authLibLogger,
+  });
+}
+
 // ─── Standard Mode Verifier ─────────────────────────────────────────
 
 /**
  * Create a token verifier for standard auth mode (API key + OIDC).
- * Returns AuthInfo so the MCP SDK populates extra.authInfo on the request,
- * enabling scope enforcement, per-request safety, and principal propagation.
- */
-export function createStandardVerifier(
-  config: ServerConfig,
-): (token: string) => Promise<import('@modelcontextprotocol/sdk/server/auth/types.js').AuthInfo> {
-  return async (token: string) => {
-    // Lazy-import SDK error classes so bearerAuth maps them to 401/403
-    const { InvalidTokenError } = await import('@modelcontextprotocol/sdk/server/auth/errors.js');
-
-    // API key: match against multi-key map or single key
-    const apiKeyMatch = matchApiKey(token, config);
-    if (apiKeyMatch) {
-      // expiresAt is required by requireBearerAuth — use far-future expiry for static keys
-      const ONE_YEAR_SECS = 365 * 24 * 60 * 60;
-      return {
-        token,
-        clientId: apiKeyMatch.clientId,
-        scopes: apiKeyMatch.scopes,
-        expiresAt: Math.floor(Date.now() / 1000) + ONE_YEAR_SECS,
-      };
-    }
-
-    // OIDC: validate JWT and extract scopes
-    if (config.oidcIssuer) {
-      try {
-        if (!joseModule || !jwksClient) {
-          await initJwks(config.oidcIssuer);
-        }
-        if (!joseModule || !jwksClient) {
-          throw new Error('OIDC not initialized — check SAP_OIDC_ISSUER configuration');
-        }
-        const { payload } = await joseModule.jwtVerify(token, jwksClient, {
-          issuer: config.oidcIssuer,
-          audience: config.oidcAudience,
-          requiredClaims: ['exp'],
-          ...(config.oidcClockTolerance != null ? { clockTolerance: config.oidcClockTolerance } : {}),
-        });
-
-        logger.debug('Standard OIDC JWT validated', { sub: payload.sub, iss: payload.iss });
-
-        const scopes = extractOidcScopes(payload);
-
-        return {
-          token,
-          clientId: (payload.azp as string) ?? (payload.sub as string) ?? 'oidc-user',
-          scopes,
-          expiresAt: payload.exp,
-          extra: { sub: payload.sub, iss: payload.iss },
-        };
-      } catch (err) {
-        // Wrap JWT validation errors as InvalidTokenError so bearerAuth returns 401
-        if (err instanceof InvalidTokenError) throw err;
-        throw new InvalidTokenError((err as Error).message ?? 'Invalid token');
-      }
-    }
-
-    throw new InvalidTokenError('Authentication failed: invalid token');
-  };
-}
-
-// ─── OIDC Verifier Factory ───────────────────────────────────────────
-
-/**
- * Create an Entra ID / OIDC token verifier using jose.
- * Returns a function compatible with the chained verifier.
- */
-async function createOidcVerifier(
-  config: ServerConfig,
-): Promise<(token: string) => Promise<import('@modelcontextprotocol/sdk/server/auth/types.js').AuthInfo>> {
-  await initJwks(config.oidcIssuer!);
-
-  return async (token: string) => {
-    if (!joseModule || !jwksClient) {
-      throw new Error('OIDC not initialized');
-    }
-    const { payload } = await joseModule.jwtVerify(token, jwksClient, {
-      issuer: config.oidcIssuer,
-      audience: config.oidcAudience,
-      requiredClaims: ['exp'],
-      ...(config.oidcClockTolerance != null ? { clockTolerance: config.oidcClockTolerance } : {}),
-    });
-
-    logger.debug('OIDC JWT validated', { sub: payload.sub, iss: payload.iss });
-
-    const scopes = extractOidcScopes(payload);
-
-    return {
-      token,
-      clientId: (payload.azp as string) ?? (payload.sub as string) ?? 'oidc-user',
-      scopes,
-      expiresAt: payload.exp,
-      extra: { sub: payload.sub, iss: payload.iss },
-    };
-  };
-}
-
-// ─── OIDC Scope Extraction ──────────────────────────────────────────
-
-const KNOWN_SCOPES = ['read', 'write', 'data', 'sql', 'transports', 'git', 'admin'];
-
-/**
- * Extract scopes from an OIDC JWT payload.
  *
- * Tries `scope` (space-separated string, standard OIDC) then `scp` (array, Azure AD style).
- * Filters to known scopes, applies implied scope expansion, and falls back to read-only
- * when no scope claims are present (safe default for providers that don't emit scopes).
+ * Built entirely from the `@arc-mcp/xsuaa-auth` package's chained verifier
+ * (constant-time api-key compare + hardened OIDC), mirroring how XSUAA mode wires
+ * its chain — minus the XSUAA verifier, which standard mode doesn't have. The
+ * chain order is XSUAA → OIDC → api-key; with no XSUAA verifier that collapses to
+ * OIDC → api-key, which is order-immaterial here (token types are disjoint) and
+ * preserves the previous behavior (api-key matched first only mattered because
+ * the two paths never overlap). Returns `AuthInfo` so the MCP SDK populates
+ * `extra.authInfo` on the request context, enabling scope enforcement,
+ * per-request safety, and principal propagation.
+ *
+ * Async because the package is dynamic-imported (lazy, consistent with the rest
+ * of this module); the returned verifier itself is the package's sync-built
+ * chained verifier.
  */
-export function extractOidcScopes(payload: Record<string, unknown>): string[] {
-  let rawScopes: string[] | undefined;
-
-  // Standard OIDC: space-separated string
-  if (typeof payload.scope === 'string') {
-    rawScopes = payload.scope.split(' ').filter((s) => s.length > 0);
-  }
-  // Azure AD / Entra: `scp` as space-delimited string (delegated tokens) or array (app tokens)
-  else if (typeof payload.scp === 'string') {
-    rawScopes = payload.scp.split(' ').filter((s) => s.length > 0);
-  } else if (Array.isArray(payload.scp)) {
-    rawScopes = (payload.scp as string[]).filter((s) => typeof s === 'string' && s.length > 0);
-  }
-
-  // No scope claims at all → read-only (safe default)
-  if (rawScopes === undefined) {
-    logger.warn(
-      'OIDC JWT has no scope/scp claims — granting read-only access. ' +
-        'Configure scope claims in your OIDC provider to grant write/data/sql access.',
-    );
-    return ['read'];
-  }
-
-  // Filter to known scopes
-  const filtered = rawScopes.filter((s) => KNOWN_SCOPES.includes(s));
-
-  // If scopes were present but none are known, grant minimum read access
-  if (filtered.length === 0) {
-    logger.warn('OIDC JWT has scope claims but none match known scopes — granting read-only', { rawScopes });
-    return ['read'];
-  }
-
-  return expandScopes(filtered);
-}
-
-/**
- * Initialize JWKS client from OIDC discovery.
- */
-async function initJwks(issuer: string): Promise<void> {
-  if (joseModule && jwksClient) return;
-
-  try {
-    if (!joseModule) {
-      joseModule = await import('jose');
-    }
-    const jwksUri = new URL('.well-known/openid-configuration', issuer.endsWith('/') ? issuer : `${issuer}/`);
-    const discoveryResp = await fetch(jwksUri.toString());
-    const discovery = (await discoveryResp.json()) as { jwks_uri: string };
-
-    if (!discovery.jwks_uri) {
-      throw new Error(`No jwks_uri in OIDC discovery response from ${jwksUri}`);
-    }
-
-    jwksClient = joseModule.createRemoteJWKSet(new URL(discovery.jwks_uri));
-    logger.info('OIDC JWKS initialized', { issuer, jwksUri: discovery.jwks_uri });
-  } catch (err) {
-    logger.error('Failed to initialize OIDC JWKS', {
-      issuer,
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
+export async function createStandardVerifier(config: ServerConfig): Promise<import('@arc-mcp/xsuaa-auth').Verifier> {
+  const { createChainedTokenVerifier, createOidcVerifier } = await import('@arc-mcp/xsuaa-auth');
+  const oidcVerifier = config.oidcIssuer ? buildPackageOidcVerifier(config, createOidcVerifier) : undefined;
+  return createChainedTokenVerifier({ apiKeys: toApiKeyEntries(config) }, undefined, oidcVerifier, {
+    expandScopes,
+    logger: authLibLogger,
+  });
 }

--- a/tests/unit/server/http.test.ts
+++ b/tests/unit/server/http.test.ts
@@ -1,11 +1,18 @@
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { describe, expect, it } from 'vitest';
-import { createStandardVerifier, extractOidcScopes } from '../../../src/server/http.js';
+import { createStandardVerifier } from '../../../src/server/http.js';
 import { DEFAULT_CONFIG } from '../../../src/server/types.js';
 
-describe('createStandardVerifier', () => {
+// These tests cover ARC-1's WIRING of the standard-mode verifier onto the
+// `@arc-mcp/xsuaa-auth` package's chained verifier (constant-time api-key compare
+// + hardened OIDC). The package ships its own 200+ tests for the verifier
+// internals (scope extraction, fallback semantics, the `algorithms` allowlist,
+// timing-safe compare), so we only assert that ARC-1 maps `config.apiKeys`
+// profiles to the right scopes/clientId and rejects unknown tokens — i.e. that
+// the adoption preserves ARC-1's observable api-key contract.
+describe('createStandardVerifier (api-key wiring)', () => {
   it('accepts a viewer API key and returns read-only auth info', async () => {
-    const verifier = createStandardVerifier({
+    const verifier = await createStandardVerifier({
       ...DEFAULT_CONFIG,
       apiKeys: [{ key: 'viewer-secret', profile: 'viewer' }],
     });
@@ -20,7 +27,7 @@ describe('createStandardVerifier', () => {
   });
 
   it('accepts an admin API key and returns expanded admin scopes', async () => {
-    const verifier = createStandardVerifier({
+    const verifier = await createStandardVerifier({
       ...DEFAULT_CONFIG,
       apiKeys: [{ key: 'admin-secret', profile: 'admin' }],
     });
@@ -32,92 +39,28 @@ describe('createStandardVerifier', () => {
   });
 
   it('rejects an unknown bearer token when OIDC is not configured', async () => {
-    const verifier = createStandardVerifier({
+    const verifier = await createStandardVerifier({
       ...DEFAULT_CONFIG,
       apiKeys: [{ key: 'known-secret', profile: 'viewer' }],
     });
 
     await expect(verifier('unknown-secret')).rejects.toBeInstanceOf(InvalidTokenError);
   });
-});
 
-describe('extractOidcScopes', () => {
-  it('extracts scopes from space-separated string claim (standard OIDC)', () => {
-    const scopes = extractOidcScopes({ scope: 'read write' });
-    expect(scopes).toContain('read');
-    expect(scopes).toContain('write');
+  it('drops api-key entries with an unknown profile (defense in depth)', async () => {
+    // toApiKeyEntries skips profiles not in API_KEY_PROFILES, so a token whose
+    // profile is bogus never matches — mirrors the old matchApiKey `undefined`.
+    const verifier = await createStandardVerifier({
+      ...DEFAULT_CONFIG,
+      apiKeys: [{ key: 'bogus-secret', profile: 'not-a-real-profile' }],
+    });
+
+    await expect(verifier('bogus-secret')).rejects.toBeInstanceOf(InvalidTokenError);
   });
 
-  it('extracts scopes from array claim (Azure AD style)', () => {
-    const scopes = extractOidcScopes({ scp: ['read', 'data'] });
-    expect(scopes).toContain('read');
-    expect(scopes).toContain('data');
-  });
+  it('rejects any token when neither api-keys nor OIDC are configured', async () => {
+    const verifier = await createStandardVerifier({ ...DEFAULT_CONFIG });
 
-  it('filters out unknown scopes', () => {
-    const scopes = extractOidcScopes({ scope: 'read openid profile email write' });
-    expect(scopes).toContain('read');
-    expect(scopes).toContain('write');
-    expect(scopes).not.toContain('openid');
-    expect(scopes).not.toContain('profile');
-    expect(scopes).not.toContain('email');
-  });
-
-  it('returns read-only when no scope claims present (safe default)', () => {
-    const scopes = extractOidcScopes({ sub: 'user123' });
-    expect(scopes).toEqual(['read']);
-  });
-
-  it('applies implied scope expansion: sql adds data', () => {
-    const scopes = extractOidcScopes({ scope: 'sql' });
-    expect(scopes).toContain('sql');
-    expect(scopes).toContain('data');
-  });
-
-  it('applies implied scope expansion: write adds read', () => {
-    const scopes = extractOidcScopes({ scope: 'write' });
-    expect(scopes).toContain('write');
-    expect(scopes).toContain('read');
-  });
-
-  it('returns minimum read when scopes are present but none are known', () => {
-    const scopes = extractOidcScopes({ scope: 'openid profile email' });
-    expect(scopes).toEqual(['read']);
-  });
-
-  it('prefers scope claim over scp claim', () => {
-    const scopes = extractOidcScopes({ scope: 'read', scp: ['write', 'admin'] });
-    expect(scopes).toContain('read');
-    expect(scopes).not.toContain('admin');
-  });
-
-  it('handles empty scope string', () => {
-    const scopes = extractOidcScopes({ scope: '' });
-    expect(scopes).toEqual(['read']);
-  });
-
-  it('handles scp array with non-string values', () => {
-    const scopes = extractOidcScopes({ scp: ['read', 42, null, 'write'] as unknown[] });
-    expect(scopes).toContain('read');
-    expect(scopes).toContain('write');
-  });
-
-  it('extracts scopes from scp as space-delimited string (Entra delegated tokens)', () => {
-    const scopes = extractOidcScopes({ scp: 'read write data' });
-    expect(scopes).toContain('read');
-    expect(scopes).toContain('write');
-    expect(scopes).toContain('data');
-  });
-
-  it('filters unknown scopes from scp string (Entra delegated tokens)', () => {
-    const scopes = extractOidcScopes({ scp: 'User.Read read openid' });
-    expect(scopes).toContain('read');
-    expect(scopes).not.toContain('User.Read');
-    expect(scopes).not.toContain('openid');
-  });
-
-  it('does not overgrant when scp is a string with no known scopes', () => {
-    const scopes = extractOidcScopes({ scp: 'User.Read User.Write' });
-    expect(scopes).toEqual(['read']);
+    await expect(verifier('anything')).rejects.toBeInstanceOf(InvalidTokenError);
   });
 });


### PR DESCRIPTION
Codex review **P1** (OIDC) + **P2** (standard-mode api-key timing / duplicated logic). ARC-1 kept inline copies of the OIDC verifier and a plain-`===` api-key match, bypassing hardening already shipped in the adopted package.

## What changed (`src/server/http.ts`)
- **OIDC** (both standard + XSUAA modes) now uses the package `createOidcVerifier` via a `buildPackageOidcVerifier` helper → pins an `algorithms` allowlist (`RS256/ES256/PS256`), drops `sub` from debug logs (logs `iss` + `hasSub`).
- **Standard mode** now builds the package `createChainedTokenVerifier` (same as XSUAA mode), so its api-key match is **constant-time** (was `token === entry.key`).
- Removes ~190 lines of duplicated inline code: `createOidcVerifier`, `extractOidcScopes`, `initJwks`, the `jose` module state, `matchApiKey`. Future package fixes now reach ARC-1 automatically.

## Behavior preserved
`fallbackScopes:[read]` (ARC-1s historical no-scope default), `acceptedScopes = KNOWN_SCOPES`, the `expandScopes` policy, `clientId = azp ?? sub ?? "oidc-user"`, `extra:{sub,iss}`, clock tolerance. Net **+102 / −289**.

## Verification
typecheck + lint + **3807 unit tests** green. Dependency unchanged (`^0.1.2` — the APIs exist there). The OAuth **callback-handler** dedup (also P2) is intentionally a **separate follow-up** (the security-critical #214 flow).

Not auto-merged — your review (security-critical auth path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)