### PR TITLE
fix: redact audit events before sink writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Full per-option details (defaults, clamps, layer interactions): [docs_page/confi
 | `SAP_PP_ENABLED` / `SAP_PP_STRICT` / `SAP_PP_ALLOW_SHARED_COOKIES` | Principal propagation + strict mode + cookie-coexistence escape hatch |
 | `SAP_DISABLE_SAML` | Disable SAML redirect — never on BTP ABAP / S/4 Public Cloud |
 | `ARC1_PROFILE` | Safety profile shortcut (viewer…developer-sql) |
-| `ARC1_LOG_HTTP_DEBUG` | Full req/resp bodies in audit (redacted, truncated; not for prod) |
+| `ARC1_LOG_HTTP_DEBUG` | HTTP debug fields in audit; bodies are centrally redacted before sink writes |
 
 ## Codebase Structure
 

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -279,7 +279,7 @@ All ARC-1 logging goes to **stderr** to keep stdout clean for MCP JSON-RPC. Neve
 | `--log-level` | `ARC1_LOG_LEVEL` | `info` | One of `debug` / `info` / `warn` / `error`. Filters every log line, including the audit stream's structured entries. |
 | `--log-format` | `ARC1_LOG_FORMAT` | `text` | `text` (human-readable) or `json` (one JSON object per line — for shipping to ELK / Loki / CF log aggregator). |
 | `--verbose` | `SAP_VERBOSE` | `false` | Alias for `--log-level=debug`. Slightly older flag, kept for compatibility. |
-| — | `ARC1_LOG_HTTP_DEBUG` | `false` | When `"true"`, attaches the full HTTP request and response bodies + headers to `http_request` audit events. Sensitive headers (`Authorization`, `Cookie`, CSRF tokens) are redacted; bodies are truncated at 64 KB. **Do not enable in production** — increases log volume substantially and can leak business data in payloads. **Boolean parsing inconsistency:** unlike other booleans, this one accepts only the literal string `"true"` — `"1"` does **not** work. |
+| — | `ARC1_LOG_HTTP_DEBUG` | `false` | When `"true"`, captures HTTP request/response body fields and headers on `http_request` audit events. Sensitive headers (`Authorization`, `Cookie`, CSRF tokens) are redacted immediately; payload bodies are length-capped and centrally redacted before sink writes. **Do not enable in production** — it still increases log volume and records payload-size/timing metadata. **Boolean parsing inconsistency:** unlike other booleans, this one accepts only the literal string `"true"` — `"1"` does **not** work. |
 
 ---
 

--- a/docs_page/deployment.md
+++ b/docs_page/deployment.md
@@ -184,7 +184,7 @@ For any deployment visible to a network, before you open the gate:
 - [ ] `ARC1_RATE_LIMIT` set (e.g. `60`) for multi-user instances — the per-user MCP quota is **off by default**, so one runaway agent loop can saturate the shared SAP request semaphore
 - [ ] `SAP_INSECURE=false` (the default) — the bundled `manifest.yml` / `mta.yaml` ship `"true"` for the Cloud Connector path; flip it on CA-signed landscapes
 - [ ] If using cookies: `SAP_PP_ENABLED=true` and cookies both set? → refuses unless `SAP_PP_ALLOW_SHARED_COOKIES=true` escape hatch is explicit
-- [ ] Audit log sink configured (file or BTP Audit Log Service) — note the file/BTP sinks contain un-redacted SAP source/error snippets, so restrict their permissions and rotation
+- [ ] Audit log sink configured (file or BTP Audit Log Service) — payload bodies and result previews are centrally redacted, but logs still contain identities, paths, statuses, sizes, and timing metadata; restrict permissions and rotation
 - [ ] `ARC1_CACHE=memory`/`none` or an encrypted volume on IP-sensitive landscapes — the SQLite cache stores SAP source in cleartext at `.arc1-cache.db`
 - [ ] Image pinned to an exact version (for example `:0.9.20`), not `:latest` <!-- x-release-please-version -->
 - [ ] Update procedure rehearsed → [updating.md](updating.md)

--- a/docs_page/log-analysis.md
+++ b/docs_page/log-analysis.md
@@ -150,8 +150,8 @@ jq -s '[.[] | select(.event == "tool_call_end" and .status == "error")] | group_
 ### Bad/Wrong Tool Calls (for improving LLM feedback)
 
 ```bash
-# Tool calls with unknown types (LLM sent wrong type parameter)
-jq 'select(.event == "tool_call_end" and .status == "error" and (.errorMessage | contains("Unknown")))' arc1-audit.jsonl
+# Tool calls that returned client-visible handler errors (unknown tool/action, validation, etc.)
+jq 'select(.event == "tool_call_end" and .status == "error" and .errorClass == "result-path")' arc1-audit.jsonl
 
 # Tool calls blocked by safety (LLM tried a blocked operation)
 jq 'select(.event == "tool_call_end" and .errorClass == "AdtSafetyError")' arc1-audit.jsonl
@@ -159,8 +159,8 @@ jq 'select(.event == "tool_call_end" and .errorClass == "AdtSafetyError")' arc1-
 # Auth scope denials (LLM called a tool the user can't access)
 jq 'select(.event == "auth_scope_denied")' arc1-audit.jsonl
 
-# All error messages — useful to find patterns in LLM mistakes
-jq -s '[.[] | select(.event == "tool_call_end" and .status == "error") | .errorMessage] | group_by(.) | map({message: .[0], count: length}) | sort_by(-.count)' arc1-audit.jsonl
+# Error counts by class — errorMessage content is redacted before sink writes
+jq -s '[.[] | select(.event == "tool_call_end" and .status == "error") | .errorClass] | group_by(.) | map({errorClass: .[0], count: length}) | sort_by(-.count)' arc1-audit.jsonl
 ```
 
 ### Slow Operations
@@ -194,7 +194,7 @@ jq -s '[.[] | select(.event == "http_request")] | group_by(.requestId) | map({re
 # Failed HTTP requests (4xx/5xx)
 jq 'select(.event == "http_request" and .statusCode >= 400)' arc1-audit.jsonl
 
-# HTTP requests with error bodies (SAP error messages)
+# HTTP requests with redacted error-body placeholders
 jq 'select(.event == "http_request" and .errorBody != null)' arc1-audit.jsonl
 
 # Most common ADT paths called

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -59,9 +59,10 @@ export interface AdtRequestOptions {
  *
  * When ARC1_LOG_HTTP_DEBUG=true, every completed HTTP call to SAP ADT attaches
  * its request body, request headers, response body, and response headers to
- * the audit event. Sensitive headers are redacted; bodies are truncated at
- * 64KB. Intended for ad-hoc debugging of content negotiation, CSRF, and
- * activation preaudit responses — not for production.
+ * the audit event. Sensitive headers are redacted here, bodies are truncated at
+ * 64KB, and the central audit logger redacts payload bodies again before any sink
+ * write. Intended for ad-hoc debugging of content negotiation, CSRF, and
+ * activation preaudit response sizes — not for production.
  */
 const HTTP_DEBUG_BODY_LIMIT = 65536;
 const HTTP_DEBUG_REDACT_HEADERS = new Set([

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -241,23 +241,53 @@ export type AuditEvent =
   | AuthRateLimitedEvent
   | McpRateLimitedEvent;
 
+const SENSITIVE_KEY_FRAGMENTS = [
+  'password',
+  'token',
+  'secret',
+  'cookie',
+  'authorization',
+  'csrf',
+  'apikey',
+  'authpwd',
+  'authtoken',
+  'remotepassword',
+];
+
+const PAYLOAD_BODY_KEYS = new Set(['errorbody', 'errormessage', 'requestbody', 'responsebody', 'resultpreview']);
+
+function isSensitiveKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return SENSITIVE_KEY_FRAGMENTS.some((fragment) => lower.includes(fragment));
+}
+
+function redactPayloadValue(value: unknown): string {
+  if (typeof value === 'string') return `[REDACTED ${value.length} chars]`;
+  return '[REDACTED]';
+}
+
+function redactValue(key: string, value: unknown): unknown {
+  if (isSensitiveKey(key)) return '[REDACTED]';
+  if (PAYLOAD_BODY_KEYS.has(key.toLowerCase())) return redactPayloadValue(value);
+  if (Array.isArray(value)) return value.map((entry) => redactValue('', entry));
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, redactValue(k, v)]),
+    );
+  }
+  return value;
+}
+
+/** Redact sensitive or high-volume SAP payload fields before any audit sink sees them. */
+export function redactAuditEvent(event: AuditEvent): AuditEvent {
+  return redactValue('', event) as AuditEvent;
+}
+
 /** Sanitize tool call arguments — remove values that might contain sensitive data */
 export function sanitizeArgs(args: Record<string, unknown>): Record<string, unknown> {
-  const sensitiveKeys = [
-    'password',
-    'token',
-    'secret',
-    'cookie',
-    'authorization',
-    'csrf',
-    'apikey',
-    'authpwd',
-    'authtoken',
-    'remotepassword',
-  ];
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(args)) {
-    if (sensitiveKeys.some((s) => key.toLowerCase().includes(s))) {
+    if (isSensitiveKey(key)) {
       result[key] = '[REDACTED]';
     } else if (typeof value === 'string' && value.length > 500) {
       result[key] = `${value.slice(0, 200)}... [truncated ${value.length} chars]`;

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -52,11 +52,11 @@ export interface HttpRequestEvent extends AuditEventBase {
   statusCode: number;
   durationMs: number;
   errorBody?: string;
-  /** Full request body when ARC1_LOG_HTTP_DEBUG=true. Truncated past 65536 chars. */
+  /** Request body captured when ARC1_LOG_HTTP_DEBUG=true; redacted before sink writes. */
   requestBody?: string;
   /** Request headers with sensitive values redacted when ARC1_LOG_HTTP_DEBUG=true. */
   requestHeaders?: Record<string, string>;
-  /** Full response body when ARC1_LOG_HTTP_DEBUG=true. Truncated past 65536 chars. */
+  /** Response body captured when ARC1_LOG_HTTP_DEBUG=true; redacted before sink writes. */
   responseBody?: string;
   /** Response headers with sensitive values redacted when ARC1_LOG_HTTP_DEBUG=true. */
   responseHeaders?: Record<string, string>;

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -271,9 +271,7 @@ function redactValue(key: string, value: unknown): unknown {
   if (PAYLOAD_BODY_KEYS.has(key.toLowerCase())) return redactPayloadValue(value);
   if (Array.isArray(value)) return value.map((entry) => redactValue('', entry));
   if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, redactValue(k, v)]),
-    );
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, redactValue(k, v)]));
   }
   return value;
 }

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -20,7 +20,7 @@
  * context (session ID, tool name, duration).
  */
 
