### PR TITLE
fix: default deployment descriptors to verified SAP TLS

### DIFF
--- a/docs/security-review-2026-06.md
+++ b/docs/security-review-2026-06.md
@@ -219,7 +219,7 @@ merged yet at time of writing.
 - **Operator caveats added (MkDocs admonitions), mitigating these register items at the operator
   level (the code fix remains open):**
   - **R6** — `SAP_PP_STRICT` privilege-escalation/audit-misattribution danger (PP docs, deployment, BTP CF).
-  - **R7 (TLS half)** — `SAP_INSECURE` disables TLS with no warning and ships `"true"` in the manifests.
+  - **R7 (TLS half)** — `SAP_INSECURE` disables TLS with no warning; at review time the manifests shipped `"true"`.
   - **R13** — PP per-user token isolation depends on `user_id`/`user_uuid` (OIDC/Entra caveat).
   - **R15** — `ARC1_CACHE=sqlite` stores SAP source cleartext at rest.
   - **R16** — BTP service key is a full credential; `.gitignore` doesn't match `*service-key*.json`.

--- a/docs_page/btp-cloud-foundry-deployment.md
+++ b/docs_page/btp-cloud-foundry-deployment.md
@@ -269,7 +269,7 @@ applications:
       SAP_URL: "http://a4h-abap:50000"
       SAP_CLIENT: "001"
       SAP_LANGUAGE: "EN"
-      SAP_INSECURE: "true"                     # TLS-off for the Cloud Connector HTTP host — set "false" on CA-signed landscapes
+      SAP_INSECURE: "false"                    # Keep TLS verification on when SAP_URL uses HTTPS
       # MCP transport (CF sets PORT env var automatically)
       SAP_TRANSPORT: "http-streamable"
       # BTP Destination Service — dual-destination pattern
@@ -291,7 +291,7 @@ applications:
     ARC-1 feeds SAP-resident content (source, comments, error text) to the LLM, which then issues the next tool calls under the user's identity — a poisoned ABAP comment is an attack vector. `SAP_ALLOW_WRITES=false` and a tight `SAP_ALLOWED_PACKAGES` are the controls that hold *regardless of what the model decides*. Enable writes / free SQL / `SAP_ALLOWED_PACKAGES=*` only when the landscape genuinely needs it.
 
 !!! warning "`SAP_INSECURE: \"true\"` disables SAP TLS verification"
