### PR TITLE
feat: cloud-correct object create on BTP ABAP Environment (G-2..G-5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,15 @@ SAP_TRANSPORT=stdio              # or: http-streamable
 # SAP_ALLOW_GIT_WRITES=true
 # SAP_ALLOWED_PACKAGES=*
 
+# ── BTP / Steampunk (ABAP Environment) note ──────────────────────
+# On the SAP BTP ABAP Environment, the default `$TMP` cannot host objects (POST → 403
+# ExceptionResourceNoAccess), and the booster-provided `ZLOCAL` is a STRUCTURE package
+# that also cannot contain development objects. Create a regular (development) sub-package
+# under ZLOCAL in ADT/Eclipse and point the allowlist at it:
+# SAP_ALLOW_WRITES=true
+# SAP_ALLOWED_PACKAGES=Z*          # or the exact name of your cloud dev package
+# (ARC-1 emits the cloud-correct create body automatically when systemType=btp.)
+
 # ── Recipe 8: FINE-GRAINED DENIALS (SAP_DENY_ACTIONS) ──────────────────────
 # Deny specific tools/actions even if scope + flag would allow.
 # Grammar: tool-qualified only (Tool, Tool.action, Tool.glob*).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ src/
 │   ├── cds-impact.ts, rap-preflight.ts, rap-handlers.ts, rap-generate.ts  # CDS/RAP intelligence
 │   ├── class-structure.ts      # Class-section surgery splice + diff (#303)
 │   ├── server-driven.ts        # Server-driven objects (DESD/EVTB/… — 8.16 AFF JSON engine)
-│   ├── btp.ts, oauth.ts, cookies.ts  # BTP Destination/Connectivity, OAuth, cookie parsing
+│   ├── oauth.ts, cookies.ts    # BTP OAuth (browser/PKCE) + cookie parsing (Destination Service lives in server.ts + @arc-mcp/xsuaa-auth)
 │   ├── ui5-repository.ts, flp.ts    # UI5 ABAP Repository + FLP OData clients
 │   └── diagnostics.ts, codeintel.ts # ST22/traces + find-def/refs/where-used/completion
 ├── context/                    # deps.ts, cds-deps.ts, contract.ts, compressor.ts, method-surgery.ts, grep.ts
@@ -208,7 +208,7 @@ Terse routing only — full gotchas per row in [docs/dev-guide.md](docs/dev-guid
 | E2E test / fixture | `tests/e2e/`, `tests/e2e/fixtures.ts` + `tests/fixtures/abap/` + `tests/e2e/setup.ts` |
 | Source caching / ETag / inactive drafts / warmup | `src/cache/caching-layer.ts` + `src/cache/*`, `src/cache/inactive-list-cache.ts` + `src/handlers/read.ts`, `src/cache/warmup.ts` |
 | Integration / BTP / CRUD tests | `tests/integration/adt.integration.test.ts`, `btp-abap[.smoke].integration.test.ts`, `crud-harness.ts` + `crud.lifecycle.integration.test.ts` |
-| BTP auth / Destination Service | `src/adt/oauth.ts` + `src/server/server.ts` / `src/adt/btp.ts` |
+| BTP auth / Destination Service | `src/adt/oauth.ts` (browser OAuth) + `src/server/server.ts` (`buildAdtConfig` per-user destination) + `@arc-mcp/xsuaa-auth` dep |
 | AFF schema / validation | `src/aff/schemas/` + `src/aff/validator.ts` / `src/handlers/write/create.ts` (create/batch_create paths) |
 | CI coverage / reliability reporting | `scripts/ci/coverage-summary.mjs`, `scripts/ci/collect-test-reliability.mjs`, `.github/workflows/test.yml` |
 

--- a/docs/research/2026-06-26-btp-object-create-fix.md
+++ b/docs/research/2026-06-26-btp-object-create-fix.md
@@ -166,3 +166,24 @@ Deferred (verified-feasible / intentional, out of this PR's create-path scope):
 
 Note: the smoke run that surfaced these executed against `arc-1-lsp-local` (the configured `arc-1-btp`
 server wasn't connected); both bugs were re-confirmed against this PR's `dist/` before fixing.
+
+## Re-test (2026-06-27) — green on the real build + one small DX fix
+
+A second smoke run, correctly on `arc-1-btp` (H01 919), passed **all 7 smokes**: INTF create works (no
+language-version 500), the ZLOCAL package 403 carries *no* SM12 hint, the data gates return the 400 +
+CDS hint, and a released-view query works. Both headline fixes are confirmed on the shipped build.
+
+One clean DX fix taken from the feedback:
+- **DOMA `outputLength` on update — FIXED.** Updating a domain's length (e.g. 10→20) without an explicit
+  `outputLength` kept the old value, so SAP warned *"Output length (10) is less than the calculated
+  output length (20)"*. The update merge now follows a changed length
+  (`provided.outputLength ?? provided.length ?? existing.outputLength`), matching the create default.
+  Unit-tested.
+
+Deferred (pre-existing, cross-cutting cache/DX — not create-path, warrant their own focused PRs):
+- **Post-activate read staleness** — after `SAPActivate`, a `SAPRead(version=active)` can return the
+  stale empty shell until `force_refresh`, even though `activate.ts` already invalidates the
+  inactive-list + source caches. Needs live cache/ETag investigation (cache key vs SAP eventual
+  consistency); risky to touch shared read paths here.
+- **DEVC ghost after delete** — a deleted object lingers in the package listing though `SAPRead` on it
+  404s (package-index/cache lag).

--- a/docs/research/2026-06-26-btp-object-create-fix.md
+++ b/docs/research/2026-06-26-btp-object-create-fix.md
@@ -116,3 +116,24 @@ An adversarial Codex pass produced four findings; resolution:
   valid `abapLanguageVersion`, and create-body acceptance is live-verified for CLAS/INTF/DDLS/DTEL/DOMA/
   TTYP — but the DDIC **update** STs (DOMA/DTEL/TTYP/SRVB/MSAG) are not yet live-verified on BTP. Track
   as a follow-up; CLAS/INTF (the common path) use source-PUT, not this path.
+
+## Tier-1 cleanup (now live-disproven test assumptions + nits)
+
+Live re-run of the BTP suite surfaced three integration tests asserting the wrong thing; all fixed and
+re-verified against H01 (919):
+
+- **T-1 — FIXED.** `getProgram('RSHOWTIM')` was asserted to be unavailable; it is **fully readable**
+  (returns its `REPORT` source). Reframed to "classic PROG is readable, but creating a classic program
+  is refused" (the create is attempted against a writable package and must reject).
+- **T-2 / T-3 — FIXED + classified.** Standard-table preview and freestyle SQL were asserted as 403/500;
+  BTP actually returns **HTTP 400 `ExceptionDataPreviewGeneral` "No authorization to view data"**
+  (`ADT_DATAPREVIEW_MSG/023`; LONGTEXT cites auth object `S_ABPLNGVS` — the ABAP-language-version gate).
+  Tests now assert the 400 shape, and `classifySapDomainError` gains a distinct
+  `data-view-not-authorized` category + hint ("query a released CDS view / a custom Z\* table instead") —
+  a separate code path from G-4's `ExceptionResourceNoAccess`. Unit-tested.
+
+Three one-line nits: **G-6** AMDP probe path `/sap/bc/adt/debugger/amdp` → `/sap/bc/adt/amdp/debugger`
+(the former resolves to the generic debugger node → 403; discovery advertises `/amdp/debugger/main`).
+**G-7** `features.ts` comment claimed BTP reports release `"sap_btp"` — it reports a numeric SAP_BASIS
+(`919`). **G-8** `AGENTS.md` referenced a non-existent `src/adt/btp.ts` — the BTP Destination Service is
+`oauth.ts` + `server.ts` (`buildAdtConfig`) + the `@arc-mcp/xsuaa-auth` dep.

--- a/docs/research/2026-06-26-btp-object-create-fix.md
+++ b/docs/research/2026-06-26-btp-object-create-fix.md
@@ -137,3 +137,32 @@ Three one-line nits: **G-6** AMDP probe path `/sap/bc/adt/debugger/amdp` → `/s
 **G-7** `features.ts` comment claimed BTP reports release `"sap_btp"` — it reports a numeric SAP_BASIS
 (`919`). **G-8** `AGENTS.md` referenced a non-existent `src/adt/btp.ts` — the BTP Destination Service is
 `oauth.ts` + `server.ts` (`buildAdtConfig`) + the `@arc-mcp/xsuaa-auth` dep.
+
+## Live smoke-test review (2026-06-27) — two more P1 create-path bugs
+
+A full MCP smoke run surfaced two real create-path bugs (both reproduced and fixed against my build, H01 919):
+
+- **INTF create — FIXED.** Cloud INTF create POSTed with `application/*` returned HTTP 500 `[?/537]
+  "ABAP language version  is not allowed in this software component"` (blank version): `application/*`
+  routes INTF to an older deserialize ST that drops `adtcore:abapLanguageVersion`. The body is correct
+  (it carries `cloudDevelopment`) — the **content-type** is the fix. `createContentTypeForType(type, cloud)`
+  now returns `application/vnd.sap.adt.oo.interfaces.v5+xml` for cloud INTF (on-prem keeps `application/*`).
+  CLAS/DDLS are unaffected (their `application/*` ST is fine). Live-verified: `INTF create → activate →
+  read → delete` green; unit + integration tested.
+- **SM12 hint on a structure-package 403 — FIXED.** The G-4 message was correct, but
+  `classifySapDomainError` then appended a contradictory *"Object is locked … check SM12"* hint, because
+  the lock-conflict rule treated *any* `ExceptionResourceNoAccess` as a lock. Create-time
+  `ExceptionResourceNoAccess` with package markers (structure package / `not authorized` / `S_DEVELOP`)
+  and no lock markers now classifies as `authorization` (no SM12); a bare/409 `ExceptionResourceNoAccess`
+  still classifies as a lock (ADR-0002 preserved). Unit-tested.
+
+Deferred (verified-feasible / intentional, out of this PR's create-path scope):
+- **TTYP on BTP** — the registry has `btp:false`, but a TTYP shell create POST **succeeds** on BTP
+  (live, 200). Enabling `btp:true` needs the full 2-step (shell + row-type PUT + activate) verified —
+  follow-up.
+- **PROG read on BTP** — classic programs are readable via ADT (T-1), but BTP `SAPRead` intentionally
+  drops PROG. `SAPSearch` still finds them, so the find-but-can't-read gap is a deliberate tool-surface
+  choice; revisit if read-only classic-program inspection is wanted.
+
+Note: the smoke run that surfaced these executed against `arc-1-lsp-local` (the configured `arc-1-btp`
+server wasn't connected); both bugs were re-confirmed against this PR's `dist/` before fixing.

--- a/docs/research/2026-06-26-btp-object-create-fix.md
+++ b/docs/research/2026-06-26-btp-object-create-fix.md
@@ -1,0 +1,118 @@
+# BTP ABAP (Steampunk) — Object-Create Path Fix (G-2..G-5)
+
+**Date:** 2026-06-26
+**System:** BTP ABAP Environment `H01`, SAP_BASIS **919**, region us10, free tier, user `marian@zeis.de`.
+**Companion:** `2026-06-26-btp-live-validation-and-gaps.md` (the gap inventory this fixes).
+**Method:** live ADT calls with a real developer JWT, driving ARC-1's built `dist/` create path.
+
+## What shipped
+
+| Gap | Fix | File |
+|-----|-----|------|
+| **G-3** | Cloud-correct create body, driven by `systemType=btp` | `src/handlers/write-helpers.ts` (`cloudifyCreateBody`) |
+| **G-4** | `ExceptionResourceNoAccess` on create → 403 package/authorization denial (not 409 "locked/SM12"); structure-package case detected | `src/adt/crud.ts` (`convertHtmlConflictToProperError`, `createObject`/`lockObject` thread `systemType`) |
+| **G-5** | ABAP user derived from the JWT `user_name` when no `SAP_USER` | `src/adt/client.ts` (`getEffectiveUser`, used by `getSystemInfo`) |
+| **G-2** | Docs: `$TMP`/`ZLOCAL` are unusable on BTP; use a regular cloud sub-package | `.env.example` |
+| responsible casing | Email-style (cloud) users kept case-sensitive, not upper-cased | `src/adt/ddic-xml.ts` (`normalizeAdtResponsible`) |
+
+## The key live finding (why "abapLanguageVersion alone wasn't enough")
+
+The on-prem create body is wrong on cloud in **three** ways, only one of which the prior doc identified:
+
+1. `adtcore:masterSystem="H00"` — invalid on cloud, must be dropped.
+2. `adtcore:abapLanguageVersion="cloudDevelopment"` — required (cloud objects are ABAP for Cloud).
+3. **`adtcore:responsible` must be OMITTED.** This was the real blocker. The cloud object-create
+   simple transformations (`CLASS_TRANSFORMATION`, `INTF_TRANSFORMATION`, `SBD_*`, …) **reject the
+   `adtcore:responsible` attribute**: when present, deserialization fails at the first child element
+   with HTTP 400 `ExceptionInvalidData` "error deserializing in <ST>". Removing it makes the body
+   deserialize; cloud assigns the object owner from the request JWT. (CLAS additionally needs explicit
+   `class:final`/`class:visibility`/`class:category`.)
+
+Triangulated via `XML_OFFSET` in the ST error: with `responsible` present the offset sits at the
+first child (`<adtcore:packageRef>`); without it the body deserializes and SAP advances to
+package-assignment.
+
+## Live verification (this session)
+
+Driving the real `dist/` `buildCreateXml(…, cloud=true)` + `createObject` against H01:
+
+- **Body accepted (deserializes) for CLAS, INTF, DDLS, DTEL, DOMA, TTYP** — all reach
+  package-assignment (403 "Structure packages cannot contain development objects") instead of a 400
+  deserialization error. (INTF additionally hits a structure-package software-component check — a
+  ZLOCAL artifact, not a body defect.)
+- **G-4:** the structure-package create now returns `403` with
+  *"…the target package is a structure package and cannot contain development objects. …create a
+  regular sub-package…"* — no more misleading 409/SM12.
+- **G-5:** `getEffectiveUser()` → `marian@zeis.de` (from the JWT); `getSystemInfo().user` no longer empty.
+- **Full lifecycle GREEN (2026-06-26):** with a writable dev package (`ZARC1_TEST`, created in Eclipse
+  under ZLOCAL), `CLAS create → activate → read → delete` passes live against H01 (11.5s) — class
+  created, source written, activated, read back (`hello`), then deleted; no orphan objects left.
+- Integration tests (`btp-abap.integration.test.ts` → "BTP object-create path") pass live against H01
+  (**3 passed**) with a pre-acquired token (`TEST_BTP_ACCESS_TOKEN`); the lifecycle case is gated on
+  `TEST_BTP_PACKAGE`.
+
+## Remaining blocker — G-11: package creation on cloud (NEW, separate gap)
+
+A full create→activate→read→delete needs a writable **regular** package. On a fresh Steampunk the
+only package is `ZLOCAL`, a **structure package** that cannot hold objects — so a sub-package must be
+created first. Package creation via plain ADT POST is blocked by a genuine SAP platform asymmetry,
+now exhaustively confirmed live against H01 (SAP_BASIS 919):
+
+- `SPAK_ST_PACKAGES` (the v2 deserialize ST) **rejects `adtcore:responsible` on the root** — the *only*
+  place the serialize ST emits it (verified by GETting ZLOCAL as `…packages.v2+xml`). Offset
+  triangulation shows the whole root open-tag incl. the responsible value is consumed, then the ST
+  errors at the first child — i.e. responsible is simply **not in the deserialize content model**
+  (value-independent: same failure for `marian@zeis.de` and bare names).
+- Omit responsible → the body deserializes, but the package framework then rejects it at the app
+  layer: `PAK/049 "Enter a valid user, not , as the person responsible"`. It is **not** defaulted from
+  the session user (objects are; packages are not).
+- The gap is **stateful-session-independent** (`X-sap-adt-sessiontype: stateful` → identical PAK/049),
+  **content-type-independent** (`application/*` and `…packages.v2+xml` identical; v1 → 415), and there
+  is **no `responsible` query param** (ADT discovery template exposes only `corrNr,lockHandle,version,
+  accessMode,_action`).
+- Both reference impls put `adtcore:responsible` on the root — `abap-adt-api` (`createBodyPackage`) and
+  `oisee/vibing-steampunk` (Go ADT→MCP bridge) — so **both hit this identical wall on Steampunk**.
+
+Conclusion: there is no body/header/query channel to set the package owner via REST on this release;
+Eclipse's interactive (SSO) session evidently resolves it through a path the OAuth/bearer ADT session
+does not. **Confirmed live:** the Eclipse-created `ZARC1_TEST` shows Responsible = `CB9980000000`
+("Initial Admin") — a *technical* user the interactive session assigns, never the bearer JWT's
+`marian@zeis.de`; the REST path has no way to supply it. This is a distinct, deeper gap (its own
+create path, `SAPManage create_package` / `buildPackageXml`), **out of scope for G-2..G-5**, and
+likely needs a SAP-side fix or the Eclipse flow. Until then, create the dev package in ADT/Eclipse and
+point `SAP_ALLOWED_PACKAGES` at it.
+
+## Running the positive lifecycle test
+
+```bash
+# 1. Create a regular (development) sub-package under ZLOCAL in ADT/Eclipse, e.g. ZARC1_TEST.
+# 2. Provide a named-user dev JWT (client_credentials is rejected by ADT) + that package:
+TEST_BTP_SERVICE_KEY_FILE=~/.config/arc-1/btp-abap-service-key.json \
+TEST_BTP_ACCESS_TOKEN=<dev-jwt> \
+TEST_BTP_PACKAGE=ZARC1_TEST \
+  npm run test:integration:btp -- -t "object-create path"
+```
+
+Without `TEST_BTP_PACKAGE` the lifecycle test skips; the body-acceptance + G-5 tests still run.
+
+## Code-review follow-ups (Codex, 2026-06-26)
+
+An adversarial Codex pass produced four findings; resolution:
+
+- **#1 (systemType=auto race) — FIXED.** The startup probe sets `systemType='btp'` and ListTools
+  awaits it before CallTool, so the normal flow is safe; but a probe failure/skip left the default
+  `auto` unresolved → on-prem XML on BTP. `resolveWriteSystemType()` now falls back to `'btp'` for
+  bearer-token auth (which is only ever the ABAP Environment). Also removes the 3× duplicated
+  resolution. Unit-tested.
+- **#2 (hard-coded `class:final="true"`) — VERIFIED non-issue.** Live-proven: a **non-final** source
+  PUT overrides the create-metadata flag — the class activates and reads back non-final. The lifecycle
+  test now creates a non-final class to lock this in.
+- **#3 (`getEffectiveUser` memoized `''` on transient failure) — FIXED.** Now memoizes only resolved
+  values; a transient token/decode error returns `''` without caching, so a later call still resolves.
+  Unit-tested.
+- **#4 (metadata-UPDATE reuses the cloud create body) — FOLLOW-UP (LOW).** The full-XML metadata
+  replace (`writeActionUpdate`, and the DTEL/MSAG post-create-update) reuses `buildCreateXml(…, cloud)`.
+  The cloudify transform only strips update-irrelevant attrs (`masterSystem`, `responsible`) and adds a
+  valid `abapLanguageVersion`, and create-body acceptance is live-verified for CLAS/INTF/DDLS/DTEL/DOMA/
+  TTYP — but the DDIC **update** STs (DOMA/DTEL/TTYP/SRVB/MSAG) are not yet live-verified on BTP. Track
+  as a follow-up; CLAS/INTF (the common path) use source-PUT, not this path.

--- a/docs_page/btp-abap-environment.md
+++ b/docs_page/btp-abap-environment.md
@@ -387,6 +387,22 @@ Without this flag, ARC-1 auto-detects the system type on the first `SAPManage pr
 
 4. **Token lifecycle**: Access tokens are cached in memory. When they expire, ARC-1 uses the refresh token to get a new one. Only if the refresh token also expires does it trigger another browser login.
 
+## Writing objects on BTP
+
+Object create/update works on the ABAP Environment (live-verified: `CLAS create → activate → read → delete`). ARC-1 emits the **cloud-correct** create body automatically when the system type is `btp` — it drops the on-prem `adtcore:masterSystem`/`adtcore:responsible` and adds `abapLanguageVersion="cloudDevelopment"`; the object owner is taken from your JWT. Two prerequisites:
+
+1. **Enable writes** — `SAP_ALLOW_WRITES=true`.
+2. **Target a real development package** — the booster-provided `ZLOCAL` is a *structure* package that cannot contain development objects, and `$TMP` does not exist on BTP. Create a development **sub-package under `ZLOCAL`** in ADT/Eclipse (e.g. `ZARC1_DEV`, software component `ZLOCAL`), then point the allowlist at it:
+
+   ```bash
+   SAP_ALLOW_WRITES=true
+   SAP_ALLOWED_PACKAGES=Z*          # or the exact package name, e.g. ZARC1_DEV
+   ```
+
+You also need the developer role assigned — see [Required: Run the Booster and Assign Developer Role](#required-run-the-booster-and-assign-developer-role).
+
+> **Package creation is Eclipse-only.** ARC-1 cannot create the package for you. The ABAP Environment rejects the package-create body every ADT REST client sends (`SPAK_ST_PACKAGES` won't accept `adtcore:responsible`, yet the package framework requires it — Eclipse's interactive session resolves the owner a bearer token can't). Create the dev package once in Eclipse; everything **inside** it is then fully scriptable via ARC-1.
+
 ## Constraints vs On-Premise
 
 BTP ABAP Environment has some limitations compared to on-premise:

--- a/scripts/ci/check-file-sizes.mjs
+++ b/scripts/ci/check-file-sizes.mjs
@@ -38,8 +38,9 @@ const BUDGETS = {
   // + ST05 SQL-trace control (#510) + clientWait split. Split out a perf/trace module if it grows much further.
   'src/adt/diagnostics.ts': 1845,
   // The ADT client facade aggregates every read/write op; set_api_state (#506) + runQueryWithMetrics
-  // (SAPQuery metrics, this PR) pushed it past the default. Keep tight headroom.
-  'src/adt/client.ts': 1560,
+  // (SAPQuery metrics) + getEffectiveUser (BTP JWT-derived user, G-5) pushed it past the default.
+  // Keep tight headroom.
+  'src/adt/client.ts': 1585,
 };
 
 const DEFAULT_SRC = 1500;

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -295,6 +295,12 @@ export class AdtClient {
   readonly safety: SafetyConfig;
   /** The configured SAP username (from --user / SAP_USER) */
   readonly username: string;
+  /** Bearer-token provider (BTP). Kept so the effective ABAP user can be read from the JWT (G-5). */
+  private readonly bearerTokenProvider?: () => Promise<string>;
+  /** True when this client authenticates via a bearer token (⇒ BTP ABAP Environment). */
+  readonly usesBearerAuth: boolean;
+  /** Memoized JWT-derived user (resolved lazily by getEffectiveUser). */
+  private effectiveUser?: string;
   /** The configured SAP client number (from --client / SAP_CLIENT) */
   readonly sapClient: string;
   /** Per-client cache of resolved TABL URLs for **reads** (transparent table at
@@ -315,6 +321,8 @@ export class AdtClient {
     const config = { ...defaultAdtClientConfig(), ...options };
     this.safety = config.safety;
     this.username = config.username;
+    this.bearerTokenProvider = config.bearerTokenProvider;
+    this.usesBearerAuth = !!config.bearerTokenProvider;
     this.sapClient = config.client;
 
     const httpConfig: AdtHttpConfig = {
@@ -1437,11 +1445,31 @@ export class AdtClient {
 
   // ─── System Information ────────────────────────────────────────────
 
+  /**
+   * The ABAP user for this session. Returns the configured SAP_USER when set; otherwise
+   * (BTP bearer auth, where no SAP_USER exists) derives it from the JWT `user_name`/`email`
+   * claim. Read-only use of an already-trusted token claim — never used for auth or access
+   * control, only for display (SAPRead SYSTEM) and `adtcore:responsible` on create. See G-5.
+   */
+  async getEffectiveUser(): Promise<string> {
+    if (this.username) return this.username;
+    if (this.effectiveUser !== undefined) return this.effectiveUser;
+    if (!this.bearerTokenProvider) return (this.effectiveUser = '');
+    try {
+      const token = await this.bearerTokenProvider();
+      const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+      return (this.effectiveUser = String(payload.user_name ?? payload.email ?? ''));
+    } catch {
+      // Transient token/decode failure — do NOT memoize, so a later call can still resolve the user.
+      return '';
+    }
+  }
+
   /** Get system info as structured JSON (user, system details from discovery XML) */
   async getSystemInfo(): Promise<string> {
     checkOperation(this.safety, OperationType.Read, 'GetSystemInfo');
     const resp = await this.http.get('/sap/bc/adt/core/discovery');
-    const info = parseSystemInfo(resp.body, this.username);
+    const info = parseSystemInfo(resp.body, await this.getEffectiveUser());
     return JSON.stringify(info, null, 2);
   }
 

--- a/src/adt/crud.ts
+++ b/src/adt/crud.ts
@@ -27,6 +27,7 @@ export async function lockObject(
   objectUrl: string,
   accessMode = 'MODIFY',
   abapRelease?: string,
+  systemType?: string,
 ): Promise<LockResult> {
   if (accessMode === 'MODIFY') {
     checkOperation(safety, OperationType.Lock, 'LockObject');
@@ -40,7 +41,7 @@ export async function lockObject(
       Accept: 'application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.lock.result, application/*;q=0.8',
     });
   } catch (err) {
-    const conv = convertHtmlConflictToProperError(err, objectUrl, abapRelease);
+    const conv = convertHtmlConflictToProperError(err, objectUrl, { abapRelease, systemType, operation: 'lock' });
     if (conv) throw conv;
     throw err;
   }
@@ -95,6 +96,8 @@ export async function createObject(
   transport?: string,
   packageName?: string,
   abapRelease?: string,
+  systemType?: string,
+  objectName?: string,
 ): Promise<string> {
   checkOperation(safety, OperationType.Create, 'CreateObject');
 
@@ -113,7 +116,12 @@ export async function createObject(
   } catch (err) {
     // Reclassify lock/exists conflicts that arrive as HTML or via structured
     // exception type — same precedence as the lockObject path.
-    const conv = convertHtmlConflictToProperError(err, objectUrl, abapRelease);
+    const conv = convertHtmlConflictToProperError(err, objectUrl, {
+      abapRelease,
+      systemType,
+      operation: 'create',
+      objectName,
+    });
     if (conv) throw conv;
     const fallback = CONTENT_TYPE_FALLBACKS[contentType];
     if (fallback && isUnsupportedMediaTypeError(err)) {
@@ -367,21 +375,48 @@ function extractXmlValue(xml: string, tag: string): string {
 export function convertHtmlConflictToProperError(
   err: unknown,
   objectUrl: string,
-  abapRelease?: string,
+  opts: { abapRelease?: string; systemType?: string; operation?: 'lock' | 'create'; objectName?: string } = {},
 ): AdtApiError | undefined {
   if (!(err instanceof AdtApiError)) return undefined;
   const body = err.responseBody ?? '';
-  const name = objectUrl.split('/').pop() ?? objectUrl;
+  const cloud = opts.systemType === 'btp';
+  // On create, objectUrl is the collection (e.g. /oo/classes) — its last segment is "classes",
+  // not the object — so the caller passes the real name explicitly (G-4).
+  const name = opts.objectName ?? objectUrl.split('/').pop() ?? objectUrl;
 
   // Layer 1: structured exception type
   const typeId = extractExceptionType(body);
-  if (typeId === 'ExceptionResourceNoAccess' || typeId === 'ExceptionResourceLockedByAnotherUser') {
+
+  // ExceptionResourceNoAccess on a CREATE is an authorization/package denial, NOT a lock
+  // (SM12/SE80 don't exist on BTP). On BTP this most often means the target package isn't
+  // writable ($TMP and on-prem packages are rejected — objects must live in a cloud package). (G-4)
+  if (typeId === 'ExceptionResourceNoAccess' && opts.operation === 'create') {
+    // Structure packages (e.g. the default ZLOCAL on a fresh ABAP Environment) cannot hold
+    // development objects — a distinct, common BTP case worth its own hint (PAK 149, live-verified).
+    const isStructurePackage = /Structure packages cannot contain development objects/i.test(body);
     return new AdtApiError(
-      `Object ${name} is locked by another session. Close the editor (Eclipse, SE80) or release the lock in SM12, then retry.`,
-      409,
+      isStructurePackage
+        ? `Cannot create ${name}: the target package is a structure package and cannot contain development objects. ` +
+            `On the ABAP Environment, create a regular sub-package under it (e.g. under ZLOCAL) and target that, ` +
+            `then set SAP_ALLOWED_PACKAGES accordingly.`
+        : cloud
+          ? `Cannot create ${name}: no authorization, or the target package is not writable on the ABAP Environment. ` +
+            `On BTP, objects must live in a regular (non-structure) cloud package — $TMP, on-prem packages, and ` +
+            `structure packages are rejected. Set SAP_ALLOWED_PACKAGES to a writable cloud package and ensure your ` +
+            `developer role (e.g. SAP_BR_DEVELOPER) is assigned.`
+          : `Cannot create ${name}: insufficient authorization for the target package. ` +
+            `Verify your S_DEVELOP authorization and that the package allows this object type.`,
+      403,
       objectUrl,
       body,
     );
+  }
+
+  if (typeId === 'ExceptionResourceNoAccess' || typeId === 'ExceptionResourceLockedByAnotherUser') {
+    const releaseHint = cloud
+      ? 'Close the object in any open editor (e.g. Eclipse ADT) and retry.'
+      : 'Close the editor (Eclipse, SE80) or release the lock in SM12, then retry.';
+    return new AdtApiError(`Object ${name} is locked by another session. ${releaseHint}`, 409, objectUrl, body);
   }
 
   // Layer 2: HTML body marker, scoped by release
@@ -393,7 +428,7 @@ export function convertHtmlConflictToProperError(
   // lowercase-only) regresses #196's behavior on releases that emit any of the
   // other two. The "Logon Error Message" marker is itself emitted as written
   // (no localization on that string), so it can stay case-sensitive.
-  const release = parseReleaseNum(abapRelease);
+  const release = parseReleaseNum(opts.abapRelease);
   const fallbackEligible = release === 0 || release < 751;
   const looksLikeHtml = /<!doctype\s+html|<html[\s>]/i.test(body);
   const isHtml4xx =

--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -164,7 +164,10 @@ export function normalizeAdtLanguage(language?: string): string {
  * fixes that. Mirrors the `normalizeAdtLanguage` / issue #343 master-language pattern.
  */
 export function normalizeAdtResponsible(responsible?: string): string {
-  return (responsible ?? '').trim().toUpperCase() || 'DEVELOPER';
+  const r = (responsible ?? '').trim();
+  if (!r) return 'DEVELOPER';
+  // Cloud (BTP) users are email-style and case-sensitive; classic SAP users are upper-case.
+  return r.includes('@') ? r : r.toUpperCase();
 }
 
 function formatLength(value: number | string | undefined, width: number): string {

--- a/src/adt/errors.ts
+++ b/src/adt/errors.ts
@@ -45,7 +45,8 @@ export interface SapErrorClassification {
     | 'icf-handler-not-bound'
     | 'icf-service-inactive'
     | 'bdef-base-not-extensible'
-    | 'include-not-initialized';
+    | 'include-not-initialized'
+    | 'data-view-not-authorized';
   hint: string;
   transaction?: string;
   details?: Record<string, string>;
@@ -560,6 +561,22 @@ export function classifySapDomainError(
     return {
       category: 'include-not-initialized',
       hint: 'This class-local include is not initialised yet (a fresh class has no testclasses/CCAU include until first write). Write to it via SAPWrite(action="update", type="CLAS", include="testclasses", source=…) — ARC-1 auto-creates the include before writing.',
+      details: typeId ? { exceptionType: typeId } : undefined,
+    };
+  }
+
+  // BTP / ABAP-Cloud data preview + freestyle SQL of SAP standard tables: HTTP 400
+  // ExceptionDataPreviewGeneral "No authorization to view data" (ADT_DATAPREVIEW_MSG/023; the
+  // LONGTEXT cites auth object S_ABPLNGVS — the ABAP language-version gate, not a missing data-read
+  // role). Distinct code path from a package/object 403 (ExceptionResourceNoAccess). Live-verified 919.
+  if (typeId === 'ExceptionDataPreviewGeneral' && /no authorization to view data/i.test(bodyRaw)) {
+    return {
+      category: 'data-view-not-authorized',
+      hint:
+        'On the ABAP Environment (ABAP Cloud), previewing SAP standard-table contents and running ' +
+        'freestyle SQL against standard tables is blocked by the cloud data-access model (authorization ' +
+        'object S_ABPLNGVS) — not a role you can grant. Query a released CDS view instead (SAPQuery ' +
+        'against a C1-released view), or read/preview a custom Z* table you own.',
       details: typeId ? { exceptionType: typeId } : undefined,
     };
   }

--- a/src/adt/errors.ts
+++ b/src/adt/errors.ts
@@ -583,6 +583,28 @@ export function classifySapDomainError(
 
   const lockPattern =
     /\blocked by\b|\bbeing edited by\b|\bcurrently editing\b|\bresource is locked\b|\balready locked\b/i.test(bodyRaw);
+
+  // A create-time package/authorization denial surfaces as ExceptionResourceNoAccess too (a structure
+  // package, a non-writable package, missing authorization), but it is NOT a lock — never send the user
+  // to SM12 (which doesn't even exist on BTP). crud.ts already produced the actionable 403 message; this
+  // keeps the classifier consistent so no contradictory lock hint is appended. A bare/409
+  // ExceptionResourceNoAccess (no package markers) still classifies as a lock below — ADR-0002.
+  if (
+    typeId === 'ExceptionResourceNoAccess' &&
+    !lockPattern &&
+    /structure package|cannot contain development objects|\bnot authorized\b|person responsible|S_DEVELOP|S_ABPLNGVS/i.test(
+      bodyRaw,
+    )
+  ) {
+    return {
+      category: 'authorization',
+      hint:
+        'This is a package or authorization denial on create — not a lock, so SM12 does not apply. ' +
+        'Target a writable, regular (non-structure) package you are authorized to develop in.',
+      details: { exceptionType: typeId },
+    };
+  }
+
   if (
     typeId === 'ExceptionResourceLockedByAnotherUser' ||
     typeId === 'ExceptionResourceNoAccess' ||

--- a/src/adt/features.ts
+++ b/src/adt/features.ts
@@ -38,7 +38,8 @@ const PROBES: FeatureProbe[] = [
   { id: 'abapGit', endpoint: '/sap/bc/adt/abapgit/repos', description: 'abapGit integration' },
   { id: 'gcts', endpoint: '/sap/bc/cts_abapvcs/system', description: 'gCTS (git-enabled CTS)' },
   { id: 'rap', endpoint: '/sap/bc/adt/ddic/ddl/sources', description: 'RAP/CDS development' },
-  { id: 'amdp', endpoint: '/sap/bc/adt/debugger/amdp', description: 'AMDP debugging' },
+  // Path is /amdp/debugger, not /debugger/amdp (the latter resolves to the generic debugger node → 403). G-6.
+  { id: 'amdp', endpoint: '/sap/bc/adt/amdp/debugger', description: 'AMDP debugging' },
   // Probe /objects, not the bare node — the bare /…/ui5-bsp path has no handler → 404 → false-disables BSP.
   { id: 'ui5', endpoint: '/sap/bc/adt/filestore/ui5-bsp/objects', description: 'UI5/Fiori BSP' },
   { id: 'transport', endpoint: '/sap/bc/adt/cts/transportrequests', description: 'CTS transport management' },
@@ -188,7 +189,7 @@ export async function probeFeatures(
  * version, falling back to Cloud (the superset) for unknown releases.
  *
  * SAP_BASIS release examples: "700", "702", "740", "750", "757", "758", "816"
- * BTP ABAP Environment reports release like "sap_btp" or similar.
+ * The BTP ABAP Environment also reports a numeric SAP_BASIS (e.g. "919"), not "sap_btp". G-7.
  */
 export function mapSapReleaseToAbaplintVersion(release: string): Version {
   const r = release.replace(/\D/g, ''); // strip non-digits ("750" → "750", "7.57" → "757")
@@ -232,7 +233,7 @@ export const ABAPLINT_MAX_RELEASE = 758;
  * abaplint's `Cloud` target does not help either. Callers (pre-write lint) use this to
  * stop treating parse failures as blocking on such systems.
  *
- * Returns false when the release is unknown / non-numeric (e.g. BTP "sap_btp") — never
+ * Returns false when the release is unknown / non-numeric (a missing or unparseable value) — never
  * demote on missing data.
  */
 export function isBeyondAbaplintCeiling(release?: string): boolean {

--- a/src/handlers/write-helpers.ts
+++ b/src/handlers/write-helpers.ts
@@ -32,7 +32,7 @@ import {
   supportsServerDrivenObject,
   updateServerDrivenObjectSource,
 } from '../adt/server-driven.js';
-import type { ResolvedFeatures } from '../adt/types.js';
+import type { ResolvedFeatures, SystemType } from '../adt/types.js';
 import { escapeXmlAttr } from '../adt/xml-parser.js';
 import type { CachingLayer } from '../cache/caching-layer.js';
 import type { LintConfigOptions, RuleOverrides } from '../lint/config-builder.js';
@@ -302,7 +302,71 @@ export async function mergeMetadataWriteProperties(
  *   "System expected the element '{http://www.sap.com/adt/programs/programs}abapProgram'"
  */
 
+/**
+ * Resolve the system type for a write. Prefers the probed feature cache, then an explicit
+ * non-`auto` config, and finally falls back to `'btp'` for bearer-token auth (which is only
+ * ever the BTP ABAP Environment) when the startup probe hasn't resolved yet — so a create can
+ * never silently emit on-prem XML on the ABAP Environment if a write races/precedes the probe (G-3).
+ */
+export function resolveWriteSystemType(config: ServerConfig, client: AdtClient): SystemType | undefined {
+  const probed =
+    cachedFeatures?.systemType ?? (config.systemType !== 'auto' ? (config.systemType as SystemType) : undefined);
+  return probed ?? (client.usesBearerAuth ? 'btp' : undefined);
+}
+
+/**
+ * Build the create-XML body, applying BTP/Steampunk corrections when `cloud` is set.
+ *
+ * On the ABAP Environment the create body is ABAP-for-Cloud: it MUST carry
+ * `adtcore:abapLanguageVersion="cloudDevelopment"` and MUST NOT hardcode the on-prem
+ * `adtcore:masterSystem="H00"`, or SAP rejects it with HTTP 400 `ExceptionInvalidData`
+ * "error deserializing in CLASS_TRANSFORMATION". CLAS additionally needs explicit
+ * class attributes. The on-prem body is left byte-for-byte unchanged. Driven by
+ * systemType=btp. See docs/research/2026-06-26-btp-live-validation-and-gaps.md (G-3).
+ */
 export function buildCreateXml(
+  type: string,
+  name: string,
+  pkg: string,
+  description: string,
+  properties?: Record<string, unknown>,
+  language?: string,
+  responsible?: string,
+  cloud = false,
+): string {
+  const xml = buildCreateXmlBody(type, name, pkg, description, properties, language, responsible);
+  return cloud ? cloudifyCreateBody(xml, type) : xml;
+}
+
+/**
+ * Rewrite an on-prem create body into the Steampunk-correct form (G-3). The input is always
+ * an ARC-1-generated body, so the string anchors below are guaranteed where they apply.
+ *
+ * Live-verified on BTP SAP_BASIS 919: the cloud object-create simple transformations
+ * (CLASS_TRANSFORMATION, INTF_TRANSFORMATION, SBD_*, …) REJECT `adtcore:responsible` — when it
+ * is present the ST fails to deserialize at the first child element (HTTP 400 ExceptionInvalidData
+ * "error deserializing in <ST>"). Cloud assigns the object owner from the request JWT, so the
+ * create body must NOT carry a responsible. On-prem still needs it, so this strip is cloud-only.
+ */
+function cloudifyCreateBody(xml: string, type: string): string {
+  let out = xml
+    // On-prem master system is invalid on cloud — drop it (and its leading whitespace/newline).
+    .replace(/\s*adtcore:masterSystem="H00"/, '')
+    // Cloud assigns the owner from the JWT; an explicit responsible breaks the create ST.
+    .replace(/\s*adtcore:responsible="[^"]*"/, '')
+    // Every cloud object is ABAP for Cloud Development.
+    .replace(/(adtcore:masterLanguage="[^"]*")/, '$1 adtcore:abapLanguageVersion="cloudDevelopment"');
+  if (type === 'CLAS') {
+    // Cloud CLAS create schema requires explicit class attributes (live: GET cl_abap_random).
+    out = out.replace(
+      'adtcore:type="CLAS/OC"',
+      'adtcore:type="CLAS/OC" class:final="true" class:visibility="public" class:category="generalObjectType"',
+    );
+  }
+  return out;
+}
+
+function buildCreateXmlBody(
   type: string,
   name: string,
   pkg: string,

--- a/src/handlers/write-helpers.ts
+++ b/src/handlers/write-helpers.ts
@@ -104,7 +104,11 @@ function needsVendorContentType(type: string): boolean {
 }
 
 /** Content type used for create POST */
-export function createContentTypeForType(type: string): string {
+export function createContentTypeForType(type: string, cloud = false): string {
+  // Cloud INTF create needs the v5 ST: `application/*` routes to an older ST that silently drops the
+  // cloud abapLanguageVersion → HTTP 500 "ABAP language version  is not allowed in this software
+  // component". On-prem INTF create keeps `application/*` (unchanged). Live-verified BTP 919.
+  if (type === 'INTF' && cloud) return 'application/vnd.sap.adt.oo.interfaces.v5+xml';
   // SRVB creation works with wildcard content type; updates use vendor v2 type.
   if (type === 'SRVB') return 'application/*';
   return needsVendorContentType(type) ? vendorContentTypeForType(type) : 'application/*';

--- a/src/handlers/write-helpers.ts
+++ b/src/handlers/write-helpers.ts
@@ -249,7 +249,9 @@ export async function mergeMetadataWriteProperties(
         dataType: provided.dataType ?? existing.dataType,
         length: provided.length ?? existing.length,
         decimals: provided.decimals ?? existing.decimals,
-        outputLength: provided.outputLength ?? existing.outputLength,
+        // When length changes but outputLength isn't given, follow the new length (mirrors the create
+        // default of `outputLength ?? length`) — otherwise SAP warns "Output length < calculated length".
+        outputLength: provided.outputLength ?? provided.length ?? existing.outputLength,
         conversionExit: provided.conversionExit ?? existing.conversionExit,
         signExists: provided.signExists ?? existing.signExists,
         lowercase: provided.lowercase ?? existing.lowercase,

--- a/src/handlers/write/create.ts
+++ b/src/handlers/write/create.ts
@@ -473,7 +473,7 @@ export async function writeActionCreate(ctx: SapWriteContext): Promise<ToolResul
   // DOMA/DTEL/BDEF require vendor-specific content types; all other types use
   // 'application/*' — the wildcard lets the SAP server resolve the correct
   // handler (matching how ADT Eclipse and abap-adt-api send requests).
-  const contentType = createContentTypeForType(type);
+  const contentType = createContentTypeForType(type, cloud);
   const needsPackageParam = type === 'BDEF' || type === 'TABL' || type === 'TABL/DT' || type === 'TABL/DS';
   let result: string;
   try {
@@ -873,7 +873,7 @@ export async function writeActionBatchCreate(ctx: SapWriteContext): Promise<Tool
         responsible,
         cloud,
       );
-      const contentType = createContentTypeForType(objType);
+      const contentType = createContentTypeForType(objType, cloud);
       const needsPackageParam =
         objType === 'BDEF' || objType === 'TABL' || objType === 'TABL/DT' || objType === 'TABL/DS';
       try {

--- a/src/handlers/write/create.ts
+++ b/src/handlers/write/create.ts
@@ -42,6 +42,7 @@ import {
   getMetadataWriteProperties,
   isMetadataWriteType,
   mergePreWriteWarnings,
+  resolveWriteSystemType,
   runPreWriteLint,
   runRapPreflightValidation,
   SKTD_V2_CONTENT_TYPE,
@@ -461,7 +462,11 @@ export async function writeActionCreate(ctx: SapWriteContext): Promise<ToolResul
   // a generic objectReferences body returns 400 "System expected the element ...".
   const metadataProperties = getMetadataWriteProperties(args);
   const bdefExtensionBase = applyBdefBehaviorExtensionMetadata(type, source, metadataProperties);
-  const body = buildCreateXml(type, name, pkg, description, metadataProperties, config.language, config.username);
+  // BTP/Steampunk needs cloud-correct create XML (G-3) and a real responsible user (G-5).
+  const systemType = resolveWriteSystemType(config, client);
+  const cloud = systemType === 'btp';
+  const responsible = config.username || (await client.getEffectiveUser());
+  const body = buildCreateXml(type, name, pkg, description, metadataProperties, config.language, responsible, cloud);
 
   // Step 1: Create the object (metadata only)
   const createUrl = objectUrl.replace(/\/[^/]+$/, ''); // parent collection URL
@@ -481,6 +486,8 @@ export async function writeActionCreate(ctx: SapWriteContext): Promise<ToolResul
       effectiveTransport,
       needsPackageParam ? pkg : undefined,
       cachedFeatures?.abapRelease,
+      systemType,
+      name,
     );
   } catch (createErr) {
     if (createErr instanceof AdtApiError && (createErr.statusCode === 400 || createErr.statusCode === 409)) {
@@ -499,7 +506,14 @@ export async function writeActionCreate(ctx: SapWriteContext): Promise<ToolResul
     if (type === 'DTEL' && dtelNeedsPostCreateUpdate(metadataProperties)) {
       const ct = vendorContentTypeForType(type);
       await client.http.withStatefulSession(async (session) => {
-        const lock = await lockObject(session, client.safety, objectUrl, 'MODIFY', cachedFeatures?.abapRelease);
+        const lock = await lockObject(
+          session,
+          client.safety,
+          objectUrl,
+          'MODIFY',
+          cachedFeatures?.abapRelease,
+          systemType,
+        );
         const lockTransport = effectiveTransport ?? (lock.corrNr || undefined);
         try {
           await updateObject(session, client.safety, objectUrl, body, lock.lockHandle, ct, lockTransport);
@@ -512,7 +526,14 @@ export async function writeActionCreate(ctx: SapWriteContext): Promise<ToolResul
     if (type === 'MSAG' && Array.isArray(metadataProperties.messages) && metadataProperties.messages.length > 0) {
       const ct = vendorContentTypeForType(type);
       await client.http.withStatefulSession(async (session) => {
-        const lock = await lockObject(session, client.safety, objectUrl, 'MODIFY', cachedFeatures?.abapRelease);
+        const lock = await lockObject(
+          session,
+          client.safety,
+          objectUrl,
+          'MODIFY',
+          cachedFeatures?.abapRelease,
+          systemType,
+        );
         const lockTransport = effectiveTransport ?? (lock.corrNr || undefined);
         try {
           await updateObject(session, client.safety, objectUrl, body, lock.lockHandle, ct, lockTransport);
@@ -715,6 +736,12 @@ export async function writeActionBatchCreate(ctx: SapWriteContext): Promise<Tool
   // terminal activateBatch when activateAtEnd=true. Order matches the input order.
   const writtenObjects: BatchActivationObject[] = [];
 
+  // BTP/Steampunk needs cloud-correct create XML (G-3) + a real responsible user (G-5);
+  // constant across the batch, so resolve once.
+  const systemType = resolveWriteSystemType(config, client);
+  const cloud = systemType === 'btp';
+  const responsible = config.username || (await client.getEffectiveUser());
+
   for (const plan of batchPlan) {
     const { obj, type: objType, name: objName, packageName: objPackage } = plan;
     const objTransport = plan.explicitTransport ?? autoTransportByPackage.get(objPackage);
@@ -843,7 +870,8 @@ export async function writeActionBatchCreate(ctx: SapWriteContext): Promise<Tool
         objDescription,
         objMetadataProps,
         config.language,
-        config.username,
+        responsible,
+        cloud,
       );
       const contentType = createContentTypeForType(objType);
       const needsPackageParam =
@@ -858,6 +886,8 @@ export async function writeActionBatchCreate(ctx: SapWriteContext): Promise<Tool
           objTransport,
           needsPackageParam ? objPackage : undefined,
           cachedFeatures?.abapRelease,
+          systemType,
+          objName,
         );
       } catch (createErr) {
         if (createErr instanceof AdtApiError && (createErr.statusCode === 400 || createErr.statusCode === 409)) {

--- a/src/handlers/write/update-delete.ts
+++ b/src/handlers/write/update-delete.ts
@@ -28,6 +28,7 @@ import {
   isMetadataWriteType,
   mergeMetadataWriteProperties,
   mergePreWriteWarnings,
+  resolveWriteSystemType,
   runPreWriteLint,
   runPreWriteSyntaxCheck,
   runRapPreflightValidation,
@@ -136,7 +137,19 @@ export async function writeActionUpdate(ctx: SapWriteContext): Promise<ToolResul
     const mergedProps = await mergeMetadataWriteProperties(client, type, name, metadataProps);
     const description = String(args.description ?? mergedProps._description ?? name);
     const pkg = String(args.package ?? existingPackage ?? mergedProps._package ?? '$TMP');
-    const body = buildCreateXml(type, name, pkg, description, mergedProps, config.language, config.username);
+    // Keep the full-XML-replace body cloud-correct on BTP (G-3); resolve the user from the JWT (G-5).
+    const systemType = resolveWriteSystemType(config, client);
+    const responsible = config.username || (await client.getEffectiveUser());
+    const body = buildCreateXml(
+      type,
+      name,
+      pkg,
+      description,
+      mergedProps,
+      config.language,
+      responsible,
+      systemType === 'btp',
+    );
     await safeUpdateObject(
       client.http,
       client.safety,

--- a/tests/integration/btp-abap.integration.test.ts
+++ b/tests/integration/btp-abap.integration.test.ts
@@ -499,5 +499,69 @@ describeIf('BTP ABAP Environment Integration Tests', () => {
         }
       }
     });
+
+    // INTF needs the v5 content-type on cloud — application/* routes to an older ST that drops the
+    // language version (HTTP 500 "ABAP language version  is not allowed"). Review fix; live-verified 919.
+    (writablePkg ? it : it.skip)(
+      'INTF create → activate → read → delete in a cloud package (v5 content-type)',
+      async () => {
+        const pkg = writablePkg as string;
+        const name = generateUniqueName('ZIF_ARC1_BTP');
+        const lc = name.toLowerCase();
+        const objectUrl = `/sap/bc/adt/oo/interfaces/${lc}`;
+        const responsible = await client.getEffectiveUser();
+        const body = buildCreateXml('INTF', name, pkg, 'ARC-1 BTP intf test', undefined, 'EN', responsible, true);
+
+        let created = false;
+        try {
+          await createObject(
+            client.http,
+            client.safety,
+            '/sap/bc/adt/oo/interfaces',
+            body,
+            createContentTypeForType('INTF', true),
+            undefined,
+            undefined,
+            '919',
+            'btp',
+            name,
+          );
+          created = true;
+
+          const source = [`INTERFACE ${lc} PUBLIC.`, '  METHODS ping.', 'ENDINTERFACE.'].join('\n');
+          await client.http.withStatefulSession(async (session) => {
+            const lock = await lockObject(session, client.safety, objectUrl, 'MODIFY', '919', 'btp');
+            try {
+              await updateSource(
+                session,
+                client.safety,
+                `${objectUrl}/source/main`,
+                source,
+                lock.lockHandle,
+                lock.corrNr || undefined,
+              );
+            } finally {
+              await unlockObject(session, objectUrl, lock.lockHandle);
+            }
+          });
+
+          await activate(client.http, client.safety, objectUrl, { name });
+          const read = await client.getInterface(name);
+          expect(read.source).toContain('ping');
+        } finally {
+          if (created) {
+            // best-effort-cleanup
+            try {
+              await client.http.withStatefulSession(async (session) => {
+                const lock = await lockObject(session, client.safety, objectUrl, 'MODIFY', '919', 'btp');
+                await deleteObject(session, client.safety, objectUrl, lock.lockHandle, lock.corrNr || undefined);
+              });
+            } catch {
+              // leave the object; a follow-up run reuses a fresh unique name
+            }
+          }
+        }
+      },
+    );
   });
 });

--- a/tests/integration/btp-abap.integration.test.ts
+++ b/tests/integration/btp-abap.integration.test.ts
@@ -26,9 +26,13 @@
 import { config } from 'dotenv';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { AdtClient } from '../../src/adt/client.js';
+import { createObject, deleteObject, lockObject, unlockObject, updateSource } from '../../src/adt/crud.js';
+import { activate } from '../../src/adt/devtools.js';
 import { createBearerTokenProvider, loadServiceKeyFile } from '../../src/adt/oauth.js';
 import { unrestrictedSafetyConfig } from '../../src/adt/safety.js';
+import { buildCreateXml, createContentTypeForType } from '../../src/handlers/write-helpers.js';
 import { expectSapFailureClass } from '../helpers/expected-error.js';
+import { generateUniqueName } from './crud-harness.js';
 import { hasBtpCredentials } from './helpers.js';
 
 // Load .env before anything else
@@ -38,7 +42,11 @@ config();
 function getBtpTestClient(): AdtClient {
   const keyFile = process.env.TEST_BTP_SERVICE_KEY_FILE || process.env.SAP_BTP_SERVICE_KEY_FILE || '';
   const serviceKey = loadServiceKeyFile(keyFile);
-  const bearerTokenProvider = createBearerTokenProvider(serviceKey);
+  // A pre-acquired dev JWT (TEST_BTP_ACCESS_TOKEN) skips the interactive browser login — required for
+  // the write tests, which need a named-user token (client_credentials is rejected by ADT), and lets
+  // these run headless once a token is cached.
+  const presetToken = process.env.TEST_BTP_ACCESS_TOKEN;
+  const bearerTokenProvider = presetToken ? async () => presetToken : createBearerTokenProvider(serviceKey);
 
   return new AdtClient({
     baseUrl: serviceKey.url,
@@ -317,6 +325,151 @@ describeIf('BTP ABAP Environment Integration Tests', () => {
     it('handles wildcard-only search', async () => {
       const results = await client.searchObject('*', 3);
       expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── BTP-Specific: object-create path (G-2..G-5) ──────────────
+  //
+  // The cloud create body differs from on-prem (no adtcore:responsible, no masterSystem,
+  // abapLanguageVersion="cloudDevelopment", explicit CLAS attributes). These tests assert the
+  // body is accepted by SAP's create simple-transformation and that the owner is taken from the JWT.
+
+  describe('BTP object-create path', () => {
+    it('surfaces the ABAP user from the JWT, not an empty string (G-5)', async () => {
+      // On-prem this is SAP_USER; on BTP there is none, so it comes from the JWT user_name claim.
+      const user = await client.getEffectiveUser();
+      expect(user).toBeTruthy();
+      expect(user.length).toBeGreaterThan(0);
+      const parsed = JSON.parse(await client.getSystemInfo());
+      expect(parsed.user).toBe(user);
+    });
+
+    it('produces a cloud create body that SAP accepts (deserializes) — G-3', async () => {
+      // Target the default structure package (or any package): a CORRECT cloud body gets past XML
+      // deserialization to package-assignment (403 ExceptionResourceNoAccess). A WRONG body (e.g. one
+      // still carrying adtcore:responsible) fails earlier with 400 "error deserializing in CLASS_TRANSFORMATION".
+      const pkg = process.env.TEST_BTP_STRUCTURE_PACKAGE || 'ZLOCAL';
+      const name = 'ZCL_ARC1_BTP_BODYCHECK';
+      const body = buildCreateXml(
+        'CLAS',
+        name,
+        pkg,
+        'ARC-1 BTP body check',
+        undefined,
+        'EN',
+        await client.getEffectiveUser(),
+        true,
+      );
+      expect(body).not.toContain('adtcore:responsible');
+      expect(body).toContain('adtcore:abapLanguageVersion="cloudDevelopment"');
+      try {
+        await createObject(
+          client.http,
+          client.safety,
+          '/sap/bc/adt/oo/classes',
+          body,
+          createContentTypeForType('CLAS'),
+          undefined,
+          undefined,
+          '919',
+          'btp',
+          name,
+        );
+        // If it actually created (pkg was writable), clean up — body is obviously accepted.
+        await client.http.withStatefulSession(async (session) => {
+          const lock = await lockObject(
+            session,
+            client.safety,
+            `/sap/bc/adt/oo/classes/${name.toLowerCase()}`,
+            'MODIFY',
+            '919',
+            'btp',
+          );
+          await deleteObject(
+            session,
+            client.safety,
+            `/sap/bc/adt/oo/classes/${name.toLowerCase()}`,
+            lock.lockHandle,
+            lock.corrNr || undefined,
+          );
+        });
+      } catch (err) {
+        // The body must have deserialized — assert it did NOT fail at the create transformation.
+        const msg = err instanceof Error ? err.message : String(err);
+        expect(msg).not.toMatch(/deserializ|transformation program/i);
+        expectSapFailureClass(err, [403], [/package/i, /authoriz/i, /structure/i]);
+      }
+    });
+
+    // Positive lifecycle needs a writable, regular (non-structure) cloud package. The default ZLOCAL
+    // is a structure package and cannot host objects, so provide one via TEST_BTP_PACKAGE.
+    const writablePkg = process.env.TEST_BTP_PACKAGE;
+    (writablePkg ? it : it.skip)('CLAS create → activate → read → delete in a cloud package (G-3)', async () => {
+      const pkg = writablePkg as string;
+      const name = generateUniqueName('ZCL_ARC1_BTP');
+      const lc = name.toLowerCase();
+      const objectUrl = `/sap/bc/adt/oo/classes/${lc}`;
+      const sourceUrl = `${objectUrl}/source/main`;
+      const responsible = await client.getEffectiveUser();
+      const body = buildCreateXml('CLAS', name, pkg, 'ARC-1 BTP lifecycle test', undefined, 'EN', responsible, true);
+
+      let created = false;
+      try {
+        await createObject(
+          client.http,
+          client.safety,
+          '/sap/bc/adt/oo/classes',
+          body,
+          createContentTypeForType('CLAS'),
+          undefined,
+          undefined,
+          '919',
+          'btp',
+          name,
+        );
+        created = true;
+
+        // Deliberately NON-final: the cloud create metadata hardcodes class:final="true", so this
+        // exercises the mismatch — the source PUT must win and yield a non-final class (Codex review #2).
+        const source = [
+          `CLASS ${lc} DEFINITION PUBLIC CREATE PUBLIC.`,
+          '  PUBLIC SECTION.',
+          '    METHODS hello RETURNING VALUE(result) TYPE string.',
+          'ENDCLASS.',
+          `CLASS ${lc} IMPLEMENTATION.`,
+          '  METHOD hello.',
+          "    result = 'hi from ARC-1'.",
+          '  ENDMETHOD.',
+          'ENDCLASS.',
+        ].join('\n');
+        await client.http.withStatefulSession(async (session) => {
+          const lock = await lockObject(session, client.safety, objectUrl, 'MODIFY', '919', 'btp');
+          try {
+            await updateSource(session, client.safety, sourceUrl, source, lock.lockHandle, lock.corrNr || undefined);
+          } finally {
+            await unlockObject(session, objectUrl, lock.lockHandle);
+          }
+        });
+
+        await activate(client.http, client.safety, objectUrl, { name });
+
+        const read = await client.getClass(name);
+        expect(read.source).toContain('hello');
+        // Source wins over the hardcoded create metadata: the activated class is non-final (Codex #2).
+        expect(read.source).not.toMatch(/\bfinal\b/i);
+      } finally {
+        if (created) {
+          // best-effort-cleanup
+          try {
+            await client.http.withStatefulSession(async (session) => {
+              const lock = await lockObject(session, client.safety, objectUrl, 'MODIFY', '919', 'btp');
+              await deleteObject(session, client.safety, objectUrl, lock.lockHandle, lock.corrNr || undefined);
+            });
+          } catch {
+            // leave the object; a follow-up run reuses a fresh unique name
+          }
+        }
+      }
     });
   });
 });

--- a/tests/integration/btp-abap.integration.test.ts
+++ b/tests/integration/btp-abap.integration.test.ts
@@ -192,9 +192,42 @@ describeIf('BTP ABAP Environment Integration Tests', () => {
   // ─── BTP-Specific: Restricted ABAP ────────────────────────────
 
   describe('BTP restricted ABAP behavior', () => {
-    it('classic programs like RSHOWTIM are NOT available', async () => {
-      // BTP ABAP doesn't have classic SE38 programs
-      await expect(client.getProgram('RSHOWTIM')).rejects.toThrow(/403|404|not found|not available|not released/i);
+    it('classic PROG is READABLE, but creating a classic program is refused (T-1)', async () => {
+      // READ: standard classic reports ARE fully readable on the ABAP Environment (live-verified —
+      // RSHOWTIM returns its REPORT source). The earlier "NOT available" assertion was wrong.
+      const prog = await client.getProgram('RSHOWTIM');
+      expect(prog.source).toMatch(/\bREPORT\b|\bMESSAGE\b/i);
+
+      // WRITE: classic executable programs (PROG) are not part of ABAP Cloud — creation is refused.
+      // Needs a writable package to isolate the program-type refusal from the package-allowlist gate.
+      const pkg = process.env.TEST_BTP_PACKAGE;
+      if (pkg) {
+        const name = 'ZARC1_SMOKE_PROG';
+        const body = buildCreateXml(
+          'PROG',
+          name,
+          pkg,
+          'arc1 prog',
+          undefined,
+          'EN',
+          await client.getEffectiveUser(),
+          true,
+        );
+        await expect(
+          createObject(
+            client.http,
+            client.safety,
+            '/sap/bc/adt/programs/programs',
+            body,
+            createContentTypeForType('PROG'),
+            undefined,
+            undefined,
+            '919',
+            'btp',
+            name,
+          ),
+        ).rejects.toThrow();
+      }
     });
 
     it('classic function modules may not be available', async () => {
@@ -205,28 +238,23 @@ describeIf('BTP ABAP Environment Integration Tests', () => {
       expect(results).toBeInstanceOf(Array);
     });
 
-    it('table preview may be restricted on BTP', async () => {
-      // T000 table preview requires specific authorization on BTP
-      try {
-        const result = await client.getTableContents('T000', 5);
-        // If it works, verify structure
-        expect(result.columns).toContain('MANDT');
-      } catch (err) {
-        // Expected on BTP: table preview is often restricted
-        expectSapFailureClass(err, [403, 500], [/restricted/i, /not authorized/i]);
-      }
+    it('standard-table preview is blocked with the BTP data-view 400 (T-2)', async () => {
+      // BTP returns HTTP 400 ExceptionDataPreviewGeneral "No authorization to view data"
+      // (ADT_DATAPREVIEW_MSG/023; auth object S_ABPLNGVS) — NOT a 403/500. Live-verified 919.
+      const err = await client.getTableContents('T000', 5).then(
+        () => null,
+        (e) => e,
+      );
+      expectSapFailureClass(err, [400], [/No authorization to view data/i]);
     });
 
-    it('free SQL query is likely blocked on BTP', async () => {
-      try {
-        const result = await client.runQuery('SELECT * FROM T000', 5);
-        // If it works, verify result shape
-        expect(result).toBeTruthy();
-        expect(typeof result).toBe('string');
-      } catch (err) {
-        // Expected: BTP blocks free SQL execution
-        expectSapFailureClass(err, [403, 500], [/blocked/i, /not authorized/i, /restricted/i]);
-      }
+    it('freestyle SQL on standard tables is blocked with the BTP data-view 400 (T-3)', async () => {
+      // Same cloud data-access gate as table preview — 400, not the 403/500 the old test expected.
+      const err = await client.runQuery('SELECT * FROM T000', 5).then(
+        () => null,
+        (e) => e,
+      );
+      expectSapFailureClass(err, [400], [/No authorization to view data/i]);
     });
   });
 

--- a/tests/unit/adt/client.test.ts
+++ b/tests/unit/adt/client.test.ts
@@ -673,6 +673,42 @@ describe('AdtClient', () => {
       expect(Array.isArray(parsed.collections)).toBe(true);
     });
 
+    it('getEffectiveUser returns the configured SAP_USER when set', async () => {
+      const client = createClient();
+      expect(await client.getEffectiveUser()).toBe('admin');
+    });
+
+    it('getEffectiveUser derives the user from the bearer JWT user_name when no SAP_USER (BTP, G-5)', async () => {
+      // BTP bearer auth has no SAP_USER — the ABAP user rides in the JWT user_name claim.
+      const payload = Buffer.from(JSON.stringify({ user_name: 'marian@zeis.de' })).toString('base64url');
+      const jwt = `h.${payload}.sig`;
+      const client = createClient({ username: '', bearerTokenProvider: async () => jwt });
+      expect(await client.getEffectiveUser()).toBe('marian@zeis.de');
+      const parsed = JSON.parse(await client.getSystemInfo());
+      expect(parsed.user).toBe('marian@zeis.de');
+    });
+
+    it('getEffectiveUser falls back to empty (not a crash) on an unparseable bearer token', async () => {
+      const client = createClient({ username: '', bearerTokenProvider: async () => 'not-a-jwt' });
+      expect(await client.getEffectiveUser()).toBe('');
+    });
+
+    it('getEffectiveUser retries after a transient token-provider failure (does not memoize empty)', async () => {
+      // A transient provider error must not pin the user to '' forever — a later call still resolves (Codex #3).
+      const payload = Buffer.from(JSON.stringify({ user_name: 'marian@zeis.de' })).toString('base64url');
+      let calls = 0;
+      const client = createClient({
+        username: '',
+        bearerTokenProvider: async () => {
+          calls += 1;
+          if (calls === 1) throw new Error('transient token failure');
+          return `h.${payload}.sig`;
+        },
+      });
+      expect(await client.getEffectiveUser()).toBe(''); // 1st call: provider throws → empty, NOT memoized
+      expect(await client.getEffectiveUser()).toBe('marian@zeis.de'); // retry resolves
+    });
+
     it('getMessages returns message class XML', async () => {
       const client = createClient();
       const messages = await client.getMessages('SY');

--- a/tests/unit/adt/crud.test.ts
+++ b/tests/unit/adt/crud.test.ts
@@ -355,7 +355,8 @@ describe('CRUD Operations', () => {
         ).rejects.toMatchObject({ statusCode: 409 });
       });
 
-      it('reclassifies structured ExceptionResourceNoAccess regardless of release', async () => {
+      it('maps ExceptionResourceNoAccess on create to a 403 authorization/package denial, not a 409 lock (G-4)', async () => {
+        // On a CREATE this exception is a package/authorization denial, not a lock — SM12/SE80 don't apply.
         const xml =
           '<exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><type id="ExceptionResourceNoAccess"/></exc:exception>';
         const http = mockHttpThatRejectsCreate(403, xml);
@@ -363,14 +364,62 @@ describe('CRUD Operations', () => {
           createObject(
             http,
             unrestrictedSafetyConfig(),
-            '/sap/bc/adt/ddic/ddl/sources',
+            '/sap/bc/adt/oo/classes',
             '<xml/>',
             'application/*',
             undefined,
             undefined,
             '758',
+            undefined,
+            'ZCL_X',
           ),
-        ).rejects.toMatchObject({ statusCode: 409 });
+        ).rejects.toMatchObject({
+          statusCode: 403,
+          message: expect.stringMatching(/Cannot create ZCL_X.*authorization/s),
+        });
+      });
+
+      it('gives a BTP-specific package hint for ExceptionResourceNoAccess on create when systemType=btp (G-4)', async () => {
+        const xml =
+          '<exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><type id="ExceptionResourceNoAccess"/></exc:exception>';
+        const http = mockHttpThatRejectsCreate(403, xml);
+        await expect(
+          createObject(
+            http,
+            unrestrictedSafetyConfig(),
+            '/sap/bc/adt/oo/classes',
+            '<xml/>',
+            'application/*',
+            undefined,
+            undefined,
+            '919',
+            'btp',
+            'ZCL_X',
+          ),
+        ).rejects.toMatchObject({
+          statusCode: 403,
+          message: expect.stringMatching(/non-structure.*cloud package|SAP_ALLOWED_PACKAGES/s),
+        });
+      });
+
+      it('detects a structure package (PAK 149) and tells the user to use a regular sub-package (G-4)', async () => {
+        const xml =
+          '<exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><type id="ExceptionResourceNoAccess"/><message lang="EN">Structure packages cannot contain development objects</message></exc:exception>';
+        const http = mockHttpThatRejectsCreate(403, xml);
+        await expect(
+          createObject(
+            http,
+            unrestrictedSafetyConfig(),
+            '/sap/bc/adt/oo/classes',
+            '<xml/>',
+            'application/*',
+            undefined,
+            undefined,
+            '919',
+            'btp',
+            'ZCL_X',
+          ),
+        ).rejects.toMatchObject({ statusCode: 403, message: expect.stringMatching(/structure package.*sub-package/s) });
       });
 
       it('does NOT reclassify when abapRelease>=751 and only HTML marker is present', async () => {

--- a/tests/unit/adt/ddic-xml.test.ts
+++ b/tests/unit/adt/ddic-xml.test.ts
@@ -192,6 +192,12 @@ describe('ddic-xml builders', () => {
       expect(normalizeAdtResponsible()).toBe('DEVELOPER');
       expect(normalizeAdtResponsible('   ')).toBe('DEVELOPER');
     });
+
+    it('normalizeAdtResponsible keeps email-style cloud users case-sensitive (BTP)', () => {
+      // Classic SAP users are upper-case; cloud (BTP) users are case-sensitive emails — never upper-case them.
+      expect(normalizeAdtResponsible('marian@zeis.de')).toBe('marian@zeis.de');
+      expect(normalizeAdtResponsible('  Marian@Zeis.de ')).toBe('Marian@Zeis.de');
+    });
   });
 
   describe('buildDomainXml', () => {

--- a/tests/unit/adt/errors.test.ts
+++ b/tests/unit/adt/errors.test.ts
@@ -429,6 +429,18 @@ describe('AdtApiError', () => {
       expect(classification?.category).toBe('lock-conflict');
     });
 
+    it('classifies a create-time structure-package 403 as authorization, NOT a lock (no SM12) — review fix', () => {
+      // Live BTP 919: creating into a structure package → 403 ExceptionResourceNoAccess + PAK/149
+      // "Structure packages cannot contain development objects". Must NOT get the misleading SM12 lock hint.
+      const xml = `<exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><type id="ExceptionResourceNoAccess"/><message lang="EN">Structure packages cannot contain development objects</message></exc:exception>`;
+      const classification = classifySapDomainError(403, xml);
+      expect(classification?.category).toBe('authorization');
+      expect(classification?.category).not.toBe('lock-conflict');
+      // Not the lock path: no SM12 transaction, and the hint is the package/auth guidance.
+      expect(classification?.transaction).not.toBe('SM12');
+      expect(classification?.hint).toMatch(/not a lock|package/i);
+    });
+
     it('does not misclassify 403 auth error as lock conflict', () => {
       const xml = `<exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework">
   <type id="ExceptionNotAuthorized"/>

--- a/tests/unit/adt/errors.test.ts
+++ b/tests/unit/adt/errors.test.ts
@@ -390,6 +390,17 @@ describe('AdtApiError', () => {
       expect(classification?.transaction).toBe('SM12');
     });
 
+    it('classifies the BTP data-preview 400 "No authorization to view data" distinctly (T-2/T-3)', () => {
+      // Live-captured on BTP 919 for both table preview and freestyle SQL on standard tables.
+      const xml = `<exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><type id="ExceptionDataPreviewGeneral"/><message lang="EN">No authorization to view data</message><properties><entry key="T100KEY-ID">ADT_DATAPREVIEW_MSG</entry><entry key="T100KEY-NO">023</entry></properties></exc:exception>`;
+      const classification = classifySapDomainError(400, xml);
+      expect(classification?.category).toBe('data-view-not-authorized');
+      expect(classification?.hint).toMatch(/released CDS view|custom Z\* table/i);
+      // Must NOT be mistaken for a generic lock/auth case.
+      expect(classification?.category).not.toBe('lock-conflict');
+      expect(classification?.category).not.toBe('authorization');
+    });
+
     it('classifies lock conflicts from 403 with "currently editing" (SAP A4H pattern)', () => {
       const xml = `<exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework">
   <exc:localizedMessage lang="EN">User MARIAN is currently editing ZARC1_TEST_REPORT</exc:localizedMessage>

--- a/tests/unit/handlers/build-create-xml-cloud.test.ts
+++ b/tests/unit/handlers/build-create-xml-cloud.test.ts
@@ -1,0 +1,92 @@
+/**
+ * buildCreateXml — BTP/Steampunk cloud-mode corrections (G-3).
+ *
+ * Live-verified on BTP SAP_BASIS 919: the object-create simple transformations reject
+ * `adtcore:responsible` and the on-prem `adtcore:masterSystem`, and require
+ * `adtcore:abapLanguageVersion="cloudDevelopment"` (plus explicit class attributes for CLAS).
+ * On-prem output must be byte-for-byte unchanged.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AdtClient } from '../../../src/adt/client.js';
+import type { ResolvedFeatures } from '../../../src/adt/types.js';
+import { resetCachedFeatures, setCachedFeatures } from '../../../src/handlers/feature-cache.js';
+import { buildCreateXml, resolveWriteSystemType } from '../../../src/handlers/write-helpers.js';
+import type { ServerConfig } from '../../../src/server/types.js';
+
+describe('buildCreateXml — cloud mode (G-3)', () => {
+  describe('on-prem (cloud=false) is unchanged', () => {
+    it('CLAS keeps masterSystem + responsible and omits the cloud attributes', () => {
+      const xml = buildCreateXml('CLAS', 'ZCL_X', 'ZPKG', 'desc', undefined, 'EN', 'MARIAN', false);
+      expect(xml).toContain('adtcore:masterSystem="H00"');
+      expect(xml).toContain('adtcore:responsible="MARIAN"');
+      expect(xml).not.toContain('abapLanguageVersion');
+      expect(xml).not.toContain('class:final');
+    });
+  });
+
+  describe('cloud (cloud=true)', () => {
+    it('CLAS drops masterSystem + responsible, adds cloud language version + class attributes', () => {
+      const xml = buildCreateXml('CLAS', 'ZCL_X', 'ZPKG', 'desc', undefined, 'EN', 'marian@zeis.de', true);
+      expect(xml).not.toContain('masterSystem');
+      expect(xml).not.toContain('responsible'); // cloud assigns the owner from the JWT
+      expect(xml).toContain('adtcore:abapLanguageVersion="cloudDevelopment"');
+      expect(xml).toContain('class:final="true"');
+      expect(xml).toContain('class:visibility="public"');
+      expect(xml).toContain('class:category="generalObjectType"');
+    });
+
+    it('INTF drops masterSystem + responsible and adds the cloud language version', () => {
+      const xml = buildCreateXml('INTF', 'ZIF_X', 'ZPKG', 'desc', undefined, 'EN', 'marian@zeis.de', true);
+      expect(xml).not.toContain('masterSystem');
+      expect(xml).not.toContain('responsible');
+      expect(xml).toContain('adtcore:abapLanguageVersion="cloudDevelopment"');
+      expect(xml).not.toContain('class:final'); // class attributes are CLAS-only
+    });
+
+    it('DDLS (CDS source) gets the cloud language version', () => {
+      const xml = buildCreateXml('DDLS', 'ZCDS_X', 'ZPKG', 'desc', undefined, 'EN', 'marian@zeis.de', true);
+      expect(xml).not.toContain('masterSystem');
+      expect(xml).not.toContain('responsible');
+      expect(xml).toContain('adtcore:abapLanguageVersion="cloudDevelopment"');
+    });
+
+    it('DTEL (builder path) also drops masterSystem + responsible and adds the cloud language version', () => {
+      const xml = buildCreateXml(
+        'DTEL',
+        'ZDT_X',
+        'ZPKG',
+        'desc',
+        { typeKind: 'predefinedAbapType', dataType: 'CHAR', length: 10 },
+        'EN',
+        'marian@zeis.de',
+        true,
+      );
+      expect(xml).not.toContain('masterSystem');
+      expect(xml).not.toContain('responsible');
+      expect(xml).toContain('adtcore:abapLanguageVersion="cloudDevelopment"');
+    });
+  });
+});
+
+describe('resolveWriteSystemType (G-3, Codex #1)', () => {
+  const cfg = (systemType: string) => ({ systemType }) as unknown as ServerConfig;
+  const client = (usesBearerAuth: boolean) => ({ usesBearerAuth }) as unknown as AdtClient;
+  afterEach(() => resetCachedFeatures());
+
+  it('prefers the probed feature cache', () => {
+    setCachedFeatures({ systemType: 'btp' } as unknown as ResolvedFeatures);
+    expect(resolveWriteSystemType(cfg('auto'), client(false))).toBe('btp');
+  });
+
+  it('uses an explicit non-auto config when the probe has not resolved', () => {
+    expect(resolveWriteSystemType(cfg('onprem'), client(true))).toBe('onprem');
+  });
+
+  it('falls back to btp for bearer auth when unresolved — so BTP creates never emit on-prem XML', () => {
+    expect(resolveWriteSystemType(cfg('auto'), client(true))).toBe('btp');
+  });
+
+  it('returns undefined when unresolved and not bearer auth (on-prem)', () => {
+    expect(resolveWriteSystemType(cfg('auto'), client(false))).toBeUndefined();
+  });
+});

--- a/tests/unit/handlers/build-create-xml-cloud.test.ts
+++ b/tests/unit/handlers/build-create-xml-cloud.test.ts
@@ -13,6 +13,7 @@ import { resetCachedFeatures, setCachedFeatures } from '../../../src/handlers/fe
 import {
   buildCreateXml,
   createContentTypeForType,
+  mergeMetadataWriteProperties,
   resolveWriteSystemType,
 } from '../../../src/handlers/write-helpers.js';
 import type { ServerConfig } from '../../../src/server/types.js';
@@ -108,5 +109,32 @@ describe('createContentTypeForType — cloud INTF content-type (review fix)', ()
 
   it('does not change CLAS (works with application/* on cloud)', () => {
     expect(createContentTypeForType('CLAS', true)).toBe('application/*');
+  });
+});
+
+describe('mergeMetadataWriteProperties — DOMA outputLength follows a length change (review fix)', () => {
+  const stubClient = (existing: Record<string, unknown>) =>
+    ({ getDomain: async () => existing }) as unknown as AdtClient;
+  const base = { description: 'd', package: 'P', dataType: 'CHAR', length: 10, outputLength: 10 };
+
+  it('defaults outputLength to a changed length when not provided (avoids SAP output-length warning)', async () => {
+    const merged = await mergeMetadataWriteProperties(stubClient(base), 'DOMA', 'ZDOMA', { length: 20 });
+    expect(merged.outputLength).toBe(20);
+    expect(merged.length).toBe(20);
+  });
+
+  it('keeps the existing outputLength when length is unchanged', async () => {
+    const merged = await mergeMetadataWriteProperties(stubClient({ ...base, outputLength: 8 }), 'DOMA', 'ZDOMA', {
+      description: 'new',
+    });
+    expect(merged.outputLength).toBe(8);
+  });
+
+  it('respects an explicit outputLength', async () => {
+    const merged = await mergeMetadataWriteProperties(stubClient(base), 'DOMA', 'ZDOMA', {
+      length: 20,
+      outputLength: 15,
+    });
+    expect(merged.outputLength).toBe(15);
   });
 });

--- a/tests/unit/handlers/build-create-xml-cloud.test.ts
+++ b/tests/unit/handlers/build-create-xml-cloud.test.ts
@@ -10,7 +10,11 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { AdtClient } from '../../../src/adt/client.js';
 import type { ResolvedFeatures } from '../../../src/adt/types.js';
 import { resetCachedFeatures, setCachedFeatures } from '../../../src/handlers/feature-cache.js';
-import { buildCreateXml, resolveWriteSystemType } from '../../../src/handlers/write-helpers.js';
+import {
+  buildCreateXml,
+  createContentTypeForType,
+  resolveWriteSystemType,
+} from '../../../src/handlers/write-helpers.js';
 import type { ServerConfig } from '../../../src/server/types.js';
 
 describe('buildCreateXml — cloud mode (G-3)', () => {
@@ -88,5 +92,21 @@ describe('resolveWriteSystemType (G-3, Codex #1)', () => {
 
   it('returns undefined when unresolved and not bearer auth (on-prem)', () => {
     expect(resolveWriteSystemType(cfg('auto'), client(false))).toBeUndefined();
+  });
+});
+
+describe('createContentTypeForType — cloud INTF content-type (review fix)', () => {
+  it('uses the v5 interfaces content-type for cloud INTF create', () => {
+    // application/* routes cloud INTF to an older ST that drops abapLanguageVersion → 500. Live-verified 919.
+    expect(createContentTypeForType('INTF', true)).toBe('application/vnd.sap.adt.oo.interfaces.v5+xml');
+  });
+
+  it('keeps application/* for on-prem INTF create (unchanged)', () => {
+    expect(createContentTypeForType('INTF', false)).toBe('application/*');
+    expect(createContentTypeForType('INTF')).toBe('application/*');
+  });
+
+  it('does not change CLAS (works with application/* on cloud)', () => {
+    expect(createContentTypeForType('CLAS', true)).toBe('application/*');
   });
 });


### PR DESCRIPTION
## What

Make SAPWrite's **object-create path work on the SAP BTP ABAP Environment (Steampunk)**. Proven broken by live testing on 2026-06-26; now fixed and **verified end-to-end against a real BTP instance** (H01, SAP_BASIS 919): `CLAS create → activate → read → delete` in a cloud package.

## Gaps fixed

| Gap | Fix |
|-----|-----|
| **G-3** | Cloud-correct create XML. `buildCreateXml(cloud)` strips `adtcore:masterSystem` + `adtcore:responsible` (cloud assigns the owner from the JWT) and adds `abapLanguageVersion="cloudDevelopment"` + explicit CLAS class attributes. On-prem body is **byte-for-byte unchanged**. The real blocker over "missing language version" was that cloud create STs *reject* `adtcore:responsible`. |
| **G-2** | `$TMP` / `ZLOCAL` (a structure package) can't host objects on BTP — documented in `.env.example`; target a regular cloud sub-package. |
| **G-4** | Create-time `ExceptionResourceNoAccess` → `403` package/auth denial (with structure-package detection) instead of a misleading `409 "locked / release in SM12"` (SM12/SE80 don't exist on cloud). |
| **G-5** | Derive the ABAP user from the bearer JWT (`getEffectiveUser`) so `SYSTEM` output and `adtcore:responsible` aren't empty on BTP. |

## Live verification (H01, SAP_BASIS 919)

```
✓ surfaces the ABAP user from the JWT (G-5)
✓ produces a cloud create body that SAP accepts (G-3)
✓ CLAS create → activate → read → delete in a cloud package (G-3)   [non-final class]
```

Object created, source written, activated, read back, deleted — no orphans left.

## Review (Codex + ponytail)

- **#1 (systemType=`auto` race) — fixed.** `resolveWriteSystemType()` falls back to `btp` for bearer-token auth when the startup probe hasn't resolved, so a create can't silently emit on-prem XML on BTP. Also removes the 3× duplicated resolution.
- **#2 (hard-coded `class:final="true"`) — verified non-issue, live.** A non-final source PUT overrides the create metadata; the lifecycle test now creates a non-final class to lock this in.
- **#3 (`getEffectiveUser` memoized `''` on transient failure) — fixed.** Memoizes only resolved values; a transient error retries.
- **#4 (metadata-UPDATE reuses the cloud create body) — LOW follow-up**, documented in the research doc (DDIC update STs not yet live-verified on BTP; CLAS/INTF use source-PUT, not this path).

## Known follow-up (out of scope)

**Package creation via REST stays blocked** by a SAP platform asymmetry: `SPAK_ST_PACKAGES` rejects `adtcore:responsible` on the body, but the package app requires it (`PAK/049`) and won't default it from the bearer session — independent of content-type, stateful session, and attribute order (both `abap-adt-api` and `vibing-steampunk` hit the same wall). Eclipse assigns a technical user (e.g. `CB9980000000`) its interactive session resolves. Create the dev package in Eclipse and point `SAP_ALLOWED_PACKAGES` at it. Full analysis in `docs/research/2026-06-26-btp-object-create-fix.md`.

## Tests

- **Unit:** `buildCreateXml` cloud mode, `resolveWriteSystemType` (incl. bearer fallback), `getEffectiveUser` retry, crud error mapping, responsible casing. **4120 pass.**
- **Live BTP integration:** non-final create lifecycle + body acceptance + G-5 (gated on `TEST_BTP_PACKAGE`; runs with a pre-acquired dev JWT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)