### PR TITLE
feat(diagnose): odata_perf client-wait + debug-slow-sql field findings

### DIFF
--- a/scripts/ci/check-file-sizes.mjs
+++ b/scripts/ci/check-file-sizes.mjs
@@ -34,8 +34,8 @@ const BUDGETS = {
   'src/handlers/tools.ts': 1790,
   'src/adt/xml-parser.ts': 1650,
   // diagnostics.ts gained the ABAP trace-request engine (#508) + the OData perf probe + CDS Show-SQL (#509)
-  // + ST05 SQL-trace control (#510). Split out a perf/trace module if it grows much further.
-  'src/adt/diagnostics.ts': 1835,
+  // + ST05 SQL-trace control (#510) + clientWait split. Split out a perf/trace module if it grows much further.
+  'src/adt/diagnostics.ts': 1845,
   // The ADT client facade aggregates every read/write op; set_api_state (#506) + runQueryWithMetrics
   // (SAPQuery metrics, this PR) pushed it past the default. Keep tight headroom.
   'src/adt/client.ts': 1560,

--- a/skills/debug-slow-sql/SKILL.md
+++ b/skills/debug-slow-sql/SKILL.md
@@ -32,6 +32,12 @@ If you only have a vague "X is slow", get the OData URL or the object name first
 
 Work top-down. Each rung is cheaper than the next and usually tells you whether to descend.
 
+> **Reachability — don't promise a plan you can't reach.** Rungs 3–4 (profiler, ST05) need `SAP_ALLOW_WRITES`
+> to arm and `S_ADT_RES` (ACTVT 01 **and** 02) to read — and don't exist on NW 7.50. If arming returns *writes
+> disabled* or a `403`, say so and **stop at rung 2**: `odata_perf` + `cds_sql` + `SAPQuery` already pin a
+> DB-bound root cause GUI-free. Tier-3–4 (the exact statement + execution plan) then depends on Basis/config, so
+> hand the user the precise ST05/SAT steps below instead of pretending you reached the plan.
+
 ### 0. Orient (no execution)
 - `SAPContext(action="deps", type="<type>", name=…)` / `SAPRead(type="DDLS", name=…)` — read the CDS/ABAP
   source. Eyeball it for the usual suspects **before** measuring: `LIKE '%term%'` (leading wildcard = no
@@ -43,7 +49,7 @@ Work top-down. Each rung is cheaper than the next and usually tells you whether 
   help, SADL/RAP, or a framework — not hand-written, so a `grep`/where-used for the literal `SELECT` comes up
   empty. Trace the generator instead: for a value-help / type-ahead screen, the **search help**
   (`DD30L.SELMETHOD` + `FUZZY_SEARCH`, `DD32S` fields) and its DSH/SADL classes (`CL_DSH_*`, the F4→WHERE
-  conversion) via `SAPSearch`/`SAPNavigate`/`SAPRead`. For an OData service, find its implementation: a **V4/RAP** binding → `SAPRead(type="SRVB", name=…)` → the service definition → the CDS view (then use `cds_sql`, rung 2); a **classic SEGW / Gateway V2** service has **no CDS** → find the DPC class (`SAPSearch "<SERVICE>_DPC*"`, read its `*_get_entityset` / `*_get_entity` / expand / `resolve_navigation_path` methods) and **skip rung 2**. (Don't
+  conversion) via `SAPSearch`/`SAPNavigate`/`SAPRead`. For an OData service, find its implementation: a **V4/RAP** binding → `SAPRead(type="SRVB", name=…)` → the service definition → the CDS view (then use `cds_sql`, rung 2). The **binding** (SRVB) name often differs from the URL's service path — if `SRVB` 404s, `SAPSearch` the service name to find the actual binding, or read the **service definition** (`SRVD`) directly for its `expose … as` entities. A **classic SEGW / Gateway V2** service has **no CDS** → find the DPC class (`SAPSearch "<SERVICE>_DPC*"`, read its `*_get_entityset` / `*_get_entity` / expand / `resolve_navigation_path` methods) and **skip rung 2**. (Don't
   confuse SE91/`WBMESSAGES`, which loads one message class in memory and searches with `CS`, with a search-help
   path that issues a real DB `LIKE`.)
 
@@ -76,8 +82,15 @@ entity/list request from the Network tab, not a `$batch` POST.)
   metrics: `queryExecutionTimeMs`, `totalRows` (total matches), `rowsReturned`, and the `executedQueryString`.
   Run it with the **real filter values** from the slow request: a large `totalRows` / `queryExecutionTimeMs` for
   a small useful result = a scan/selectivity problem. It does **not** expose the HANA execution plan or buffer