-    The bundled templates ship `SAP_INSECURE: "true"` for the on-prem-via-HTTP Cloud Connector path. On a landscape with CA-signed certificates set it to `"false"` and supply the CA via `NODE_EXTRA_CA_CERTS` — it accepts *any* certificate otherwise, masking man-in-the-middle. ARC-1 prints no startup warning when verification is off.
+    The bundled templates ship `SAP_INSECURE: "false"`. Only set it `"true"` in isolated development when you deliberately accept any SAP certificate. For internal CAs, keep verification enabled and supply the CA via `NODE_EXTRA_CA_CERTS`.
 
 ### 5. Build and Push Docker Image
 

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -56,8 +56,8 @@ The bare minimum needed to reach a SAP system. None of these affect what tool ca
 
 ARC-1 uses [undici](https://github.com/nodejs/undici) for all SAP HTTP. It respects standard `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` env vars. For custom CA certificates, set `NODE_EXTRA_CA_CERTS=/path/to/ca.pem` (read by Node, not by ARC-1 directly). For Docker mounts of CA bundles, see [docker.md](docker.md#self-signed-or-internal-ca-certificates).
 
-!!! danger "`SAP_INSECURE` has no startup warning, and the repo's manifests ship it `\"true\"`"
-    `SAP_INSECURE=true` disables all SAP TLS verification — it accepts *any* certificate (masking man-in-the-middle), not just self-signed ones, and ARC-1 logs nothing when it is on. The bundled `manifest.yml` / `mta.yaml` set it `"true"` for the on-prem HTTP Cloud Connector path; set it `"false"` on CA-signed landscapes and use `NODE_EXTRA_CA_CERTS` for an internal CA instead.
+!!! danger "Avoid `SAP_INSECURE=true` outside isolated development"
+    `SAP_INSECURE=true` disables all SAP TLS verification — it accepts *any* certificate (masking man-in-the-middle), not just self-signed ones, and ARC-1 logs nothing when it is on. The bundled `manifest.yml` / `mta.yaml` keep it `"false"`; use `NODE_EXTRA_CA_CERTS` for an internal CA instead of disabling verification.
 
 ---
 

--- a/docs_page/deployment-best-practices.md
+++ b/docs_page/deployment-best-practices.md
@@ -219,7 +219,7 @@ applications:
 5. **Deploy separate instances per system** — limits blast radius
 6. **Use XSUAA auth for deployed instances** — proper OAuth 2.0 with scopes (read/write/data/sql/transports/git/admin)
 7. **Set `SAP_SYSTEM_TYPE`** explicitly in production — ensures correct tool definitions from startup
-8. **Set `SAP_INSECURE=false` on CA-signed landscapes** — the tracked `mta.yaml` / `manifest.yml` ship `"true"` for the on-prem HTTP Cloud Connector path; on a TLS landscape it silently disables certificate verification (no startup warning)
+8. **Keep `SAP_INSECURE=false` on CA-signed landscapes** — the tracked `mta.yaml` / `manifest.yml` ship `"false"`; only set it `"true"` in isolated development when you deliberately accept all SAP certificates
 9. **Set `ARC1_RATE_LIMIT` (e.g. `60`) on multi-user instances** — the per-user MCP quota is off by default, so one runaway agent loop can saturate the shared SAP request semaphore
 10. **Set a stable `ARC1_DCR_SIGNING_SECRET` on XSUAA OAuth instances** — otherwise the DCR signing key derives from the XSUAA `clientsecret`, so every `cf deploy` that recreates the service binding rotates it and invalidates all cached MCP `client_id`s. Users then hit `invalid_client` after each redeploy, and some clients (Eclipse Copilot, Cursor) can't recover without manual cache surgery. Set it once with `cf set-env arc1-mcp-server ARC1_DCR_SIGNING_SECRET "$(openssl rand -base64 48)"`; see [Stable DCR signing key](xsuaa-setup.md#stable-dcr-signing-key-recommended)
 
@@ -240,7 +240,7 @@ If you deploy ARC-1 behind a reverse proxy (nginx, Envoy, etc.) outside of Cloud
 
 | File | Purpose | Customize? |
 |------|---------|-----------|
-| `mta.yaml` | MTA build descriptor — services, conservative `SAP_ALLOW_*` defaults, **placeholder destinations**. Tracked. Ships `SAP_INSECURE: "true"` for the Cloud Connector HTTP path — override to `"false"` on CA-signed landscapes. | Rarely — use `.mtaext` for overrides |
+| `mta.yaml` | MTA build descriptor — services, conservative `SAP_ALLOW_*` defaults, **placeholder destinations**. Tracked. Ships `SAP_INSECURE: "false"`; prefer `NODE_EXTRA_CA_CERTS` for internal CAs over disabling verification. | Rarely — use `.mtaext` for overrides |
 | `mta-overrides.mtaext.example` | Tracked template documenting every overridable property. | No — copy it to `mta-overrides.mtaext` (gitignored) and edit that |
 | `mta-overrides.mtaext` (or any `mta-*.mtaext`) | Per-landscape MTA extension (real destinations, safety flags). **Gitignored.** | Yes — uncomment and set values for your environment |
 | `manifest.yml` | CF deployment manifest (on-premise via Cloud Connector) | Yes — change `SAP_URL`, destination name, safety flags |

--- a/docs_page/deployment.md
+++ b/docs_page/deployment.md
@@ -184,7 +184,7 @@ For any deployment visible to a network, before you open the gate:
 - [ ] `SAP_ALLOW_GIT_WRITES=false` unless you need gCTS/abapGit writes (reads are always allowed when the backends are available)
 - [ ] `SAP_PP_STRICT=true` if principal propagation is on — otherwise a PP failure silently runs as the shared service account (wrong identity + wrong SAP audit)
 - [ ] `ARC1_RATE_LIMIT` set (e.g. `60`) for multi-user instances — the per-user MCP quota is **off by default**, so one runaway agent loop can saturate the shared SAP request semaphore
-- [ ] `SAP_INSECURE=false` (the default) — the bundled `manifest.yml` / `mta.yaml` ship `"true"` for the Cloud Connector path; flip it on CA-signed landscapes
+- [ ] `SAP_INSECURE=false` (the default) — the bundled `manifest.yml` / `mta.yaml` ship `"false"`; keep it that way on CA-signed landscapes
 - [ ] If using cookies: `SAP_PP_ENABLED=true` and cookies both set? → refuses unless `SAP_PP_ALLOW_SHARED_COOKIES=true` escape hatch is explicit
 - [ ] Audit log sink configured (file or BTP Audit Log Service) — note the file/BTP sinks contain un-redacted SAP source/error snippets, so restrict their permissions and rotation
 - [ ] `ARC1_CACHE=memory`/`none` or an encrypted volume on IP-sensitive landscapes — the SQLite cache stores SAP source in cleartext at `.arc1-cache.db`

--- a/docs_page/docker.md
+++ b/docs_page/docker.md
@@ -530,8 +530,8 @@ when a new `ghcr.io/arc-mcp/arc-1` image tag is published.
 6. **Use `SAP_INSECURE=false` (the default).** Only set it to `true` in isolated
    development environments with no sensitive data — it disables SAP TLS
    verification entirely (any certificate accepted, MITM masked) with no startup
-   warning. Note the bundled `manifest.yml` / `mta.yaml` ship `"true"` for the
-   Cloud Connector path; flip them to `"false"` on CA-signed landscapes.
+   warning. The bundled `manifest.yml` / `mta.yaml` ship `"false"`; keep that
+   default on CA-signed landscapes.
 
 7. **The SQLite cache stores SAP source in cleartext.** In HTTP mode the cache
    defaults to `sqlite` at `.arc1-cache.db` (full ABAP source, unencrypted, default

--- a/manifest.yml
+++ b/manifest.yml
@@ -28,7 +28,7 @@ applications:
       SAP_URL: "http://a4h-abap:50000"
       SAP_CLIENT: "001"
       SAP_LANGUAGE: "EN"
-      SAP_INSECURE: "true"
+      SAP_INSECURE: "false"
       # System type (auto-detects, or set explicitly)
       SAP_SYSTEM_TYPE: "auto"
       # MCP transport (CF sets PORT env var automatically)

--- a/mta.yaml
+++ b/mta.yaml
@@ -96,7 +96,7 @@ modules:
       SAP_TRANSPORT: http-streamable
       SAP_SYSTEM_TYPE: auto
       SAP_LANGUAGE: EN
-      SAP_INSECURE: "true"
+      SAP_INSECURE: "false"
       SAP_XSUAA_AUTH: "true"
       # Destinations. The base values below are placeholders — every landscape
       # MUST override them via `mta-overrides.mtaext` (see the

--- a/tests/unit/plugin/plugin-manifest.test.ts
+++ b/tests/unit/plugin/plugin-manifest.test.ts
@@ -19,11 +19,16 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
 function readJson(rel: string): Record<string, any> {
   return JSON.parse(readFileSync(join(ROOT, rel), 'utf8'));
+}
+
+function readYaml(rel: string): Record<string, any> {
+  return parse(readFileSync(join(ROOT, rel), 'utf8')) as Record<string, any>;
 }
 
 const plugin = readJson('.claude-plugin/plugin.json');
@@ -177,6 +182,16 @@ describe('deployment templates', () => {
       const body = readFileSync(join(ROOT, rel), 'utf8');
       expect(body, rel).toContain('ARC1_UI: "off"');
     }
+  });
+
+  it('keep SAP TLS verification enabled by default in shipped CF descriptors', () => {
+    const mta = readYaml('mta.yaml');
+    const appModule = (mta.modules as Array<Record<string, any>>).find((entry) => entry.name === 'arc1-mcp-server');
+    expect(appModule?.properties?.SAP_INSECURE).toBe('false');
+
+    const manifest = readYaml('manifest.yml');
+    const app = (manifest.applications as Array<Record<string, any>>).find((entry) => entry.name === 'arc1-mcp-server');
+    expect(app?.env?.SAP_INSECURE).toBe('false');
   });
 });
 


