### PR TITLE
refactor(auth): adopt @arc-mcp/xsuaa-auth createOAuthCallbackHandler

### DIFF
--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -25,7 +25,7 @@
  * 4. Health endpoint is always unauthenticated — needed for CF health checks.
  */
 
-import type { ApiKeyEntry, OAuthStateCodec, StatelessDcrClientStore, XsuaaCredentials } from '@arc-mcp/xsuaa-auth';
+import type { ApiKeyEntry, XsuaaCredentials } from '@arc-mcp/xsuaa-auth';
 import type { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import cors from 'cors';
@@ -37,223 +37,6 @@ import { API_KEY_PROFILES } from './config.js';
 import { authLibLogger, logger } from './logger.js';
 import { VERSION } from './server.js';
 import type { ServerConfig } from './types.js';
-
-// ─── OAuth Callback Proxy Handler (issue #214) ───────────────────────
-
-/**
- * Minimal HTML-escape for embedding untrusted text (e.g. an OAuth
- * `error_description` from the query string) into the error page below.
- */
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-/**
- * Is this a loopback HTTP redirect URI (`http://localhost|127.0.0.1|[::1]`)?
- * Such callbacks are ephemeral local listeners that native MCP clients (GitHub
- * Copilot, MCP Inspector) tear down on failure — so on an OAuth error we render
- * a self-hosted page for them rather than 302-ing to a dead port. Hosted HTTPS
- * callbacks (claude.ai, Copilot Studio) and custom-scheme app callbacks
- * (`vscode:`, `cursor:`) are live and expect the spec error redirect, so they
- * keep getting it.
- */
-function isLoopbackHttpRedirect(url: URL): boolean {
-  if (url.protocol !== 'http:') return false;
-  const host = url.hostname.toLowerCase();
-  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
-}
-
-/**
- * Render a self-hosted OAuth error page for `/oauth/callback`. Surfaces the
- * IdP's error to the human (loopback MCP clients usually can't — they close
- * their listener on failure) with an actionable hint for the most common case,
- * `invalid_scope` (authenticated but no granted scopes → an admin must assign an
- * ARC-1 role collection under the user's login IdP). `clientReturnUrl` carries
- * the error + original state for the rare client still listening.
- */
-function renderOAuthErrorPage(error: string, errorDescription: string, clientReturnUrl: string): string {
-  const hint =
-    error === 'invalid_scope'
-      ? 'You are signed in, but your user is not granted any ARC-1 scopes. An administrator must assign you an ARC-1 role collection (for example "ARC-1 Admin") under the identity provider you sign in with — see the ARC-1 authorization docs.'
-      : 'Retry the sign-in from your MCP client. If it keeps failing, share this error with your ARC-1 administrator.';
-  const descBlock = errorDescription ? `<p><code>${escapeHtml(errorDescription)}</code></p>` : '';
-  return (
-    '<!doctype html><html><head><meta charset="utf-8"><title>ARC-1 sign-in failed</title></head>' +
-    '<body style="font-family:sans-serif;max-width:42rem;margin:3rem auto;padding:0 1rem;line-height:1.5">' +
-    '<h1>ARC-1 sign-in failed</h1>' +
-    `<p><strong>Error:</strong> <code>${escapeHtml(error)}</code></p>` +
-    descBlock +
-    `<p>${escapeHtml(hint)}</p>` +
-    `<p><a href="${escapeHtml(clientReturnUrl)}">Return to your application</a></p>` +
-    '</body></html>'
-  );
-}
-
-/**
- * Express handler for ARC-1's `/oauth/callback`, the second half of the
- * XSUAA callback proxy that fixes the `+`-in-state bug (issue #214).
- *
- * XSUAA redirects here (not to the client) with an opaque base64url `state`
- * token that ARC-1's `authorize()` minted. We verify + decode it to recover
- * the client's ORIGINAL `redirect_uri` and `state`, then 302 to the client
- * re-emitting the state via `URL.searchParams` — whose serializer encodes a
- * literal `+` as `%2B`, exactly the encoding the client's parser expects.
- *
- * Removal condition + upstream tracking (XSUAA root cause, arc-1#214,
- * vscode#314715) are documented at the top of `oauth-state.ts`.
- *
- * SECURITY (authorization-code interception, security audit 2026-06): the
- * signed state carries the originating DCR `client_id` (`decoded.clientId`).
- * Before forwarding the auth code (or an error) to `decoded.clientRedirectUri`,
- * we verify that redirect_uri is actually registered for that client. The
- * signature alone is insufficient: all DCR clients share one XSUAA app, so a
- * forged-state attack is blocked by the HMAC, but the redirect target must
- * still belong to the client that will exchange the code. For stateless DCR
- * clients (`arc1-…`) the registered redirect_uris are baked immutably into the
- * signed `client_id`, so this check deterministically rejects an attacker who
- * substitutes their own redirect_uri on a victim's `client_id`. For the shared
- * pre-registered XSUAA default client the redirect_uri is checked against the
- * static allowlist (mirrors xs-security.json) instead — `clientStore` makes
- * both decisions via `checkRedirectUri`.
- *
- * Exported for unit tests; mounted in `startHttpServer`. When `clientStore` is
- * omitted (legacy unit tests of the issue-#214 round-trip) the binding check is
- * skipped; production always passes it.
- */
-export function createOAuthCallbackHandler(stateCodec: OAuthStateCodec, clientStore?: StatelessDcrClientStore) {
-  return async (req: Request, res: Response): Promise<void> => {
-    const stateToken = typeof req.query.state === 'string' ? req.query.state : '';
-    const decoded = stateCodec.decode(stateToken);
-    if (decoded.kind !== 'ok') {
-      logger.warn('OAuth callback: invalid state token', { reason: decoded.reason });
-      // We cannot safely redirect anywhere — the client redirect_uri lives
-      // inside the (unverified) token. Return a terminal error page.
-      res
-        .status(400)
-        .type('html')
-        .send(
-          '<!doctype html><html><body style="font-family:sans-serif;padding:2rem">' +
-            '<h1>Authentication failed</h1>' +
-            '<p>The OAuth state token was invalid or expired. Please retry the sign-in from your MCP client.</p>' +
-            '</body></html>',
-        );
-      return;
-    }
-
-    // ── Client-binding validation (authorization-code interception defense) ──
-    // Verify the recovered redirect_uri is an allowed target for the client_id
-    // that minted this state, BEFORE the success or error branches below — so
-    // neither a code nor an error response is ever steered to an unverified URI.
-    // The store decides per client type: a DCR client (`arc1-…`) is checked
-    // against the redirect_uris baked into its signed id; the shared XSUAA
-    // default client is checked against the static allowlist (mirrors
-    // xs-security.json), statelessly. Fails CLOSED on any lookup error.
-    if (clientStore && decoded.clientId) {
-      let verdict: 'ok' | 'unknown_client' | 'unregistered';
-      try {
-        verdict = await clientStore.checkRedirectUri(decoded.clientId, decoded.clientRedirectUri);
-      } catch (err) {
-        logger.warn('OAuth callback: redirect_uri check threw — failing closed', {
-          clientId: decoded.clientId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        verdict = 'unknown_client';
-      }
-      if (verdict === 'unknown_client') {
-        logger.warn('OAuth callback: state references unknown client_id', { clientId: decoded.clientId });
-        res
-          .status(400)
-          .type('html')
-          .send(
-            '<!doctype html><html><body style="font-family:sans-serif;padding:2rem">' +
-              '<h1>Authentication failed</h1>' +
-              '<p>The OAuth client referenced in the state token is no longer valid. Please retry the sign-in.</p>' +
-              '</body></html>',
-          );
-        return;
-      }
-      if (verdict === 'unregistered') {
-        logger.warn('OAuth callback: redirect_uri not allowed for client', {
-          clientId: decoded.clientId,
-          redirectUri: decoded.clientRedirectUri,
-        });
-        res
-          .status(400)
-          .type('html')
-          .send(
-            '<!doctype html><html><body style="font-family:sans-serif;padding:2rem">' +
-              '<h1>Authentication failed</h1>' +
-              '<p>The redirect URI in the state token is not registered for this client. Please retry the sign-in.</p>' +
-              '</body></html>',
-          );
-        return;
-      }
-    }
-
-    let target: URL;
-    try {
-      target = new URL(decoded.clientRedirectUri);
-    } catch {
-      logger.warn('OAuth callback: stored redirect_uri is not a valid URL');
-      res.status(400).type('html').send('<!doctype html><html><body>Invalid redirect target.</body></html>');
-      return;
-    }
-
-    // On error there is no auth code. Forward the error to the client per the
-    // OAuth spec — EXCEPT for loopback HTTP callbacks. Native MCP clients
-    // (GitHub Copilot, MCP Inspector, …) tear down their ephemeral localhost
-    // listener the instant the flow fails, so a 302 there lands on a dead port
-    // and the user sees a blank ERR_CONNECTION_REFUSED with no clue why. For
-    // those we render a self-hosted page that surfaces the real reason (e.g.
-    // invalid_scope → missing role collection), with a best-effort link back.
-    // Hosted HTTPS callbacks (claude.ai, Copilot Studio) and custom-scheme app
-    // callbacks (vscode:, cursor:) are live and expect the redirect, so they
-    // keep getting it.
-    const error = typeof req.query.error === 'string' ? req.query.error : undefined;
-    if (error) {
-      const errorDescription = typeof req.query.error_description === 'string' ? req.query.error_description : '';
-      if (decoded.clientState !== undefined) target.searchParams.set('state', decoded.clientState);
-      target.searchParams.set('error', error);
-      if (errorDescription) target.searchParams.set('error_description', errorDescription);
-      const loopback = isLoopbackHttpRedirect(target);
-      logger.warn('OAuth callback: identity provider returned an error', {
-        error,
-        errorDescriptionPreview: errorDescription.slice(0, 200),
-        clientRedirectUriHost: target.host,
-        loopback,
-      });
-      if (loopback) {
-        res
-          .status(400)
-          .type('html')
-          .send(renderOAuthErrorPage(error, errorDescription, target.toString()));
-      } else {
-        res.redirect(302, target.toString());
-      }
-      return;
-    }
-
-    // Success: forward the authorization code, re-attaching the client's
-    // ORIGINAL state. URLSearchParams serialization encodes `+` as `%2B`, which
-    // is exactly what fixes the round-trip (issue #214).
-    const code = typeof req.query.code === 'string' ? req.query.code : '';
-    target.searchParams.set('code', code);
-    if (decoded.clientState !== undefined) {
-      target.searchParams.set('state', decoded.clientState);
-    }
-
-    logger.debug('OAuth callback: redirecting to client', {
-      clientRedirectUriHost: target.host,
-      hasState: decoded.clientState !== undefined,
-    });
-    res.redirect(302, target.toString());
-  };
-}
 
 // ─── API Key Entry Mapping ───────────────────────────────────────────
 
@@ -473,8 +256,13 @@ export async function startHttpServer(
   if (config.xsuaaAuth && xsuaaCredentials) {
     const { mcpAuthRouter } = await import('@modelcontextprotocol/sdk/server/auth/router.js');
     const { requireBearerAuth } = await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');
-    const { createXsuaaOAuthProvider, createChainedTokenVerifier, createXsuaaTokenVerifier, createOidcVerifier } =
-      await import('@arc-mcp/xsuaa-auth');
+    const {
+      createXsuaaOAuthProvider,
+      createChainedTokenVerifier,
+      createXsuaaTokenVerifier,
+      createOidcVerifier,
+      createOAuthCallbackHandler,
+    } = await import('@arc-mcp/xsuaa-auth');
     const { getAppUrl } = await import('./app-url.js');
 
     // Determine app URL for OAuth metadata
@@ -653,7 +441,7 @@ export async function startHttpServer(
     // XSUAA as oauthCallbackUrl. A strip-prefix proxy maps the public path
     // back to this root route. Handler is extracted (exported) so the
     // state-round-trip contract is unit-testable without a live XSUAA.
-    app.get('/oauth/callback', createOAuthCallbackHandler(stateCodec, clientStore));
+    app.get('/oauth/callback', createOAuthCallbackHandler(stateCodec, clientStore, { logger: authLibLogger }));
 
     // ─── Path-prefix-aware OAuth metadata override ────────────────
     // The MCP SDK's `mcpAuthRouter` builds endpoint URLs with

--- a/tests/unit/server/oauth-callback.test.ts
+++ b/tests/unit/server/oauth-callback.test.ts
@@ -1,8 +1,7 @@
-import { OAuthStateCodec, StatelessDcrClientStore } from '@arc-mcp/xsuaa-auth';
+import { createOAuthCallbackHandler, OAuthStateCodec, StatelessDcrClientStore } from '@arc-mcp/xsuaa-auth';
 import express from 'express';
 import request from 'supertest';
 import { describe, expect, it } from 'vitest';
-import { createOAuthCallbackHandler } from '../../../src/server/http.js';
 
 const SECRET = 'callback-test-signing-secret-1234567890';
 const TEST_CLIENT_ID = 'arc1-test-client';


### PR DESCRIPTION
Codex review **P2** — the last duplicated-logic item. ARC-1 kept an inline copy of the `/oauth/callback` handler (the **issue-#214** OAuth-state callback proxy + the auth-code-interception redirect-binding defense), which the package ships as a *verbatim* port.

## Change
- Drop the ~210-line inline copy (`escapeHtml` / `isLoopbackHttpRedirect` / `renderOAuthErrorPage` / `createOAuthCallbackHandler`) and mount the package's `createOAuthCallbackHandler(stateCodec, clientStore, { logger: authLibLogger })`. Future security fixes to the handler now reach ARC-1 automatically.
- `oauth-callback.test.ts` repointed to `@arc-mcp/xsuaa-auth` and kept as a **contract test** (18 cases — #214 round-trip + client-binding defense; no assertion weakened).

## Behavior
Identical — it is the same code (verbatim port); the only delta is the injected logger (same destination). **+10 / −223.** typecheck + lint + **3815 unit tests** green. Dependency unchanged (`^0.1.2`). Also live-verified end-to-end earlier (browser OAuth on BTP).

_Note: an unrelated CORS test (`http-security-headers.test.ts`) is intermittently flaky (passes in isolation + on baseline + on reruns); it never touches the OAuth handler._

Not auto-merged — your review (security-critical #214 flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)