### PR TITLE
fix: add minimal client-facing SAP errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ Full per-option details (defaults, clamps, layer interactions): [docs_page/confi
 | `SAP_PP_ENABLED` / `SAP_PP_STRICT` / `SAP_PP_ALLOW_SHARED_COOKIES` | Principal propagation + strict mode + cookie-coexistence escape hatch |
 | `SAP_DISABLE_SAML` | Disable SAML redirect — never on BTP ABAP / S/4 Public Cloud |
 | `ARC1_PROFILE` | Safety profile shortcut (viewer…developer-sql) |
+| `ARC1_MINIMAL_ERRORS` | Hide SAP diagnostic details from client-facing tool errors; keep request correlation for operators |
 | `ARC1_LOG_HTTP_DEBUG` | Full req/resp bodies in audit (redacted, truncated; not for prod) |
 
 ## Codebase Structure

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -278,6 +278,7 @@ All ARC-1 logging goes to **stderr** to keep stdout clean for MCP JSON-RPC. Neve
 | `--log-file` | `ARC1_LOG_FILE` | — | Path to an additional file sink. Stderr output is unchanged; the file gets the same stream. |
 | `--log-level` | `ARC1_LOG_LEVEL` | `info` | One of `debug` / `info` / `warn` / `error`. Filters every log line, including the audit stream's structured entries. |
 | `--log-format` | `ARC1_LOG_FORMAT` | `text` | `text` (human-readable) or `json` (one JSON object per line — for shipping to ELK / Loki / CF log aggregator). |
+| `--minimal-errors` | `ARC1_MINIMAL_ERRORS` | `false` | When `true`, client-facing tool errors hide SAP diagnostic details such as lock owners, transport IDs, T100 variables, and authorization object names. Server-side audit logs retain request correlation and status data; use SAP-native logs or a trusted admin retry for full diagnostics. |
 | `--verbose` | `SAP_VERBOSE` | `false` | Alias for `--log-level=debug`. Slightly older flag, kept for compatibility. |
 | — | `ARC1_LOG_HTTP_DEBUG` | `false` | When `"true"`, attaches the full HTTP request and response bodies + headers to `http_request` audit events. Sensitive headers (`Authorization`, `Cookie`, CSRF tokens) are redacted; bodies are truncated at 64 KB. **Do not enable in production** — increases log volume substantially and can leak business data in payloads. **Boolean parsing inconsistency:** unlike other booleans, this one accepts only the literal string `"true"` — `"1"` does **not** work. |
 

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -128,6 +128,8 @@ function buildBaseErrorMessage(
   config: ServerConfig,
 ): string {
   if (err instanceof AdtApiError) {
+    if (config.minimalErrors) return formatMinimalAdtError(err);
+
     // Append additional SAP messages (line numbers, secondary errors) if available
     const enriched = enrichWithSapDetails(err, message);
     const argType = canonicalTablType(String(args.type ?? '').toUpperCase());
@@ -249,6 +251,16 @@ function buildBaseErrorMessage(
   }
 
   return message;
+}
+
+function formatMinimalAdtError(err: AdtApiError): string {
+  const classification = classifySapDomainError(err.statusCode, err.responseBody, err.path);
+  const category = classification ? ` Category: ${classification.category}.` : '';
+  return (
+    `ADT API error: status ${err.statusCode}.${category}\n\n` +
+    'Hint: Detailed SAP error text is hidden because ARC1_MINIMAL_ERRORS=true. ' +
+    'Use the request ID to correlate server-side audit and SAP-native logs, or retry in a trusted admin session with minimal errors disabled.'
+  );
 }
 
 function buildDiagnosticsNotFoundHint(tool: string, args: Record<string, unknown>): string | undefined {

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -268,7 +268,10 @@ function redactPayloadValue(value: unknown): string {
 
 function redactValue(key: string, value: unknown): unknown {
   if (isSensitiveKey(key)) return '[REDACTED]';
-  if (PAYLOAD_BODY_KEYS.has(key.toLowerCase())) return redactPayloadValue(value);
+  if (PAYLOAD_BODY_KEYS.has(key.toLowerCase())) {
+    if (value == null) return value;
+    return redactPayloadValue(value);
+  }
   if (Array.isArray(value)) return value.map((entry) => redactValue('', entry));
   if (value && typeof value === 'object') {
     return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, redactValue(k, v)]));

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -664,6 +664,7 @@ export function resolveConfig(args: string[]): { config: ServerConfig; sources: 
   ) as ServerConfig['logLevel'];
   const logFormat = resolveStr('log-format', 'ARC1_LOG_FORMAT', 'text', 'logFormat');
   config.logFormat = (logFormat === 'json' ? 'json' : 'text') as ServerConfig['logFormat'];
+  config.minimalErrors = resolveBool('minimal-errors', 'ARC1_MINIMAL_ERRORS', false, 'minimalErrors');
 
   // ── Misc ───────────────────────────────────────────────────────────
   config.verbose = resolveBool('verbose', 'SAP_VERBOSE', false, 'verbose');

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -127,6 +127,8 @@ export interface ServerConfig {
   logFile?: string;
   logLevel: 'debug' | 'info' | 'warn' | 'error';
   logFormat: 'text' | 'json';
+  /** Hide SAP response details from client-facing tool errors while retaining server-side correlation data. */
+  minimalErrors: boolean;
 
   // --- Tool Mode ---
   /** Tool mode: 'standard' (12 intent tools, SAPGit feature-gated) or 'hyperfocused' (1 universal SAP tool, ~200 tokens) */
@@ -268,5 +270,6 @@ export const DEFAULT_CONFIG: ServerConfig = {
   allowedOrigins: [],
   logLevel: 'info',
   logFormat: 'text',
+  minimalErrors: false,
   verbose: false,
 };

--- a/tests/unit/handlers/dispatch-misc.test.ts
+++ b/tests/unit/handlers/dispatch-misc.test.ts
@@ -1046,6 +1046,42 @@ describe('tool dispatch & cross-cutting handler behavior', () => {
       expect(result.content[0]?.text).not.toContain('DDIC diagnostics:');
     });
 
+    it('hides SAP diagnostic details from client-facing errors when minimal errors are enabled', async () => {
+      const xmlResponse = `<?xml version="1.0" encoding="utf-8"?>
+<exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework">
+  <exc:localizedMessage lang="EN">Object is locked by SECRETUSER</exc:localizedMessage>
+  <exc:properties>
+    <entry key="LOCK_USER">SECRETUSER</entry>
+    <entry key="TRANSPORT">DEVK900001</entry>
+  </exc:properties>
+</exc:exception>`;
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(423, xmlResponse, { 'x-csrf-token': 'T' }));
+
+      const detailed = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'PROG',
+        name: 'ZTEST',
+      });
+      expect(detailed.isError).toBe(true);
+      expect(detailed.content[0]?.text).toContain('SECRETUSER');
+      expect(detailed.content[0]?.text).toContain('DEVK900001');
+
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(423, xmlResponse, { 'x-csrf-token': 'T' }));
+      const minimal = await handleToolCall(createClient(), { ...DEFAULT_CONFIG, minimalErrors: true }, 'SAPRead', {
+        type: 'PROG',
+        name: 'ZTEST',
+      });
+
+      expect(minimal.isError).toBe(true);
+      const text = minimal.content[0]?.text ?? '';
+      expect(text).toContain('ADT API error: status 423');
+      expect(text).toContain('ARC1_MINIMAL_ERRORS=true');
+      expect(text).not.toContain('SECRETUSER');
+      expect(text).not.toContain('DEVK900001');
+      expect(text).not.toContain('Properties:');
+    });
+
     it('includes DDIC diagnostics block when T100KEY entries are present', async () => {
       const xmlResponse = `<?xml version="1.0" encoding="utf-8"?>
 <exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework">

--- a/tests/unit/server/audit-redaction.test.ts
+++ b/tests/unit/server/audit-redaction.test.ts
@@ -77,6 +77,23 @@ describe('audit redaction', () => {
     }
   });
 
+  it('does not add redacted placeholders for absent payload fields', () => {
+    const redacted = redactAuditEvent({
+      timestamp: '2026-06-24T00:00:00.000Z',
+      level: 'info',
+      event: 'tool_call_end',
+      tool: 'SAPRead',
+      durationMs: 1,
+      status: 'success',
+      errorMessage: undefined,
+      resultSize: 2,
+      resultPreview: undefined,
+    } satisfies ToolCallEndEvent) as ToolCallEndEvent;
+
+    expect(redacted.errorMessage).toBeUndefined();
+    expect(redacted.resultPreview).toBeUndefined();
+  });
+
   it('attaches request context before redacting the event', async () => {
     const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     try {

--- a/tests/unit/server/config.test.ts
+++ b/tests/unit/server/config.test.ts
@@ -102,6 +102,18 @@ describe('parseArgs', () => {
     expect(config.allowGitWrites).toBe(true);
   });
 
+  it('parses ARC1_MINIMAL_ERRORS env var', () => {
+    process.env.ARC1_MINIMAL_ERRORS = 'true';
+    const config = parseArgs([]);
+    expect(config.minimalErrors).toBe(true);
+  });
+
+  it('--minimal-errors takes precedence over ARC1_MINIMAL_ERRORS env var', () => {
+    process.env.ARC1_MINIMAL_ERRORS = 'false';
+    const config = parseArgs(['--minimal-errors', 'true']);
+    expect(config.minimalErrors).toBe(true);
+  });
+
   it('defaults ppStrict to true when principal propagation is enabled', () => {
     process.env.SAP_PP_ENABLED = 'true';
     const config = parseArgs([]);


### PR DESCRIPTION
## Goal

Fix the P1 information-disclosure concern where detailed SAP errors can expose lock owners, transport IDs, T100 variables, authorization object names, and other environment details directly to MCP clients.

## Plan and Review

- Add an opt-in compatibility flag instead of changing default client-facing diagnostics.
- Apply the minimal-error behavior only at the client response formatting boundary for `AdtApiError`.
- Keep useful machine-actionable data: HTTP status and existing domain classification category.
- Avoid promising full SAP payloads in audit logs; operators should use request correlation, SAP-native logs, or a trusted admin retry for full diagnostics.

Review result: the feature is opt-in (`false` by default), so existing developer workflows keep detailed errors until an operator chooses the safer client surface.

## What Changed

- Added `minimalErrors` to `ServerConfig` and `DEFAULT_CONFIG`.
- Added `--minimal-errors` / `ARC1_MINIMAL_ERRORS` parsing with normal config precedence.
- Added minimal `AdtApiError` formatting that hides SAP response details from client-facing tool errors.
- Documented the option in `AGENTS.md` and `docs_page/configuration-reference.md`.
- Added focused dispatch/config tests for the opt-in behavior.

## Validation

- `npx vitest run tests/unit/handlers/dispatch-misc.test.ts tests/unit/server/config.test.ts` passed.
- `npm run typecheck` passed.
- `git diff --cached --check` passed.

## Security Result

The original disclosure path no longer reproduces when `ARC1_MINIMAL_ERRORS=true`: the regression test verifies that a SAP lock-owner/transport response no longer reaches the MCP client, while the default mode still preserves existing detailed behavior.