### PR DESCRIPTION
## Goal

Close the P0 deployment hardening finding where the shipped Cloud Foundry descriptors set `SAP_INSECURE: "true"`, making copy-paste deployments silently disable SAP TLS certificate verification.

## Root Cause

The runtime default is `SAP_INSECURE=false`, but the committed `mta.yaml` and `manifest.yml` overrode that safe default with `"true"`. Several docs also described the unsafe descriptor value as expected.

## Plan Reviewed

- Change only shipped deployment descriptors, not runtime semantics.
- Set `SAP_INSECURE: "false"` in `mta.yaml` and `manifest.yml`.
- Update active deployment/config docs so operators are told to keep verification enabled and use `NODE_EXTRA_CA_CERTS` for internal CAs.
- Add a YAML-parsing regression test over the descriptors so the unsafe default cannot be reintroduced by text churn.

## Changes

- Changed `mta.yaml` and `manifest.yml` to ship `SAP_INSECURE: "false"`.
- Updated TLS guidance in configuration, Docker, deployment, deployment best practices, and BTP Cloud Foundry docs.
- Clarified the historical June security review note as historical wording.
- Extended `tests/unit/plugin/plugin-manifest.test.ts` to parse the shipped CF descriptors and assert `SAP_INSECURE` is `"false"`.

## Security Impact

Fresh deployments from the repository templates now preserve SAP TLS verification by default. Operators can still opt into `SAP_INSECURE=true` for isolated development, but production-like templates no longer copy an unsafe value into the environment.

## Validation

- `npx vitest run tests/unit/plugin/plugin-manifest.test.ts` passed.
- `npm run typecheck` passed.
- `npm run lint` passed; Biome emitted existing schema-version informational messages only.
