### PR TITLE
fix: gate quickfix application as a write

### DIFF
--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -9,7 +9,7 @@
  */
 
 import { logger } from '../server/logger.js';
-import { AdtApiError } from './errors.js';
+import { AdtApiError, AdtSafetyError } from './errors.js';
 import type { AdtHttpClient } from './http.js';
 import { checkOperation, OperationType, type SafetyConfig } from './safety.js';
 import type {
@@ -669,6 +669,25 @@ export function supportsCdsTestCases(http: AdtHttpClient): boolean | undefined {
   return http.discoveryAcceptFor('/sap/bc/adt/aunit/dbtestdoubles/cds/testcases') !== undefined;
 }
 
+function assertQuickfixProposalUri(uri: string): void {
+  const quickfixProposalPrefix = '/sap/bc/adt/quickfixes/';
+  let parsed: URL;
+  try {
+    parsed = new URL(uri, 'https://arc1.invalid');
+  } catch {
+    throw new AdtSafetyError(`ApplyFixProposal refused invalid quickfix proposal URI: '${uri}'`);
+  }
+  if (
+    !uri.startsWith(quickfixProposalPrefix) ||
+    parsed.origin !== 'https://arc1.invalid' ||
+    !parsed.pathname.startsWith(quickfixProposalPrefix)
+  ) {
+    throw new AdtSafetyError(
+      `ApplyFixProposal refused non-quickfix proposal URI: '${uri}'. Use a proposal URI returned by SAPDiagnose(action="quickfix").`,
+    );
+  }
+}
+
 /** Get SAP quick fix proposals for a given source position */
 export async function getFixProposals(
   http: AdtHttpClient,
@@ -707,7 +726,8 @@ export async function applyFixProposal(
   line: number,
   column: number,
 ): Promise<FixDelta[]> {
-  checkOperation(safety, OperationType.Read, 'ApplyFixProposal');
+  checkOperation(safety, OperationType.Update, 'ApplyFixProposal');
+  assertQuickfixProposalUri(proposal.uri);
 
   const uriWithStart = `${sourceUri}#start=${line},${column}`;
   const userContent =

--- a/src/authz/policy.ts
+++ b/src/authz/policy.ts
@@ -142,7 +142,7 @@ export const ACTION_POLICY: Record<string, ActionPolicy> = {
   'SAPDiagnose.gateway_errors': { scope: 'read', opType: OperationType.Read },
   'SAPDiagnose.object_state': { scope: 'read', opType: OperationType.Read },
   'SAPDiagnose.quickfix': { scope: 'read', opType: OperationType.Read },
-  'SAPDiagnose.apply_quickfix': { scope: 'read', opType: OperationType.Read },
+  'SAPDiagnose.apply_quickfix': { scope: 'write', opType: OperationType.Update },
 
   // ── SAPTransport ─────────────────────────────────────────────────
   // CLASSIFICATION BUG FIX: check/history/list/get are reads; previously required write

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -66,8 +66,9 @@ const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
   SAPNavigate: { readOnlyHint: true },
   SAPQuery: { readOnlyHint: true },
   SAPContext: { readOnlyHint: true },
-  SAPDiagnose: { readOnlyHint: true },
   // Mutating, non-destructive (no delete action).
+  // SAPDiagnose.apply_quickfix is a write/Update action, so the tool is not read-only.
+  SAPDiagnose: { readOnlyHint: false, destructiveHint: false },
   SAPLint: { readOnlyHint: false, destructiveHint: false },
   SAPActivate: { readOnlyHint: false, destructiveHint: false },
   // Mutating AND destructive (delete / unlink / overwriting actions).

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -1426,7 +1426,8 @@
       ]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": false,
+      "destructiveHint": false
     }
   },
   {

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -480,7 +480,8 @@
       ]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": false,
+      "destructiveHint": false
     }
   },
   {

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -1451,7 +1451,8 @@
       ]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": false,
+      "destructiveHint": false
     }
   },
   {

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -1451,7 +1451,8 @@
       ]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": false,
+      "destructiveHint": false
     }
   },
   {

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -1451,7 +1451,8 @@
       ]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": false,
+      "destructiveHint": false
     }
   },
   {

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -1451,7 +1451,8 @@
       ]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": false,
