### PR TITLE
docs: surface stable ARC1_DCR_SIGNING_SECRET as a deploy best practice

### DIFF
--- a/docs_page/btp-cloud-foundry-deployment.md
+++ b/docs_page/btp-cloud-foundry-deployment.md
@@ -160,6 +160,16 @@ cf set-env arc1-mcp-server SAP_CLIENT "001"
 cf restage arc1-mcp-server
 ```
 
+**Set a stable DCR signing secret (XSUAA OAuth instances).** With `SAP_XSUAA_AUTH=true`, the DCR signing key defaults to the XSUAA `clientsecret`, which `cf deploy` rotates — invalidating every cached MCP `client_id` and forcing all users to re-register (`invalid_client`). Set a dedicated, stable secret so logins survive redeploys:
+
+```bash
+cf set-env arc1-mcp-server ARC1_DCR_SIGNING_SECRET "$(openssl rand -base64 48)"
+cf set-env arc1-mcp-server ARC1_OAUTH_DCR_TTL_SECONDS 0   # for clients that don't auto-re-register (Eclipse Copilot, Cursor)
+cf restage arc1-mcp-server
+```
+
+Why it matters, plus how to recover a client that's already stuck: [Stable DCR signing key](xsuaa-setup.md#stable-dcr-signing-key-recommended).
+
 The base `mta.yaml` already configures these properties (override any of them via `mta-overrides.mtaext`):
 - `SAP_TRANSPORT: http-streamable` — HTTP transport for MCP
 - `SAP_BTP_DESTINATION` / `SAP_BTP_PP_DESTINATION` — placeholders, MUST be overridden
@@ -317,9 +327,16 @@ cf push
 # Optional API key for break-glass/admin testing
 cf set-env arc1-mcp-server ARC1_API_KEYS "your-secure-api-key:admin"
 
+# Stable DCR signing secret — keeps MCP client logins valid across redeploys.
+# Without it the key derives from the XSUAA clientsecret, which cf deploy rotates → invalid_client.
+cf set-env arc1-mcp-server ARC1_DCR_SIGNING_SECRET "$(openssl rand -base64 48)"
+cf set-env arc1-mcp-server ARC1_OAUTH_DCR_TTL_SECONDS 0   # for clients that don't auto-re-register (Eclipse Copilot, Cursor)
+
 # Restart to apply
 cf restart arc1-mcp-server
 ```
+
+See [Stable DCR signing key](xsuaa-setup.md#stable-dcr-signing-key-recommended) for why this matters and how to recover a client that's already stuck.
 
 For normal BTP-native deployments, `SAP_XSUAA_AUTH=true` in the manifest/MTA properties is the MCP authentication path. XSUAA uses the subaccount trust setup, which may show SAP Cloud Identity Services, SAP ID service, or a federated corporate IdP depending on your BTP trust configuration. Generic OIDC (`SAP_OIDC_ISSUER` / `SAP_OIDC_AUDIENCE`) is still supported for non-BTP identity-provider setups, but it is not required for XSUAA deployments.
 

--- a/docs_page/deployment-best-practices.md
+++ b/docs_page/deployment-best-practices.md
@@ -221,6 +221,7 @@ applications:
 7. **Set `SAP_SYSTEM_TYPE`** explicitly in production — ensures correct tool definitions from startup
 8. **Set `SAP_INSECURE=false` on CA-signed landscapes** — the tracked `mta.yaml` / `manifest.yml` ship `"true"` for the on-prem HTTP Cloud Connector path; on a TLS landscape it silently disables certificate verification (no startup warning)
 9. **Set `ARC1_RATE_LIMIT` (e.g. `60`) on multi-user instances** — the per-user MCP quota is off by default, so one runaway agent loop can saturate the shared SAP request semaphore
+10. **Set a stable `ARC1_DCR_SIGNING_SECRET` on XSUAA OAuth instances** — otherwise the DCR signing key derives from the XSUAA `clientsecret`, so every `cf deploy` that recreates the service binding rotates it and invalidates all cached MCP `client_id`s. Users then hit `invalid_client` after each redeploy, and some clients (Eclipse Copilot, Cursor) can't recover without manual cache surgery. Set it once with `cf set-env arc1-mcp-server ARC1_DCR_SIGNING_SECRET "$(openssl rand -base64 48)"`; see [Stable DCR signing key](xsuaa-setup.md#stable-dcr-signing-key-recommended)
 
 !!! note "Why the package allowlist matters"
     ARC-1 feeds SAP-resident content (source, comments, errors) to the LLM, which then issues tool calls under the user's identity. `SAP_ALLOWED_PACKAGES` is the backstop that contains a prompt-injected model writing outside its scope — prefer a DEVCLASS subtree (`ZTEAM/**`) over `*` so the containment survives even a steered model.

--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -220,6 +220,8 @@ Properties:
 
 ARC-1 logs the active signing source as `dcrSigningSource: 'env' | 'xsuaa'` in the startup INFO line for observability — `'env'` means the dedicated `ARC1_DCR_SIGNING_SECRET` is in use, `'xsuaa'` means the legacy `clientsecret` fallback.
 
+**Why this is best practice.** A `client_id` issued via [RFC 7591 Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591) is only as durable as the key that signs it — in ARC-1's stateless design the signing key *is* the registration store. Tying that key to a credential that rotates on deploy (the XSUAA `clientsecret`) turns every redeploy into an unintended key rotation — the same failure mode a web framework hits when its session-signing key (Django `SECRET_KEY`, Rails `secret_key_base`) is regenerated per release: all previously-signed artifacts silently become invalid. The fix is the standard one for any signing key — externalize it from the deploy artifact and keep it stable across releases ([12-Factor Config](https://12factor.net/config)), rotating only when you intend to ([OWASP Secrets Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)).
+
 ### Service-binding rotation
 
 The XSUAA `clientsecret` is the trust anchor for both upstream OAuth calls and the DCR signing key. Rotating the binding is the only way to force-revoke every outstanding DCR registration in one shot:


### PR DESCRIPTION
## What

Promotes the stable `ARC1_DCR_SIGNING_SECRET` recommendation from XSUAA OAuth troubleshooting to the deployer-facing docs, and adds the rationale + external references for *why* a stable signing key is best practice.

## Why

Without a dedicated signing secret, the DCR signing key derives from the XSUAA `clientsecret`. Every `cf deploy` that recreates the service binding rotates it, invalidating all cached MCP `client_id`s — users hit `invalid_client` after each redeploy, and clients that don't auto-re-register (Eclipse GitHub Copilot, Cursor) can't recover without manual cache-file surgery.

Two community reports in #483 traced back to exactly this. The fix (`ARC1_DCR_SIGNING_SECRET` + `ARC1_OAUTH_DCR_TTL_SECONDS=0`) was already documented — but only under troubleshooting, so deployers discovered it *after* the breakage instead of avoiding it up front.

## Changes

- **deployment-best-practices.md** — new item in the Security Recommendations list
- **btp-cloud-foundry-deployment.md** — `cf set-env` step added to both deploy paths (MTA method 1 §3 and Docker method 2 §7)
- **xsuaa-setup.md** — a "Why this is best practice" note citing [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591), [12-Factor Config](https://12factor.net/config), and the [OWASP Secrets Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)

Canonical depth stays in the existing `xsuaa-setup.md#stable-dcr-signing-key-recommended` section; the deployer pages cross-link to it (no duplicated prose).

Docs-only (`docs:` → no release). `mkdocs build --strict` surfaces no new warnings for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