-  state — use ST05/HANA for those. (Needs `SAP_ALLOW_FREE_SQL` for freestyle SQL; multi-column `WHERE` via
-  `SAPRead(type="TABLE_QUERY")` needs `SAP_ALLOW_DATA_PREVIEW`.)
+  state — use ST05/HANA for those. A `SAPQuery` that **times out** is itself evidence of an unbounded scan —
+  record the timeout as the signal, don't just retry with a smaller `maxRows`. (Needs `SAP_ALLOW_FREE_SQL` for
+  freestyle SQL; multi-column `WHERE` via `SAPRead(type="TABLE_QUERY")` needs `SAP_ALLOW_DATA_PREVIEW`.)
+- **Equality also slow? It's the view, not your filter.** If `SAPQuery` with an exact `WHERE key = '…'` is as
+  slow as a `LIKE '%…%'` (both tens of seconds), the `LIKE` is a red herring — the cost is the CDS itself: a wide
+  `SELECT DISTINCT`, a deep join the filter can't start from (the filtered field isn't index-leading), or an
+  aggregate / `$count=true`. `cds_sql` shows the join order; the fix is to invert the join so the **selective**
+  table leads, trim the `DISTINCT`/aggregate out of the list projection, or drop `$count=true` on a large scan —
+  not to touch the `LIKE`.
 - Compare signals: probe the OData URL, then run `SAPQuery` on the underlying CDS/base — if `queryExecutionTimeMs`
   is close to the OData `gwappdb`, the DB query is the cost; if OData is slow but the query is fast, it's the
   SADL/framework layer above. For the exact statement + execution plan, descend to ST05.
@@ -189,13 +202,21 @@ handful of rows. **Fix:** drop the leading wildcard (anchor the search) / add a 
 pre-filter on an indexed field first. For the HANA plan + rows-fetched, arm an ST05 trace (rung 4), reproduce,
 and open the directory deep-link.
 
+This is the **simple** case — a single-table scan where the leading wildcard really is the bottleneck. On a
+wide CDS view it often is **not**: if an exact-match `WHERE key = '…'` is just as slow as the `LIKE`, the cost is
+the view's joins / `DISTINCT` / `$count`, not the wildcard (rung 2, "Equality also slow?"). Measure both before
+you blame the `LIKE`.
+
 ---
 
 ## Output
 
 Deliver a tight diagnosis, not a tool log:
 
