### PR TITLE
fix: require auth for HTTP transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,10 @@ SAP_TRANSPORT=stdio              # or: http-streamable
 # Each profile maps to a scope set AND a partial SafetyConfig that INTERSECTS
 # the server ceiling (tight side wins field-by-field).
 # ARC1_API_KEYS=viewer-key-abc:viewer,dev-key-def:developer
+#
+# HTTP transport refuses to start without API key, OIDC, or XSUAA auth unless
+# this unsafe local/dev-only escape hatch is set explicitly.
+# ARC1_ALLOW_HTTP_NO_AUTH=false
 
 # ── OIDC (self-hosted IdP like Entra ID, Okta, etc.) ──
 # SAP_OIDC_ISSUER=https://login.microsoftonline.com/TENANT/v2.0

--- a/docs_page/cli-guide.md
+++ b/docs_page/cli-guide.md
@@ -53,7 +53,7 @@ Start the MCP server. This is the default command when no subcommand is given.
 arc1
 
 # HTTP Streamable transport (for VS Code, Copilot Studio)
-arc1 --transport http-streamable --http-addr 0.0.0.0:3000
+arc1 --transport http-streamable --http-addr 0.0.0.0:3000 --api-keys "my-secret-key:viewer"
 ```
 
 ### call

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -140,6 +140,7 @@ Set nothing. Stdio only. Anyone who can pipe stdin to the process is "authentica
 | Flag | Env var | Effect |
 |---|---|---|
 | `--api-keys` | `ARC1_API_KEYS` | Comma-separated `key:profile` pairs. Each profile maps to a scope set (read/write/data/sql/transports/git/admin) **and** a partial SafetyConfig intersected with the server ceiling. Valid profiles: `viewer`, `viewer-data`, `viewer-sql`, `developer`, `developer-data`, `developer-sql`, `admin`. Caller sends `Authorization: Bearer <key>` (or `X-API-Key: <key>`); ARC-1 looks the key up and applies that profile's scopes for the request. |
+| `--allow-http-no-auth` | `ARC1_ALLOW_HTTP_NO_AUTH` | Unsafe local/dev escape hatch. HTTP transport refuses to start without API key, OIDC, or XSUAA auth unless this is explicitly `true`. Never use on a network-reachable instance. |
 
 Full reference: [api-key-setup.md](api-key-setup.md). The single-key `ARC1_API_KEY` env var was removed in v0.7 — see [updating.md](updating.md#v07-authorization-refactor-breaking-change).
 

--- a/docs_page/security-guide.md
+++ b/docs_page/security-guide.md
@@ -291,7 +291,8 @@ When ARC-1 runs with `--transport http-streamable`, the default bind address is 
 
 - Always place ARC-1 behind a TLS-terminating reverse proxy or load balancer.
 - Restrict network access using firewall rules, security groups, or VPN.
-- Without `--api-keys`, `--oidc-issuer`, or `--xsuaa-auth`, the HTTP endpoint is open to anyone who can reach the port.
+- ARC-1 refuses to start HTTP transport without `--api-keys`, `--oidc-issuer`, or `--xsuaa-auth`
+  unless `ARC1_ALLOW_HTTP_NO_AUTH=true` / `--allow-http-no-auth true` is set explicitly for local/dev use.
 
 ### HTTP Security Headers (helmet)
 

--- a/scripts/e2e-server-start.sh
+++ b/scripts/e2e-server-start.sh
@@ -57,6 +57,7 @@ SAP_PASSWORD=$(cat "${DEPLOY_DIR}/.sap_password") \
 SAP_CLIENT="${SAP_CLIENT:-001}" \
 SAP_INSECURE=true \
 SAP_TRANSPORT=http-streamable \
+ARC1_ALLOW_HTTP_NO_AUTH=true \
 SAP_HTTP_ADDR="0.0.0.0:${MCP_PORT}" \
 SAP_VERBOSE=true \
 SAP_ALLOW_WRITES=true \

--- a/scripts/e2e-start-local.sh
+++ b/scripts/e2e-start-local.sh
@@ -78,6 +78,7 @@ echo "-- Starting MCP server..."
 
 SAP_TRANSPORT=http-streamable \
 ARC1_PORT="${MCP_PORT}" \
+ARC1_ALLOW_HTTP_NO_AUTH=true \
 SAP_INSECURE=true \
 SAP_ALLOW_WRITES=true \
 SAP_ALLOW_DATA_PREVIEW=true \

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -481,6 +481,7 @@ export function resolveConfig(args: string[]): { config: ServerConfig; sources: 
     config.oidcClockTolerance = Number.isNaN(parsed) ? undefined : parsed;
   }
   config.xsuaaAuth = resolveBool('xsuaa-auth', 'SAP_XSUAA_AUTH', false, 'xsuaaAuth');
+  config.allowHttpNoAuth = resolveBool('allow-http-no-auth', 'ARC1_ALLOW_HTTP_NO_AUTH', false, 'allowHttpNoAuth');
 
   // OAuth DCR client_id lifetime. Default: 30 days (matches typical
   // refresh-token lifetimes). Positive values are clamped to [60s, 90d] so
@@ -696,6 +697,14 @@ export function validateConfig(config: ServerConfig): void {
   if (config.ppStrict && !config.ppEnabled) {
     throw new Error(
       'SAP_PP_STRICT=true requires SAP_PP_ENABLED=true — strict mode has no effect without principal propagation enabled',
+    );
+  }
+
+  const hasHttpAuth = !!(config.apiKeys?.length || config.oidcIssuer || config.xsuaaAuth);
+  if (config.transport === 'http-streamable' && !hasHttpAuth && !config.allowHttpNoAuth) {
+    throw new Error(
+      'HTTP transport requires ARC-1 authentication. Set ARC1_API_KEYS, SAP_OIDC_ISSUER/SAP_OIDC_AUDIENCE, or SAP_XSUAA_AUTH=true. ' +
+        'For local/dev-only unauthenticated HTTP, set ARC1_ALLOW_HTTP_NO_AUTH=true explicitly.',
     );
   }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -82,6 +82,8 @@ export interface ServerConfig {
   /** Clock tolerance in seconds for JWT exp/nbf validation (default: 0 — no tolerance) */
   oidcClockTolerance?: number;
   xsuaaAuth: boolean;
+  /** Explicit unsafe opt-in for HTTP `/mcp` without API-key, OIDC, or XSUAA auth. */
+  allowHttpNoAuth: boolean;
 
   /**
    * Lifetime of an OAuth DCR registration (`client_id`) in seconds.
@@ -240,6 +242,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   featureFlp: 'auto',
   systemType: 'auto',
   xsuaaAuth: false,
+  allowHttpNoAuth: false,
   oauthDcrTtlSeconds: 30 * 24 * 60 * 60, // 30 days; set to 0 to disable expiration
   btpOAuthCallbackPort: 0,
   ppEnabled: false,

--- a/tests/unit/server/config.test.ts
+++ b/tests/unit/server/config.test.ts
@@ -113,9 +113,16 @@ describe('parseArgs', () => {
     expect(config.allowGitWrites).toBe(true);
   });
 
-  it('parses transport type', () => {
-    const config = parseArgs(['--transport', 'http-streamable']);
+  it('parses transport type with explicit no-auth opt-in', () => {
+    const config = parseArgs(['--transport', 'http-streamable', '--allow-http-no-auth', 'true']);
     expect(config.transport).toBe('http-streamable');
+    expect(config.allowHttpNoAuth).toBe(true);
+  });
+
+  it('parses ARC1_ALLOW_HTTP_NO_AUTH env var', () => {
+    process.env.ARC1_ALLOW_HTTP_NO_AUTH = 'true';
+    const config = parseArgs(['--transport', 'http-streamable']);
+    expect(config.allowHttpNoAuth).toBe(true);
   });
 
   it('defaults unknown transport to stdio', () => {
@@ -230,7 +237,7 @@ describe('parseArgs', () => {
   });
 
   it('rejects web UI mode without HTTP authentication', () => {
-    expect(() => parseArgs(['--transport', 'http-streamable', '--ui', 'web'])).toThrow(
+    expect(() => parseArgs(['--transport', 'http-streamable', '--allow-http-no-auth', 'true', '--ui', 'web'])).toThrow(
       /ARC1_UI=web requires HTTP authentication/,
     );
   });
@@ -1089,12 +1096,42 @@ describe('validateConfig', () => {
     expect(() => validateConfig({ ...DEFAULT_CONFIG, client: '' })).not.toThrow();
   });
 
+  it('throws when HTTP transport has no authentication and no explicit unsafe opt-in', () => {
+    expect(() =>
+      validateConfig({
+        ...DEFAULT_CONFIG,
+        transport: 'http-streamable',
+      }),
+    ).toThrow('HTTP transport requires ARC-1 authentication');
+  });
+
+  it('accepts HTTP transport without authentication only with explicit unsafe opt-in', () => {
+    expect(() =>
+      validateConfig({
+        ...DEFAULT_CONFIG,
+        transport: 'http-streamable',
+        allowHttpNoAuth: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts HTTP transport with API key authentication', () => {
+    expect(() =>
+      validateConfig({
+        ...DEFAULT_CONFIG,
+        transport: 'http-streamable',
+        apiKeys: [{ key: 'viewer-secret', profile: 'viewer' }],
+      }),
+    ).not.toThrow();
+  });
+
   it('throws when web UI is enabled without HTTP auth', () => {
     expect(() =>
       validateConfig({
         ...DEFAULT_CONFIG,
         transport: 'http-streamable',
         uiMode: 'web',
+        allowHttpNoAuth: true,
       }),
     ).toThrow('ARC1_UI=web requires HTTP authentication');
   });


### PR DESCRIPTION
## Goal

Close the P0 finding `arc1.http.open-mcp-no-auth`: HTTP transport could mount `/mcp` without any ARC-1 authentication when no API key, OIDC issuer, or XSUAA mode was configured.

## Root Cause

`http-streamable` startup did not fail closed when Layer A authentication was absent. Because the default HTTP bind address is `0.0.0.0:8080`, a direct or misconfigured deployment could expose MCP tool access to any network client that could reach the port.

## Changes

- Added `allowHttpNoAuth` / `ARC1_ALLOW_HTTP_NO_AUTH` / `--allow-http-no-auth` as an explicit unsafe local/dev escape hatch.
- Added startup validation that rejects HTTP transport without API key, OIDC, or XSUAA auth unless the escape hatch is set.
- Added config regression tests for the rejected unsafe default, the explicit opt-in path, and authenticated HTTP.
- Updated `.env.example` and HTTP/security docs so examples use authentication and describe the new fail-closed behavior.

## Security Impact

The original vulnerable configuration no longer starts by default. Operators must configure `ARC1_API_KEYS`, OIDC, or XSUAA for HTTP deployments, or intentionally acknowledge local/dev unauthenticated HTTP with `ARC1_ALLOW_HTTP_NO_AUTH=true`.

## Validation

- `npx vitest run tests/unit/server/config.test.ts` passed.
- `npm run typecheck` passed.
- `npm run lint` passed; Biome emitted existing schema-version informational messages only.