-import type { AuditEvent } from './audit.js';
+import { type AuditEvent, redactAuditEvent } from './audit.js';
 import { getCurrentContext } from './context.js';
 import { type LogFormat as SinkLogFormat, StderrSink } from './sinks/stderr.js';
 import type { LogSink } from './sinks/types.js';
@@ -84,18 +84,24 @@ export class Logger {
    * Automatically attaches requestId from AsyncLocalStorage context.
    */
   emitAudit(event: AuditEvent): void {
+    let eventWithContext = event;
     // Attach requestId from context if not already set
     if (!event.requestId) {
       const ctx = getCurrentContext();
       if (ctx) {
-        event.requestId = ctx.requestId;
-        if (!event.user && ctx.user) event.user = ctx.user;
+        eventWithContext = {
+          ...event,
+          requestId: ctx.requestId,
+          ...(!event.user && ctx.user ? { user: ctx.user } : {}),
+        };
       }
     }
 
+    const safeEvent = redactAuditEvent(eventWithContext);
+
     for (const sink of this.sinks) {
       try {
-        sink.write(event);
+        sink.write(safeEvent);
       } catch {
         // Sinks must not throw — but if they do, don't crash the server
       }

--- a/src/server/sinks/stderr.ts
+++ b/src/server/sinks/stderr.ts
@@ -33,41 +33,12 @@ export class StderrSink implements LogSink {
   write(event: AuditEvent): void {
     if (LEVEL_PRIORITY[event.level] < this.minLevel) return;
 
-    const safeEvent = redactSensitive(event);
-
     if (this.format === 'json') {
-      process.stderr.write(`${JSON.stringify(safeEvent)}\n`);
+      process.stderr.write(`${JSON.stringify(event)}\n`);
     } else {
-      const { timestamp, level, event: eventType, ...rest } = safeEvent;
+      const { timestamp, level, event: eventType, ...rest } = event;
       const ctx = Object.keys(rest).length > 0 ? ` ${JSON.stringify(rest)}` : '';
       process.stderr.write(`[${timestamp}] ${level.toUpperCase()}: [${eventType}]${ctx}\n`);
     }
   }
-}
-
-/** Redact known sensitive fields to prevent credential leakage in logs */
-function redactSensitive(event: AuditEvent): AuditEvent {
-  const sensitiveKeys = ['password', 'token', 'cookie', 'authorization', 'secret', 'csrf'];
-  const result: Record<string, unknown> = {};
-
-  for (const [key, value] of Object.entries(event)) {
-    if (sensitiveKeys.some((s) => key.toLowerCase().includes(s))) {
-      result[key] = '[REDACTED]';
-    } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-      // Shallow redaction for nested objects (e.g., args)
-      const nested: Record<string, unknown> = {};
-      for (const [nk, nv] of Object.entries(value as Record<string, unknown>)) {
-        if (sensitiveKeys.some((s) => nk.toLowerCase().includes(s))) {
-          nested[nk] = '[REDACTED]';
-        } else {
-          nested[nk] = nv;
-        }
-      }
-      result[key] = nested;
-    } else {
-      result[key] = value;
-    }
-  }
-
-  return result as unknown as AuditEvent;
 }

--- a/tests/unit/server/audit-integration.test.ts
+++ b/tests/unit/server/audit-integration.test.ts
@@ -201,7 +201,7 @@ describe('Audit Logging Integration', () => {
       | Record<string, unknown>
       | undefined;
     const preview = String(end?.resultPreview ?? '');
-    expect(preview).toContain('[omitted');
+    expect(preview).toContain('[REDACTED');
     expect(preview).not.toContain('SECRET_DUMP_CONTENT_SHOULD_NOT_APPEAR_IN_AUDIT_PREVIEW');
   });
 });