+      "destructiveHint": false
     }
   },
   {

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -497,7 +497,8 @@
       ]
     },
     "annotations": {
-      "readOnlyHint": true
+      "readOnlyHint": false,
+      "destructiveHint": false
     }
   },
   {

--- a/tests/unit/adt/devtools.test.ts
+++ b/tests/unit/adt/devtools.test.ts
@@ -1553,6 +1553,94 @@ describe('DevTools', () => {
       expect((http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[3]).toEqual({ Accept: 'application/xml' });
     });
 
+    it('applyFixProposal requires write safety before posting', async () => {
+      const http = mockHttp('<quickfixes:applicationResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes"/>');
+      await expect(
+        applyFixProposal(
+          http,
+          defaultSafetyConfig(),
+          {
+            uri: '/sap/bc/adt/quickfixes/123',
+            type: 'quickfix/proposal',
+            name: 'Fix',
+            description: 'Fix',
+            userContent: 'opaque',
+          },
+          '/sap/bc/adt/programs/programs/ZTEST/source/main',
+          'REPORT ztest.',
+          1,
+          0,
+        ),
+      ).rejects.toThrow(AdtSafetyError);
+      expect(http.post).not.toHaveBeenCalled();
+    });
+
+    it('applyFixProposal rejects caller-controlled non-quickfix ADT URIs', async () => {
+      const http = mockHttp('<quickfixes:applicationResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes"/>');
+      await expect(
+        applyFixProposal(
+          http,
+          unrestrictedSafetyConfig(),
+          {
+            uri: '/sap/bc/adt/oo/classes/ZCL_TARGET/source/main',
+            type: 'quickfix/proposal',
+            name: 'Fix',
+            description: 'Fix',
+            userContent: 'opaque',
+          },
+          '/sap/bc/adt/programs/programs/ZTEST/source/main',
+          'REPORT ztest.',
+          1,
+          0,
+        ),
+      ).rejects.toThrow(/non-quickfix proposal URI/);
+      expect(http.post).not.toHaveBeenCalled();
+    });
+
+    it('applyFixProposal rejects absolute quickfix URIs', async () => {
+      const http = mockHttp('<quickfixes:applicationResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes"/>');
+      await expect(
+        applyFixProposal(
+          http,
+          unrestrictedSafetyConfig(),
+          {
+            uri: 'https://sap.example.test/sap/bc/adt/quickfixes/123',
+            type: 'quickfix/proposal',
+            name: 'Fix',
+            description: 'Fix',
+            userContent: 'opaque',
+          },
+          '/sap/bc/adt/programs/programs/ZTEST/source/main',
+          'REPORT ztest.',
+          1,
+          0,
+        ),
+      ).rejects.toThrow(/non-quickfix proposal URI/);
+      expect(http.post).not.toHaveBeenCalled();
+    });
+
+    it('applyFixProposal rejects protocol-relative quickfix URIs', async () => {
+      const http = mockHttp('<quickfixes:applicationResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes"/>');
+      await expect(
+        applyFixProposal(
+          http,
+          unrestrictedSafetyConfig(),
+          {
+            uri: '//arc1.invalid/sap/bc/adt/quickfixes/123',
+            type: 'quickfix/proposal',
+            name: 'Fix',
+            description: 'Fix',
+            userContent: 'opaque',
+          },
+          '/sap/bc/adt/programs/programs/ZTEST/source/main',
+          'REPORT ztest.',
+          1,
+          0,
+        ),
+      ).rejects.toThrow(/non-quickfix proposal URI/);
+      expect(http.post).not.toHaveBeenCalled();
+    });
+
     it('applyFixProposal includes userContent in request XML', async () => {
       const http = mockHttp('<quickfixes:applicationResult xmlns:quickfixes="http://www.sap.com/adt/quickfixes"/>');
       await applyFixProposal(

--- a/tests/unit/authz/policy.test.ts
+++ b/tests/unit/authz/policy.test.ts
@@ -115,6 +115,14 @@ describe('ACTION_POLICY matrix', () => {
     expect(hasRequiredScope(['read'], policy!.scope)).toBe(true);
   });
 
+  it('SAPDiagnose.apply_quickfix requires write scope', () => {
+    const policy = getActionPolicy('SAPDiagnose', 'apply_quickfix');
+    expect(policy?.scope).toBe('write');
+    expect(policy?.opType).toBe(OperationType.Update);
+    expect(hasRequiredScope(['read'], policy!.scope)).toBe(false);
+    expect(hasRequiredScope(['read', 'write'], policy!.scope)).toBe(true);
+  });
+
   it('hyperfocused mixed delegators are read-scoped; concrete sub-actions enforce mutations', () => {
     expect(getActionPolicy('SAP', 'transport')?.scope).toBe('read');
     expect(getActionPolicy('SAP', 'git')?.scope).toBe('read');

--- a/tests/unit/handlers/lint-diagnose.test.ts
+++ b/tests/unit/handlers/lint-diagnose.test.ts
@@ -15,6 +15,8 @@ import { createClient, mockFetch } from './setup-undici-mock.js';
 const { handleToolCall } = await import('../../../src/handlers/dispatch.js');
 const { resetCachedFeatures, setCachedFeatures } = await import('../../../src/handlers/feature-cache.js');
 
+const WRITE_CONFIG = { ...DEFAULT_CONFIG, allowWrites: true };
+
 function fetchedPathWithVersion(urls: string[], pathname: string, version: 'active' | 'inactive'): boolean {
   return urls.some((rawUrl) => {
     const url = new URL(rawUrl);
@@ -652,7 +654,7 @@ ENDCLASS.`;
         },
       );
 
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPDiagnose', {
+      const result = await handleToolCall(createClient(), WRITE_CONFIG, 'SAPDiagnose', {
         action: 'apply_quickfix',
         type: 'CLAS',
         name: 'ZCL_TEST',
@@ -701,7 +703,7 @@ ENDCLASS.`;
         },
       );
 
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPDiagnose', {
+      const result = await handleToolCall(createClient(), WRITE_CONFIG, 'SAPDiagnose', {
         action: 'apply_quickfix',
         type: 'CLAS',
         name: 'ZCL_TEST',
@@ -728,6 +730,24 @@ ENDCLASS.`;
       expect(applyCall?.body).toContain('<affectedObjects>');
       expect(applyCall?.body).toContain('adtcore:uri="/sap/bc/adt/oo/classes/ZCL_HELPER/source/main"');
       expect(applyCall?.body).toContain('<content>CLASS zcl_helper DEFINITION. ENDCLASS.</content>');
+    });
+
+    it('apply_quickfix action rejects non-quickfix proposal URIs before posting', async () => {
+      const result = await handleToolCall(createClient(), WRITE_CONFIG, 'SAPDiagnose', {
+        action: 'apply_quickfix',
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        source: 'CLASS zcl_test DEFINITION. ENDCLASS.',
+        line: 3,
+        proposalUri: '/sap/bc/adt/oo/classes/ZCL_TARGET/source/main',
+        proposalUserContent: 'opaque-state',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('refused non-quickfix proposal URI');
+      expect(mockFetch).not.toHaveBeenCalledWith(
+        expect.stringContaining('/sap/bc/adt/oo/classes/ZCL_TARGET'),
+        expect.anything(),
+      );
     });
 
     it('apply_quickfix action returns error when proposalUri is missing', async () => {

--- a/tests/unit/server/server.test.ts
+++ b/tests/unit/server/server.test.ts
@@ -90,6 +90,28 @@ describe('MCP Server', () => {
     expect(filtered.map((tool) => tool.name)).toContain('SAPWrite');
   });
 
+  it('prunes SAPDiagnose apply_quickfix for read-scoped users', () => {
+    const tools = getToolDefinitions({ ...DEFAULT_CONFIG, allowWrites: true });
+    const filtered = filterToolsByAuthScope(tools, ['read']);
+    const sapDiagnose = filtered.find((tool) => tool.name === 'SAPDiagnose');
+    expect(sapDiagnose).toBeDefined();
+    const schema = sapDiagnose!.inputSchema as Record<string, any>;
+    const actionEnum: string[] = schema.properties.action.enum;
+    expect(actionEnum).toContain('quickfix');
+    expect(actionEnum).not.toContain('apply_quickfix');
+  });
+
+  it('keeps SAPDiagnose apply_quickfix for write-scoped users', () => {
+    const tools = getToolDefinitions({ ...DEFAULT_CONFIG, allowWrites: true });
+    const filtered = filterToolsByAuthScope(tools, ['read', 'write']);
+    const sapDiagnose = filtered.find((tool) => tool.name === 'SAPDiagnose');
+    expect(sapDiagnose).toBeDefined();
+    const schema = sapDiagnose!.inputSchema as Record<string, any>;
+    const actionEnum: string[] = schema.properties.action.enum;
+    expect(actionEnum).toContain('quickfix');
+    expect(actionEnum).toContain('apply_quickfix');
+  });
+
   it('prunes hyperfocused SAP actions for read-scoped users', () => {
     const tools = getToolDefinitions({
       ...DEFAULT_CONFIG,


### PR DESCRIPTION
## Goal

Close the P0 finding `arc1.quickfix.read-scoped-post`: `SAPDiagnose.apply_quickfix` accepted a caller-controlled `proposalUri` and posted to it under read scope/safety.

## Root Cause

The policy classified `SAPDiagnose.apply_quickfix` as read/read even though the ADT helper performs an authenticated POST. The helper also accepted any caller-supplied ADT URI.

## Changes

- Reclassified `SAPDiagnose.apply_quickfix` as `write` / `OperationType.Update`.
- Changed `applyFixProposal` to require update/write safety before posting.
- Added a low-level URI guard that only accepts relative `/sap/bc/adt/quickfixes/...` proposal URIs and rejects arbitrary ADT paths, absolute URLs, and protocol-relative URLs.
- Added regression tests for policy scope, read-scoped tool pruning, write-scoped visibility, write-safety enforcement, accepted proposal POSTs, and URI rejection.

## Security Impact

The original read-scoped POST path no longer reproduces: read-scoped callers do not see the action in filtered tool listings, policy requires write scope, read-only safety blocks the helper, and non-quickfix `proposalUri` values are rejected before any SAP POST.

## Validation

- `npx vitest run tests/unit/adt/devtools.test.ts tests/unit/handlers/lint-diagnose.test.ts tests/unit/authz/policy.test.ts tests/unit/server/server.test.ts` passed.
- `npm run typecheck` passed.
- `npm run lint` passed; Biome emitted existing schema-version informational messages only.
