### PR TITLE
fix: enforce package allowlist for gCTS mutations

### DIFF
--- a/src/adt/gcts.ts
+++ b/src/adt/gcts.ts
@@ -105,6 +105,33 @@ function withRepoCredentials(payload: Record<string, unknown>, user?: string, pa
   };
 }
 
+function repoPackage(repo: GctsRepo): string | undefined {
+  return typeof repo.package === 'string' && repo.package.trim() ? repo.package.trim() : undefined;
+}
+
+function findRepoById(repos: GctsRepo[], repoId: string): GctsRepo | undefined {
+  return repos.find((repo) => repo.rid === repoId || repo.name === repoId);
+}
+
+async function enforceExistingRepoPackage(
+  http: AdtHttpClient,
+  safety: SafetyConfig,
+  repoId: string,
+  operation: string,
+  resolver?: PackageHierarchyResolver | null,
+): Promise<void> {
+  if (safety.allowedPackages.length === 0) return;
+
+  const repo = findRepoById(await listRepos(http, safety), repoId);
+  const pkg = repo ? repoPackage(repo) : undefined;
+  if (!pkg) {
+    throw new AdtSafetyError(
+      `${operation} could not resolve package for gCTS repository '${repoId}'; refusing to mutate because allowedPackages is configured.`,
+    );
+  }
+  await checkPackage(safety, pkg, resolver);
+}
+
 /** gCTS system status (/system). */
 export async function getSystemInfo(http: AdtHttpClient, safety: SafetyConfig): Promise<GctsSystemInfo> {
   checkOperation(safety, OperationType.Read, 'GctsGetSystemInfo');
@@ -208,9 +235,11 @@ export async function pullRepo(
   safety: SafetyConfig,
   repoId: string,
   commit?: string,
+  resolver?: PackageHierarchyResolver | null,
 ): Promise<Record<string, unknown>> {
   checkOperation(safety, OperationType.Update, 'GctsPullRepo');
   checkGit(safety, 'pull');
+  await enforceExistingRepoPackage(http, safety, repoId, 'GctsPullRepo', resolver);
 
   const path = `${GCTS_BASE}/repository/${encodeURIComponent(repoId)}/pullByCommit`;
   const resp = await requestGcts(path, () =>
@@ -230,9 +259,11 @@ export async function commitRepo(
   safety: SafetyConfig,
   repoId: string,
   params: GctsCommitParams,
+  resolver?: PackageHierarchyResolver | null,
 ): Promise<Record<string, unknown>> {
   checkOperation(safety, OperationType.Update, 'GctsCommitRepo');
   checkGit(safety, 'commit');
+  await enforceExistingRepoPackage(http, safety, repoId, 'GctsCommitRepo', resolver);
 
   const path = `${GCTS_BASE}/repository/${encodeURIComponent(repoId)}/commit`;
   const body = JSON.stringify({

--- a/src/adt/gcts.ts
+++ b/src/adt/gcts.ts
@@ -324,9 +324,13 @@ export async function switchBranch(
   safety: SafetyConfig,
   repoId: string,
   branch: string,
+  resolver?: PackageHierarchyResolver | null,
 ): Promise<Record<string, unknown>> {
   checkOperation(safety, OperationType.Update, 'GctsSwitchBranch');
   checkGit(safety, 'switch_branch');
+  // A checkout deserializes the branch's objects into the repo's server-bound package, just like a
+  // pull — gate it against the same allowlist so it cannot mutate a package outside the ceiling.
+  await enforceExistingRepoPackage(http, safety, repoId, 'GctsSwitchBranch', resolver);
 
   const path = `${GCTS_BASE}/repository/${encodeURIComponent(repoId)}/checkout/${encodeURIComponent(branch)}`;
   const resp = await requestGcts(path, () => http.post(path, JSON.stringify({}), JSON_CONTENT_TYPE, JSON_HEADERS));

--- a/src/handlers/git.ts
+++ b/src/handlers/git.ts
@@ -184,7 +184,13 @@ export async function handleSAPGit(
     case 'pull':
       if (!repoId) return errorResult('SAPGit(action="pull") requires repoId.');
       if (backend === 'gcts') {
-        result = await gctsPullRepo(client.http, client.safety, repoId, String(args.commit ?? '').trim() || undefined);
+        result = await gctsPullRepo(
+          client.http,
+          client.safety,
+          repoId,
+          String(args.commit ?? '').trim() || undefined,
+          client.getPackageHierarchyResolver(),
+        );
       } else {
         // R9: a pull deserializes remote content into the repo's server-bound package, which is
         // NOT the caller-supplied `package` (abapGit ignores that for an existing repo). Gate the
@@ -227,11 +233,17 @@ export async function handleSAPGit(
     }
     case 'commit':
       if (!repoId) return errorResult('SAPGit(action="commit") requires repoId.');
-      result = await gctsCommitRepo(client.http, client.safety, repoId, {
-        message: String(args.message ?? '').trim() || undefined,
-        description: String(args.description ?? '').trim() || undefined,
-        objects: Array.isArray(args.objects) ? (args.objects as Array<{ type?: string; name?: string }>) : undefined,
-      });
+      result = await gctsCommitRepo(
+        client.http,
+        client.safety,
+        repoId,
+        {
+          message: String(args.message ?? '').trim() || undefined,
+          description: String(args.description ?? '').trim() || undefined,
+          objects: Array.isArray(args.objects) ? (args.objects as Array<{ type?: string; name?: string }>) : undefined,
+        },
+        client.getPackageHierarchyResolver(),
+      );
       break;
     case 'switch_branch':
       if (!repoId || !branch) return errorResult('SAPGit(action="switch_branch") requires repoId and branch.');

--- a/src/handlers/git.ts
+++ b/src/handlers/git.ts
@@ -248,7 +248,13 @@ export async function handleSAPGit(
     case 'switch_branch':
       if (!repoId || !branch) return errorResult('SAPGit(action="switch_branch") requires repoId and branch.');
       if (backend === 'gcts') {
-        result = await gctsSwitchBranch(client.http, client.safety, repoId, branch);
+        result = await gctsSwitchBranch(
+          client.http,
+          client.safety,
+          repoId,
+          branch,
+          client.getPackageHierarchyResolver(),
+        );
       } else {
         await abapGitSwitchBranch(client.http, client.safety, repoId, branch, false);
         result = { ok: true };

--- a/tests/unit/adt/gcts.test.ts
+++ b/tests/unit/adt/gcts.test.ts
@@ -147,6 +147,56 @@ describe('gCTS client helpers', () => {
     );
   });
 
+  it('pullRepo enforces existing repository package allowlist before posting', async () => {
+    const http = mockHttp(loadFixture('gcts-repository.json'));
+    const safety = { ...gitSafety, allowedPackages: ['$TMP'] };
+
+    await expect(pullRepo(http, safety, 'ZARC1')).rejects.toThrow(AdtSafetyError);
+    expect(http.get).toHaveBeenCalledWith(
+      '/sap/bc/cts_abapvcs/repository',
+      expect.objectContaining({ Accept: 'application/json' }),
+    );
+    expect(http.post).not.toHaveBeenCalled();
+  });
+
+  it('pullRepo allows existing repository package that matches the allowlist', async () => {
+    const http = mockHttp(loadFixture('gcts-repository.json'));
+    const safety = { ...gitSafety, allowedPackages: ['ZARC1'] };
+
+    await expect(pullRepo(http, safety, 'ZARC1')).resolves.toBeDefined();
+    expect(http.post).toHaveBeenCalledTimes(1);
+    expect((http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toContain(
+      '/sap/bc/cts_abapvcs/repository/ZARC1/pullByCommit',
+    );
+  });
+
+  it('pullRepo fails closed when repository package metadata is unavailable', async () => {
+    const http = mockHttp('{"result":[{"rid":"ZARC1","name":"ZARC1"}]}');
+    const safety = { ...gitSafety, allowedPackages: ['ZARC1'] };
+
+    await expect(pullRepo(http, safety, 'ZARC1')).rejects.toThrow(/could not resolve package/);
+    expect(http.post).not.toHaveBeenCalled();
+  });
+
+  it('commitRepo enforces existing repository package allowlist before posting', async () => {
+    const http = mockHttp(loadFixture('gcts-repository.json'));
+    const safety = { ...gitSafety, allowedPackages: ['$TMP'] };
+
+    await expect(commitRepo(http, safety, 'ZARC1', { message: 'test' })).rejects.toThrow(AdtSafetyError);
+    expect(http.post).not.toHaveBeenCalled();
+  });
+
+  it('commitRepo allows existing repository package that matches the allowlist', async () => {
+    const http = mockHttp(loadFixture('gcts-repository.json'));
+    const safety = { ...gitSafety, allowedPackages: ['ZARC1'] };
+
+    await expect(commitRepo(http, safety, 'ZARC1', { message: 'test' })).resolves.toBeDefined();
+    expect(http.post).toHaveBeenCalledTimes(1);
+    expect((http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toContain(
+      '/sap/bc/cts_abapvcs/repository/ZARC1/commit',
+    );
+  });
+
   it('pullRepo surfaces 200/log ERROR payload as AdtApiError', async () => {
     const http = mockHttp(loadFixture('gcts-log-error.json'));
     await expect(pullRepo(http, gitSafety, 'ZARC1')).rejects.toThrow(AdtApiError);

--- a/tests/unit/adt/gcts.test.ts
+++ b/tests/unit/adt/gcts.test.ts
@@ -197,6 +197,25 @@ describe('gCTS client helpers', () => {
     );
   });
 
+  it('switchBranch enforces existing repository package allowlist before posting', async () => {
+    const http = mockHttp(loadFixture('gcts-repository.json'));
+    const safety = { ...gitSafety, allowedPackages: ['$TMP'] };
+
+    await expect(switchBranch(http, safety, 'ZARC1', 'feature')).rejects.toThrow(AdtSafetyError);
+    expect(http.post).not.toHaveBeenCalled();
+  });
+
+  it('switchBranch allows existing repository package that matches the allowlist', async () => {
+    const http = mockHttp(loadFixture('gcts-repository.json'));
+    const safety = { ...gitSafety, allowedPackages: ['ZARC1'] };
+
+    await expect(switchBranch(http, safety, 'ZARC1', 'feature')).resolves.toBeDefined();
+    expect(http.post).toHaveBeenCalledTimes(1);
+    expect((http.post as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toContain(
+      '/sap/bc/cts_abapvcs/repository/ZARC1/checkout/feature',
+    );
+  });
+
   it('pullRepo surfaces 200/log ERROR payload as AdtApiError', async () => {
     const http = mockHttp(loadFixture('gcts-log-error.json'));
     await expect(pullRepo(http, gitSafety, 'ZARC1')).rejects.toThrow(AdtApiError);


### PR DESCRIPTION
## Goal

Close the P0 gCTS package-allowlist bypass where `SAPGit(action="pull", backend="gcts")` and `SAPGit(action="commit", backend="gcts")` mutated an existing repository without checking the repository's server-bound ABAP package against `SAP_ALLOWED_PACKAGES`.

## Root Cause

`cloneRepo` checked the caller-provided package, but existing-repository mutations did not resolve repository metadata before POSTing to gCTS. That meant pull/commit could operate on a repo bound to a package outside the server safety ceiling.

## Plan Reviewed

- Resolve the existing gCTS repository from `/sap/bc/cts_abapvcs/repository` before mutating.
- Extract the repository's bound `package`, not a caller-supplied package value.
- Fail closed when `allowedPackages` is configured and the repository or package cannot be resolved.
- Reuse `checkPackage` so exact, wildcard, and subtree allowlist behavior remains centralized.
- Pass the existing package hierarchy resolver from the SAPGit handler so subtree rules keep working.

## Changes

- Added a shared gCTS existing-repository package gate for package-scoped mutations.
- Applied the gate to `pullRepo` and `commitRepo` before their POST calls.
- Wired `client.getPackageHierarchyResolver()` through the gCTS pull/commit handler paths.
- Added regression tests for denied pull, allowed pull, fail-closed missing metadata, denied commit, and allowed commit.

## Security Impact

A gCTS pull or commit can no longer bypass `SAP_ALLOWED_PACKAGES` by targeting an existing repo outside the allowlist. When the package binding is unavailable, the mutation is refused before any gCTS POST.

## Validation

- `npx vitest run tests/unit/adt/gcts.test.ts` passed.
- `npm run typecheck` passed.
- `npm run lint` passed; Biome emitted existing schema-version informational messages only.
