### PR TITLE
docs: add practical SAP migration dossier skill

### DIFF
--- a/docs_page/skills.md
+++ b/docs_page/skills.md
@@ -392,6 +392,7 @@ References: [ABAP Development Tools for VS Code marketplace page](https://market
 |---|---|---|
 | [explain-abap-code](https://github.com/arc-mcp/arc-1/blob/main/skills/explain-abap-code/SKILL.md) | Reads an ABAP object, pulls dependency context, and explains it in structure | Onboarding, debugging, and code comprehension |
 | [migrate-custom-code](https://github.com/arc-mcp/arc-1/blob/main/skills/migrate-custom-code/SKILL.md) | Runs migration-oriented checks and groups findings by priority | S/4HANA migration and ABAP Cloud readiness |
+| [sap-migration-dossier](https://github.com/arc-mcp/arc-1/blob/main/skills/sap-migration-dossier/SKILL.md) | Builds a scoped ECC to S/4HANA migration dossier with inventory, usage, ATC, Clean Core, dependency, and SAP Docs evidence | Package- or namespace-level migration planning |
 | [sap-object-documenter](https://github.com/arc-mcp/arc-1/blob/main/skills/sap-object-documenter/SKILL.md) | Batch-documents custom objects as Markdown | Package onboarding and handoffs |
 
 ### Clean Core And Custom Code Retirement
@@ -426,6 +427,7 @@ References: [ABAP Development Tools for VS Code marketplace page](https://market
 
 - Run `bootstrap-system-context` first when starting a session against an unfamiliar system — it grounds every later prompt in real constraints.
 - Run `setup-abap-mirror` after bootstrap to pull a package into local abapGit-style files for IDE context and `git diff`.
+- Use `sap-migration-dossier` when the user wants a shareable migration audit rather than a chat-only answer or one-object fix workflow.
 - Start with `generate-rap-service` when the goal is speed and the design is straightforward.
 - Start with `generate-rap-service-researched` when writing into transportable packages or when team conventions matter.
 - Use `explain-abap-code` before editing unfamiliar objects.

--- a/skills/README.md
+++ b/skills/README.md
@@ -198,6 +198,7 @@ Both skills produce the same RAP artifact stack. The difference is how they get 
 |---|---|---|
 | [explain-abap-code](explain-abap-code/SKILL.md) | Reads an ABAP object, fetches all dependencies via SAPContext, and produces a structured explanation — including behavior definitions (BDEF: parses `implementation in class`, reads the behavior pool CCIMP handlers, runs SAPContext impact on the bound CDS root) | Onboarding to unfamiliar code, investigating bugs, documenting undocumented objects, understanding a RAP behavior (SAP Joule "AI Explain for Behavior Definitions" parity) |
 | [migrate-custom-code](migrate-custom-code/SKILL.md) | Runs ATC readiness checks, groups findings by priority, and generates replacement code | Preparing custom code for S/4HANA migration or ABAP Cloud readiness |
+| [sap-migration-dossier](sap-migration-dossier/SKILL.md) | Creates human-reviewed ECC → S/4HANA migration dossiers with inventory, usage, ATC, clean-core, review cards, and optional Markdown/HTML/JSON/CSV/graph outputs | Package- or namespace-level migration planning where the output needs to be saved, reviewed, visualized, or shared |
 | [sap-object-documenter](sap-object-documenter/SKILL.md) | Batch-documents many custom objects at once — purpose, style (Classic/Modern/Mixed), dependencies — as Markdown | Onboarding packages, handoffs, seeding a repo wiki (vs. explain-abap-code which is single-object interactive) |
 | [sap-transport-review](sap-transport-review/SKILL.md) | Reviews what *changed* — in a transport or in your unactivated drafts — as per-object unified diffs (`SAPTransport summary` to scan, `SAPRead action="diff"` to diff) plus risk flags and optional impact/ATC. The headless/whole-transport twin of Eclipse ADT 3.6's "Object Changes" | Pre-release/pre-activation gate, reviewing a transport (senior dev), "what have I changed since my last release?", change hand-off or audit |
 | [sap-transport-overview](sap-transport-overview/SKILL.md) | System-wide inventory of every open transport (all users) — owner, size, and risk flags (object in two requests, $TMP, stale, empty) via `SAPTransport(list, summary=true, user="*")`. Breadth, no diffs — the companion to sap-transport-review | Basis/release manager: "what's open across the system and what's risky to import", backlog & cleanup, pre-go-live conflict check |
@@ -277,6 +278,7 @@ For codebase onboarding or pre-migration work:
 2. setup-abap-mirror         →  Pull the target package(s) into abapGit-style files
 3. explain-abap-code         →  Understand key objects with dependency context
 4. migrate-custom-code       →  Run ATC readiness checks and group findings
+5. sap-migration-dossier     →  Save a reviewed dossier with optional HTML/CSV/graph outputs
 ```
 
 For clean-core / custom-code retirement planning:
@@ -287,6 +289,7 @@ For clean-core / custom-code retirement planning:
 3. sap-clean-core-atc        →  Classify the USED code into Levels A–D
 4. sap-object-documenter     →  Document the keepers before rewriting
 5. migrate-custom-code       →  Fix the Level B/C/D findings one at a time
+6. sap-migration-dossier     →  Package the evidence into a reviewed migration plan
 ```
 
 For end-to-end legacy SEGW + UI5 modernization (backend + UI):

--- a/skills/migrate-custom-code/SKILL.md
+++ b/skills/migrate-custom-code/SKILL.md
@@ -282,7 +282,7 @@ Next steps:
 ### What This Skill Does NOT Do
 
 - **No transport management**: User is responsible for creating and releasing transport requests
-- **No mass migration**: Handles one object or one package at a time — not a full system migration tool
+- **No migration dossier**: Handles one object or one package finding workflow — for reviewed, saved, or visual package-level dossiers, use [sap-migration-dossier](../sap-migration-dossier/SKILL.md)
 - **No custom ATC variant creation**: Uses existing ATC variants on the system
 - **No table structure migration**: Cannot modify DDIC table structures (e.g., field length changes for S/4HANA)
 - **No test execution**: Does not run regression tests after fixes — user should validate manually or use generate-abap-unit-test skill

--- a/skills/sap-clean-core-atc/SKILL.md
+++ b/skills/sap-clean-core-atc/SKILL.md
@@ -163,6 +163,7 @@ Offer next steps:
 - "Want to migrate one of these objects now?" (→ [migrate-custom-code](../migrate-custom-code/SKILL.md))
 - "Want to see which Z-objects are even USED?" (→ [sap-unused-code](../sap-unused-code/SKILL.md) — no point migrating dead code)
 - "Want to document the Level A objects as reference examples?" (→ [sap-object-documenter](../sap-object-documenter/SKILL.md))
+- "Want a reviewed dossier with saved evidence, customer questions, and visualizations?" (→ [sap-migration-dossier](../sap-migration-dossier/SKILL.md))
 
 ## Error Handling
 

--- a/skills/sap-migration-dossier/SKILL.md
+++ b/skills/sap-migration-dossier/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: sap-migration-dossier
+description: Create human-reviewed ECC to S/4HANA custom-code migration dossiers for SAP packages, namespaces, object lists, or uploaded extracts. Use when asked to audit custom ABAP for S/4HANA readiness, produce a migration-readiness dossier, classify enhancements/user exits/BAdIs/standard modifications, combine ATC + unused-code + clean-core evidence, build a review queue, save results to Markdown/HTML/JSON/CSV, or visualize custom-code dependencies and migration risk.
+---
+
+# SAP Migration Dossier
+
+Create an evidence-backed migration dossier instead of a one-object fix report. This skill composes ARC-1 inventory, usage, dependency, ATC, clean-core, and documentation workflows into a package/scope-level audit with optional persistent review and visualization artifacts.
+
+For the design rationale learned from `sergio-gracia/ecc-s4h-migrator-auditor`, read `references/auditor-patterns.md` when the user asks for persistent artifacts, human review, imported extracts, or HTML/graph output.
+
+## First Decisions
+
+Do not silently collapse the workflow to the simplest chat answer when the user wants an audit. Ask for missing decisions, but keep it to these three:
+
+| Decision | Options |
+|---|---|
+| Scope | package, recursive package, namespace/prefix, object list, uploaded/local extract |
+| Evidence depth | `standard` ARC-1 only, `deep` with governed `SAPQuery` tables, `reviewed` with draft cards and validation gate |
+| Output | chat only, local folder, Markdown, HTML, JSONL/CSV, Mermaid/Graphviz, static dashboard |
+
+If the user does not specify output and the scope has more than a few objects, recommend a local folder:
+
+```
+docs/migration-dossiers/<scope-slug>/<YYYY-MM-DD>/
+```
+
+## Evidence Profiles
+
+### Standard
+
+Use existing ARC-1 read and analysis tools. This works without free SQL and is the default when the admin has not enabled SQL.
+
+Collect:
+- object inventory via `SAPRead(type="DEVC")` or `SAPSearch`
+- source/metadata via `SAPRead`
+- dependencies via `SAPContext` and `SAPNavigate(action="references")`
+- ATC findings via `SAPDiagnose(action="atc")`
+- API release state via `SAPRead(type="API_STATE")` or mcp-sap-docs when available
+- versions and transport history via `SAPRead(type="VERSIONS")` and `SAPTransport(action="history")`
+
+### Deep
+
+Use only when the user wants ECC-style enhancement coverage and the ARC-1 server allows `SAP_ALLOW_FREE_SQL=true`. Check authorization and scope first; do not run unbounded system-wide queries.
+
+Add optional table evidence:
+- runtime usage from SCMON/SUSG using the `sap-unused-code` workflow
+- classic exits via `MODATTR`, `MODACT`, `MODSAP`, `TRDIR` for `ZX*` includes
+- classic BAdIs via `SXC_ATTR` / `SXC_EXIT` if present
+- standard modifications via `SMODILOG` / `SMODISRC`
+- cross-reference tables (`CROSS`, `WBCROSSGT`) only for narrowed object sets; prefer `SAPContext`/`SAPNavigate` first
+
+If any table is unavailable or forbidden, record the gap in `methodology.md` and continue with the standard profile.
+
+### Reviewed
+
+Use when the dossier will be customer-facing or used for planning decisions. Create draft assessment cards first; final reports must include only `validated` or `corrected` cards unless the user explicitly requests a draft report.
+
+Card status values:
+
+```
+ai_draft | validated | corrected | skipped | ai_error
+```
+
+Decision enums:
+
+```
+REMOVE | KEEP | ADAPT | COVERED_BY_STANDARD | UNDETERMINED
+```
+
+Keep clean-core level and unused-code status separate:
+
+```
+cleanCoreLevel: A | B | C | D | unknown
+usageStatus: USED | LIKELY_UNUSED | UNUSED | INDETERMINATE
+```
+
+## Workflow
+
+### 1. Bootstrap and Scope
+
+If `system-info.md` is absent and live ARC-1 access is available, run the `bootstrap-system-context` workflow first. Record SID, client, release, system type, HANA availability, feature flags, and whether ATC, transports, SCMON/SUSG, and free SQL are available.
+
+Resolve scope:
+- Package: `SAPRead(type="DEVC", name="<package>")`
+- Prefix: call `SAPSearch` per relevant type (`PROG`, `CLAS`, `FUGR`, `FUNC`, `DDLS`, `BDEF`, `SRVD`, `TABL`)
+- Object list: resolve each ambiguous item with `SAPSearch`
+- Local extract: parse the supplied JSON and mark evidence source as imported, not live ARC-1
+
+Stop and ask before auditing more than 100 objects unless the user explicitly chose a persistent dossier mode.
+
+### 2. Build the Inventory
+
+For each object, collect a compact inventory row:
+
+```
+id, type, name, package, description, loc, author, changedOn,
+sourceHash, hasSource, dynamicCallHints, transportHistory, versionInfo
+```
+
+Prefer ARC-1 source reads over raw table extraction. Use `SAPRead(type="CLAS", method="*")` for class APIs, `SAPRead(type="DDLS", include="elements")` for CDS fields, and `SAPRead(type="ENHO")` for enhancement metadata when object names are known.
+
+For local artifacts, write:
+
+```
+inventory.json
+inventory.csv
+methodology.md
+```
+
+### 3. Add Usage and Retirement Evidence
+
+Use the `sap-unused-code` workflow when SCMON/SUSG data is available. Otherwise, record `usageStatus=INDETERMINATE` and say which runtime source was missing.
+
+For each unused or likely-unused object, add static reference evidence:
+
+```
+SAPNavigate(action="references", type="<type>", name="<name>")
+```
+
+Do not recommend deletion solely from a zero-usage observation. State whether the measured source is SCMON, SUSG, ST03N, or unavailable.
+
+### 4. Add Migration and Clean-Core Evidence
+
+Run ATC per object or per manageable batch:
+
+```
+SAPDiagnose(action="atc", type="<type>", name="<name>", variant="<variant>")
+```
+
+Use `sap-clean-core-atc` logic for package-level Clean Core A-D rollups. Use `migrate-custom-code` only for selected objects or findings that the user wants to explain or remediate; do not attempt mass automated fixes as part of a dossier.
+
+Record per object:
+
+```
+atcPriority1, atcPriority2, atcPriority3,
+worstCleanCoreLevel, topViolations[], successorHints[]
+```
+
+### 5. Create Draft Assessment Cards
+
+Create cards for objects with migration relevance:
+- user exits / `ZX*` includes
+- BAdI implementations
+- enhancement implementations (`ENHO`)
+- standard modifications
+- high-risk Clean Core C/D objects
+- used objects with priority-1 ATC findings
+- unused large objects that might remove migration scope
+
+Each card must include bounded context:
+
+```
+object id, type, package, standard anchor if known,
+LOC, last change, usage evidence, dynamic-call flag,
+top dependencies/callers, ATC summary, clean-core level,
+source excerpt or full source if small
+```
+
+Draft assessments must be strict JSON-compatible records:
+
+```json
+{
+  "status": "ai_draft",
+  "classification": "REMOVE",
+  "effort": "S",
+  "confidence": 0.82,
+  "functionalSummary": "...",
+  "rationale": "...",
+  "risks": ["..."],
+  "questions": ["..."],
+  "evidenceRefs": ["inventory:ZCL_FOO", "atc:ZCL_FOO:1"]
+}
+```
+
+If confidence is low, source is truncated, usage is missing, or dynamic calls exist, lower confidence and add concrete customer questions.
+
+### 6. Review Gate
+
+If the user selected `reviewed`, write draft cards and ask for review decisions rather than publishing them as final.
+
+Supported review actions:
+- validate as-is
+- correct classification/effort/rationale
+- add note
+- skip
+
+For local artifacts, use append-only files where practical:
+
+```
+cards.jsonl
+reviews.jsonl
+review-summary.md
+```
+
+The final reviewed dossier includes only `validated` and `corrected` cards. If the user asks for a draft report, label it prominently as unreviewed and keep a separate filename such as `draft-report.html`.
+
+### 7. Generate Outputs
+
+Let the user choose one or more outputs:
+
+| Output | Use |
+|---|---|
+| `report.md` | editable consultant handoff |
+| `report.html` | self-contained executive dossier, printable to PDF |
+| `inventory.csv` / `cards.csv` | Excel, BI, or PMO planning |
+| `inventory.json` / `cards.jsonl` | reruns, review queues, integration |
+| `graph.mmd` | Mermaid dependency/risk visualization |
+| `dashboard.html` | local filtering/search without a server |
+
+Recommended report sections:
+1. Executive summary
+2. Scope and methodology
+3. Usage and retirement candidates
+4. Standard modifications / SPAU risk
+5. Clean-core level distribution
+6. ATC priority findings
+7. Reviewed migration cards
+8. Open questions and assumptions
+9. Integrity and evidence appendix
+
+Always declare evidence gaps: missing SCMON/SUSG, blocked SQL tables, unavailable ATC variants, incomplete cross-reference indexes, dynamic calls, generated source, and unreviewed cards.
+
+## Visualization
+
+When visualization is requested, generate a bounded graph rather than the whole system. Default to the top 50 high-risk or high-fanout nodes unless the user asks for more.
+
+Mermaid example:
+
+```mermaid
+flowchart LR
+  ZR_OLD_REPORT["ZR_OLD_REPORT<br/>UNUSED - P1=3"] --> ZCL_HELPER["ZCL_HELPER<br/>C"]
+  ZENH_EXIT["ZXVVFU02<br/>ADAPT - M"] --> SAPMV45A["SAPMV45A<br/>standard anchor"]
+```
+
+Use color classes for risk when emitting Mermaid or HTML:
+- red: standard modifications, Clean Core D, ATC P1
+- amber: ADAPT, Clean Core C, likely unused
+- green: REMOVE candidates with no runtime/static blockers
+- blue: KEEP / covered by standard
+
+## Safety Rules
+
+- Do not run unscoped system-wide extraction.
+- Do not use `SAPQuery` unless free SQL is enabled and the user chose deep evidence.
+- Do not treat zero ATC findings as clean if the object is `$TMP` or ATC skipped it.
+- Do not delete, update, activate, or transport objects from this skill.
+- Do not publish AI-only assessments as final decisions unless explicitly labeled draft.
+- Preserve SAP authorization and ARC-1 server safety ceilings; gaps are report findings, not reasons to bypass controls.

--- a/skills/sap-migration-dossier/SKILL.md
+++ b/skills/sap-migration-dossier/SKILL.md
@@ -11,6 +11,8 @@ Default to a concise chat report. Offer files, review cards, HTML, CSV/JSON, and
 
 Read `references/auditor-patterns.md` only when the user asks for persistent artifacts, human review, imported extracts, deep ECC enhancement extraction, integrity hashes, HTML dashboards, or graph output.
 
+Use SAP Docs MCP when available, especially for Clean Core/API status, successor APIs, release-specific syntax, and migration guidance. If SAP Docs MCP is not connected, still run the dossier with ARC-1 evidence and list "SAP Docs MCP unavailable" as an evidence gap.
+
 ## Default Path
 
 If the scope is clear, start immediately:
@@ -24,6 +26,7 @@ If the scope is clear, start immediately:
 3. Add migration signals:
    - ATC: `SAPDiagnose(action="atc", type="<type>", name="<name>")`
    - Clean-core/API risk: reuse `sap-clean-core-atc` logic
+   - SAP Docs MCP: enrich SAP API references with `sap_get_object_details`; use `search`/`fetch` for the top ATC themes or replacement guidance
    - Usage/retirement: reuse `sap-unused-code` only if SCMON/SUSG data is available
    - Dependencies/where-used: `SAPContext` or `SAPNavigate(action="references")`
 4. Return a concise report with:
@@ -51,6 +54,8 @@ Use optional modes only when the user asks or the scope makes chat output imprac
 | "reviewed", "consultant validation", "not AI-only" | Create draft cards and include only validated/corrected cards in the final report |
 | "graph", "visualize", "dependency map" | Generate a bounded Mermaid graph for the top risk/high-fanout objects |
 | "deep ECC", "user exits", "BAdIs", "standard modifications" | Use deep evidence from `references/auditor-patterns.md`; only use `SAPQuery` when allowed |
+| "successor API", "released API", "what replaces this" | Use SAP Docs MCP `sap_get_object_details`, then `search`/`fetch` for guidance if needed |
+| "will this syntax work on release X" | Use SAP Docs MCP `abap_feature_matrix` plus `search` with the right ABAP flavor |
 | "fix this" | Switch to `migrate-custom-code` for selected findings; this skill should not mass-remediate |
 
 ## Output Shape
@@ -61,7 +66,7 @@ For chat output, keep it short:
 Migration Dossier - <scope>
 
 Scope: <n> objects, <types>, <packages>
-Evidence: ATC=<variant/default>, usage=<SCMON/SUSG/unavailable>, clean-core=<source>, dependencies=<source>
+Evidence: ATC=<variant/default>, docs=<SAP Docs MCP/unavailable>, usage=<SCMON/SUSG/unavailable>, clean-core=<source>, dependencies=<source>
 
 Summary:
 - <1-3 lines>

--- a/skills/sap-migration-dossier/SKILL.md
+++ b/skills/sap-migration-dossier/SKILL.md
@@ -1,249 +1,128 @@
 ---
 name: sap-migration-dossier
-description: Create human-reviewed ECC to S/4HANA custom-code migration dossiers for SAP packages, namespaces, object lists, or uploaded extracts. Use when asked to audit custom ABAP for S/4HANA readiness, produce a migration-readiness dossier, classify enhancements/user exits/BAdIs/standard modifications, combine ATC + unused-code + clean-core evidence, build a review queue, save results to Markdown/HTML/JSON/CSV, or visualize custom-code dependencies and migration risk.
+description: Create practical ECC to S/4HANA custom-code migration dossiers for SAP packages, namespaces, object lists, or uploaded extracts. Use when asked to audit custom ABAP for S/4HANA readiness, create a shareable migration-readiness report, combine ATC + unused-code + clean-core evidence, classify user exits/BAdIs/enhancements/standard modifications, save results to Markdown/HTML/CSV/JSON, or visualize migration scope.
 ---
 
 # SAP Migration Dossier
 
-Create an evidence-backed migration dossier instead of a one-object fix report. This skill composes ARC-1 inventory, usage, dependency, ATC, clean-core, and documentation workflows into a package/scope-level audit with optional persistent review and visualization artifacts.
+Build a migration planning artifact, not a one-object fix workflow. Use this skill to combine the existing ARC-1 migration skills into a scoped dossier that is easy to start and can become more formal only when the user asks.
 
-For the design rationale learned from `sergio-gracia/ecc-s4h-migrator-auditor`, read `references/auditor-patterns.md` when the user asks for persistent artifacts, human review, imported extracts, or HTML/graph output.
+Default to a concise chat report. Offer files, review cards, HTML, CSV/JSON, and graphs as optional follow-ups; do not ask the user to design a reporting system up front.
 
-## First Decisions
+Read `references/auditor-patterns.md` only when the user asks for persistent artifacts, human review, imported extracts, deep ECC enhancement extraction, integrity hashes, HTML dashboards, or graph output.
 
-Do not silently collapse the workflow to the simplest chat answer when the user wants an audit. Ask for missing decisions, but keep it to these three:
+## Default Path
 
-| Decision | Options |
+If the scope is clear, start immediately:
+
+1. Resolve the scope.
+   - Package: `SAPRead(type="DEVC", name="<package>")`
+   - Prefix/namespace: `SAPSearch` per relevant type (`PROG`, `CLAS`, `FUGR`, `FUNC`, `DDLS`, `BDEF`, `SRVD`, `TABL`)
+   - Object list: resolve ambiguous names with `SAPSearch`
+   - Local extract: parse the file and state that evidence is imported, not live ARC-1
+2. Build a small inventory: object, type, package, description, LOC when available, last change/version when available.
+3. Add migration signals:
+   - ATC: `SAPDiagnose(action="atc", type="<type>", name="<name>")`
+   - Clean-core/API risk: reuse `sap-clean-core-atc` logic
+   - Usage/retirement: reuse `sap-unused-code` only if SCMON/SUSG data is available
+   - Dependencies/where-used: `SAPContext` or `SAPNavigate(action="references")`
+4. Return a concise report with:
+   - headline counts
+   - highest-risk objects
+   - likely retirement candidates
+   - standard modification / enhancement hotspots
+   - top ATC/Clean Core themes
+   - clear evidence gaps
+   - suggested next action
+
+Ask only when required:
+- If no scope is provided, ask for a package, namespace/prefix, or object list.
+- If the scope is very large, ask whether to narrow it or save a file-based dossier.
+- If the user wants customer-facing decisions, ask whether to use a human-reviewed flow.
+
+## When To Escalate
+
+Use optional modes only when the user asks or the scope makes chat output impractical.
+
+| User asks for | Do this |
 |---|---|
-| Scope | package, recursive package, namespace/prefix, object list, uploaded/local extract |
-| Evidence depth | `standard` ARC-1 only, `deep` with governed `SAPQuery` tables, `reviewed` with draft cards and validation gate |
-| Output | chat only, local folder, Markdown, HTML, JSONL/CSV, Mermaid/Graphviz, static dashboard |
+| "save it", "share it", "dossier", "client report" | Create `docs/migration-dossiers/<scope>/<date>/` with `report.md` and optional `inventory.csv` |
+| "HTML", "PDF", "dashboard" | Generate a self-contained `report.html`; mention it can be printed to PDF |
+| "reviewed", "consultant validation", "not AI-only" | Create draft cards and include only validated/corrected cards in the final report |
+| "graph", "visualize", "dependency map" | Generate a bounded Mermaid graph for the top risk/high-fanout objects |
+| "deep ECC", "user exits", "BAdIs", "standard modifications" | Use deep evidence from `references/auditor-patterns.md`; only use `SAPQuery` when allowed |
+| "fix this" | Switch to `migrate-custom-code` for selected findings; this skill should not mass-remediate |
 
-If the user does not specify output and the scope has more than a few objects, recommend a local folder:
+## Output Shape
+
+For chat output, keep it short:
 
 ```
-docs/migration-dossiers/<scope-slug>/<YYYY-MM-DD>/
+Migration Dossier - <scope>
+
+Scope: <n> objects, <types>, <packages>
+Evidence: ATC=<variant/default>, usage=<SCMON/SUSG/unavailable>, clean-core=<source>, dependencies=<source>
+
+Summary:
+- <1-3 lines>
+
+Priority objects:
+| Object | Why it matters | Suggested action |
+
+Retirement candidates:
+| Object | Evidence | Caveat |
+
+Main risks:
+- <ATC/Clean Core/standard modification themes>
+
+Evidence gaps:
+- <missing usage data, skipped objects, dynamic calls, unavailable variants>
+
+Next step:
+- <one recommendation>
 ```
 
-## Evidence Profiles
+For file output, keep the default artifact set small:
 
-### Standard
+```
+docs/migration-dossiers/<scope>/<date>/
+  report.md
+  inventory.csv
+  methodology.md
+```
 
-Use existing ARC-1 read and analysis tools. This works without free SQL and is the default when the admin has not enabled SQL.
+Add `report.html`, `cards.jsonl`, `reviews.jsonl`, `graph.mmd`, or `dashboard.html` only when requested.
 
-Collect:
-- object inventory via `SAPRead(type="DEVC")` or `SAPSearch`
-- source/metadata via `SAPRead`
-- dependencies via `SAPContext` and `SAPNavigate(action="references")`
-- ATC findings via `SAPDiagnose(action="atc")`
-- API release state via `SAPRead(type="API_STATE")` or mcp-sap-docs when available
-- versions and transport history via `SAPRead(type="VERSIONS")` and `SAPTransport(action="history")`
+## Review Rules
 
-### Deep
+Use a human review gate only for customer-facing or decision-grade reports.
 
-Use only when the user wants ECC-style enhancement coverage and the ARC-1 server allows `SAP_ALLOW_FREE_SQL=true`. Check authorization and scope first; do not run unbounded system-wide queries.
-
-Add optional table evidence:
-- runtime usage from SCMON/SUSG using the `sap-unused-code` workflow
-- classic exits via `MODATTR`, `MODACT`, `MODSAP`, `TRDIR` for `ZX*` includes
-- classic BAdIs via `SXC_ATTR` / `SXC_EXIT` if present
-- standard modifications via `SMODILOG` / `SMODISRC`
-- cross-reference tables (`CROSS`, `WBCROSSGT`) only for narrowed object sets; prefer `SAPContext`/`SAPNavigate` first
-
-If any table is unavailable or forbidden, record the gap in `methodology.md` and continue with the standard profile.
-
-### Reviewed
-
-Use when the dossier will be customer-facing or used for planning decisions. Create draft assessment cards first; final reports must include only `validated` or `corrected` cards unless the user explicitly requests a draft report.
-
-Card status values:
+Statuses:
 
 ```
 ai_draft | validated | corrected | skipped | ai_error
 ```
 
-Decision enums:
+Classifications:
 
 ```
 REMOVE | KEEP | ADAPT | COVERED_BY_STANDARD | UNDETERMINED
 ```
 
-Keep clean-core level and unused-code status separate:
+Keep these separate from the decision:
 
 ```
 cleanCoreLevel: A | B | C | D | unknown
 usageStatus: USED | LIKELY_UNUSED | UNUSED | INDETERMINATE
 ```
 
-## Workflow
+Final reviewed reports must exclude `ai_draft` cards unless explicitly labeled as drafts.
 
-### 1. Bootstrap and Scope
-
-If `system-info.md` is absent and live ARC-1 access is available, run the `bootstrap-system-context` workflow first. Record SID, client, release, system type, HANA availability, feature flags, and whether ATC, transports, SCMON/SUSG, and free SQL are available.
-
-Resolve scope:
-- Package: `SAPRead(type="DEVC", name="<package>")`
-- Prefix: call `SAPSearch` per relevant type (`PROG`, `CLAS`, `FUGR`, `FUNC`, `DDLS`, `BDEF`, `SRVD`, `TABL`)
-- Object list: resolve each ambiguous item with `SAPSearch`
-- Local extract: parse the supplied JSON and mark evidence source as imported, not live ARC-1
-
-Stop and ask before auditing more than 100 objects unless the user explicitly chose a persistent dossier mode.
-
-### 2. Build the Inventory
-
-For each object, collect a compact inventory row:
-
-```
-id, type, name, package, description, loc, author, changedOn,
-sourceHash, hasSource, dynamicCallHints, transportHistory, versionInfo
-```
-
-Prefer ARC-1 source reads over raw table extraction. Use `SAPRead(type="CLAS", method="*")` for class APIs, `SAPRead(type="DDLS", include="elements")` for CDS fields, and `SAPRead(type="ENHO")` for enhancement metadata when object names are known.
-
-For local artifacts, write:
-
-```
-inventory.json
-inventory.csv
-methodology.md
-```
-
-### 3. Add Usage and Retirement Evidence
-
-Use the `sap-unused-code` workflow when SCMON/SUSG data is available. Otherwise, record `usageStatus=INDETERMINATE` and say which runtime source was missing.
-
-For each unused or likely-unused object, add static reference evidence:
-
-```
-SAPNavigate(action="references", type="<type>", name="<name>")
-```
-
-Do not recommend deletion solely from a zero-usage observation. State whether the measured source is SCMON, SUSG, ST03N, or unavailable.
-
-### 4. Add Migration and Clean-Core Evidence
-
-Run ATC per object or per manageable batch:
-
-```
-SAPDiagnose(action="atc", type="<type>", name="<name>", variant="<variant>")
-```
-
-Use `sap-clean-core-atc` logic for package-level Clean Core A-D rollups. Use `migrate-custom-code` only for selected objects or findings that the user wants to explain or remediate; do not attempt mass automated fixes as part of a dossier.
-
-Record per object:
-
-```
-atcPriority1, atcPriority2, atcPriority3,
-worstCleanCoreLevel, topViolations[], successorHints[]
-```
-
-### 5. Create Draft Assessment Cards
-
-Create cards for objects with migration relevance:
-- user exits / `ZX*` includes
-- BAdI implementations
-- enhancement implementations (`ENHO`)
-- standard modifications
-- high-risk Clean Core C/D objects
-- used objects with priority-1 ATC findings
-- unused large objects that might remove migration scope
-
-Each card must include bounded context:
-
-```
-object id, type, package, standard anchor if known,
-LOC, last change, usage evidence, dynamic-call flag,
-top dependencies/callers, ATC summary, clean-core level,
-source excerpt or full source if small
-```
-
-Draft assessments must be strict JSON-compatible records:
-
-```json
-{
-  "status": "ai_draft",
-  "classification": "REMOVE",
-  "effort": "S",
-  "confidence": 0.82,
-  "functionalSummary": "...",
-  "rationale": "...",
-  "risks": ["..."],
-  "questions": ["..."],
-  "evidenceRefs": ["inventory:ZCL_FOO", "atc:ZCL_FOO:1"]
-}
-```
-
-If confidence is low, source is truncated, usage is missing, or dynamic calls exist, lower confidence and add concrete customer questions.
-
-### 6. Review Gate
-
-If the user selected `reviewed`, write draft cards and ask for review decisions rather than publishing them as final.
-
-Supported review actions:
-- validate as-is
-- correct classification/effort/rationale
-- add note
-- skip
-
-For local artifacts, use append-only files where practical:
-
-```
-cards.jsonl
-reviews.jsonl
-review-summary.md
-```
-
-The final reviewed dossier includes only `validated` and `corrected` cards. If the user asks for a draft report, label it prominently as unreviewed and keep a separate filename such as `draft-report.html`.
-
-### 7. Generate Outputs
-
-Let the user choose one or more outputs:
-
-| Output | Use |
-|---|---|
-| `report.md` | editable consultant handoff |
-| `report.html` | self-contained executive dossier, printable to PDF |
-| `inventory.csv` / `cards.csv` | Excel, BI, or PMO planning |
-| `inventory.json` / `cards.jsonl` | reruns, review queues, integration |
-| `graph.mmd` | Mermaid dependency/risk visualization |
-| `dashboard.html` | local filtering/search without a server |
-
-Recommended report sections:
-1. Executive summary
-2. Scope and methodology
-3. Usage and retirement candidates
-4. Standard modifications / SPAU risk
-5. Clean-core level distribution
-6. ATC priority findings
-7. Reviewed migration cards
-8. Open questions and assumptions
-9. Integrity and evidence appendix
-
-Always declare evidence gaps: missing SCMON/SUSG, blocked SQL tables, unavailable ATC variants, incomplete cross-reference indexes, dynamic calls, generated source, and unreviewed cards.
-
-## Visualization
-
-When visualization is requested, generate a bounded graph rather than the whole system. Default to the top 50 high-risk or high-fanout nodes unless the user asks for more.
-
-Mermaid example:
-
-```mermaid
-flowchart LR
-  ZR_OLD_REPORT["ZR_OLD_REPORT<br/>UNUSED - P1=3"] --> ZCL_HELPER["ZCL_HELPER<br/>C"]
-  ZENH_EXIT["ZXVVFU02<br/>ADAPT - M"] --> SAPMV45A["SAPMV45A<br/>standard anchor"]
-```
-
-Use color classes for risk when emitting Mermaid or HTML:
-- red: standard modifications, Clean Core D, ATC P1
-- amber: ADAPT, Clean Core C, likely unused
-- green: REMOVE candidates with no runtime/static blockers
-- blue: KEEP / covered by standard
-
-## Safety Rules
+## Safety
 
 - Do not run unscoped system-wide extraction.
 - Do not use `SAPQuery` unless free SQL is enabled and the user chose deep evidence.
 - Do not treat zero ATC findings as clean if the object is `$TMP` or ATC skipped it.
 - Do not delete, update, activate, or transport objects from this skill.
 - Do not publish AI-only assessments as final decisions unless explicitly labeled draft.
-- Preserve SAP authorization and ARC-1 server safety ceilings; gaps are report findings, not reasons to bypass controls.
+- State evidence gaps plainly instead of filling them with assumptions.

--- a/skills/sap-migration-dossier/agents/openai.yaml
+++ b/skills/sap-migration-dossier/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SAP Migration Dossier"
+  short_description: "Create reviewed S/4HANA migration dossiers."
+  default_prompt: "Use $sap-migration-dossier to create a migration-readiness dossier for this SAP custom-code scope."

--- a/skills/sap-migration-dossier/references/auditor-patterns.md
+++ b/skills/sap-migration-dossier/references/auditor-patterns.md
@@ -128,11 +128,52 @@ Usage:
 - prefer SCMON/SUSG from `sap-unused-code`
 - ST03N-style aggregates are weaker evidence; label them as aggregate usage, not per-object proof
 
+## SAP Docs MCP Tool Map
+
+The SAP Docs MCP server is optional for running the dossier, but strongly recommended for better migration decisions. Tool namespaces vary by client; use the tool with the matching function name when available.
+
+| Tool | Use in a migration dossier | When to skip |
+|---|---|---|
+| `sap_get_object_details` | Classify SAP references by release state and Clean Core level; find successor objects for deprecated/internal APIs | Skip for custom Z/Y objects; use ARC-1 metadata instead |
+| `search` | Find official/reference docs for ATC themes, RAP/ABAP Cloud patterns, simplification guidance, and replacement APIs | Skip broad generic queries; query only top themes or uncertain decisions |
+| `fetch` | Retrieve full content for search results actually used in the rationale | Skip low-ranked or merely interesting results |
+| `abap_feature_matrix` | Check whether ABAP syntax/features are available in the target release | Skip when the target release is unknown; first record it as a methodology gap |
+| `sap_community_search` | Troubleshoot exact errors or obscure migration symptoms after official docs are insufficient | Skip for normal architecture decisions; community content is supporting evidence |
+| `sap_discovery_center_service` | Assess BTP service feasibility, pricing, and roadmap when a replacement implies SAP BTP services | Skip for pure ABAP code audits with no BTP service decision |
+
+Older connector variants may expose equivalent tools as `_search`, `_fetch`, `_sap_docs_search`, `_sap_docs_get`, `_sap_help_search`, or `_sap_help_get`. Prefer the richer `search` / `fetch` / `sap_get_object_details` / `abap_feature_matrix` set when present.
+
+Recommended usage:
+
+1. Extract SAP references from the audited custom objects.
+2. Call `sap_get_object_details` for unique SAP APIs that drive risk, not for every trivial reference.
+3. Use `search(includeSamples=false)` for official/reference guidance on top ATC themes and replacement strategy.
+4. Use `fetch` only for results cited in the report.
+5. Use `abap_feature_matrix` for release-sensitive remediation proposals.
+6. Use `sap_community_search` only for exact errors, niche symptoms, or workaround research.
+
+Suggested queries:
+
+```
+search(query="<ATC check title> S/4HANA migration", includeSamples=false, abapFlavor="<cloud|standard>")
+search(query="<deprecated API> successor released API", includeSamples=false, abapFlavor="<cloud|standard>")
+search(query="ABAP Cloud released API replacement <object>", includeSamples=false, abapFlavor="cloud")
+abap_feature_matrix(query="<ABAP feature>")
+sap_community_search(query="<exact error text or obscure symptom>")
+```
+
+Report evidence source labels:
+- `docs=sap_get_object_details` when Clean Core levels or successors came from SAP Docs MCP
+- `docs=search/fetch` when rationale cites documentation
+- `docs=unavailable` when SAP Docs MCP is not connected
+- `docs=not-used` when the scope did not require external documentation
+
 ## Report Quality Rules
 
 - Put reviewed/corrected evidence before generated rationale.
 - Exclude `ai_draft` cards from final reports unless the file is explicitly a draft.
 - Show pending review counts on the cover or executive summary.
 - Separate retirement candidates from migration-remediation candidates.
+- Separate SAP Docs evidence from ARC-1 live-system evidence; one is documentation/release-state context, the other is observed system state.
 - Keep top-level decision labels stable; put nuance in rationale and questions.
 - Include customer questions when evidence is incomplete instead of inventing migration conclusions.

--- a/skills/sap-migration-dossier/references/auditor-patterns.md
+++ b/skills/sap-migration-dossier/references/auditor-patterns.md
@@ -1,0 +1,138 @@
+# Auditor Patterns
+
+Use these patterns when a user wants a full migration-readiness dossier, persistent artifacts, review workflow, imported extractor data, or visual output. They are distilled from the `sergio-gracia/ecc-s4h-migrator-auditor` repository and adapted to ARC-1's governed MCP model.
+
+## What To Borrow
+
+| Pattern | Why it matters | ARC-1 adaptation |
+|---|---|---|
+| Versioned extract schema | Makes reruns and imported evidence reproducible | Write `inventory.json` with `schemaVersion`, `system`, `scope`, `generatedAt`, and `evidenceSources` |
+| Node/edge/source model | Separates inventory, graph, and source text | Keep `inventory.json`, `graph.json`, and optional source mirror separate |
+| Bounded LLM cards | Prevents huge prompts and hidden assumptions | Cap source context, summarize dependencies, flag truncation |
+| Strict enums | Makes review/report aggregation reliable | Use fixed `classification`, `effort`, `status`, `usageStatus`, and `cleanCoreLevel` values |
+| Human review state | Keeps AI drafts out of customer-facing decisions | Use `cards.jsonl` + `reviews.jsonl`; final report includes only validated/corrected cards |
+| Integrity seal | Helps prove the report matches extracted source | Hash source bodies or source excerpts and report match/missing counts |
+| Declared limits | Makes the dossier honest | Always list missing runtime data, dynamic calls, skipped objects, and unavailable APIs |
+
+## Suggested Local Artifact Layout
+
+```
+docs/migration-dossiers/<scope>/<YYYY-MM-DD>/
+  system-info.md
+  methodology.md
+  inventory.json
+  inventory.csv
+  graph.json
+  graph.mmd
+  atc-findings.json
+  usage.json
+  cards.jsonl
+  reviews.jsonl
+  review-summary.md
+  report.md
+  report.html
+  dashboard.html
+  skipped.md
+```
+
+Write only the files needed for the user's chosen output. For chat-only reports, do not create this folder.
+
+## Minimal Schemas
+
+Inventory record:
+
+```json
+{
+  "schemaVersion": "arc1-migration-dossier/1",
+  "object": {"id": "CLAS:ZCL_FOO", "type": "CLAS", "name": "ZCL_FOO"},
+  "package": "ZPKG",
+  "description": "",
+  "loc": 0,
+  "changedOn": null,
+  "sourceHash": null,
+  "evidence": {
+    "source": "SAPRead",
+    "usage": "SUSG",
+    "dependencies": "SAPContext",
+    "atc": "SAPDiagnose"
+  },
+  "flags": {
+    "dynamicCalls": false,
+    "sourceTruncated": false,
+    "generated": false
+  }
+}
+```
+
+Card record:
+
+```json
+{
+  "schemaVersion": "arc1-migration-card/1",
+  "id": "card:CLAS:ZCL_FOO",
+  "objectId": "CLAS:ZCL_FOO",
+  "status": "ai_draft",
+  "classification": "ADAPT",
+  "effort": "M",
+  "confidence": 0.74,
+  "functionalSummary": "",
+  "rationale": "",
+  "risks": [],
+  "questions": [],
+  "evidenceRefs": []
+}
+```
+
+Review record:
+
+```json
+{
+  "cardId": "card:CLAS:ZCL_FOO",
+  "action": "validated",
+  "reviewer": "consultant",
+  "reviewedAt": "2026-06-20T00:00:00Z",
+  "correctedClassification": null,
+  "correctedEffort": null,
+  "note": ""
+}
+```
+
+## ECC Enhancement Inventory Hints
+
+Prefer ARC-1 tools where available. Use table reads only in deep evidence mode.
+
+Classic user exits:
+- CMOD projects: `MODATTR`
+- project to enhancement assignment: `MODACT`
+- enhancement components: `MODSAP`
+- customer include source: `TRDIR` names like `ZX*`, then `SAPRead(type="INCL")`
+
+Classic BAdIs:
+- implementation metadata often lives in `SXC_ATTR` / `SXC_EXIT`
+- release-specific fields vary; query failures are methodology gaps
+
+Enhancement framework:
+- use `SAPRead(type="ENHO")` when names are known
+- package inventory may reveal `ENHO` / `ENHS` entries
+
+Standard modifications:
+- `SMODILOG` indicates modified standard objects
+- `SMODISRC` can hint volume
+- treat every standard modification as SPAU-relevant effort
+
+Cross references:
+- prefer `SAPContext` and `SAPNavigate(action="references")`
+- `CROSS` and `WBCROSSGT` are optional fallback evidence and can be stale
+
+Usage:
+- prefer SCMON/SUSG from `sap-unused-code`
+- ST03N-style aggregates are weaker evidence; label them as aggregate usage, not per-object proof
+
+## Report Quality Rules
+
+- Put reviewed/corrected evidence before generated rationale.
+- Exclude `ai_draft` cards from final reports unless the file is explicitly a draft.
+- Show pending review counts on the cover or executive summary.
+- Separate retirement candidates from migration-remediation candidates.
+- Keep top-level decision labels stable; put nuance in rationale and questions.
+- Include customer questions when evidence is incomplete instead of inventing migration conclusions.

--- a/skills/sap-object-documenter/SKILL.md
+++ b/skills/sap-object-documenter/SKILL.md
@@ -191,6 +191,7 @@ Longest objects (may need deeper docs):
 - "Want to expand any of these into deeper explanations?" (→ [explain-abap-code](../explain-abap-code/SKILL.md))
 - "Want to check clean-core readiness for this package?" (→ [sap-clean-core-atc](../sap-clean-core-atc/SKILL.md))
 - "Want to prune the dead ones first?" (→ [sap-unused-code](../sap-unused-code/SKILL.md))
+- "Want to package documentation, usage, ATC, and review cards into a migration dossier?" (→ [sap-migration-dossier](../sap-migration-dossier/SKILL.md))
 
 ## Error Handling
 

--- a/skills/sap-unused-code/SKILL.md
+++ b/skills/sap-unused-code/SKILL.md
@@ -257,6 +257,7 @@ A LIKELY_UNUSED object whose callers are all UNUSED is transitively deletable. O
 - "Want to see the static reference graph as a tree?" (→ chained `SAPNavigate where-used`)
 - "Want to clean-core-check the USED objects before worrying about unused ones?" (→ [sap-clean-core-atc](../sap-clean-core-atc/SKILL.md))
 - "Want documentation for the USED objects?" (→ [sap-object-documenter](../sap-object-documenter/SKILL.md))
+- "Want to turn this into a reviewed S/4HANA migration dossier with HTML/CSV/graph outputs?" (→ [sap-migration-dossier](../sap-migration-dossier/SKILL.md))
 - "Want to start deleting UNUSED objects?" → Manual: this skill **does not delete anything**; the user does it via `SAPWrite` or a transport
 
 ## Error Handling


### PR DESCRIPTION
## Summary

- Add `sap-migration-dossier`, a package/namespace-level orchestration skill for ECC to S/4HANA custom-code migration audits.
- Keep the default workflow lightweight: scoped inventory, ATC/Clean Core/usage/dependency evidence, a concise chat dossier, and one recommended next step.
- Add optional escalation paths for saved dossiers, Markdown/HTML, CSV/JSON, Mermaid graphs, static dashboards, and human-reviewed assessment cards when the user wants deeper output.
- Capture advanced auditor patterns in `references/auditor-patterns.md`, including node/edge/source evidence, review states, integrity hashes, ECC enhancement inventory hints, and SAP Docs MCP tool usage.
- Cross-link the new skill from adjacent migration, clean-core, unused-code, and object-documentation skills.

## SAP Docs MCP

The skill treats SAP Docs MCP as strongly recommended but optional:

- `sap_get_object_details` for Clean Core/API release state and successor APIs
- `search` / `fetch` for official migration guidance and top ATC themes
- `abap_feature_matrix` for release-sensitive syntax
- `sap_community_search` only for exact errors or workarounds
- `sap_discovery_center_service` when a BTP service decision is involved

When SAP Docs MCP is unavailable, the skill still runs with ARC-1 evidence and records that as an evidence gap.

## Validation

- `python3 /Users/marianzeis/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/sap-migration-dossier`
- `for f in skills/*/SKILL.md; do d=${f%/SKILL.md}; python3 /Users/marianzeis/.codex/skills/.system/skill-creator/scripts/quick_validate.py "$d"; done`
- `git diff --check`

No TypeScript test suite was run because this change is limited to skill/docs content.
