### PR TITLE
test: cover per-user Cloud Connector proxy selection

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,7 +7,7 @@
  * - http-streamable: for remote/containerized deployments
  */
 
-import type { BTPConfig, BTPProxyConfig, PerUserAuthTokens } from '@arc-mcp/xsuaa-auth/btp';
+import type { BTPConfig, BTPProxyConfig, Destination, PerUserAuthTokens } from '@arc-mcp/xsuaa-auth/btp';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
@@ -221,6 +221,32 @@ export function buildAdtConfig(
 }
 
 /**
+ * Pick the Cloud Connector proxy for a per-user (principal-propagation) request.
+ * Exported for unit testing.
+ *
+ * Only on-premise destinations tunnel through the Cloud Connector proxy. Internet
+ * destinations (e.g. S/4HANA Public Cloud with SAMLAssertion) must connect directly —
+ * returning a proxy here would wrongly route them through the SCC, since http.ts
+ * proxies whenever btpProxy is set.
+ *
+ * For on-prem, the PP destination's own CloudConnectorLocationId overrides the startup
+ * proxy's: dual-destination setups (SAP_BTP_DESTINATION vs SAP_BTP_PP_DESTINATION) may
+ * point at different Cloud Connectors, and reusing the startup Location ID would route PP
+ * requests to the wrong SCC (hard-to-debug 401/403/404).
+ */
+export function selectPerUserProxy(
+  destination: Pick<Destination, 'ProxyType' | 'CloudConnectorLocationId'>,
+  btpProxy: BTPProxyConfig | undefined,
+): BTPProxyConfig | undefined {
+  if (destination.ProxyType !== 'OnPremise' || !btpProxy) {
+    return undefined;
+  }
+  return destination.CloudConnectorLocationId !== undefined
+    ? { ...btpProxy, locationId: destination.CloudConnectorLocationId }
+    : btpProxy;
+}
+
+/**
  * Create a per-user ADT client for principal propagation.
  *
  * Called per MCP request when ppEnabled=true and user JWT is available.
@@ -250,25 +276,7 @@ async function createPerUserClient(
 
   const { destination, authTokens } = await lookupDestinationWithUserToken(btpConfig, destName, userJwt, authLibLogger);
 
-  // Build an effective proxy that uses the PP destination's Location ID, not the
-  // startup destination's. In dual-destination setups, SAP_BTP_DESTINATION and
-  // SAP_BTP_PP_DESTINATION may point to different Cloud Connectors (different
-  // Location IDs). If we blindly reuse the startup proxy, PP requests route to
-  // the wrong SCC instance — causing 401/403/404 errors that are hard to debug.
-  //
-  // Only on-premise destinations go through the Cloud Connector proxy. Internet
-  // destinations (e.g. S/4HANA Public Cloud with SAMLAssertion) must connect
-  // directly — otherwise, if the Connectivity service is also bound, the request
-  // would be wrongly tunnelled through the proxy (http.ts proxies whenever btpProxy is set).
-  let effectiveProxy: BTPProxyConfig | undefined;
-  if (destination.ProxyType === 'OnPremise' && btpProxy) {
-    effectiveProxy =
-      destination.CloudConnectorLocationId !== undefined
-        ? { ...btpProxy, locationId: destination.CloudConnectorLocationId }
-        : btpProxy;
-  } else {
-    effectiveProxy = undefined;
-  }
+  const effectiveProxy = selectPerUserProxy(destination, btpProxy);
 
   const adtConfig = buildAdtConfig(config, effectiveProxy, undefined, { perUser: true }, adtSemaphore);
   // Override URL from destination (in case it differs from startup-resolved URL)

--- a/tests/unit/server/select-per-user-proxy.test.ts
+++ b/tests/unit/server/select-per-user-proxy.test.ts
@@ -1,0 +1,35 @@
+import type { BTPProxyConfig } from '@arc-mcp/xsuaa-auth/btp';
+import { describe, expect, it } from 'vitest';
+import { selectPerUserProxy } from '../../../src/server/server.js';
+
+// A startup-resolved Cloud Connector proxy descriptor, as createPerUserClient receives it.
+function btpProxy(): BTPProxyConfig {
+  return { host: 'connectivityproxy.internal', port: 20003, protocol: 'http', getProxyToken: async () => 'tok' };
+}
+
+describe('selectPerUserProxy', () => {
+  it('reuses the startup proxy unchanged for an OnPremise destination without a Location ID', () => {
+    const proxy = btpProxy();
+    expect(selectPerUserProxy({ ProxyType: 'OnPremise' }, proxy)).toBe(proxy);
+  });
+
+  it("applies the OnPremise destination's CloudConnectorLocationId over the startup proxy's", () => {
+    const proxy = btpProxy();
+    const result = selectPerUserProxy({ ProxyType: 'OnPremise', CloudConnectorLocationId: 'scc-tokyo' }, proxy);
+
+    expect(result).not.toBe(proxy); // dual-SCC: a fresh descriptor, startup proxy left untouched
+    expect(result?.locationId).toBe('scc-tokyo');
+    expect(result?.host).toBe('connectivityproxy.internal'); // other fields preserved
+  });
+
+  it('returns no proxy for an Internet destination even when the Connectivity proxy is bound', () => {
+    // S/4HANA Public Cloud (SAMLAssertion) must connect directly, not through the SCC.
+    expect(selectPerUserProxy({ ProxyType: 'Internet' }, btpProxy())).toBeUndefined();
+  });
+
+  it('returns no proxy when none is bound (guards the !btpProxy half of the condition)', () => {
+    expect(
+      selectPerUserProxy({ ProxyType: 'OnPremise', CloudConnectorLocationId: 'scc-tokyo' }, undefined),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

PR #524 (S/4HANA Public Cloud support) changed `createPerUserClient` in `src/server/server.ts` to select the Cloud Connector proxy **only for on-premise destinations** — Internet destinations (S/4HANA Public Cloud, `SAMLAssertion`) now connect directly. That logic shipped without a unit test. This adds one.

- Extracted the proxy choice into a pure, exported helper `selectPerUserProxy(destination, btpProxy)` (behavior-preserving — `createPerUserClient` now just calls it). The dynamic `@arc-mcp/xsuaa-auth/btp` import + `AdtClient` construction made the call site awkward to test directly, so the branch is now a small pure function.
- Added `tests/unit/server/select-per-user-proxy.test.ts`, mirroring the sibling `applyPerUserAuthTokens` test in `per-user-auth-tokens.test.ts`.

## Why

Lock in the three cases #524 introduced so a future refactor can't silently route Internet targets through the SCC (which would break S/4HANA Public Cloud) or reuse the wrong Location ID in dual-destination / dual-SCC setups:

1. **OnPremise** + proxy, no `CloudConnectorLocationId` → reuse the startup proxy unchanged.
2. **OnPremise** + proxy + `CloudConnectorLocationId` → override onto a fresh descriptor (startup proxy untouched).
3. **Internet** + proxy bound → no proxy, connect directly.

Plus a 4th guarding the `!btpProxy` half of the condition (OnPremise but no proxy → `undefined`).

## Reviewer notes

- Behavior-preserving extraction; the inline `if/else` and its comment moved verbatim into the helper's body + doc comment.
- `test:` prefix → release-please cuts no release.
- Verified: `npm run typecheck` ✓ · `npm test` (4113 passed) ✓ · `npm run lint` ✓.