-1. **Verdict** — DB / app / framework / auth, with the number that proves it (e.g. "`gwappdb` 412 ms of 480 ms").
+1. **Verdict** — DB / app / framework / auth, with the number that proves it (e.g. "`gwappdb` 412 ms of `gwtotal`
+   480 ms"). Cite the **SAP** figure (`gwtotal`/`gwappdb`), never `wallClockMs`: wall-clock also counts
+   network/MCP/proxy (`odata_perf` returns that gap as `clientWaitMs`), so when `clientWaitMs` dwarfs `gwtotal`
+   the latency is the landscape, not the query.
 2. **The statement** — the offending SQL (from `cds_sql` / ST05) and what it scans (`SAPQuery totalRows` / ST05
    rows fetched, the table, the missing index).
 3. **Root cause** — one sentence, mapped to the catalog above.

--- a/src/adt/diagnostics.ts
+++ b/src/adt/diagnostics.ts
@@ -1004,6 +1004,8 @@ export interface ODataPerfResult {
   url: string;
   statusCode: number;
   wallClockMs: number;
+  /** `wallClockMs − gwtotal`: time spent OUTSIDE SAP Gateway (network/MCP/proxy/queueing). Only when gwtotal is present. */
+  clientWaitMs?: number;
   /** Parsed `sap-statistics` header — variable field set; `gwappdb` (when present) is DB time. */
   statistics: Record<string, number>;
   fesrecMicros?: number;
@@ -1068,6 +1070,27 @@ export function verdictFromStatistics(m: Record<string, number>): ODataPerfResul
 }
 
 /**
+ * Time spent outside SAP Gateway (network/MCP/proxy/queueing): `wallClockMs − gwtotal`. When that overhead
+ * dwarfs the SAP server time, the latency is the landscape, not the query — return a note so the LLM cites
+ * `gwtotal` rather than `wallClockMs` as "SAP time".
+ */
+export function clientWaitFrom(
+  wallClockMs: number,
+  statistics: Record<string, number>,
+): { clientWaitMs?: number; note?: string } {
+  const gwtotal = statistics.gwtotal ?? statistics.total;
+  if (gwtotal === undefined || !Number.isFinite(gwtotal)) return {};
+  const clientWaitMs = Math.max(Math.round(wallClockMs - gwtotal), 0);
+  if (clientWaitMs > gwtotal && clientWaitMs > 1000) {
+    return {
+      clientWaitMs,
+      note: `${clientWaitMs}ms of the ${Math.round(wallClockMs)}ms wall-clock was OUTSIDE SAP Gateway (gwtotal=${gwtotal}ms) — network/MCP/proxy/queueing, not server time. Cite gwtotal/gwappdb as the SAP figure, not wallClockMs.`,
+    };
+  }
+  return { clientWaitMs };
+}
+
+/**
  * GET an OData URL with `?sap-statistics=true` + a wall-clock timer → server-side timing split + verdict.
  * Security: `url` must be a host-relative path on the configured SAP system (no absolute URLs / SSRF).
  */
@@ -1084,14 +1107,18 @@ export async function probeODataPerformance(
   const wallClockMs = Date.now() - t0;
   const statistics = parseSapStatistics(resp.headers['sap-statistics'] ?? '');
   const fesrec = Number(resp.headers['sap-perf-fesrec']);
+  const verdict = verdictFromStatistics(statistics);
+  const { clientWaitMs, note: clientNote } = clientWaitFrom(wallClockMs, statistics);
+  if (clientNote) verdict.note += ` ${clientNote}`;
   return {
     url: withStat,
     statusCode: resp.statusCode,
     wallClockMs,
+    clientWaitMs,
     statistics,
     fesrecMicros: Number.isFinite(fesrec) ? fesrec : undefined,
     responseBytes: Buffer.byteLength(resp.body ?? ''),
-    verdict: verdictFromStatistics(statistics),
+    verdict,
   };
 }
 
@@ -1132,7 +1159,7 @@ function isODataPath(pathname: string): boolean {
 
 function invalidODataPerfUrl(): Error {
   return new Error(
-    'odata_perf url must be a host-relative OData path on the configured SAP system (e.g. "/sap/opu/odata4/.../Entity?$filter=..."); absolute URLs and non-OData SAP paths are not allowed.',
+    'odata_perf url must be a host-relative OData path on the configured SAP system — V4 "/sap/opu/odata4/sap/.../Entity?$filter=..." or classic V2/SEGW "/sap/opu/odata/sap/<SRV>/<EntitySet>?$top=20"; absolute URLs and non-OData SAP paths are not allowed.',
   );
 }
 

--- a/tests/unit/adt/diagnostics.test.ts
+++ b/tests/unit/adt/diagnostics.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  clientWaitFrom,
   createTraceRequest,
   decodeHtmlEntities,
   deleteTraceRequest,
@@ -1466,6 +1467,25 @@ describe('probeODataPerformance', () => {
     const http = mockHttp();
     await expect(probeODataPerformance(http, unrestrictedSafetyConfig(), url)).rejects.toThrow(/OData path/);
     expect(http.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('clientWaitFrom', () => {
+  it('flags time outside SAP Gateway when client wait dwarfs gwtotal', () => {
+    const { clientWaitMs, note } = clientWaitFrom(75043, { gwtotal: 30126 });
+    expect(clientWaitMs).toBe(44917);
+    expect(note).toMatch(/OUTSIDE SAP Gateway/);
+    expect(note).toMatch(/not wallClockMs/);
+  });
+
+  it('reports clientWaitMs without a note when wall-clock ≈ gwtotal', () => {
+    const { clientWaitMs, note } = clientWaitFrom(190, { gwtotal: 173 });
+    expect(clientWaitMs).toBe(17);
+    expect(note).toBeUndefined();
+  });
+
+  it('returns nothing when gwtotal is absent (no SAP figure to subtract)', () => {
+    expect(clientWaitFrom(5000, { gwhub: 200 })).toEqual({});
   });
 });
 


### PR DESCRIPTION
Acts on a live-system evaluation of ARC-1's SQL/OData perf tools + the `debug-slow-sql` skill. Most of the evaluator's "gaps" were already handled (V2 paths are accepted and tested; `$batch` guidance is in the skill) — this PR ships the **two findings that were real**, plus the cheap doc fixes for the friction the run actually hit.

## Code — `odata_perf` client-wait (`src/adt/diagnostics.ts`)
The probe returned `wallClockMs` and the `sap-statistics` split as **unrelated** numbers. On the real run that gap was huge — **wallClock 75 s vs `gwtotal` 30 s** — i.e. ~45 s spent *outside* SAP Gateway (network / MCP / proxy / queueing), which the tool made invisible and the LLM then misreported as "SAP time".

- New `clientWaitMs` (= `wallClockMs − gwtotal`) on `ODataPerfResult`, computed by a pure `clientWaitFrom()` helper.
- When that overhead dwarfs `gwtotal`, a note is appended to the verdict: *"…was OUTSIDE SAP Gateway — cite gwtotal/gwappdb, not wallClockMs."*
- `invalidODataPerfUrl()` message now shows **V2 and V4** examples (the allowlist already accepts `/sap/opu/odata/`; the old message only showed `odata4`, which led the evaluator to wrongly assume V2 was unsupported).
- 3 unit tests on `clientWaitFrom` (incl. the real 75043/30126 → 44917 case); `diagnostics.ts` size budget 1835→1845 for the helper.

No tool **input** schema change → no snapshot/schema-budget regen.

## Skill — `skills/debug-slow-sql/SKILL.md`
- **Rung 2 — "Equality also slow? It's the view, not your filter."** The keystone field finding: on a wide `SELECT DISTINCT` CDS, an exact-match `WHERE key = '…'` was as slow as `LIKE '%…%'` (both ~24 s) — the cost was join order / `DISTINCT` / `$count`, not the wildcard. De-universalizes the leading-wildcard worked example.
- **Output** — cite `gwtotal`/`gwappdb`, never `wallClockMs` (pairs with `clientWaitMs`).
- **Reachability note** — rungs 3–4 (profiler, ST05) need `SAP_ALLOW_WRITES` + `S_ADT_RES`; if blocked, stop at rung 2 honestly instead of promising an unreachable execution plan (the run's "over-sells GUI-free completion" critique).
- **Rung 0** — the SRVB binding name often differs from the URL service path (the run's `SRVB` 404).
- **Rung 2** — a `SAPQuery` timeout is itself scan evidence.

## Verification
`npm test` (4104 pass) · `typecheck` · `lint` · `build` · `validate:policy` (✓) · `check:sizes` (✓) · plugin-manifest (37/37, frontmatter untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)