### PR TITLE
feat: S/4HANA Public Cloud support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ Terse routing only — full gotchas per row in [docs/dev-guide.md](docs/dev-guid
 | Elicitation / XSUAA / OIDC / DCR store | `src/server/elicit.ts` / `src/server/xsuaa.ts` / `src/server/http.ts` / DCR store + OAuth proxy in the `@arc-mcp/xsuaa-auth` dep (revocation = rotate `ARC1_DCR_SIGNING_SECRET` or rebind XSUAA; `KDF_LABEL` bump lives in the package) |
 | Scope enforcement / auth scopes | `src/authz/policy.ts` (`ACTION_POLICY`), `src/handlers/dispatch.ts`, `src/server/server.ts`, `xs-security.json` |
 | Auth combination rule | `src/server/config.ts` (`validateConfig`), `src/server/types.ts`, `docs_page/enterprise-auth.md` |
-| Layer B auth mechanism | `src/adt/http.ts` (`applyAuthHeader`), `src/server/server.ts` (`buildAdtConfig` perUser flag — strips shared creds) |
+| Layer B auth mechanism | `src/adt/http.ts` (`applyAuthHeader` — Basic / `samlAuthorization`→`Authorization`+`x-sap-security-session:create`), `src/server/server.ts` (`applyPerUserAuthTokens` sets PP creds incl. SAMLAssertion for S/4HC; `buildAdtConfig` perUser flag — strips shared creds). New Layer B field must also be mapped in `src/adt/client.ts` httpConfig + set only per-user |
 | Safety config option | `src/adt/safety.ts`, `src/server/config.ts`, `src/server/types.ts` |
 | AdtClient instance field / `withSafety()` clone | `src/adt/client.ts` — clone is `Object.assign(Object.create(proto), this, {safety})`; new own fields share automatically (use TS `private`, never `#private`) (#333) |
 | `allowedPackages` pattern syntax | `src/adt/safety.ts`, `src/adt/package-hierarchy.ts`, `src/handlers/write-helpers.ts` (`enforceAllowedPackageForObjectUrl`, fail-closed) — details: dev-guide |

--- a/docs_page/deployment.md
+++ b/docs_page/deployment.md
@@ -16,6 +16,7 @@ For single-developer setups on your own laptop, use [local-development.md](local
 | Destination Service resolves it (on-prem via Cloud Connector) | BTP Destination | Depends on destination type |
 | Destination uses `PrincipalPropagation` + Cloud Connector | **Principal Propagation** | ✅ Per-user |
 | BTP CF app connects to BTP ABAP Environment | Destination `OAuth2UserTokenExchange` | ✅ Per-user |
+| BTP CF app connects to S/4HANA Public Cloud (developer extensibility) | Destination `SAMLAssertion` (same as BAS) | ✅ Per-user (PP only) |
 | Local developer connects to BTP ABAP Environment | BTP service-key OAuth + browser login | ✅ One local user; not headless |
 
 **Who authenticates to ARC-1 (the MCP endpoint)?**
@@ -34,6 +35,7 @@ For single-developer setups on your own laptop, use [local-development.md](local
 | Docker on any VM / container host | [Docker deployment](#docker-on-any-vm) |
 | BTP Cloud Foundry, on-prem SAP via Cloud Connector | [BTP CF with PP](#btp-cloud-foundry-with-principal-propagation) |
 | BTP Cloud Foundry, BTP ABAP backend | [BTP CF + BTP ABAP](#btp-cloud-foundry-btp-abap-environment) |
+| BTP Cloud Foundry, S/4HANA Public Cloud backend | [S/4HANA Public Cloud (PP via SAMLAssertion)](s4hana-public-cloud.md) |
 
 ---
 

--- a/docs_page/principal-propagation-setup.md
+++ b/docs_page/principal-propagation-setup.md
@@ -126,6 +126,32 @@ export SAP_PP_ENABLED=true
 - **PP failure + explicit `SAP_PP_STRICT=false`** → falls back to shared destination
 - **API key / non-JWT request** → uses shared destination unless `SAP_PP_STRICT=true` was set explicitly
 
+## Cloud targets: S/4HANA Public Cloud & BTP ABAP (no Cloud Connector)
+
+The Steps above describe **on-premise** propagation via the Cloud Connector (destination type
+`PrincipalPropagation`). For **cloud** targets reached over the Internet, there is no Cloud Connector
+— ARC-1 connects directly and the per-user identity rides in the destination's auth token. Pick the
+destination `Authentication` type the target supports:
+
+| Target | Destination `Authentication` | `ProxyType` | Per-user credential ARC-1 sends |
+|--------|------------------------------|-------------|---------------------------------|
+| **S/4HANA Public Cloud** (developer extensibility) | `SAMLAssertion` | `Internet` | `Authorization: SAML2.0 …` + `x-sap-security-session: create` — the **same flow BAS uses** |
+| S/4HANA Public Cloud / BTP ABAP (OAuth client configured) | `OAuth2SAMLBearerAssertion` | `Internet` | `Authorization: Bearer …` |
+| BTP ABAP, same subaccount | `OAuth2UserTokenExchange` | `Internet` | `Authorization: Bearer …` |
+
+For all of these you only need the **Destination + XSUAA** service instances bound (no Connectivity
+service / Cloud Connector). ARC-1 detects `ProxyType: Internet` and connects directly — the
+connectivity proxy is used **only** for `OnPremise` destinations.
+
+For the full **S/4HANA Public Cloud** walkthrough (the `SAMLAssertion` destination + S/4HC SAML trust,
+identical to the BAS setup, plus ARC-1 configuration), see the dedicated guide:
+**[SAP S/4HANA Public Cloud Setup](s4hana-public-cloud.md)**.
+
+> `OAuth2SAMLBearerAssertion` is SAP's *recommended* alternative (the SDK warns about raw
+> `SAMLAssertion`), but it needs an OAuth 2.0 client/communication arrangement on the S/4HC side.
+> `SAMLAssertion` reuses the SAML trust BAS already established, so it's usually the lower-config path.
+> Either way, keep `SAP_DISABLE_SAML` **unset/false** — never disable SAML on S/4HANA Public Cloud.
+
 !!! warning "Use `SAP_PP_STRICT=false` only for intentional mixed-mode fallback"
     With `SAP_PP_ENABLED=true`, ARC-1 fails closed by default when per-user PP fails. Setting `SAP_PP_STRICT=false` restores the shared-service-account fallback for JWT PP failures: the request then runs with the technical user's authorizations and SAP audits the technical user, not the human. Keep this only for deployments that intentionally mix fallback shared-client access with PP.
 

--- a/docs_page/s4hana-public-cloud.md
+++ b/docs_page/s4hana-public-cloud.md
@@ -1,0 +1,178 @@
+# SAP S/4HANA Public Cloud Setup
+
+ARC-1 connects to **SAP S/4HANA Cloud Public Edition (developer extensibility / ABAP Cloud)** through ADT, using **principal propagation only**.
+
+> **Principal propagation is the only supported way to reach ADT on S/4HANA Public Cloud.**
+> There is no technical-user / Basic-auth path and no local service-key browser flow (unlike the
+> [BTP ABAP Environment](btp-abap-environment.md)). ARC-1 must run on **BTP Cloud Foundry** and act
+> as **each MCP user's own S/4HANA Cloud identity** via a `SAMLAssertion` BTP destination — the
+> **same destination type and setup SAP Business Application Studio (BAS) uses**.
+
+If you already connect BAS to your S/4HANA Cloud system for ABAP development, you can **reuse that
+exact destination** — just point ARC-1 at it. The destination setup follows the SAP tutorial
+[Connect SAP Business Application Studio and SAP S/4HANA Cloud System](https://developers.sap.com/tutorials/abap-custom-ui-bas-connect-s4hc.html).
+
+> **Do not set `SAP_DISABLE_SAML=true`.** The SAML disable opt-in is for on-prem systems and breaks
+> S/4HANA Public Cloud authentication. See [enterprise-auth.md](enterprise-auth.md).
+
+## How it works
+
+```
+MCP Client (user JWT — XSUAA / OIDC)
+  │
+  ▼
+ARC-1 on BTP Cloud Foundry (/mcp)
+  │  validates the user JWT, passes it to the Destination service as X-User-Token
+  ▼
+BTP Destination service (SAMLAssertion destination)
+  │  mints a per-user SAML assertion (NameID = user email)
+  ▼
+ARC-1 sends:  Authorization: SAML2.0 <assertion>
+              x-sap-security-session: create        (direct, Internet — no Cloud Connector)
+  ▼
+S/4HANA Cloud (Communication System = trusted SAML Bearer Assertion Provider)
+  │  validates the assertion, maps the email to a business user
+  ▼
+ADT request runs as that individual S/4HANA Cloud user (their own authorizations apply)
+```
+
+Each MCP user therefore acts in S/4HANA Cloud as themselves — no shared SAP credentials, full
+per-user audit trail. SAP returns a security session cookie on the first call (`x-sap-security-session: create`),
+which ARC-1's cookie jar reuses for the rest of the session.
+
+## Prerequisites
+
+- ARC-1 deployed on **BTP Cloud Foundry** (`http-streamable` transport) — see [BTP Cloud Foundry Deployment](btp-cloud-foundry-deployment.md)
+- JWT-based MCP-client auth working ([XSUAA](xsuaa-setup.md) or [OIDC](oauth-jwt-setup.md))
+- **XSUAA** + **Destination** service instances bound to ARC-1 (no Connectivity service / Cloud Connector — the system is Internet-facing)
+- An S/4HANA Cloud user (business user) for each MCP user, whose **email matches** the JWT, holding a business role with **ABAP developer (developer extensibility)** authorization — the same access needed to develop via BAS/ADT
+- Administrator access to the S/4HANA Cloud system (Communication Management) and the BTP subaccount
+
+## Step 1: Establish SAML trust on S/4HANA Cloud
+
+This is identical to the BAS connection setup — follow the SAP tutorial
+[Connect SAP Business Application Studio and SAP S/4HANA Cloud System](https://developers.sap.com/tutorials/abap-custom-ui-bas-connect-s4hc.html).
+Summary:
+
+1. **BTP subaccount → Connectivity → Destination Trust**: choose **Generate Trust** (if no trust
+   certificate exists yet), then **Export** the subaccount's signing certificate (PEM).
+2. **S/4HANA Cloud → Communication Systems** app: create a system (e.g. `BAS_<subaccount-subdomain>`):
+   - **General → Technical Data**: enable **Inbound Only**.
+   - **General → Identity Provider / OAuth 2.0 / SAML**: set **SAML Bearer Assertion Provider** to **ON**, upload the exported BTP certificate, and set the **SAML Bearer Issuer** to the certificate's Subject CN.
+
+No communication *arrangement* and no communication *user* are needed for the developer connection —
+the SAML assertion carries the real user identity (email), which S/4HANA Cloud maps to a business user.
+
+## Step 2: Create the `SAMLAssertion` destination
+
+In the BTP subaccount (**Connectivity → Destinations**) create the destination — or **reuse your
+existing BAS destination** (the one named like `<SYSTEM_ID>_SAML_ASSERTION`). These are the values from
+the SAP tutorial:
+
+| Property | Value |
+|---|---|
+| **Name** | `<SYSTEM_ID>_SAML_ASSERTION` (your choice — this is what `SAP_BTP_PP_DESTINATION` points at) |
+| **Type** | `HTTP` |
+| **URL** | your S/4HANA Cloud system URL, e.g. `https://my<NNNNN>-api.s4hana.cloud.sap` |
+| **Proxy Type** | `Internet` |
+| **Authentication** | `SAMLAssertion` |
+| **Audience** | the S/4HANA Cloud OAuth 2.0 SAML2 audience (the system's SAML2 local provider name) |
+| **AuthnContextClassRef** | `urn:oasis:names:tc:SAML:2.0:ac:classes:PreviousSession` |
+| **Client Key** | leave empty (tick "set empty") |
+| **Name ID Format** | `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress` |
+
+Additional Properties (BAS-oriented; harmless for ARC-1, keep them if you reuse the BAS destination):
+
+| Property | Value |
+|---|---|
+| `HTML5.DynamicDestination` | `true` |
+| `HTML5.Timeout` | `60000` |
+| `WebIDEEnabled` | `true` |
+| `WebIDEUsage` | `odata_abap,dev_abap` |
+
+Also enable **Use default JDK truststore** so the public S/4HANA Cloud TLS certificate is trusted.
+
+> ARC-1 only consumes the `SAMLAssertion` auth flow from this destination — it forwards the assertion
+> verbatim as `Authorization` plus `x-sap-security-session: create`. The `WebIDE*` / `HTML5.*`
+> properties are BAS hints and are ignored by ARC-1.
+
+## Step 3: Bind BTP services
+
+ARC-1 needs **XSUAA** (MCP-client login) and **Destination** only — no Connectivity service, because
+there is no Cloud Connector for a cloud-to-cloud call:
+
+```bash
+cf create-service xsuaa application arc1-xsuaa -c xs-security.json
+cf create-service destination lite arc1-destination
+```
+
+## Step 4: Configure ARC-1
+
+```yaml
+env:
+  SAP_SYSTEM_TYPE: btp                       # ABAP Cloud tool surface from startup
+  SAP_TRANSPORT: http-streamable
+  SAP_XSUAA_AUTH: "true"                     # MCP clients authenticate via XSUAA OAuth
+  SAP_PP_ENABLED: "true"                     # per-user principal propagation
+  SAP_BTP_PP_DESTINATION: <SYSTEM_ID>_SAML_ASSERTION
+  # SAP_PP_STRICT: "true"                    # optional: reject non-JWT / PP failures (no fallback)
+services:
+  - arc1-xsuaa
+  - arc1-destination
+```
+
+Per request, ARC-1 validates the MCP user's JWT, has the Destination service mint a per-user SAML
+assertion, and sends it to S/4HANA Cloud. SAP sees the actual end user, so SAP-side authorizations
+apply per user. ARC-1 detects `ProxyType: Internet` and connects **directly** — the Cloud Connector
+proxy is used only for on-premise destinations.
+
+## Step 5: Grant users access
+
+1. **BTP** — assign each MCP user a role collection granting the ARC-1 scopes they need (e.g. `ARC-1 Developer`); XSUAA only issues a token for scopes the user actually holds.
+2. **S/4HANA Cloud** — the matching business user (same email as the JWT) must hold a business role with **developer extensibility / ABAP development** authorization. Without it, ADT calls fail with a logon/authorization error even though the SAML assertion is accepted.
+
+## What to expect (ABAP Cloud)
+
+S/4HANA Public Cloud developer extensibility is **ABAP Cloud** — the same restricted surface as the
+[BTP ABAP Environment](btp-abap-environment.md#constraints-vs-on-premise): released APIs (C1) only,
+ADT-only (no SAP GUI), `Z`/customer namespaces, gCTS-style transports, and SAP standard tables blocked
+in `SAPQuery` (use released CDS views). Setting `SAP_SYSTEM_TYPE=btp` exposes the ABAP Cloud tool
+definitions from startup; see [BTP ABAP Environment → What to Expect](btp-abap-environment.md#what-to-expect-on-btp-abap).
+
+## Verification
+
+With `ARC1_LOG_LEVEL=debug`, make any tool call (e.g. "search for ZCL_* classes") and check the
+ARC-1 logs:
+
+- `Destination Service PP response` — lists the SAML auth-token entry returned by the destination
+- `BTP destination resolved (per-user) … hasSamlAssertion:true`
+- `auth_pp_created … success:true`
+- the `SAPRead` returns data, and S/4HANA Cloud `SM20`/session shows the **individual** user
+
+## Troubleshooting
+
+### `auth_pp_created success:false … no SAML assertion returned`
+The destination did not return a SAML assertion. Check the destination `Authentication` is exactly
+`SAMLAssertion`, that the BTP destination-trust certificate is uploaded to the S/4HANA Cloud
+Communication System, and that the **SAML Bearer Assertion Provider** is **ON**.
+
+### Assertion accepted but ADT returns 401 / "not successfully logged on"
+The SAML NameID (user email) didn't map to an authorized S/4HANA Cloud user. Confirm a business user
+exists with the **same email** as the JWT, and that it holds a **developer (developer extensibility)**
+business role.
+
+### Requests fail / time out only when the Connectivity service is bound
+Internet destinations must connect directly. ARC-1 already routes `ProxyType: Internet` destinations
+direct (the connectivity proxy is used only for `OnPremise`); make sure the destination's **Proxy Type**
+is `Internet`.
+
+### See the raw SAP rejection text
+If the `errorBody`/`errorMessage` audit opt-in is enabled, set `ARC1_LOG_HTTP_DEBUG=true` to surface
+the SAP rejection message instead of `[REDACTED]`. See [Log Analysis](log-analysis.md).
+
+## References
+
+- SAP tutorial — [Connect SAP Business Application Studio and SAP S/4HANA Cloud System](https://developers.sap.com/tutorials/abap-custom-ui-bas-connect-s4hc.html) (the destination + trust setup ARC-1 reuses)
+- [Principal Propagation Setup](principal-propagation-setup.md) — ARC-1's per-user auth in depth (incl. the on-premise Cloud Connector variant)
+- [BTP Destination Setup](btp-destination-setup.md) · [BTP Cloud Foundry Deployment](btp-cloud-foundry-deployment.md)
+- [BTP ABAP Environment](btp-abap-environment.md) — the closely related Steampunk setup (`OAuth2UserTokenExchange`)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Docker: docker.md
       - BTP Cloud Foundry: btp-cloud-foundry-deployment.md
       - BTP ABAP Environment: btp-abap-environment.md
+      - S/4HANA Public Cloud: s4hana-public-cloud.md
       - Best Practices: deployment-best-practices.md
   - Auth & Permissions:
       - Overview: enterprise-auth.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@abaplint/core": "^2.119.43",
-        "@arc-mcp/xsuaa-auth": "^0.1.3",
+        "@arc-mcp/xsuaa-auth": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@sap-cloud-sdk/connectivity": "^4.7.0",
         "@sap/xsenv": "^6.2.1",
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@arc-mcp/xsuaa-auth": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@arc-mcp/xsuaa-auth/-/xsuaa-auth-0.1.3.tgz",
-      "integrity": "sha512-So/l1wioLluhXt96OmSrmFZ9qIpKMEWJWHBXd/cdKSWr27wx5zFnCvLd355g+C5WFWSbf55s5IPH4BDY4Yrl+Q==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@arc-mcp/xsuaa-auth/-/xsuaa-auth-0.1.4.tgz",
+      "integrity": "sha512-f2Dhh2xAy8Zv+PFVy5tnPcFJYSffhb+0BYgY9gFErYM4ipve6NuDE4kyvBBGiGk7jwKDl68NTi572d0n/oJsMg==",
       "license": "MIT",
       "dependencies": {
         "@sap-cloud-sdk/connectivity": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "dependencies": {
     "@abaplint/core": "^2.119.43",
-    "@arc-mcp/xsuaa-auth": "^0.1.3",
+    "@arc-mcp/xsuaa-auth": "^0.1.4",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@sap-cloud-sdk/connectivity": "^4.7.0",
     "@sap/xsenv": "^6.2.1",

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -331,6 +331,7 @@ export class AdtClient {
       sapConnectivityAuth: config.sapConnectivityAuth,
       ppProxyAuth: config.ppProxyAuth,
       bearerTokenProvider: config.bearerTokenProvider,
+      samlAuthorization: config.samlAuthorization,
       disableSaml: config.disableSaml,
       // Prefer the shared server-wide semaphore when provided so all per-user PP clients
       // share one cap. Fall back to a private semaphore for stdio/tests when only maxConcurrent

--- a/src/adt/config.ts
+++ b/src/adt/config.ts
@@ -90,6 +90,13 @@ export interface AdtClientConfig {
    * The function handles token lifecycle (caching, refresh, re-login).
    */
   bearerTokenProvider?: () => Promise<string>;
+  /**
+   * Per-user SAMLAssertion Authorization header value (e.g. "SAML2.0 <assertion>") from the BTP
+   * Destination Service. When set, sent verbatim as `Authorization` + `x-sap-security-session: create`
+   * (mirrors the SAP Cloud SDK's SAMLAssertion handling). Used for S/4HANA Public Cloud developer
+   * extensibility — the same destination flow BAS uses. Set only per-user, never from shared creds.
+   */
+  samlAuthorization?: string;
   /** Opt-in: disable SAML redirect via X-SAP-SAML2 header + saml2 query param */
   disableSaml?: boolean;
   /** Maximum concurrent SAP HTTP requests. When set, requests beyond this limit queue.

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -153,6 +153,12 @@ export interface AdtHttpConfig {
    * Used for direct BTP ABAP connections via service key.
    */
   bearerTokenProvider?: () => Promise<string>;
+  /**
+   * Per-user SAMLAssertion Authorization header value (e.g. "SAML2.0 <assertion>") from the BTP
+   * Destination Service. When set, sent verbatim as `Authorization` + `x-sap-security-session: create`.
+   * Used for S/4HANA Public Cloud developer extensibility (the same destination flow BAS uses).
+   */
+  samlAuthorization?: string;
   /** Opt-in: disable SAML redirect via X-SAP-SAML2 header + saml2 query param */
   disableSaml?: boolean;
   /** Optional concurrency limiter shared across requests */
@@ -1130,6 +1136,16 @@ export class AdtHttpClient {
 
   /** Apply Basic Auth header if username/password are configured (and no bearer provider) */
   private applyAuthHeader(headers: Record<string, string>): void {
+    // Principal Propagation via SAMLAssertion (e.g. S/4HANA Public Cloud developer extensibility —
+    // the same destination flow BAS uses). The BTP Destination Service returns a ready-to-use
+    // Authorization value (the SAML assertion); send it verbatim plus `x-sap-security-session: create`
+    // so SAP establishes a session and returns cookies the jar reuses (mirrors @sap-cloud-sdk's
+    // SAMLAssertion handling). Mutually exclusive with the other per-user auth modes below.
+    if (this.config.samlAuthorization) {
+      headers.Authorization = this.config.samlAuthorization;
+      headers['x-sap-security-session'] = 'create';
+      return;
+    }
     if (
       this.config.username &&
       this.config.password &&

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -255,10 +255,20 @@ async function createPerUserClient(
   // SAP_BTP_PP_DESTINATION may point to different Cloud Connectors (different
   // Location IDs). If we blindly reuse the startup proxy, PP requests route to
   // the wrong SCC instance — causing 401/403/404 errors that are hard to debug.
-  const effectiveProxy =
-    btpProxy && destination.CloudConnectorLocationId !== undefined
-      ? { ...btpProxy, locationId: destination.CloudConnectorLocationId }
-      : btpProxy;
+  //
+  // Only on-premise destinations go through the Cloud Connector proxy. Internet
+  // destinations (e.g. S/4HANA Public Cloud with SAMLAssertion) must connect
+  // directly — otherwise, if the Connectivity service is also bound, the request
+  // would be wrongly tunnelled through the proxy (http.ts proxies whenever btpProxy is set).
+  let effectiveProxy: BTPProxyConfig | undefined;
+  if (destination.ProxyType === 'OnPremise' && btpProxy) {
+    effectiveProxy =
+      destination.CloudConnectorLocationId !== undefined
+        ? { ...btpProxy, locationId: destination.CloudConnectorLocationId }
+        : btpProxy;
+  } else {
+    effectiveProxy = undefined;
+  }
 
   const adtConfig = buildAdtConfig(config, effectiveProxy, undefined, { perUser: true }, adtSemaphore);
   // Override URL from destination (in case it differs from startup-resolved URL)
@@ -319,11 +329,17 @@ export function applyPerUserAuthTokens(
     logger.debug('PP: using destination-exchanged Bearer token (OAuth2UserTokenExchange)', {
       destination: destName,
     });
+  } else if (authTokens.samlAssertionAuthorization) {
+    // SAMLAssertion (e.g. S/4HANA Public Cloud developer extensibility — same flow BAS uses):
+    // the Destination Service returns a ready-to-use Authorization header value (the assertion);
+    // http.ts sends it verbatim as Authorization + `x-sap-security-session: create`.
+    adtConfig.samlAuthorization = authTokens.samlAssertionAuthorization;
+    logger.debug('PP: using SAMLAssertion Authorization header', { destination: destName });
   } else {
     // No per-user auth token received.
     throw new Error(
       `Principal propagation failed for destination '${destName}': ` +
-        'no SAP-Connectivity-Authentication header, Bearer token, or jwt-bearer exchange token returned. ' +
+        'no SAP-Connectivity-Authentication header, Bearer token, SAML assertion, or jwt-bearer exchange token returned. ' +
         'Check Cloud Connector status, destination configuration, and user JWT validity.',
     );
   }

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -118,6 +118,57 @@ describe('AdtHttpClient', () => {
     });
   });
 
+  // ─── Auth headers ──────────────────────────────────────────────────
+
+  describe('SAMLAssertion principal propagation (S/4HANA Public Cloud)', () => {
+    function samlConfig(): AdtHttpConfig {
+      // Per-user config as applyPerUserAuthTokens builds it: shared Basic creds stripped,
+      // the ready-to-use assertion in samlAuthorization.
+      return {
+        baseUrl: 'https://my.s4hana.cloud.sap',
+        client: '100',
+        language: 'EN',
+        samlAuthorization: 'SAML2.0 ass=base64assertion',
+      } as AdtHttpConfig;
+    }
+
+    it('sends the SAML assertion as Authorization plus x-sap-security-session: create', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient(samlConfig());
+      await client.get('/sap/bc/adt/core/discovery');
+
+      const headers = fetchHeaders(0);
+      expect(headers.Authorization).toBe('SAML2.0 ass=base64assertion');
+      expect(headers['x-sap-security-session']).toBe('create');
+    });
+
+    it('does NOT send Basic auth when a SAML assertion is configured', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      // Even if creds linger, the SAML path wins and Basic is never emitted.
+      const client = new AdtHttpClient({ ...samlConfig(), username: 'TECH', password: 'secret' } as AdtHttpConfig);
+      await client.get('/sap/bc/adt/core/discovery');
+
+      expect(fetchHeaders(0).Authorization).toBe('SAML2.0 ass=base64assertion');
+      expect(fetchHeaders(0).Authorization).not.toContain('Basic');
+    });
+
+    it('carries the SAML assertion on the CSRF fetch for a write (same session)', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, '', { 'x-csrf-token': 'T' })); // CSRF fetch
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'created')); // POST
+
+      const client = new AdtHttpClient(samlConfig());
+      await client.post('/sap/bc/adt/path', '<xml/>', 'application/xml');
+
+      // CSRF fetch (call 0) must also carry the assertion + session-create so the token
+      // binds to the SAML-authenticated session.
+      expect(fetchHeaders(0).Authorization).toBe('SAML2.0 ass=base64assertion');
+      expect(fetchHeaders(0)['x-sap-security-session']).toBe('create');
+      expect(fetchHeaders(1).Authorization).toBe('SAML2.0 ass=base64assertion');
+    });
+  });
+
   // ─── POST/PUT/DELETE ───────────────────────────────────────────────
 
   describe('modifying requests', () => {

--- a/tests/unit/server/per-user-auth-tokens.test.ts
+++ b/tests/unit/server/per-user-auth-tokens.test.ts
@@ -55,6 +55,35 @@ describe('applyPerUserAuthTokens', () => {
     expect(cfg.bearerTokenProvider).toBeUndefined();
   });
 
+  it('wires a SAMLAssertion Authorization header (S/4HANA Public Cloud, same flow as BAS)', () => {
+    const cfg = applyPerUserAuthTokens(
+      baseConfig(),
+      { samlAssertionAuthorization: 'SAML2.0 ass=base64assertion' },
+      'jdoe@example.com',
+      'S4HC_PP',
+    );
+
+    expect(cfg.samlAuthorization).toBe('SAML2.0 ass=base64assertion');
+    // SAML path must clear shared Basic creds and must NOT set the other per-user auth modes.
+    expect(cfg.password).toBeUndefined();
+    expect(cfg.username).toBe('jdoe@example.com');
+    expect(cfg.bearerTokenProvider).toBeUndefined();
+    expect(cfg.sapConnectivityAuth).toBeUndefined();
+    expect(cfg.ppProxyAuth).toBeUndefined();
+  });
+
+  it('prefers a Bearer token over a SAML assertion when both are present', () => {
+    const cfg = applyPerUserAuthTokens(
+      baseConfig(),
+      { bearerToken: 'abap-user-token', samlAssertionAuthorization: 'SAML2.0 ass=x' },
+      'jdoe@example.com',
+      'S4HC_PP',
+    );
+
+    expect(cfg.bearerTokenProvider).toBeDefined();
+    expect(cfg.samlAuthorization).toBeUndefined();
+  });
+
   it('throws when the Destination Service returns no usable per-user token', () => {
     expect(() => applyPerUserAuthTokens(baseConfig(), {}, 'jdoe@example.com', 'ABAP_PP')).toThrow(
       /Principal propagation failed for destination 'ABAP_PP'/,


### PR DESCRIPTION
## Summary

Adds support for connecting ARC-1 to **SAP S/4HANA Public Cloud (developer extensibility / ABAP Cloud)** via **per-user principal propagation** using a BTP `SAMLAssertion` destination — the same destination type and trust setup SAP Business Application Studio (BAS) uses.

Previously, pointing ARC-1 at a `SAMLAssertion` destination failed with `Principal propagation failed … no SAP-Connectivity-Authentication header, Bearer token, or jwt-bearer exchange token returned`: the destination's SAML assertion token was silently dropped, so no per-user credential reached SAP. S/4HANA Public Cloud only exposes ADT through principal propagation, so this was the missing piece for that target.

## How it works

1. The MCP user's JWT is exchanged at the BTP Destination service, which mints a per-user SAML assertion (NameID = user email) for the `SAMLAssertion` destination.
2. ARC-1 forwards it verbatim as `Authorization: SAML2.0 <assertion>` plus `x-sap-security-session: create` — mirroring the SAP Cloud SDK's `SAMLAssertion` handling — and connects **directly** over the Internet (no Cloud Connector).
3. S/4HANA Public Cloud (configured as a trusted SAML Bearer Assertion Provider) maps the email to a business user; the ADT request runs as that individual user, so SAP-side authorizations and audit apply per user.

## Changes

**Per-user auth (`SAMLAssertion`)**
- `applyPerUserAuthTokens` (`src/server/server.ts`) now wires a SAML branch: when the destination returns `samlAssertionAuthorization`, it sets `samlAuthorization` on the per-user client config and clears the shared Basic credentials (precedence: `ppProxyAuth` → `sapConnectivityAuth` → `bearerToken` → `samlAssertionAuthorization`). The "PP failed" error message now lists the SAML option too.
- `applyAuthHeader` (`src/adt/http.ts`) sends `Authorization: <assertion>` + `x-sap-security-session: create` when `samlAuthorization` is set — covering the request, 401-retry, and CSRF-fetch paths from one place. New `samlAuthorization` field on both `AdtClientConfig` (`src/adt/config.ts`) and `AdtHttpConfig`, mapped through in `src/adt/client.ts`.

**Direct routing for cloud targets**
- `createPerUserClient` (`src/server/server.ts`) now attaches the Cloud Connector proxy only for `ProxyType: OnPremise` destinations; Internet destinations (S/4HANA Public Cloud) connect directly. Without this, a deployment that also binds the Connectivity service would wrongly tunnel the request through the proxy. Existing on-premise behavior (incl. the per-destination Location ID override) is preserved.

**Docs**
- New deployment guide: `docs_page/s4hana-public-cloud.md` (PP-only, the `SAMLAssertion` destination table from the SAP BAS tutorial, S/4HC SAML trust, ARC-1 config, behavior, troubleshooting).
- Registered in the Deployment nav (`mkdocs.yml`); cross-linked from `deployment.md` and `principal-propagation-setup.md`; `AGENTS.md` Layer B row updated.

## Tests

- `tests/unit/server/per-user-auth-tokens.test.ts`: SAML assertion wires `samlAuthorization`, clears Basic creds, and yields to a Bearer token when both are present.
- `tests/unit/adt/http.test.ts`: requests send `Authorization` + `x-sap-security-session: create`, never Basic, and carry the assertion on the CSRF fetch.
- Full suite green: `npm test` (4109), `typecheck`, `lint`, `build`, `check:sizes`.

## Dependency

Relies on `@arc-mcp/xsuaa-auth` exposing `PerUserAuthTokens.samlAssertionAuthorization` (the SAML extraction lives in that package). Bump `@arc-mcp/xsuaa-auth` to the published version that includes the field (≥ 0.1.4) before/with merge so CI typechecks.