### PR TITLE
chore(deps): bump @arc-mcp/xsuaa-auth to ^0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@abaplint/core": "^2.119.29",
-        "@arc-mcp/xsuaa-auth": "^0.1.2",
+        "@arc-mcp/xsuaa-auth": "^0.1.3",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@sap-cloud-sdk/connectivity": "^4.7.0",
         "@sap/xsenv": "^6.2.1",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@arc-mcp/xsuaa-auth": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@arc-mcp/xsuaa-auth/-/xsuaa-auth-0.1.2.tgz",
-      "integrity": "sha512-f/b0b18LR4AHn3heoYY870gag0vZ5F89TW3FPpFrEdvZfT6KDp/gMU8l4GTUoSu9ix6xreBMACtxab0vMCwYLA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@arc-mcp/xsuaa-auth/-/xsuaa-auth-0.1.3.tgz",
+      "integrity": "sha512-So/l1wioLluhXt96OmSrmFZ9qIpKMEWJWHBXd/cdKSWr27wx5zFnCvLd355g+C5WFWSbf55s5IPH4BDY4Yrl+Q==",
       "license": "MIT",
       "dependencies": {
         "@sap-cloud-sdk/connectivity": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "dependencies": {
     "@abaplint/core": "^2.119.29",
-    "@arc-mcp/xsuaa-auth": "^0.1.2",
+    "@arc-mcp/xsuaa-auth": "^0.1.3",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@sap-cloud-sdk/connectivity": "^4.7.0",
     "@sap/xsenv": "^6.2.1",


### PR DESCRIPTION
The "update auth module after release" step. 0.1.3 is now on npm; bumps ARC-1 `^0.1.2 → ^0.1.3` to pick up the post-extraction package fixes (`oidc.acceptedScopes`, tarball ships SECURITY/CHANGELOG/examples, `ppProxyAuth` reserved). No functional change for ARC-1 — the consumed API is unchanged. typecheck + **3815 unit tests** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)