### PR TITLE
fix(diagnose): correct odata_perf "app" verdict note 

### DIFF
--- a/src/adt/diagnostics.ts
+++ b/src/adt/diagnostics.ts
@@ -1043,7 +1043,7 @@ export function verdictFromStatistics(m: Record<string, number>): ODataPerfResul
     [
       'app',
       Math.max((m.gwapp ?? 0) - db, 0),
-      'ABAP/SADL-bound: application logic dominates (not the DB). Arm an ABAP profiler trace (SAPDiagnose action="traces") and read its hitlist for the hot path.',
+      'ABAP/SADL-bound: application logic dominates, not the DB (an $expand N+1 is the classic cause) — do not ST05-hunt for a slow query. Find the OData implementation (the CDS behind a V4/RAP binding, or the SEGW Gateway DPC class) and arm a profiler trace via SAPDiagnose(action="trace_start"), then read it with action="traces" analysis="dbAccesses". Note: for HTTP/OData traces the ABAP hitlist/statements are usually empty — use ST12/SAT in SAP GUI for the call tree.',
     ],
     [
       // gwfw (GW framework) and gwhub (GW hub processing) both measure framework time; older

--- a/tests/unit/adt/diagnostics.test.ts
+++ b/tests/unit/adt/diagnostics.test.ts
@@ -1400,6 +1400,15 @@ describe('verdictFromStatistics', () => {
     expect(verdictFromStatistics({ gwtotal: 100, icfauth: 80, gwapp: 5, gwappdb: 2, gwfw: 3 }).bound).toBe('auth');
   });
 
+  it('routes a gwapp-dominant (gwappdb-absent) request to app, arming via trace_start (not "traces")', () => {
+    // live GWSAMPLE_BASIC ?$expand: gwapp 439 of gwtotal 609, gwappdb absent → app-bound
+    const v = verdictFromStatistics({ gwtotal: 609, gwapp: 439, gwfw: 167 });
+    expect(v.bound).toBe('app');
+    // regression: the note used to say arm via action="traces" (wrong) + "read its hitlist" (empty for HTTP)
+    expect(v.note).toContain('trace_start');
+    expect(v.note).toMatch(/dbAccesses|ST12|SAT/);
+  });
+
   it('does not let an inconsistent gwapp/gwappdb split produce negative app time', () => {
     expect(verdictFromStatistics({ gwtotal: 100, gwapp: 20, gwappdb: 80, gwfw: 30 }).bound).toBe('db');
   });


### PR DESCRIPTION
## What

The `odata_perf` **`app`** verdict note had two inaccuracies, both caught by a live app-bound run:

- It said *"Arm an ABAP profiler trace (SAPDiagnose action=\"traces\")"* — but `traces` **lists/analyzes**; the **arm** action is **`trace_start`**.
- It said *"read its hitlist for the hot path"* — but for **HTTP/OData traces the hitlist/statements are empty** on HANA (live-verified: `analysis=statements` → `400 "Data is invalid…"`; business tables sit in a `<DB Access from Kernel>` bucket).

## Why

`odata_perf(GWSAMPLE_BASIC ?$expand=ToBusinessPartner,ToLineItems)` → `verdict: app, gwapp 439 of 609, gwappdb absent`. Following the old note's advice (`action="traces"` to arm, "read the hitlist") dead-ends. Rewrote it to the path that actually works:

> ABAP/SADL-bound: application logic dominates, not the DB (an `$expand` N+1 is the classic cause) — do not ST05-hunt for a slow query. Find the OData implementation (the CDS behind a V4/RAP binding, or the SEGW Gateway DPC class) and arm a profiler trace via `SAPDiagnose(action="trace_start")`, then read it with `action="traces" analysis="dbAccesses"`. Note: for HTTP/OData traces the ABAP hitlist/statements are usually empty — use ST12/SAT in SAP GUI for the call tree.

## Notes
- Runtime string only (not the tool schema) → no schema-budget/snapshot change; line count unchanged.
- Added a regression test asserting the `app` note names `trace_start` (not `traces`) and points to `dbAccesses`/ST12/SAT.
- Live-verified the new note on a4h 758. Gate green (128 diagnostics tests; typecheck/lint/validate:policy/check:sizes); the pre-existing `ui.test.ts` failure is unrelated.
- Pairs with the `/debug-slow-sql` skill update in #511 (same finding from the same run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)