--- a/tests/unit/server/audit-redaction.test.ts
+++ b/tests/unit/server/audit-redaction.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AuditEvent, HttpRequestEvent, ToolCallEndEvent } from '../../../src/server/audit.js';
+import { redactAuditEvent } from '../../../src/server/audit.js';
+import { requestContext } from '../../../src/server/context.js';
+import { Logger } from '../../../src/server/logger.js';
+import type { LogSink } from '../../../src/server/sinks/types.js';
+
+class CaptureSink implements LogSink {
+  events: AuditEvent[] = [];
+
+  write(event: AuditEvent): void {
+    this.events.push(event);
+  }
+}
+
+describe('audit redaction', () => {
+  it('redacts sensitive keys and SAP payload bodies recursively', () => {
+    const redacted = redactAuditEvent({
+      timestamp: '2026-06-24T00:00:00.000Z',
+      level: 'error',
+      event: 'http_request',
+      method: 'POST',
+      path: '/sap/bc/adt/object',
+      statusCode: 500,
+      durationMs: 12,
+      errorBody: '<error>contains SAP source and stack details</error>',
+      requestBody: 'REPORT zsecret.',
+      responseBody: 'full SAP response',
+      requestHeaders: {
+        authorization: 'Bearer secret-token',
+        'x-csrf-token': 'csrf-token',
+      },
+      responseHeaders: {
+        'set-cookie': 'SAP_SESSIONID=abc',
+      },
+    } satisfies HttpRequestEvent) as HttpRequestEvent;
+
+    expect(redacted.errorBody).toBe('[REDACTED 52 chars]');
+    expect(redacted.requestBody).toBe('[REDACTED 15 chars]');
+    expect(redacted.responseBody).toBe('[REDACTED 17 chars]');
+    expect(redacted.requestHeaders?.authorization).toBe('[REDACTED]');
+    expect(redacted.requestHeaders?.['x-csrf-token']).toBe('[REDACTED]');
+    expect(redacted.responseHeaders?.['set-cookie']).toBe('[REDACTED]');
+  });
+
+  it('redacts before dispatching to every sink', () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const logger = new Logger('json', true);
+      const sink = new CaptureSink();
+      logger.addSink(sink);
+
+      logger.emitAudit({
+        timestamp: '2026-06-24T00:00:00.000Z',
+        level: 'error',
+        event: 'tool_call_end',
+        tool: 'SAPRead',
+        durationMs: 1,
+        status: 'error',
+        errorClass: 'result-path',
+        errorMessage: 'Object is locked by SECRETUSER',
+        resultSize: 21,
+        resultPreview: 'REPORT zsecret.\nWRITE x.',
+      });
+
+      expect(sink.events).toHaveLength(1);
+      const captured = sink.events[0] as ToolCallEndEvent;
+      expect(captured).toMatchObject({
+        event: 'tool_call_end',
+        errorMessage: '[REDACTED 30 chars]',
+        resultPreview: '[REDACTED 24 chars]',
+      });
+      expect(JSON.stringify(captured)).not.toContain('REPORT zsecret');
+      expect(JSON.stringify(captured)).not.toContain('SECRETUSER');
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  it('attaches request context before redacting the event', async () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const logger = new Logger('json', true);
+      const sink = new CaptureSink();
+      logger.addSink(sink);
+
+      const original: ToolCallEndEvent = {
+        timestamp: '2026-06-24T00:00:00.000Z',
+        level: 'info',
+        event: 'tool_call_end',
+        tool: 'SAPRead',
+        durationMs: 1,
+        status: 'success',
+        resultPreview: 'REPORT zsecret.',
+      };
+
+      await requestContext.run({ requestId: 'REQ-CTX', user: 'alice' }, async () => {
+        logger.emitAudit(original);
+      });
+
+      expect(sink.events[0]).toMatchObject({
+        requestId: 'REQ-CTX',
+        user: 'alice',
+        resultPreview: '[REDACTED 15 chars]',
+      });
+      expect(original.requestId).toBeUndefined();
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+});

--- a/tests/unit/server/sinks/stderr.test.ts
+++ b/tests/unit/server/sinks/stderr.test.ts
@@ -57,19 +57,8 @@ describe('StderrSink', () => {
     expect(stderrSpy).toHaveBeenCalled();
   });
 
-  it('redacts sensitive fields', () => {
-    const sink = new StderrSink('json', 'info');
-    sink.write(
-      makeEvent({
-        args: { password: 'secret', token: 'abc', name: 'visible' },
-      } as Partial<AuditEvent>),
-    );
-    const output = stderrSpy.mock.calls[0]?.[0] as string;
-    const parsed = JSON.parse(output);
-    expect(parsed.args.password).toBe('[REDACTED]');
-    expect(parsed.args.token).toBe('[REDACTED]');
-    expect(parsed.args.name).toBe('visible');
-  });
+  // Redaction is now centralized in Logger.emitAudit (covered by audit-redaction.test.ts),
+  // so StderrSink no longer self-redacts — it writes whatever the logger already sanitized.
 
   it('shows debug messages when min level is debug', () => {
     const sink = new StderrSink('text', 'debug');


### PR DESCRIPTION
## Goal

Fix the P1 audit-log exposure finding where sensitive SAP payloads, source previews, and diagnostic error text could reach audit sinks without a consistent redaction boundary.

## Plan and Review

- Enforce redaction once in `Logger.emitAudit()` after request context is attached and before any sink receives the event.
- Reuse the existing sensitive-key vocabulary so tool argument sanitization and audit event redaction do not drift.
- Redact high-risk payload text fields (`errorBody`, `requestBody`, `responseBody`, `resultPreview`, `errorMessage`) with length-preserving placeholders instead of passing raw SAP/source content through.
- Remove the older stderr-only shallow redactor so stderr, file, and BTP audit sinks all consume the same safe event shape.

Review result: the chosen boundary is the central audit fan-out, not individual sinks, so future sinks inherit the control by construction. Request/user context is attached before redaction and the caller's event object is no longer mutated.

## What Changed

- Added recursive `redactAuditEvent()` in `src/server/audit.ts`.
- Updated `Logger.emitAudit()` to redact before dispatching to sinks.
- Removed the local shallow redaction helper from `StderrSink`.
- Added focused regression tests for nested sensitive keys, SAP payload fields, tool error messages, and request-context preservation.

## Validation

- `npx vitest run tests/unit/server/audit-redaction.test.ts` passed.
- `npm run typecheck` passed.
- `git diff --cached --check` passed.

## Security Result

The original issue no longer reproduces in the unit harness: sink-captured events contain placeholders for SAP bodies, result previews, and tool error messages, and nested auth/cookie/CSRF fields are redacted before any sink write.
