### PR TITLE
fix(cli): send correct arg shapes from sql/search shortcuts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,7 +171,8 @@ program
   .description('Execute an OpenSQL query (SAPQuery; requires SAP_ALLOW_FREE_SQL=true)')
   .addOption(outputOption)
   .action(async (query: string, opts: { output: OutputMode }) => {
-    process.exit(await runToolCall('SAPQuery', { action: 'sql', query }, opts.output));
+    // SAPQuerySchema is { sql, maxRows } — no `action`, and the query field is `sql` (not `query`).
+    process.exit(await runToolCall('SAPQuery', { sql: query }, opts.output));
   });
 
 // ─── Legacy / local-only commands ──────────────────────────────────────
@@ -182,9 +183,8 @@ program
   .option('--max <number>', 'Maximum results', '50')
   .addOption(outputOption)
   .action(async (query: string, opts: { max: string; output: OutputMode }) => {
-    process.exit(
-      await runToolCall('SAPSearch', { action: 'object', query, maxResults: Number(opts.max) }, opts.output),
-    );
+    // SAPSearchSchema has no `action` field (object search is the default searchType); pass query + maxResults.
+    process.exit(await runToolCall('SAPSearch', { query, maxResults: Number(opts.max) }, opts.output));
   });
 
 program

--- a/tests/unit/cli/cli.test.ts
+++ b/tests/unit/cli/cli.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { getToolSchema } from '../../../src/handlers/schemas.js';
 import { detectFilename } from '../../../src/lint/lint.js';
 import { VERSION } from '../../../src/server/server.js';
 
@@ -10,5 +11,19 @@ describe('CLI', () => {
   it('detectFilename works for CLI lint command', () => {
     expect(detectFilename('REPORT ztest.', 'ZTEST')).toBe('ztest.prog.abap');
     expect(detectFilename('CLASS zcl_test DEFINITION.', 'ZCL_TEST')).toBe('zcl_test.clas.abap');
+  });
+
+  // Pins the arg shapes the `sql` / `search` shortcuts must send. The schemas have
+  // no `action` field and SAPQuery's query field is `sql` (not `query`) — passing the
+  // old `{ action, query }` shape made `arc1-cli sql "..."` always fail Zod validation.
+  it('sql shortcut arg shape satisfies SAPQuerySchema', () => {
+    const schema = getToolSchema('SAPQuery', false)!;
+    expect(schema.safeParse({ sql: 'SELECT mandt FROM t000' }).success).toBe(true);
+    expect(schema.safeParse({ action: 'sql', query: 'SELECT mandt FROM t000' }).success).toBe(false);
+  });
+
+  it('search shortcut arg shape satisfies SAPSearchSchema', () => {
+    const schema = getToolSchema('SAPSearch', false)!;
+    expect(schema.safeParse({ query: 'ZCL_FOO*', maxResults: 50 }).success).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

`arc1-cli sql "SELECT ..."` always failed with:

```
Invalid arguments for SAPQuery: - "sql": required (expected string)
```

The `sql` shortcut in [src/cli.ts](src/cli.ts) passed `{ action: 'sql', query }`, but `SAPQuerySchema` is `{ sql, maxRows }` — there is **no** `action` field and the query field is named `sql`, not `query`. The handler reads `args.sql`, so Zod rejected the call before it ever reached SAP. The MCP `SAPQuery` tool itself was unaffected — only this CLI wrapper was broken.

A scan of the other shortcuts surfaced one more stale arg: the `search` shortcut passed a bogus `action: 'object'`. `SAPSearchSchema` has no `action` field (object search is the default `searchType`), so Zod silently stripped it — harmless, but dead/misleading. Fixed in the same pass.

(`read`/`source` pass a `flat` flag that the schema no longer has, but CLAS already defaults to flat source, so those produce the intended output and are left untouched.)

## Fix

| Shortcut | Before | After |
|----------|--------|-------|
| `sql`    | `{ action: 'sql', query }` | `{ sql: query }` |
| `search` | `{ action: 'object', query, maxResults }` | `{ query, maxResults }` |

## Verification

Live against **a4h (SAP_BASIS 758)**:

```
SAP_ALLOW_FREE_SQL=true arc1-cli sql "SELECT sprsl, arbgb, msgnr FROM t100 WHERE sprsl = 'E'" --output json
```

Returns the #508 datapreview metrics:

```json
{ "totalRows": 318837, "queryExecutionTimeMs": 14.28, "rowsReturned": 100, ... }
```

Added a regression test in `tests/unit/cli/cli.test.ts` pinning the arg shapes against the live schemas.

Full gate green: `npm test` (4081 pass; the pre-existing unrelated `tests/unit/server/ui.test.ts` failure is the only red), `typecheck`, `lint`, `validate:policy`, `build`, `check:sizes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)