### PR TITLE
fix: create audit and cache files privately

### DIFF
--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -265,7 +265,7 @@ ARC-1 caches SAP source/metadata with ETag revalidation on every hit. See [cachi
 | `--cache-warmup-packages` | `ARC1_CACHE_WARMUP_PACKAGES` | (empty = all custom) | Comma-separated package filter for warmup (e.g. `Z*,Y*,/COMPANY/*`). Empty matches all custom packages found in TADIR. Ignored when `ARC1_CACHE_WARMUP=false`. |
 
 !!! warning "`ARC1_CACHE=sqlite` stores SAP source in cleartext at rest"
-    The SQLite cache holds full ABAP source unencrypted at `.arc1-cache.db`, created with default file permissions. For IP-sensitive landscapes use `ARC1_CACHE=memory` or `none`, or place the file on an encrypted volume with restricted permissions. The file audit sink (`ARC1_LOG_FILE`) similarly contains un-redacted source/error snippets.
+    The SQLite cache holds full ABAP source unencrypted at `.arc1-cache.db`. ARC-1 creates and repairs the cache DB and file audit sink (`ARC1_LOG_FILE`) with owner-only file permissions (`0600`), but this is not encryption. For IP-sensitive landscapes use `ARC1_CACHE=memory` or `none`, or place persistent files on an encrypted volume with restricted access.
 
 ---
 

--- a/docs_page/docker.md
+++ b/docs_page/docker.md
@@ -534,10 +534,11 @@ when a new `ghcr.io/arc-mcp/arc-1` image tag is published.
    Cloud Connector path; flip them to `"false"` on CA-signed landscapes.
 
 7. **The SQLite cache stores SAP source in cleartext.** In HTTP mode the cache
-   defaults to `sqlite` at `.arc1-cache.db` (full ABAP source, unencrypted, default
-   file perms), and a mounted volume persists it. For IP-sensitive landscapes set
-   `ARC1_CACHE=memory` or `none`, or use an encrypted volume. The file audit sink
-   (`ARC1_LOG_FILE`) likewise contains un-redacted source/error snippets.
+   defaults to `sqlite` at `.arc1-cache.db` (full ABAP source, unencrypted), and a
+   mounted volume persists it. ARC-1 creates and repairs cache DB and file audit
+   sink files with owner-only permissions (`0600`), but this is not encryption. For
+   IP-sensitive landscapes set `ARC1_CACHE=memory` or `none`, or use an encrypted
+   volume.
 
 ---
 

--- a/src/cache/sqlite.ts
+++ b/src/cache/sqlite.ts
@@ -8,6 +8,7 @@
  * alternatives for single-process use (no Promise overhead).
  */
 
+import { chmodSync, closeSync, openSync } from 'node:fs';
 import Database from 'better-sqlite3';
 import type {
   Cache,
@@ -26,6 +27,7 @@ export class SqliteCache implements Cache {
   private db: Database.Database;
 
   constructor(dbPath: string) {
+    ensurePrivateSqliteFile(dbPath);
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
@@ -349,6 +351,15 @@ export class SqliteCache implements Cache {
   close(): void {
     this.db.close();
   }
+}
+
+const PRIVATE_FILE_MODE = 0o600;
+
+function ensurePrivateSqliteFile(dbPath: string): void {
+  if (dbPath === ':memory:') return;
+  const fd = openSync(dbPath, 'a', PRIVATE_FILE_MODE);
+  closeSync(fd);
+  chmodSync(dbPath, PRIVATE_FILE_MODE);
 }
 
 function rowToNode(row: Record<string, unknown>): CacheNode {

--- a/src/server/sinks/file.ts
+++ b/src/server/sinks/file.ts
@@ -8,13 +8,16 @@
  * All events are written regardless of level (file is the full audit trail).
  */
 
-import { appendFile } from 'node:fs/promises';
+import { appendFile, chmod } from 'node:fs/promises';
 import type { AuditEvent } from '../audit.js';
 import type { LogSink } from './types.js';
+
+const PRIVATE_FILE_MODE = 0o600;
 
 export class FileSink implements LogSink {
   private buffer: string[] = [];
   private flushTimer: ReturnType<typeof setInterval> | undefined;
+  private permissionsPromise: Promise<void> | undefined;
 
   constructor(private filePath: string) {
     // Flush buffer every 500ms to balance write frequency vs latency
@@ -44,7 +47,7 @@ export class FileSink implements LogSink {
     const lines = this.buffer.splice(0);
     const data = `${lines.join('\n')}\n`;
     // Fire-and-forget — errors go to stderr
-    appendFile(this.filePath, data, 'utf-8').catch((err) => {
+    this.appendPrivate(data).catch((err) => {
       process.stderr.write(`[FileSink] Failed to write to ${this.filePath}: ${err}\n`);
     });
   }
@@ -54,9 +57,23 @@ export class FileSink implements LogSink {
     const lines = this.buffer.splice(0);
     const data = `${lines.join('\n')}\n`;
     try {
-      await appendFile(this.filePath, data, 'utf-8');
+      await this.appendPrivate(data);
     } catch (err) {
       process.stderr.write(`[FileSink] Failed to write to ${this.filePath}: ${err}\n`);
     }
+  }
+
+  private async appendPrivate(data: string): Promise<void> {
+    await this.ensurePrivateFile();
+    await appendFile(this.filePath, data, { encoding: 'utf-8', mode: PRIVATE_FILE_MODE });
+  }
+
+  private ensurePrivateFile(): Promise<void> {
+    if (!this.permissionsPromise) {
+      this.permissionsPromise = appendFile(this.filePath, '', { encoding: 'utf-8', mode: PRIVATE_FILE_MODE }).then(
+        () => chmod(this.filePath, PRIVATE_FILE_MODE),
+      );
+    }
+    return this.permissionsPromise;
   }
 }

--- a/src/server/sinks/file.ts
+++ b/src/server/sinks/file.ts
@@ -70,8 +70,8 @@ export class FileSink implements LogSink {
 
   private ensurePrivateFile(): Promise<void> {
     if (!this.permissionsPromise) {
-      this.permissionsPromise = appendFile(this.filePath, '', { encoding: 'utf-8', mode: PRIVATE_FILE_MODE }).then(
-        () => chmod(this.filePath, PRIVATE_FILE_MODE),
+      this.permissionsPromise = appendFile(this.filePath, '', { encoding: 'utf-8', mode: PRIVATE_FILE_MODE }).then(() =>
+        chmod(this.filePath, PRIVATE_FILE_MODE),
       );
     }
     return this.permissionsPromise;

--- a/tests/unit/cache/sqlite.test.ts
+++ b/tests/unit/cache/sqlite.test.ts
@@ -18,6 +18,10 @@ function makeNode(id: string, pkg = '$TMP'): CacheNode {
   };
 }
 
+function fileMode(filePath: string): number {
+  return fs.statSync(filePath).mode & 0o777;
+}
+
 describe('SqliteCache', () => {
   let cache: SqliteCache;
 
@@ -40,6 +44,34 @@ describe('SqliteCache', () => {
 
   it('returns null for missing node', () => {
     expect(cache.getNode('MISSING')).toBeNull();
+  });
+
+  it('creates file-backed cache databases with private file permissions', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arc1-cache-mode-'));
+    const dbPath = path.join(dir, 'cache.db');
+    const fileCache = new SqliteCache(dbPath);
+
+    try {
+      expect(fileMode(dbPath)).toBe(0o600);
+    } finally {
+      fileCache.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('repairs permissive permissions on an existing cache database', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arc1-cache-mode-'));
+    const dbPath = path.join(dir, 'cache.db');
+    fs.writeFileSync(dbPath, '', { mode: 0o666 });
+    fs.chmodSync(dbPath, 0o666);
+
+    const fileCache = new SqliteCache(dbPath);
+    try {
+      expect(fileMode(dbPath)).toBe(0o600);
+    } finally {
+      fileCache.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('finds nodes by package (case-insensitive)', () => {

--- a/tests/unit/server/sinks/file.test.ts
+++ b/tests/unit/server/sinks/file.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { chmodSync, existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -25,6 +25,8 @@ describe('FileSink', () => {
       ...overrides,
     }) as AuditEvent;
 
+  const fileMode = () => statSync(tmpFile).mode & 0o777;
+
   it('writes JSON lines to file', async () => {
     const sink = new FileSink(tmpFile);
     sink.write(makeEvent());
@@ -41,6 +43,25 @@ describe('FileSink', () => {
 
     const second = JSON.parse(lines[1]!);
     expect(second.requestId).toBe('REQ-2');
+  });
+
+  it('creates the audit log with private file permissions', async () => {
+    const sink = new FileSink(tmpFile);
+    sink.write(makeEvent());
+    await sink.flush();
+
+    expect(fileMode()).toBe(0o600);
+  });
+
+  it('repairs permissive permissions on an existing audit log', async () => {
+    writeFileSync(tmpFile, '', { mode: 0o666 });
+    chmodSync(tmpFile, 0o666);
+
+    const sink = new FileSink(tmpFile);
+    sink.write(makeEvent());
+    await sink.flush();
+
+    expect(fileMode()).toBe(0o600);
   });
 
   it('writes all event types', async () => {


### PR DESCRIPTION
## Goal

Fix the P1 local file-permission finding where the SQLite cache DB and file audit sink could be created with process/default permissions despite containing SAP source, audit data, and operational metadata.

## Plan and Review

- Enforce owner-only file mode at each file creation boundary.
- Create/chmod the SQLite DB file before `better-sqlite3` opens it, so new cache files do not start with permissive defaults.
- Create/chmod the file audit sink before appending, and repair an existing too-open log file on first write.
- Keep the cleartext-at-rest warning in docs because `0600` is not encryption.

Review result: the control is local to the two file writers and does not change cache or audit semantics beyond file mode hardening.

## What Changed

- Added private-mode setup for file-backed `SqliteCache` databases.
- Added private-mode setup/repair for `FileSink` audit logs.
- Added focused unit tests for new-file `0600` and existing-permissive-file repair in both code paths.
- Updated cache/audit file documentation to describe owner-only permissions while preserving the cleartext warning.

## Validation

- `npx vitest run tests/unit/server/sinks/file.test.ts tests/unit/cache/sqlite.test.ts` passed.
- `npm run typecheck` passed.
- `git diff --cached --check` passed.

## Security Result

The original issue no longer reproduces in the unit harness: newly created audit/cache files are `0600`, and existing files deliberately set to `0666` are repaired to `0600` before use.
