### PR TITLE
fix: warn on insecure SAP TLS and encode trace paths

### DIFF
--- a/src/adt/diagnostics.ts
+++ b/src/adt/diagnostics.ts
@@ -193,7 +193,7 @@ export async function listDumps(
 export async function getDump(http: AdtHttpClient, safety: SafetyConfig, dumpId: string): Promise<DumpDetail> {
   checkOperation(safety, OperationType.Read, 'GetDump');
 
-  const safeId = normalizeDumpId(dumpId);
+  const safeId = normalizeAdtPathSegment(dumpId);
 
   // Fetch XML metadata and formatted text in parallel
   const [xmlResp, textResp] = await Promise.all([
@@ -214,8 +214,8 @@ export async function getDump(http: AdtHttpClient, safety: SafetyConfig, dumpId:
  * `%20` for spaces); otherwise we encode it once. Trims surrounding
  * whitespace which would otherwise be encoded as `%20` and break lookup.
  */
-function normalizeDumpId(dumpId: string): string {
-  const trimmed = String(dumpId ?? '').trim();
+function normalizeAdtPathSegment(value: string): string {
+  const trimmed = String(value ?? '').trim();
   if (!trimmed) return '';
   return trimmed.includes('%') ? trimmed : encodeURIComponent(trimmed);
 }
@@ -321,7 +321,8 @@ export async function getTraceHitlist(
 ): Promise<TraceHitlistEntry[]> {
   checkOperation(safety, OperationType.Read, 'GetTraceHitlist');
 
-  const resp = await http.get(`/sap/bc/adt/runtime/traces/abaptraces/${traceId}/hitlist`, {
+  const safeTraceId = normalizeAdtPathSegment(traceId);
+  const resp = await http.get(`/sap/bc/adt/runtime/traces/abaptraces/${safeTraceId}/hitlist`, {
     Accept: 'application/xml',
   });
 
@@ -340,7 +341,8 @@ export async function getTraceStatements(
 ): Promise<TraceStatement[]> {
   checkOperation(safety, OperationType.Read, 'GetTraceStatements');
 
-  const resp = await http.get(`/sap/bc/adt/runtime/traces/abaptraces/${traceId}/statements`, {
+  const safeTraceId = normalizeAdtPathSegment(traceId);
+  const resp = await http.get(`/sap/bc/adt/runtime/traces/abaptraces/${safeTraceId}/statements`, {
     Accept: 'application/xml',
   });
 
@@ -359,7 +361,8 @@ export async function getTraceDbAccesses(
 ): Promise<TraceDbAccess[]> {
   checkOperation(safety, OperationType.Read, 'GetTraceDbAccesses');
 
-  const resp = await http.get(`/sap/bc/adt/runtime/traces/abaptraces/${traceId}/dbAccesses`, {
+  const safeTraceId = normalizeAdtPathSegment(traceId);
+  const resp = await http.get(`/sap/bc/adt/runtime/traces/abaptraces/${safeTraceId}/dbAccesses`, {
     Accept: 'application/xml',
   });
 

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -753,6 +753,12 @@ export function validateConfig(config: ServerConfig): void {
     );
   }
 
+  if (config.insecure) {
+    console.error(
+      '[warn] SAP_INSECURE=true disables SAP TLS certificate verification. Use only in isolated development, and prefer NODE_EXTRA_CA_CERTS for internal CAs.',
+    );
+  }
+
   if (config.dcrSigningSecret && !config.xsuaaAuth) {
     console.error(
       '[warn] ARC1_DCR_SIGNING_SECRET is set but SAP_XSUAA_AUTH=false — the secret is unused. Unset it to reduce attack surface, or enable XSUAA OAuth proxy mode (SAP_XSUAA_AUTH=true).',

--- a/tests/unit/adt/diagnostics.test.ts
+++ b/tests/unit/adt/diagnostics.test.ts
@@ -1001,6 +1001,26 @@ describe('Runtime Diagnostics', () => {
         Accept: 'application/xml',
       });
     });
+
+    it('encodes raw trace IDs as one path segment', async () => {
+      const http = mockHttp('<hitList/>');
+      const rawId = 'TRACE 001/../../secret';
+      await getTraceHitlist(http, unrestrictedSafetyConfig(), rawId);
+      expect(http.get).toHaveBeenCalledWith(
+        `/sap/bc/adt/runtime/traces/abaptraces/${encodeURIComponent(rawId)}/hitlist`,
+        { Accept: 'application/xml' },
+      );
+    });
+
+    it('passes already-encoded trace IDs through unchanged', async () => {
+      const http = mockHttp('<hitList/>');
+      const encodedId = 'TRACE%20001%2Fsegment';
+      await getTraceHitlist(http, unrestrictedSafetyConfig(), encodedId);
+      expect(http.get).toHaveBeenCalledWith(`/sap/bc/adt/runtime/traces/abaptraces/${encodedId}/hitlist`, {
+        Accept: 'application/xml',
+      });
+      expect((http.get as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).not.toContain('%252F');
+    });
   });
 
   describe('getTraceStatements', () => {
@@ -1011,6 +1031,16 @@ describe('Runtime Diagnostics', () => {
         Accept: 'application/xml',
       });
     });
+
+    it('encodes raw trace IDs as one path segment', async () => {
+      const http = mockHttp('<statements/>');
+      const rawId = 'TRACE 002/../../secret';
+      await getTraceStatements(http, unrestrictedSafetyConfig(), rawId);
+      expect(http.get).toHaveBeenCalledWith(
+        `/sap/bc/adt/runtime/traces/abaptraces/${encodeURIComponent(rawId)}/statements`,
+        { Accept: 'application/xml' },
+      );
+    });
   });
 
   describe('getTraceDbAccesses', () => {
@@ -1020,6 +1050,16 @@ describe('Runtime Diagnostics', () => {
       expect(http.get).toHaveBeenCalledWith('/sap/bc/adt/runtime/traces/abaptraces/TRACE_003/dbAccesses', {
         Accept: 'application/xml',
       });
+    });
+
+    it('encodes raw trace IDs as one path segment', async () => {
+      const http = mockHttp('<dbAccesses/>');
+      const rawId = 'TRACE 003/../../secret';
+      await getTraceDbAccesses(http, unrestrictedSafetyConfig(), rawId);
+      expect(http.get).toHaveBeenCalledWith(
+        `/sap/bc/adt/runtime/traces/abaptraces/${encodeURIComponent(rawId)}/dbAccesses`,
+        { Accept: 'application/xml' },
+      );
     });
   });
 

--- a/tests/unit/server/config.test.ts
+++ b/tests/unit/server/config.test.ts
@@ -1068,6 +1068,23 @@ describe('validateConfig', () => {
     }
   });
 
+  it('warns to stderr (without throwing) when SAP TLS verification is disabled', () => {
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      expect(() =>
+        validateConfig({
+          ...DEFAULT_CONFIG,
+          insecure: true,
+        }),
+      ).not.toThrow();
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('SAP_INSECURE=true disables SAP TLS certificate verification'),
+      );
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
   it('warns to stderr (without throwing) when dcrSigningSecret is set with xsuaaAuth=false', () => {
     const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     try {


### PR DESCRIPTION
## Goal

Fix the P1 TLS/path-hardening follow-up by making insecure SAP TLS mode visible at startup and by preventing runtime trace IDs from being interpolated into ADT paths as raw path fragments.

## Plan and Review

- Preserve `SAP_INSECURE=true` as an explicit development escape hatch, but warn every startup when TLS verification is disabled.
- Reuse the existing dump ID path-segment normalization pattern for trace IDs.
- Treat raw trace IDs as a single path segment with `encodeURIComponent`, while preserving already encoded ADT IDs to avoid breaking existing SAP trace identifiers.
- Cover every trace endpoint that interpolates `traceId`: hitlist, statements, and DB accesses.

Review result: this keeps the compatibility contract for existing encoded IDs and applies the encoding exactly where the path is built, which is the narrowest reliable boundary.

## What Changed

- Added a startup warning in `validateConfig()` when `config.insecure` is true.
- Generalized the diagnostics path-segment normalizer.
- Encoded trace IDs in `getTraceHitlist()`, `getTraceStatements()`, and `getTraceDbAccesses()`.
- Added focused tests for raw traversal-like trace IDs, already-encoded IDs, and the insecure TLS warning.

## Validation

- `npx vitest run tests/unit/adt/diagnostics.test.ts tests/unit/server/config.test.ts` passed.
- `npm run typecheck` passed.
- `git diff --cached --check` passed.

## Security Result

The original path-construction issue no longer reproduces in the diagnostics unit tests: raw IDs containing spaces and `/../../` are encoded as one ADT path segment before `http.get()` is called. Operators also now get a visible warning when SAP TLS verification is disabled.
