### PR TITLE
feat(config): reject non-3-digit SAP_CLIENT at startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@
 SAP_URL=http://sapnwas.example.com:8000
 SAP_USER=DEVELOPER
 SAP_PASSWORD=YOUR_PASSWORD
-SAP_CLIENT=100
+SAP_CLIENT=100  # 3-digit SAP client (000-999); SAP does not pad, so write '010' not '10'
 SAP_LANGUAGE=EN
 # SAP_INSECURE=true  # Skip TLS verification — dev/test only
 

--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@
 SAP_URL=http://sapnwas.example.com:8000
 SAP_USER=DEVELOPER
 SAP_PASSWORD=YOUR_PASSWORD
-SAP_CLIENT=100  # 3-digit SAP client (000-999); SAP does not pad, so write '010' not '10'
+SAP_CLIENT=100
 SAP_LANGUAGE=EN
 # SAP_INSECURE=true  # Skip TLS verification — dev/test only
 

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -611,6 +611,19 @@ export function parseArgs(args: string[]): ServerConfig {
  * Fails fast at startup for invalid or dangerous config combinations.
  */
 export function validateConfig(config: ServerConfig): void {
+  // SAP client (MANDT) is a canonical 3-digit value (CHAR 3, range 000-999). SAP
+  // does NOT zero-pad the sap-client URL parameter, so a 1-2 digit value like '10'
+  // authenticates against a different (or non-existent) client and surfaces as a
+  // confusing 401 — not an obvious config error. Fail fast with a clear hint instead.
+  // Empty is skipped here: resolveConfig already substitutes the '100' default for it.
+  if (config.client && !/^\d{3}$/.test(config.client)) {
+    throw new Error(
+      `Invalid SAP_CLIENT '${config.client}': must be a 3-digit SAP client (000-999). ` +
+        `SAP does not pad the client number — write it with leading zeros, ` +
+        `e.g. '010' for client 10 or '100' for client 100.`,
+    );
+  }
+
   if (config.oidcIssuer && !config.oidcAudience) {
     throw new Error(
       'SAP_OIDC_AUDIENCE is required when SAP_OIDC_ISSUER is set — ' +

--- a/tests/unit/server/config.test.ts
+++ b/tests/unit/server/config.test.ts
@@ -63,6 +63,14 @@ describe('parseArgs', () => {
     expect(config.client).toBe('200');
   });
 
+  it('throws end-to-end on a non-3-digit client', () => {
+    expect(() => parseArgs(['--client', '10'])).toThrow(/Invalid SAP_CLIENT '10'/);
+  });
+
+  it('accepts a zero-padded 3-digit client', () => {
+    expect(parseArgs(['--client', '010']).client).toBe('010');
+  });
+
   it('CLI flags take precedence over env vars', () => {
     process.env.SAP_URL = 'http://env:8000';
     const config = parseArgs(['--url', 'http://cli:9000']);
@@ -1004,5 +1012,17 @@ describe('validateConfig', () => {
   it('parseArgs fails with oidcIssuer but no oidcAudience', () => {
     process.env.SAP_OIDC_ISSUER = 'https://example.com';
     expect(() => parseArgs([])).toThrow('SAP_OIDC_AUDIENCE is required');
+  });
+
+  it.each(['100', '000', '999', '010', '001'])('accepts the 3-digit client %s', (client) => {
+    expect(() => validateConfig({ ...DEFAULT_CONFIG, client })).not.toThrow();
+  });
+
+  it.each(['10', '1', '0', '1000', '00', 'abc', '10a', ' 100'])('throws on the malformed client %s', (client) => {
+    expect(() => validateConfig({ ...DEFAULT_CONFIG, client })).toThrow(/Invalid SAP_CLIENT/);
+  });
+
+  it('skips client validation when empty (resolveConfig substitutes the default)', () => {
+    expect(() => validateConfig({ ...DEFAULT_CONFIG, client: '' })).not.toThrow();
   });
 });


### PR DESCRIPTION
## Problem

A real debugging session: a user's MCP config had `SAP_CLIENT=10`, but the working SAP client was `100`. SAP **does not zero-pad** the `sap-client` URL parameter, so `10` authenticated against a different (or non-existent) client and returned an **HTTP 401 with an empty SU53** — indistinguishable from a wrong password. Hours were lost chasing roles/`S_ADT_RES`/SICF when the real cause was one dropped digit in a config value.

`401` (authentication) ≠ `403` (authorization), and a missing/`10`-style client manifests as the former — so none of the usual authorization debugging surfaces it.

## Change

`validateConfig()` now rejects a non-3-digit `SAP_CLIENT` at startup, before any SAP call:

```
Invalid SAP_CLIENT '10': must be a 3-digit SAP client (000-999). SAP does not
pad the client number — write it with leading zeros, e.g. '010' for client 10
or '100' for client 100.
```

- Rule: `^\d{3}$` — canonical MANDT (CHAR 3, `000`–`999`)
- **Error, not auto-pad**: padding `10`→`010` could silently pick the *wrong* client (the real one was `100`). Fail-fast forces the operator to be explicit.
- Empty stays valid — `resolveConfig` already substitutes the `100` default for an empty value (existing behavior, unchanged).
- Mirrors the existing fail-fast `--port` validation.

## Tests

- `validateConfig`: accepts `100/000/999/010/001`; throws on `10/1/0/1000/00/abc/10a/' 100'`; skips empty
- `parseArgs` end-to-end: throws on `--client 10`, accepts `--client 010`

Full gate green: 3831 unit tests, typecheck, lint, build, `validate:policy`, `check:sizes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)