### PR TITLE
fix: make nullable SAPWrite schemas opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,6 +179,8 @@ SAP_TRANSPORT=stdio              # or: http-streamable
 # ARC1_LOG_HTTP_DEBUG=false
 # ARC1_MAX_CONCURRENT=10         # lower toward ~4 when several test runs share one small SAP system
 # ARC1_TOOL_MODE=standard        # standard|hyperfocused
+# ARC1_SCHEMA_NULLABLE_OPTIONALS=auto  # auto|off|on. auto/off keep portable plain schemas; set on only
+#                                      # for tested OpenAI/Azure strict-mode clients that need nullable optionals (#360).
 # SAP_VERBOSE=false
 
 # ── Extensions (FEAT-61) — add your own Custom_* tools; see docs_page/extensions.md ──

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Full per-option details (defaults, clamps, layer interactions): [docs_page/confi
 | `SAP_SYSTEM_TYPE` | `auto` (default), `btp`, `onprem` |
 | `SAP_ABAP_RELEASE` | SAP_BASIS release override for abaplint (e.g. 758, 816); probe wins |
 | `ARC1_TOOL_MODE` | `standard` (12 tools) or `hyperfocused` (1 tool, ~200 tokens) |
+| `ARC1_SCHEMA_NULLABLE_OPTIONALS` | `auto`/`off`/`on` for optional `SAPWrite` schema null unions; default `auto` emits portable plain schemas, `on` is explicit OpenAI/Azure strict-mode compatibility (#360/#520) |
 | `ARC1_PLUGINS` | FEAT-61 extensions: CSV of absolute LOCAL paths (`.js`/`.json`), NOT npm. Adds `Custom_*` tools (reads + gated non-ADT writes/execute) — docs_page/extensions.md |
 | `SAP_ALLOW_PLUGIN_EXECUTE` | Opt-in (default false): let plugin tools execute ABAP console classes (`ctx.run.classRun`). ALSO needs `SAP_ALLOW_WRITES` + a `write`-scoped tool |
 | `SAP_ALLOW_PLUGIN_RAW_WRITES` | Opt-in (default false): let plugin tools `ctx.http.post`/`put`/`delete` to **non-ADT** (OData/ICF) paths. ALSO needs `SAP_ALLOW_WRITES` + a `write`-scoped tool; `/sap/bc/adt/…` writes always refused |

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -18,7 +18,7 @@ The full grouped template with inline commentary is [`.env.example`](https://git
 6. [Caching](#caching) — source cache, warmup
 7. [Logging and observability](#logging-and-observability) — log file, level, format, HTTP debug
 8. [ABAP feature toggles](#abap-feature-toggles) — abapGit, gCTS, RAP, AMDP, UI5, HANA, FLP
-9. [Code-quality gates](#code-quality-gates) — pre-write lint/check, abaplint config, tool mode
+9. [Code-quality gates](#code-quality-gates) — pre-write lint/check, abaplint config, tool/schema mode
 10. [Extensions](#extensions-feat-61) — `ARC1_PLUGINS`, plugin code-execution opt-in
 
 ---
@@ -308,7 +308,7 @@ When a feature is `off` (either set explicitly or detected as unavailable), ever
 
 ## Code-quality gates
 
-Optional pre-write validation layers and tool-set selection.
+Optional pre-write validation layers and tool/schema selection.
 
 | Flag | Env var | Default | Effect |
 |---|---|---|---|
@@ -316,6 +316,7 @@ Optional pre-write validation layers and tool-set selection.
 | `--abaplint-config` | `SAP_ABAPLINT_CONFIG` | — (uses built-in preset) | Path to a custom `abaplint.jsonc`. When unset, ARC-1 builds a preset config based on the detected system type (cloud-strict for BTP, relaxed for on-prem). Custom config takes full precedence. |
 | `--check-before-write` | `SAP_CHECK_BEFORE_WRITE` | `false` | See [Authorization and safety](#authorization-and-safety) — adds a server-side ADT syntax check round-trip before save. Different layer from `lint-before-write` (this hits SAP, lint runs locally). |
 | `--tool-mode` | `ARC1_TOOL_MODE` | `standard` | `standard` exposes the 12 intent-based tools (schema payload guarded by CI budgets). `hyperfocused` exposes a single universal `sap` tool (~200 tokens) that dispatches everything internally. Use `hyperfocused` for severely token-constrained LLM clients (e.g. GPT-4o-mini, Copilot Studio). |
+| `--schema-nullable-optionals` | `ARC1_SCHEMA_NULLABLE_OPTIONALS` | `auto` | Controls whether optional `SAPWrite` JSON Schema fields are emitted as nullable unions (`type: ["string","null"]`). `auto` currently resolves to `off` and logs MCP client info for future allow-listing. `off` keeps the portable plain schema required by clients that reject unions (GitHub Copilot IDEs, Gemini CLI, Cursor/Foundry-style converters). `on` is an explicit compatibility escape hatch for OpenAI/Azure strict-mode function schemas that need nullable optionals to avoid fabricated enum values ([#360](https://github.com/arc-mcp/arc-1/issues/360)). Use `on` only after testing the target client accepts nullable unions; it can break clients affected by [#520](https://github.com/arc-mcp/arc-1/issues/520). |
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,12 +25,11 @@ import type { AdtClientConfig } from './adt/config.js';
 import { buildArgs, type OutputMode } from './cli-args.js';
 import { getToolRegistry, handleToolCall } from './handlers/dispatch.js';
 import type { ToolResult } from './handlers/shared.js';
-import { getToolDefinitions } from './handlers/tools.js';
 import { detectFilename, lintAbapSource } from './lint/lint.js';
 import { parseArgs, resolveConfig } from './server/config.js';
 import { initLogger } from './server/logger.js';
 import { loadPlugins } from './server/plugin-loader.js';
-import { buildAdtConfig, VERSION } from './server/server.js';
+import { buildAdtConfig, getConfiguredToolDefinitions, VERSION } from './server/server.js';
 import type { ConfigSource, ServerConfig } from './server/types.js';
 
 // Load .env without printing dotenv tips to stdout.
@@ -103,7 +102,7 @@ program
           ? [{ name: e.name, description: e.listing.description, inputSchema: e.listing.inputSchema }]
           : [],
       );
-    const defs = [...getToolDefinitions(serverConfig), ...pluginDefs];
+    const defs = [...getConfiguredToolDefinitions(serverConfig), ...pluginDefs];
     if (!tool) {
       for (const def of defs) {
         const firstLine = def.description.split('\n')[0].trim();
@@ -337,7 +336,7 @@ async function runToolCall(toolName: string, args: Record<string, unknown>, outp
   if (serverConfig.plugins?.length) {
     await loadPlugins(serverConfig.plugins, getToolRegistry());
   }
-  const available = new Set(getToolDefinitions(serverConfig).map((t) => t.name));
+  const available = new Set(getConfiguredToolDefinitions(serverConfig).map((t) => t.name));
   for (const e of getToolRegistry().list()) {
     if (e.source === 'plugin') available.add(e.name);
   }

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -47,6 +47,10 @@ export interface ToolDefinition {
   annotations?: ToolAnnotations;
 }
 
+export interface ToolDefinitionOptions {
+  nullableOptionals?: boolean;
+}
+
 /**
  * Read-only / destructive hints for the 12 standard tools. Clients use them to badge tools
  * and to decide auto-approval (read-only tools are safe to auto-run); they are also required
@@ -380,8 +384,8 @@ function buildSAPSearchTool(btp: boolean, textSearchAvailable?: boolean): ToolDe
 
 // ─── GPT/OpenAI strict-mode nullable helper (issue #360) ────────────
 
-/** Add `null` to a property's `type` (string → ["string","null"]). Per OpenAI's Structured
- *  Outputs guide, null goes in `type` ONLY — never added to `enum`. */
+/** Add `null` to a property's `type` (string -> ["string","null"]). Per OpenAI's Structured
+ *  Outputs guide, null goes in `type` only, never into `enum`. */
 function makeNullableType(def: Record<string, unknown>): Record<string, unknown> {
   const d = { ...def };
   const t = d.type;
@@ -394,17 +398,15 @@ function makeNullableType(def: Record<string, unknown>): Record<string, unknown>
 }
 
 /**
- * Recursively make every NON-required property of a JSON-schema object nullable.
+ * Recursively make every non-required property of a JSON-schema object nullable.
  *
- * GPT/OpenAI strict mode (the default for the Responses API) marks every property required;
- * a non-nullable optional field then leaves the model no way to signal "unused" — for an enum
- * it is FORCED to emit one of the values (the hallucinated typeKind=domain / odataVersion=V4
- * seen on unrelated writes, issue #360). The OpenAI-documented fix is a union with null
- * (`"type": ["string","null"]`) so the model can emit null = "not used"; ARC-1's runtime
- * `stripLlmEmptyValues` then drops the nulls before Zod. Each object node's OWN `required`
- * array decides what stays non-nullable, so it is correct at every nesting level (top level
- * keeps `action`; batch `objects[]` items keep `type`/`name`; leaf arrays keep their keys).
- * Pure — returns a copy, does not mutate the input.
+ * This exists only for explicit OpenAI/Azure strict-mode compatibility (#360), where a strict
+ * function schema can force every optional field to be present and enum optionals then get
+ * fabricated values. Several MCP clients reject `type: ["x","null"]` unions, so the default
+ * visible schema stays plain for broad client compatibility (#520).
+ *
+ * Pure — returns a copy and does not mutate the input. Each object node's own `required` array
+ * decides what stays non-nullable, so top-level `action` and batch-item `type`/`name` remain plain.
  */
 function makeOptionalPropertiesNullable(node: unknown): unknown {
   if (Array.isArray(node)) return node.map(makeOptionalPropertiesNullable);
@@ -433,6 +435,7 @@ export function getToolDefinitions(
   config: ServerConfig,
   textSearchAvailable?: boolean,
   resolvedFeatures?: ResolvedFeatures,
+  options: ToolDefinitionOptions = {},
 ): ToolDefinition[] {
   // Hyperfocused mode: single universal SAP tool (~200 tokens)
   if (config.toolMode === 'hyperfocused') {
@@ -594,12 +597,12 @@ export function getToolDefinitions(
       const pkgList = config.allowedPackages.join(', ');
       sapWriteDesc += ` Write access is restricted to packages: ${pkgList}.`;
     }
-    tools.push({
+    const sapWriteTool: ToolDefinition = {
       name: 'SAPWrite',
       description: sapWriteDesc,
-      // Make optional fields nullable so GPT/OpenAI strict-mode callers can emit null for
-      // unused fields instead of fabricating values; the runtime strip removes the nulls (#360).
-      inputSchema: makeOptionalPropertiesNullable({
+      // Keep visible schemas on widely supported JSON Schema primitives. Runtime argument
+      // normalization still strips null-valued optionals from strict clients before Zod (#360).
+      inputSchema: {
         type: 'object',
         properties: {
           action: {
@@ -920,8 +923,12 @@ export function getToolDefinitions(
           },
         },
         required: ['action'],
-      }) as Record<string, unknown>,
-    });
+      },
+    };
+    if (options.nullableOptionals) {
+      sapWriteTool.inputSchema = makeOptionalPropertiesNullable(sapWriteTool.inputSchema) as Record<string, unknown>;
+    }
+    tools.push(sapWriteTool);
 
     tools.push({
       name: 'SAPActivate',

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -19,7 +19,14 @@
 import type { SafetyConfig } from '../adt/safety.js';
 import { parseDenyActions, validateDenyActions } from './deny-actions.js';
 import { logger } from './logger.js';
-import type { ConfigSource, FeatureToggle, ServerConfig, TransportType, UiMode } from './types.js';
+import type {
+  ConfigSource,
+  FeatureToggle,
+  NullableOptionalsMode,
+  ServerConfig,
+  TransportType,
+  UiMode,
+} from './types.js';
 import { DEFAULT_CONFIG } from './types.js';
 
 /**
@@ -156,6 +163,12 @@ function parseUiMode(raw: string, transport: TransportType): UiMode {
     return transport === 'stdio' ? 'local' : 'web';
   }
   throw new Error('Invalid ARC1_UI value: expected off, local, web, true, or false');
+}
+
+function parseNullableOptionalsMode(raw: string): NullableOptionalsMode {
+  const value = raw.trim().toLowerCase();
+  if (value === 'auto' || value === 'on' || value === 'off') return value;
+  throw new Error('Invalid ARC1_SCHEMA_NULLABLE_OPTIONALS value: expected auto, on, or off');
 }
 
 /** Map of legacy env-var names → human-readable migration hint. */
@@ -557,6 +570,13 @@ export function resolveConfig(args: string[]): { config: ServerConfig; sources: 
   // ── Tool Mode ──────────────────────────────────────────────────────
   const toolMode = resolveStr('tool-mode', 'ARC1_TOOL_MODE', 'standard', 'toolMode');
   config.toolMode = (toolMode === 'hyperfocused' ? 'hyperfocused' : 'standard') as ServerConfig['toolMode'];
+  const schemaNullableOptionals = resolveStr(
+    'schema-nullable-optionals',
+    'ARC1_SCHEMA_NULLABLE_OPTIONALS',
+    DEFAULT_CONFIG.schemaNullableOptionals,
+    'schemaNullableOptionals',
+  );
+  config.schemaNullableOptionals = parseNullableOptionalsMode(schemaNullableOptionals);
 
   // ── Extensions (FEAT-61) ───────────────────────────────────────────
   // CSV of absolute paths to extension plugins (local dirs/files, NOT npm names). Loaded at startup.
@@ -752,6 +772,11 @@ export function validateConfig(config: ServerConfig): void {
     console.error(
       '[warn] SAP_DISABLE_SAML=true on a BTP system usually breaks login — BTP ABAP and S/4HANA Public Cloud require SAML. Continuing because you explicitly set this, but check docs/enterprise-auth.md if login starts failing.',
     );
+  }
+
+  // Normal resolveConfig() already parses this fail-fast; keep the guard for tests and hand-built configs.
+  if (!['auto', 'on', 'off'].includes(config.schemaNullableOptionals)) {
+    throw new Error('Invalid ARC1_SCHEMA_NULLABLE_OPTIONALS value: expected auto, on, or off');
   }
 
   if (config.insecure) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10,7 +10,7 @@
 import type { BTPConfig, BTPProxyConfig, Destination, PerUserAuthTokens } from '@arc-mcp/xsuaa-auth/btp';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, type Implementation, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { AdtClient } from '../adt/client.js';
 import type { AdtClientConfig } from '../adt/config.js';
 import { resolveCookies } from '../adt/cookies.js';
@@ -29,7 +29,7 @@ import {
   setCachedDiscovery,
   setCachedFeatures,
 } from '../handlers/feature-cache.js';
-import { getToolDefinitions, type ToolDefinition } from '../handlers/tools.js';
+import { getToolDefinitions, type ToolDefinition, type ToolDefinitionOptions } from '../handlers/tools.js';
 import { API_KEY_PROFILES } from './config.js';
 import { isActionDenied } from './deny-actions.js';
 import { authLibLogger, initLogger, logger } from './logger.js';
@@ -60,6 +60,33 @@ function warnIfToolsListTooLarge(tools: ToolDefinition[]): void {
       '(tools may then fail to load). Consider ARC1_TOOL_MODE=hyperfocused, or reduce the surface (fewer enabled write/data/SQL/git scopes or plugins).',
     { bytes, tools: tools.length },
   );
+}
+
+function schemaNullableClientInfo(client?: Implementation): { clientName: string; clientVersion: string } {
+  return {
+    clientName: client?.name ?? 'unknown',
+    clientVersion: client?.version ?? 'unknown',
+  };
+}
+
+export function resolveNullableOptionals(config: ServerConfig, client?: Implementation): boolean {
+  if (config.schemaNullableOptionals === 'on') return true;
+  if (config.schemaNullableOptionals === 'off') return false;
+  logger.debug('schema nullable optionals auto mode resolved to off', schemaNullableClientInfo(client));
+  return false;
+}
+
+export function getToolDefinitionOptions(config: ServerConfig, client?: Implementation): ToolDefinitionOptions {
+  return { nullableOptionals: resolveNullableOptionals(config, client) };
+}
+
+export function getConfiguredToolDefinitions(
+  config: ServerConfig,
+  textSearchAvailable?: boolean,
+  resolvedFeatures?: Parameters<typeof getToolDefinitions>[2],
+  client?: Implementation,
+): ToolDefinition[] {
+  return getToolDefinitions(config, textSearchAvailable, resolvedFeatures, getToolDefinitionOptions(config, client));
 }
 
 /**
@@ -612,6 +639,7 @@ export function createServer(
   // wasting one round-trip per startup-stale-cookie cycle. We propagate the stale state
   // once on first tool call — idempotent flag keeps later calls O(1).
   let preflightStalePropagated = false;
+  let schemaNullableAutoClientInfoLogged = false;
 
   // Register tool listing — filtered by user's scopes when auth is active
   server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
@@ -622,7 +650,15 @@ export function createServer(
       await Promise.race([startupProbePromise, new Promise((resolve) => setTimeout(resolve, 10_000))]);
     }
     const features = getCachedFeatures();
-    let tools = getToolDefinitions(config, features?.textSearch?.available, features);
+    const clientVersion = server.getClientVersion();
+    if (config.schemaNullableOptionals === 'auto' && !schemaNullableAutoClientInfoLogged) {
+      schemaNullableAutoClientInfoLogged = true;
+      logger.info('schema nullable optionals auto mode clientInfo', {
+        ...schemaNullableClientInfo(clientVersion),
+        resolvedNullableOptionals: false,
+      });
+    }
+    let tools = getConfiguredToolDefinitions(config, features?.textSearch?.available, features, clientVersion);
 
     // When authenticated, only show tools the user has scopes for
     if (extra.authInfo) {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -17,6 +17,9 @@ export type UiMode = 'off' | 'local' | 'web';
 /** Feature toggle: auto detects from SAP system, on/off forces */
 export type FeatureToggle = 'auto' | 'on' | 'off';
 
+/** Tool-schema nullable optional mode: auto currently resolves to portable off. */
+export type NullableOptionalsMode = 'auto' | 'on' | 'off';
+
 /** Per-field config source (used by resolveConfig + startup log + `config show`). */
 export type ConfigSource = 'default' | { env: string } | { flag: string } | { file: string };
 
@@ -133,6 +136,8 @@ export interface ServerConfig {
   // --- Tool Mode ---
   /** Tool mode: 'standard' (12 intent tools, SAPGit feature-gated) or 'hyperfocused' (1 universal SAP tool, ~200 tokens) */
   toolMode: 'standard' | 'hyperfocused';
+  /** JSON Schema compatibility for optional SAPWrite fields. */
+  schemaNullableOptionals: NullableOptionalsMode;
 
   // --- Extensions (FEAT-61) ---
   /** Absolute paths to extension plugins to load at startup (from ARC1_PLUGINS, CSV). Each contributes
@@ -255,6 +260,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   ppAllowSharedCookies: false,
   disableSaml2: false,
   toolMode: 'standard',
+  schemaNullableOptionals: 'auto',
   plugins: [],
   allowPluginExecute: false,
   allowPluginRawWrites: false,

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -250,10 +250,7 @@
           "description": "Write action. create/update/delete: standard object writes. edit_method: replace one method body (type=CLAS, method, source). Class-section surgery (type=CLAS only): edit_class_definition without include= replaces the global DEFINITION block (refuses a diff that would leave the class non-activatable, e.g. a concrete method with no IMPL stub); with include= it whole-replaces a class-local include (CCDEF/CCIMP/macros/testclasses), auto-creating it. add_method inserts a METHODS clause + empty stub (visibility, abstract=true skips the stub); edit_method_signature replaces one METHODS clause (no IMPL change); delete_method removes the clause AND body — WARNING: destructive, discards the method body (to re-section a method use change_method_visibility, NOT delete+add); change_method_visibility moves a method between PUBLIC/PROTECTED/PRIVATE, preserves the body. add_method/edit_method_signature/delete_method/change_method_visibility act on /source/main only. batch_create: create+activate multiple objects (objects array). scaffold_rap_handlers / generate_behavior_implementation: derive RAP behavior-pool handlers from the BDEF (the latter the equivalent of Eclipse's \"Generate Behavior Implementation\")."
         },
         "type": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "CLAS",
             "INTF",
@@ -281,24 +278,15 @@
           "description": "Object type (for create/update/delete/edit_method/edit_class_definition/add_method/edit_method_signature/delete_method/change_method_visibility). Supported on BTP: CLAS, INTF, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD or KTD (Knowledge Transfer Documents), TABL, TABL/DT, TABL/DS, DOMA, DTEL, MSAG. Class-section surgery actions require type=CLAS. Server-driven objects (8.16+, discovery-gated): DESD, DTSC, CSNM, EVTB, EVTO, COTA — create/update/delete with AFF JSON in \"source\", then SAPActivate."
         },
         "name": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Object name (for create/update/delete/edit_method/edit_class_definition/add_method/edit_method_signature/delete_method/change_method_visibility)."
         },
         "source": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "ABAP source code. create/update: full source body. edit_method: the new method body. edit_class_definition without include=: only the new global CLASS…DEFINITION…ENDCLASS block (no IMPLEMENTATION); with include=: the full replacement body of that include. edit_method_signature: only the new METHODS clause. Not used by add_method/delete_method/change_method_visibility (use `method`/`visibility`)."
         },
         "include": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "definitions",
             "implementations",
@@ -308,17 +296,11 @@
           "description": "CLAS-ONLY. Do NOT send unless type=CLAS AND action is update / edit_method / edit_class_definition. OMIT it entirely for every other type and for delete / batch_create / add_method / edit_method_signature / delete_method / change_method_visibility (those use /source/main). Targets a class-local include: definitions (CCDEF), implementations (CCIMP), macros, testclasses. edit_method auto-detects it from the method specifier (lhc_*/lcl_* → implementations, ltc_* → testclasses), so you rarely pass it; use include=testclasses to create a new local test class. Whole-include writes auto-create a missing include and produce an inactive draft (read with SAPRead version=\"inactive\" before activation)."
         },
         "method": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "edit_method/edit_method_signature/delete_method/change_method_visibility: the method NAME (e.g. \"get_name\", \"zif_order~process\", \"lhc_project~approve_project\"). add_method: the full METHODS clause as ABAP source. Local-class methods auto-route by prefix (lhc_*/lcl_* → implementations, ltc_* → testclasses); use the qualified <localclass>~<method> form when a bare name is ambiguous."
         },
         "visibility": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "public",
             "protected",
@@ -327,101 +309,59 @@
           "description": "For action=add_method: target visibility section to insert into (default \"public\"). For action=change_method_visibility: the TARGET section to move the method to (required). The target section header must already exist in the DEFINITION block — if not, ARC-1 refuses with a hint to use edit_class_definition first."
         },
         "abstract": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For action=add_method: when true, only the METHODS clause is inserted into DEFINITION; no METHOD/ENDMETHOD stub is added to IMPLEMENTATION. Default false (concrete method — DEFINITION + IMPL stub written atomically)."
         },
         "bdefName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For scaffold_rap_handlers: interface BDEF name whose actions/determinations/validations/authorizations define the required handlers (e.g. ZI_TRAVELREQ). For generate_behavior_implementation: optional override (default discovery reads the class rootEntityRef)."
         },
         "autoApply": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For scaffold_rap_handlers: true inserts missing METHODS signatures + empty stubs and writes the class under one lock; false (default) returns a required-vs-missing report without modifying (preview, then re-run with autoApply=true). Not used by generate_behavior_implementation (use dryRun to preview there)."
         },
         "targetAlias": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For scaffold_rap_handlers and generate_behavior_implementation: optional RAP entity alias filter (e.g., Travel, Segment) to scaffold only one handler class. When omitted, all entities declared in the BDEF are scaffolded. Case-insensitive."
         },
         "activate": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For generate_behavior_implementation: true (default) activates the class after writing; false writes source only. The known \"Local classes of CL_ABAP_BEHAVIOR_HANDLER…\" stale-active activation failure does not throw — it returns activation.success=false with a recovery hint."
         },
         "activateAtEnd": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For batch_create only. false (default): per-object inline activation in order. true: write all inactive drafts then one terminal activateBatch so SAP resolves cross-references between siblings — use for interdependent RAP stacks (TABL→DDLS→DCLS→BDEF→SRVD). A write-phase failure still breaks the loop; the terminal activate runs over the already-written subset."
         },
         "dryRun": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For generate_behavior_implementation: when true, runs discovery + cross-validation + scaffold planning and returns the report without writing or activating. Use this to preview what would change."
         },
         "description": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Object description for create action (defaults to name if omitted). Max 60 chars for most types."
         },
         "package": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Package for new objects (default $TMP). Non-$TMP packages require a transport number."
         },
         "transport": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Transport request number. Required for non-$TMP packages. Use SAPTransport(action=\"list\") to find or SAPTransport(action=\"create\") to create one."
         },
         "group": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted."
         },
         "dataType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA/DTEL: ABAP data type (e.g., CHAR, NUMC, DEC)"
         },
         "rowType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "TTYP create: the row type — a built-in ABAP type (STRING, I, …) or a DDIC structure/type name. Required for TTYP create."
         },
         "rowTypeKind": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "builtin",
             "structure"
@@ -429,52 +369,31 @@
           "description": "TTYP create: row-type mode (auto-detected from rowType if omitted)."
         },
         "length": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA/DTEL: data type length"
         },
         "decimals": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA/DTEL: decimal places"
         },
         "outputLength": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA: output length"
         },
         "conversionExit": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA: conversion exit (e.g., ALPHA)"
         },
         "signExists": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DOMA: signed values allowed"
         },
         "lowercase": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DOMA: lowercase characters allowed"
         },
         "fixedValues": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "DOMA: fixed value ranges",
           "items": {
             "type": "object",
@@ -484,17 +403,11 @@
                 "description": "Low value (required)"
               },
               "high": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "High value for ranges (optional)"
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Value description (optional)"
               }
             },
@@ -504,17 +417,11 @@
           }
         },
         "valueTable": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA: value table reference (e.g., T001)"
         },
         "typeKind": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "domain",
             "predefinedAbapType"
@@ -522,87 +429,51 @@
           "description": "DTEL: type source (domain reference or predefined ABAP type)"
         },
         "typeName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: domain/type name reference (for typeKind=domain)"
         },
         "domainName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: alias for typeName when referencing a domain"
         },
         "shortLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: short field label"
         },
         "mediumLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: medium field label"
         },
         "longLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: long field label"
         },
         "headingLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: heading field label"
         },
         "searchHelp": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: search help name"
         },
         "searchHelpParameter": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: search help parameter"
         },
         "setGetParameter": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: SET/GET parameter ID"
         },
         "defaultComponentName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: default component name"
         },
         "changeDocument": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DTEL: enable change document flag"
         },
         "messages": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "MSAG: message entries for create/update",
           "items": {
             "type": "object",
@@ -623,10 +494,7 @@
           }
         },
         "parameters": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "FUNC: structured signature parameters. ARC-1 builds the IMPORTING/EXPORTING/CHANGING/TABLES/EXCEPTIONS/RAISING clause and splices it into the FM body. When omitted, the supplied source is PUT verbatim.",
           "items": {
             "type": "object",
@@ -648,31 +516,19 @@
                 "description": "Parameter / exception name (uppercased on emit)."
               },
               "type": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "ABAP type expression. Required for IMPORTING/EXPORTING/CHANGING/TABLES; ignored for EXCEPTIONS/RAISING. Examples: \"STRING\", \"I\", \"BAPIRET2\", \"TYPE STANDARD TABLE OF X\", \"LIKE DOKHL-OBJECT\". For TABLES, include the leading TYPE/LIKE keyword."
               },
               "byValue": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
+                "type": "boolean",
                 "description": "Emit `VALUE(name)` wrapper. Default false (pass-by-reference)."
               },
               "default": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Raw ABAP literal — IMPORTING/CHANGING only. Emitted verbatim. Example: \"'X'\", \"0\", \"SPACE\"."
               },
               "optional": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
+                "type": "boolean",
                 "description": "Emit `OPTIONAL` keyword."
               }
             },
@@ -683,24 +539,15 @@
           }
         },
         "serviceDefinition": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: service definition name (SRVD) to bind to"
         },
         "bindingType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: binding type — human-readable values like \"ODataV4-UI\", \"OData V2 - Web API\" are auto-normalized (sets odataVersion + category)."
         },
         "odataVersion": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "V2",
             "V4"
@@ -708,10 +555,7 @@
           "description": "SRVB: OData protocol version (default: V2). Overrides version inferred from bindingType."
         },
         "category": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "0",
             "1"
@@ -719,59 +563,35 @@
           "description": "SRVB: binding category (0=UI, 1=Web API; default: 0). Overrides category inferred from bindingType."
         },
         "version": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: service version number (default: 0001)"
         },
         "lintBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Override server lint-before-write for this call (false skips it). Lint covers PROG/CLAS/INTF/FUNC and DDLS; other types rely on RAP preflight."
         },
         "preflightBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Enable/disable deterministic RAP preflight checks (default true) — TABL/BDEF/DDLX static rules (curr/quan semantics, invalid BDEF enums, DDLX scope on 7.5x)."
         },
         "checkBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Override server check-before-write (default off). When true, runs a SAP syntax check and appends diagnostics to the response — the write is NOT blocked. Off by default (adds a round-trip; intermediate refactor writes legitimately trip transient dependency errors). Activation remains the definitive check."
         },
         "refObjectType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create (required): ADT type+subtype of the documented parent (e.g. \"DDLS/DF\", \"BDEF/BDO\", \"SRVD/SRV\", \"DEVC/K\"). Not CLAS/INTF/PROG (use ABAP Doc for code)."
         },
         "refObjectName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create: name of the parent object the KTD documents (defaults to \"name\")."
         },
         "refObjectDescription": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create: description of the parent object (shown in Eclipse tooltips)."
         },
         "objects": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {
@@ -808,96 +628,54 @@
                 "description": "Object name"
               },
               "source": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "ABAP source code (optional — some objects have no source)"
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object description (defaults to name if omitted)"
               },
               "package": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object-specific package. Overrides top-level package for this item."
               },
               "transport": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object-specific transport request. Overrides top-level transport for this item."
               },
               "dataType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "rowType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "rowTypeKind": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "builtin",
                   "structure"
                 ]
               },
               "length": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "decimals": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "outputLength": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "conversionExit": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "signExists": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "lowercase": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "fixedValues": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -905,16 +683,10 @@
                       "type": "string"
                     },
                     "high": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     },
                     "description": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -923,92 +695,50 @@
                 }
               },
               "valueTable": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "typeKind": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "domain",
                   "predefinedAbapType"
                 ]
               },
               "typeName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "domainName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "shortLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "mediumLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "longLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "headingLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "searchHelp": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "searchHelpParameter": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "setGetParameter": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "defaultComponentName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "changeDocument": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "messages": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -1026,42 +756,27 @@
                 }
               },
               "serviceDefinition": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "bindingType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "odataVersion": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "V2",
                   "V4"
                 ]
               },
               "category": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "0",
                   "1"
                 ]
               },
               "version": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               }
             },
             "required": [

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -268,10 +268,7 @@
           "description": "Write action. create/update/delete: standard object writes. edit_method: replace one method body (type=CLAS, method, source). Class-section surgery (type=CLAS only): edit_class_definition without include= replaces the global DEFINITION block (refuses a diff that would leave the class non-activatable, e.g. a concrete method with no IMPL stub); with include= it whole-replaces a class-local include (CCDEF/CCIMP/macros/testclasses), auto-creating it. add_method inserts a METHODS clause + empty stub (visibility, abstract=true skips the stub); edit_method_signature replaces one METHODS clause (no IMPL change); delete_method removes the clause AND body — WARNING: destructive, discards the method body (to re-section a method use change_method_visibility, NOT delete+add); change_method_visibility moves a method between PUBLIC/PROTECTED/PRIVATE, preserves the body. add_method/edit_method_signature/delete_method/change_method_visibility act on /source/main only. batch_create: create+activate multiple objects (objects array). scaffold_rap_handlers / generate_behavior_implementation: derive RAP behavior-pool handlers from the BDEF (the latter the equivalent of Eclipse's \"Generate Behavior Implementation\")."
         },
         "type": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "PROG",
             "CLAS",
@@ -304,24 +301,15 @@
           "description": "Object type (for create/update/delete/edit_method/edit_class_definition/add_method/edit_method_signature/delete_method/change_method_visibility). Supported on-prem: PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD or KTD (Knowledge Transfer Documents), TABL, TABL/DT, TABL/DS, DOMA, DTEL, MSAG. Class-section surgery actions require type=CLAS. Server-driven objects (8.16+, discovery-gated): DESD, DTSC, CSNM, EVTB, EVTO, COTA — create/update/delete with AFF JSON in \"source\", then SAPActivate."
         },
         "name": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Object name (for create/update/delete/edit_method/edit_class_definition/add_method/edit_method_signature/delete_method/change_method_visibility)."
         },
         "source": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "ABAP source code. create/update: full source body. edit_method: the new method body. edit_class_definition without include=: only the new global CLASS…DEFINITION…ENDCLASS block (no IMPLEMENTATION); with include=: the full replacement body of that include. edit_method_signature: only the new METHODS clause. Not used by add_method/delete_method/change_method_visibility (use `method`/`visibility`)."
         },
         "include": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "definitions",
             "implementations",
@@ -331,17 +319,11 @@
           "description": "CLAS-ONLY. Do NOT send unless type=CLAS AND action is update / edit_method / edit_class_definition. OMIT it entirely for every other type and for delete / batch_create / add_method / edit_method_signature / delete_method / change_method_visibility (those use /source/main). Targets a class-local include: definitions (CCDEF), implementations (CCIMP), macros, testclasses. edit_method auto-detects it from the method specifier (lhc_*/lcl_* → implementations, ltc_* → testclasses), so you rarely pass it; use include=testclasses to create a new local test class. Whole-include writes auto-create a missing include and produce an inactive draft (read with SAPRead version=\"inactive\" before activation)."
         },
         "method": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "edit_method/edit_method_signature/delete_method/change_method_visibility: the method NAME (e.g. \"get_name\", \"zif_order~process\", \"lhc_project~approve_project\"). add_method: the full METHODS clause as ABAP source. Local-class methods auto-route by prefix (lhc_*/lcl_* → implementations, ltc_* → testclasses); use the qualified <localclass>~<method> form when a bare name is ambiguous."
         },
         "visibility": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "public",
             "protected",
@@ -350,101 +332,59 @@
           "description": "For action=add_method: target visibility section to insert into (default \"public\"). For action=change_method_visibility: the TARGET section to move the method to (required). The target section header must already exist in the DEFINITION block — if not, ARC-1 refuses with a hint to use edit_class_definition first."
         },
         "abstract": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For action=add_method: when true, only the METHODS clause is inserted into DEFINITION; no METHOD/ENDMETHOD stub is added to IMPLEMENTATION. Default false (concrete method — DEFINITION + IMPL stub written atomically)."
         },
         "bdefName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For scaffold_rap_handlers: interface BDEF name whose actions/determinations/validations/authorizations define the required handlers (e.g. ZI_TRAVELREQ). For generate_behavior_implementation: optional override (default discovery reads the class rootEntityRef)."
         },
         "autoApply": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For scaffold_rap_handlers: true inserts missing METHODS signatures + empty stubs and writes the class under one lock; false (default) returns a required-vs-missing report without modifying (preview, then re-run with autoApply=true). Not used by generate_behavior_implementation (use dryRun to preview there)."
         },
         "targetAlias": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For scaffold_rap_handlers and generate_behavior_implementation: optional RAP entity alias filter (e.g., Travel, Segment) to scaffold only one handler class. When omitted, all entities declared in the BDEF are scaffolded. Case-insensitive."
         },
         "activate": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For generate_behavior_implementation: true (default) activates the class after writing; false writes source only. The known \"Local classes of CL_ABAP_BEHAVIOR_HANDLER…\" stale-active activation failure does not throw — it returns activation.success=false with a recovery hint."
         },
         "activateAtEnd": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For batch_create only. false (default): per-object inline activation in order. true: write all inactive drafts then one terminal activateBatch so SAP resolves cross-references between siblings — use for interdependent RAP stacks (TABL→DDLS→DCLS→BDEF→SRVD). A write-phase failure still breaks the loop; the terminal activate runs over the already-written subset."
         },
         "dryRun": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For generate_behavior_implementation: when true, runs discovery + cross-validation + scaffold planning and returns the report without writing or activating. Use this to preview what would change."
         },
         "description": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Object description for create action (defaults to name if omitted). Max 60 chars for most types."
         },
         "package": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Package for new objects (default $TMP). Non-$TMP packages require a transport number."
         },
         "transport": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Transport request number. Required for non-$TMP packages. Use SAPTransport(action=\"list\") to find or SAPTransport(action=\"create\") to create one."
         },
         "group": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted."
         },
         "dataType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA/DTEL: ABAP data type (e.g., CHAR, NUMC, DEC)"
         },
         "rowType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "TTYP create: the row type — a built-in ABAP type (STRING, I, …) or a DDIC structure/type name. Required for TTYP create."
         },
         "rowTypeKind": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "builtin",
             "structure"
@@ -452,52 +392,31 @@
           "description": "TTYP create: row-type mode (auto-detected from rowType if omitted)."
         },
         "length": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA/DTEL: data type length"
         },
         "decimals": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA/DTEL: decimal places"
         },
         "outputLength": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA: output length"
         },
         "conversionExit": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA: conversion exit (e.g., ALPHA)"
         },
         "signExists": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DOMA: signed values allowed"
         },
         "lowercase": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DOMA: lowercase characters allowed"
         },
         "fixedValues": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "DOMA: fixed value ranges",
           "items": {
             "type": "object",
@@ -507,17 +426,11 @@
                 "description": "Low value (required)"
               },
               "high": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "High value for ranges (optional)"
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Value description (optional)"
               }
             },
@@ -527,17 +440,11 @@
           }
         },
         "valueTable": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA: value table reference (e.g., T001)"
         },
         "typeKind": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "domain",
             "predefinedAbapType"
@@ -545,87 +452,51 @@
           "description": "DTEL: type source (domain reference or predefined ABAP type)"
         },
         "typeName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: domain/type name reference (for typeKind=domain)"
         },
         "domainName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: alias for typeName when referencing a domain"
         },
         "shortLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: short field label"
         },
         "mediumLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: medium field label"
         },
         "longLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: long field label"
         },
         "headingLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: heading field label"
         },
         "searchHelp": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: search help name"
         },
         "searchHelpParameter": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: search help parameter"
         },
         "setGetParameter": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: SET/GET parameter ID"
         },
         "defaultComponentName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: default component name"
         },
         "changeDocument": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DTEL: enable change document flag"
         },
         "messages": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "MSAG: message entries for create/update",
           "items": {
             "type": "object",
@@ -646,10 +517,7 @@
           }
         },
         "parameters": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "FUNC: structured signature parameters. ARC-1 builds the IMPORTING/EXPORTING/CHANGING/TABLES/EXCEPTIONS/RAISING clause and splices it into the FM body. When omitted, the supplied source is PUT verbatim.",
           "items": {
             "type": "object",
@@ -671,31 +539,19 @@
                 "description": "Parameter / exception name (uppercased on emit)."
               },
               "type": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "ABAP type expression. Required for IMPORTING/EXPORTING/CHANGING/TABLES; ignored for EXCEPTIONS/RAISING. Examples: \"STRING\", \"I\", \"BAPIRET2\", \"TYPE STANDARD TABLE OF X\", \"LIKE DOKHL-OBJECT\". For TABLES, include the leading TYPE/LIKE keyword."
               },
               "byValue": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
+                "type": "boolean",
                 "description": "Emit `VALUE(name)` wrapper. Default false (pass-by-reference)."
               },
               "default": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Raw ABAP literal — IMPORTING/CHANGING only. Emitted verbatim. Example: \"'X'\", \"0\", \"SPACE\"."
               },
               "optional": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
+                "type": "boolean",
                 "description": "Emit `OPTIONAL` keyword."
               }
             },
@@ -706,24 +562,15 @@
           }
         },
         "serviceDefinition": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: service definition name (SRVD) to bind to"
         },
         "bindingType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: binding type — human-readable values like \"ODataV4-UI\", \"OData V2 - Web API\" are auto-normalized (sets odataVersion + category)."
         },
         "odataVersion": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "V2",
             "V4"
@@ -731,10 +578,7 @@
           "description": "SRVB: OData protocol version (default: V2). Overrides version inferred from bindingType."
         },
         "category": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "0",
             "1"
@@ -742,59 +586,35 @@
           "description": "SRVB: binding category (0=UI, 1=Web API; default: 0). Overrides category inferred from bindingType."
         },
         "version": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: service version number (default: 0001)"
         },
         "lintBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Override server lint-before-write for this call (false skips it). Lint covers PROG/CLAS/INTF/FUNC and DDLS; other types rely on RAP preflight."
         },
         "preflightBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Enable/disable deterministic RAP preflight checks (default true) — TABL/BDEF/DDLX static rules (curr/quan semantics, invalid BDEF enums, DDLX scope on 7.5x)."
         },
         "checkBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Override server check-before-write (default off). When true, runs a SAP syntax check and appends diagnostics to the response — the write is NOT blocked. Off by default (adds a round-trip; intermediate refactor writes legitimately trip transient dependency errors). Activation remains the definitive check."
         },
         "refObjectType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create (required): ADT type+subtype of the documented parent (e.g. \"DDLS/DF\", \"BDEF/BDO\", \"SRVD/SRV\", \"DEVC/K\"). Not CLAS/INTF/PROG (use ABAP Doc for code)."
         },
         "refObjectName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create: name of the parent object the KTD documents (defaults to \"name\")."
         },
         "refObjectDescription": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create: description of the parent object (shown in Eclipse tooltips)."
         },
         "objects": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {
@@ -836,96 +656,54 @@
                 "description": "Object name"
               },
               "source": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "ABAP source code (optional — some objects have no source)"
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object description (defaults to name if omitted)"
               },
               "package": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object-specific package. Overrides top-level package for this item."
               },
               "transport": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object-specific transport request. Overrides top-level transport for this item."
               },
               "dataType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "rowType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "rowTypeKind": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "builtin",
                   "structure"
                 ]
               },
               "length": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "decimals": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "outputLength": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "conversionExit": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "signExists": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "lowercase": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "fixedValues": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -933,16 +711,10 @@
                       "type": "string"
                     },
                     "high": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     },
                     "description": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -951,92 +723,50 @@
                 }
               },
               "valueTable": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "typeKind": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "domain",
                   "predefinedAbapType"
                 ]
               },
               "typeName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "domainName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "shortLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "mediumLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "longLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "headingLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "searchHelp": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "searchHelpParameter": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "setGetParameter": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "defaultComponentName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "changeDocument": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "messages": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -1054,42 +784,27 @@
                 }
               },
               "serviceDefinition": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "bindingType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "odataVersion": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "V2",
                   "V4"
                 ]
               },
               "category": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "0",
                   "1"
                 ]
               },
               "version": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               }
             },
             "required": [

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -268,10 +268,7 @@
           "description": "Write action. create/update/delete: standard object writes. edit_method: replace one method body (type=CLAS, method, source). Class-section surgery (type=CLAS only): edit_class_definition without include= replaces the global DEFINITION block (refuses a diff that would leave the class non-activatable, e.g. a concrete method with no IMPL stub); with include= it whole-replaces a class-local include (CCDEF/CCIMP/macros/testclasses), auto-creating it. add_method inserts a METHODS clause + empty stub (visibility, abstract=true skips the stub); edit_method_signature replaces one METHODS clause (no IMPL change); delete_method removes the clause AND body — WARNING: destructive, discards the method body (to re-section a method use change_method_visibility, NOT delete+add); change_method_visibility moves a method between PUBLIC/PROTECTED/PRIVATE, preserves the body. add_method/edit_method_signature/delete_method/change_method_visibility act on /source/main only. batch_create: create+activate multiple objects (objects array). scaffold_rap_handlers / generate_behavior_implementation: derive RAP behavior-pool handlers from the BDEF (the latter the equivalent of Eclipse's \"Generate Behavior Implementation\")."
         },
         "type": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "PROG",
             "CLAS",
@@ -304,24 +301,15 @@
           "description": "Object type (for create/update/delete/edit_method/edit_class_definition/add_method/edit_method_signature/delete_method/change_method_visibility). Supported on-prem: PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD or KTD (Knowledge Transfer Documents), TABL, TABL/DT, TABL/DS, DOMA, DTEL, MSAG. Class-section surgery actions require type=CLAS. Server-driven objects (8.16+, discovery-gated): DESD, DTSC, CSNM, EVTB, EVTO, COTA — create/update/delete with AFF JSON in \"source\", then SAPActivate."
         },
         "name": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Object name (for create/update/delete/edit_method/edit_class_definition/add_method/edit_method_signature/delete_method/change_method_visibility)."
         },
         "source": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "ABAP source code. create/update: full source body. edit_method: the new method body. edit_class_definition without include=: only the new global CLASS…DEFINITION…ENDCLASS block (no IMPLEMENTATION); with include=: the full replacement body of that include. edit_method_signature: only the new METHODS clause. Not used by add_method/delete_method/change_method_visibility (use `method`/`visibility`)."
         },
         "include": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "definitions",
             "implementations",
@@ -331,17 +319,11 @@
           "description": "CLAS-ONLY. Do NOT send unless type=CLAS AND action is update / edit_method / edit_class_definition. OMIT it entirely for every other type and for delete / batch_create / add_method / edit_method_signature / delete_method / change_method_visibility (those use /source/main). Targets a class-local include: definitions (CCDEF), implementations (CCIMP), macros, testclasses. edit_method auto-detects it from the method specifier (lhc_*/lcl_* → implementations, ltc_* → testclasses), so you rarely pass it; use include=testclasses to create a new local test class. Whole-include writes auto-create a missing include and produce an inactive draft (read with SAPRead version=\"inactive\" before activation)."
         },
         "method": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "edit_method/edit_method_signature/delete_method/change_method_visibility: the method NAME (e.g. \"get_name\", \"zif_order~process\", \"lhc_project~approve_project\"). add_method: the full METHODS clause as ABAP source. Local-class methods auto-route by prefix (lhc_*/lcl_* → implementations, ltc_* → testclasses); use the qualified <localclass>~<method> form when a bare name is ambiguous."
         },
         "visibility": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "public",
             "protected",
@@ -350,101 +332,59 @@
           "description": "For action=add_method: target visibility section to insert into (default \"public\"). For action=change_method_visibility: the TARGET section to move the method to (required). The target section header must already exist in the DEFINITION block — if not, ARC-1 refuses with a hint to use edit_class_definition first."
         },
         "abstract": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For action=add_method: when true, only the METHODS clause is inserted into DEFINITION; no METHOD/ENDMETHOD stub is added to IMPLEMENTATION. Default false (concrete method — DEFINITION + IMPL stub written atomically)."
         },
         "bdefName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For scaffold_rap_handlers: interface BDEF name whose actions/determinations/validations/authorizations define the required handlers (e.g. ZI_TRAVELREQ). For generate_behavior_implementation: optional override (default discovery reads the class rootEntityRef)."
         },
         "autoApply": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For scaffold_rap_handlers: true inserts missing METHODS signatures + empty stubs and writes the class under one lock; false (default) returns a required-vs-missing report without modifying (preview, then re-run with autoApply=true). Not used by generate_behavior_implementation (use dryRun to preview there)."
         },
         "targetAlias": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For scaffold_rap_handlers and generate_behavior_implementation: optional RAP entity alias filter (e.g., Travel, Segment) to scaffold only one handler class. When omitted, all entities declared in the BDEF are scaffolded. Case-insensitive."
         },
         "activate": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For generate_behavior_implementation: true (default) activates the class after writing; false writes source only. The known \"Local classes of CL_ABAP_BEHAVIOR_HANDLER…\" stale-active activation failure does not throw — it returns activation.success=false with a recovery hint."
         },
         "activateAtEnd": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For batch_create only. false (default): per-object inline activation in order. true: write all inactive drafts then one terminal activateBatch so SAP resolves cross-references between siblings — use for interdependent RAP stacks (TABL→DDLS→DCLS→BDEF→SRVD). A write-phase failure still breaks the loop; the terminal activate runs over the already-written subset."
         },
         "dryRun": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For generate_behavior_implementation: when true, runs discovery + cross-validation + scaffold planning and returns the report without writing or activating. Use this to preview what would change."
         },
         "description": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Object description for create action (defaults to name if omitted). Max 60 chars for most types."
         },
         "package": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Package for new objects (default $TMP). Non-$TMP packages require a transport number."
         },
         "transport": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Transport request number. Required for non-$TMP packages. Use SAPTransport(action=\"list\") to find or SAPTransport(action=\"create\") to create one."
         },
         "group": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted."
         },
         "dataType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA/DTEL: ABAP data type (e.g., CHAR, NUMC, DEC)"
         },
         "rowType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "TTYP create: the row type — a built-in ABAP type (STRING, I, …) or a DDIC structure/type name. Required for TTYP create."
         },
         "rowTypeKind": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "builtin",
             "structure"
@@ -452,52 +392,31 @@
           "description": "TTYP create: row-type mode (auto-detected from rowType if omitted)."
         },
         "length": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA/DTEL: data type length"
         },
         "decimals": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA/DTEL: decimal places"
         },
         "outputLength": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA: output length"
         },
         "conversionExit": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA: conversion exit (e.g., ALPHA)"
         },
         "signExists": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DOMA: signed values allowed"
         },
         "lowercase": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DOMA: lowercase characters allowed"
         },
         "fixedValues": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "DOMA: fixed value ranges",
           "items": {
             "type": "object",
@@ -507,17 +426,11 @@
                 "description": "Low value (required)"
               },
               "high": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "High value for ranges (optional)"
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Value description (optional)"
               }
             },
@@ -527,17 +440,11 @@
           }
         },
         "valueTable": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA: value table reference (e.g., T001)"
         },
         "typeKind": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "domain",
             "predefinedAbapType"
@@ -545,87 +452,51 @@
           "description": "DTEL: type source (domain reference or predefined ABAP type)"
         },
         "typeName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: domain/type name reference (for typeKind=domain)"
         },
         "domainName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: alias for typeName when referencing a domain"
         },
         "shortLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: short field label"
         },
         "mediumLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: medium field label"
         },
         "longLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: long field label"
         },
         "headingLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: heading field label"
         },
         "searchHelp": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: search help name"
         },
         "searchHelpParameter": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: search help parameter"
         },
         "setGetParameter": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: SET/GET parameter ID"
         },
         "defaultComponentName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: default component name"
         },
         "changeDocument": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DTEL: enable change document flag"
         },
         "messages": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "MSAG: message entries for create/update",
           "items": {
             "type": "object",
@@ -646,10 +517,7 @@
           }
         },
         "parameters": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "FUNC: structured signature parameters. ARC-1 builds the IMPORTING/EXPORTING/CHANGING/TABLES/EXCEPTIONS/RAISING clause and splices it into the FM body. When omitted, the supplied source is PUT verbatim.",
           "items": {
             "type": "object",
@@ -671,31 +539,19 @@
                 "description": "Parameter / exception name (uppercased on emit)."
               },
               "type": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "ABAP type expression. Required for IMPORTING/EXPORTING/CHANGING/TABLES; ignored for EXCEPTIONS/RAISING. Examples: \"STRING\", \"I\", \"BAPIRET2\", \"TYPE STANDARD TABLE OF X\", \"LIKE DOKHL-OBJECT\". For TABLES, include the leading TYPE/LIKE keyword."
               },
               "byValue": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
+                "type": "boolean",
                 "description": "Emit `VALUE(name)` wrapper. Default false (pass-by-reference)."
               },
               "default": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Raw ABAP literal — IMPORTING/CHANGING only. Emitted verbatim. Example: \"'X'\", \"0\", \"SPACE\"."
               },
               "optional": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
+                "type": "boolean",
                 "description": "Emit `OPTIONAL` keyword."
               }
             },
@@ -706,24 +562,15 @@
           }
         },
         "serviceDefinition": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: service definition name (SRVD) to bind to"
         },
         "bindingType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: binding type — human-readable values like \"ODataV4-UI\", \"OData V2 - Web API\" are auto-normalized (sets odataVersion + category)."
         },
         "odataVersion": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "V2",
             "V4"
@@ -731,10 +578,7 @@
           "description": "SRVB: OData protocol version (default: V2). Overrides version inferred from bindingType."
         },
         "category": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "0",
             "1"
@@ -742,59 +586,35 @@
           "description": "SRVB: binding category (0=UI, 1=Web API; default: 0). Overrides category inferred from bindingType."
         },
         "version": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: service version number (default: 0001)"
         },
         "lintBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Override server lint-before-write for this call (false skips it). Lint covers PROG/CLAS/INTF/FUNC and DDLS; other types rely on RAP preflight."
         },
         "preflightBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Enable/disable deterministic RAP preflight checks (default true) — TABL/BDEF/DDLX static rules (curr/quan semantics, invalid BDEF enums, DDLX scope on 7.5x)."
         },
         "checkBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Override server check-before-write (default off). When true, runs a SAP syntax check and appends diagnostics to the response — the write is NOT blocked. Off by default (adds a round-trip; intermediate refactor writes legitimately trip transient dependency errors). Activation remains the definitive check."
         },
         "refObjectType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create (required): ADT type+subtype of the documented parent (e.g. \"DDLS/DF\", \"BDEF/BDO\", \"SRVD/SRV\", \"DEVC/K\"). Not CLAS/INTF/PROG (use ABAP Doc for code)."
         },
         "refObjectName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create: name of the parent object the KTD documents (defaults to \"name\")."
         },
         "refObjectDescription": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create: description of the parent object (shown in Eclipse tooltips)."
         },
         "objects": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {
@@ -836,96 +656,54 @@
                 "description": "Object name"
               },
               "source": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "ABAP source code (optional — some objects have no source)"
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object description (defaults to name if omitted)"
               },
               "package": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object-specific package. Overrides top-level package for this item."
               },
               "transport": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object-specific transport request. Overrides top-level transport for this item."
               },
               "dataType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "rowType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "rowTypeKind": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "builtin",
                   "structure"
                 ]
               },
               "length": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "decimals": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "outputLength": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "conversionExit": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "signExists": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "lowercase": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "fixedValues": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -933,16 +711,10 @@
                       "type": "string"
                     },
                     "high": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     },
                     "description": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -951,92 +723,50 @@
                 }
               },
               "valueTable": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "typeKind": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "domain",
                   "predefinedAbapType"
                 ]
               },
               "typeName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "domainName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "shortLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "mediumLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "longLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "headingLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "searchHelp": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "searchHelpParameter": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "setGetParameter": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "defaultComponentName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "changeDocument": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "messages": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -1054,42 +784,27 @@
                 }
               },
               "serviceDefinition": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "bindingType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "odataVersion": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "V2",
                   "V4"
                 ]
               },
               "category": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "0",
                   "1"
                 ]
               },
               "version": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               }
             },
             "required": [

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -268,10 +268,7 @@
           "description": "Write action. create/update/delete: standard object writes. edit_method: replace one method body (type=CLAS, method, source). Class-section surgery (type=CLAS only): edit_class_definition without include= replaces the global DEFINITION block (refuses a diff that would leave the class non-activatable, e.g. a concrete method with no IMPL stub); with include= it whole-replaces a class-local include (CCDEF/CCIMP/macros/testclasses), auto-creating it. add_method inserts a METHODS clause + empty stub (visibility, abstract=true skips the stub); edit_method_signature replaces one METHODS clause (no IMPL change); delete_method removes the clause AND body — WARNING: destructive, discards the method body (to re-section a method use change_method_visibility, NOT delete+add); change_method_visibility moves a method between PUBLIC/PROTECTED/PRIVATE, preserves the body. add_method/edit_method_signature/delete_method/change_method_visibility act on /source/main only. batch_create: create+activate multiple objects (objects array). scaffold_rap_handlers / generate_behavior_implementation: derive RAP behavior-pool handlers from the BDEF (the latter the equivalent of Eclipse's \"Generate Behavior Implementation\")."
         },
         "type": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "PROG",
             "CLAS",
@@ -304,24 +301,15 @@
           "description": "Object type (for create/update/delete/edit_method/edit_class_definition/add_method/edit_method_signature/delete_method/change_method_visibility). Supported on-prem: PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD or KTD (Knowledge Transfer Documents), TABL, TABL/DT, TABL/DS, DOMA, DTEL, MSAG. Class-section surgery actions require type=CLAS. Server-driven objects (8.16+, discovery-gated): DESD, DTSC, CSNM, EVTB, EVTO, COTA — create/update/delete with AFF JSON in \"source\", then SAPActivate."
         },
         "name": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Object name (for create/update/delete/edit_method/edit_class_definition/add_method/edit_method_signature/delete_method/change_method_visibility)."
         },
         "source": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "ABAP source code. create/update: full source body. edit_method: the new method body. edit_class_definition without include=: only the new global CLASS…DEFINITION…ENDCLASS block (no IMPLEMENTATION); with include=: the full replacement body of that include. edit_method_signature: only the new METHODS clause. Not used by add_method/delete_method/change_method_visibility (use `method`/`visibility`)."
         },
         "include": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "definitions",
             "implementations",
@@ -331,17 +319,11 @@
           "description": "CLAS-ONLY. Do NOT send unless type=CLAS AND action is update / edit_method / edit_class_definition. OMIT it entirely for every other type and for delete / batch_create / add_method / edit_method_signature / delete_method / change_method_visibility (those use /source/main). Targets a class-local include: definitions (CCDEF), implementations (CCIMP), macros, testclasses. edit_method auto-detects it from the method specifier (lhc_*/lcl_* → implementations, ltc_* → testclasses), so you rarely pass it; use include=testclasses to create a new local test class. Whole-include writes auto-create a missing include and produce an inactive draft (read with SAPRead version=\"inactive\" before activation)."
         },
         "method": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "edit_method/edit_method_signature/delete_method/change_method_visibility: the method NAME (e.g. \"get_name\", \"zif_order~process\", \"lhc_project~approve_project\"). add_method: the full METHODS clause as ABAP source. Local-class methods auto-route by prefix (lhc_*/lcl_* → implementations, ltc_* → testclasses); use the qualified <localclass>~<method> form when a bare name is ambiguous."
         },
         "visibility": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "public",
             "protected",
@@ -350,101 +332,59 @@
           "description": "For action=add_method: target visibility section to insert into (default \"public\"). For action=change_method_visibility: the TARGET section to move the method to (required). The target section header must already exist in the DEFINITION block — if not, ARC-1 refuses with a hint to use edit_class_definition first."
         },
         "abstract": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For action=add_method: when true, only the METHODS clause is inserted into DEFINITION; no METHOD/ENDMETHOD stub is added to IMPLEMENTATION. Default false (concrete method — DEFINITION + IMPL stub written atomically)."
         },
         "bdefName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For scaffold_rap_handlers: interface BDEF name whose actions/determinations/validations/authorizations define the required handlers (e.g. ZI_TRAVELREQ). For generate_behavior_implementation: optional override (default discovery reads the class rootEntityRef)."
         },
         "autoApply": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For scaffold_rap_handlers: true inserts missing METHODS signatures + empty stubs and writes the class under one lock; false (default) returns a required-vs-missing report without modifying (preview, then re-run with autoApply=true). Not used by generate_behavior_implementation (use dryRun to preview there)."
         },
         "targetAlias": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For scaffold_rap_handlers and generate_behavior_implementation: optional RAP entity alias filter (e.g., Travel, Segment) to scaffold only one handler class. When omitted, all entities declared in the BDEF are scaffolded. Case-insensitive."
         },
         "activate": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For generate_behavior_implementation: true (default) activates the class after writing; false writes source only. The known \"Local classes of CL_ABAP_BEHAVIOR_HANDLER…\" stale-active activation failure does not throw — it returns activation.success=false with a recovery hint."
         },
         "activateAtEnd": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For batch_create only. false (default): per-object inline activation in order. true: write all inactive drafts then one terminal activateBatch so SAP resolves cross-references between siblings — use for interdependent RAP stacks (TABL→DDLS→DCLS→BDEF→SRVD). A write-phase failure still breaks the loop; the terminal activate runs over the already-written subset."
         },
         "dryRun": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For generate_behavior_implementation: when true, runs discovery + cross-validation + scaffold planning and returns the report without writing or activating. Use this to preview what would change."
         },
         "description": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Object description for create action (defaults to name if omitted). Max 60 chars for most types."
         },
         "package": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Package for new objects (default $TMP). Non-$TMP packages require a transport number."
         },
         "transport": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Transport request number. Required for non-$TMP packages. Use SAPTransport(action=\"list\") to find or SAPTransport(action=\"create\") to create one."
         },
         "group": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted."
         },
         "dataType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA/DTEL: ABAP data type (e.g., CHAR, NUMC, DEC)"
         },
         "rowType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "TTYP create: the row type — a built-in ABAP type (STRING, I, …) or a DDIC structure/type name. Required for TTYP create."
         },
         "rowTypeKind": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "builtin",
             "structure"
@@ -452,52 +392,31 @@
           "description": "TTYP create: row-type mode (auto-detected from rowType if omitted)."
         },
         "length": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA/DTEL: data type length"
         },
         "decimals": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA/DTEL: decimal places"
         },
         "outputLength": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA: output length"
         },
         "conversionExit": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA: conversion exit (e.g., ALPHA)"
         },
         "signExists": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DOMA: signed values allowed"
         },
         "lowercase": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DOMA: lowercase characters allowed"
         },
         "fixedValues": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "DOMA: fixed value ranges",
           "items": {
             "type": "object",
@@ -507,17 +426,11 @@
                 "description": "Low value (required)"
               },
               "high": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "High value for ranges (optional)"
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Value description (optional)"
               }
             },
@@ -527,17 +440,11 @@
           }
         },
         "valueTable": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA: value table reference (e.g., T001)"
         },
         "typeKind": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "domain",
             "predefinedAbapType"
@@ -545,87 +452,51 @@
           "description": "DTEL: type source (domain reference or predefined ABAP type)"
         },
         "typeName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: domain/type name reference (for typeKind=domain)"
         },
         "domainName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: alias for typeName when referencing a domain"
         },
         "shortLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: short field label"
         },
         "mediumLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: medium field label"
         },
         "longLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: long field label"
         },
         "headingLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: heading field label"
         },
         "searchHelp": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: search help name"
         },
         "searchHelpParameter": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: search help parameter"
         },
         "setGetParameter": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: SET/GET parameter ID"
         },
         "defaultComponentName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: default component name"
         },
         "changeDocument": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DTEL: enable change document flag"
         },
         "messages": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "MSAG: message entries for create/update",
           "items": {
             "type": "object",
@@ -646,10 +517,7 @@
           }
         },
         "parameters": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "FUNC: structured signature parameters. ARC-1 builds the IMPORTING/EXPORTING/CHANGING/TABLES/EXCEPTIONS/RAISING clause and splices it into the FM body. When omitted, the supplied source is PUT verbatim.",
           "items": {
             "type": "object",
@@ -671,31 +539,19 @@
                 "description": "Parameter / exception name (uppercased on emit)."
               },
               "type": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "ABAP type expression. Required for IMPORTING/EXPORTING/CHANGING/TABLES; ignored for EXCEPTIONS/RAISING. Examples: \"STRING\", \"I\", \"BAPIRET2\", \"TYPE STANDARD TABLE OF X\", \"LIKE DOKHL-OBJECT\". For TABLES, include the leading TYPE/LIKE keyword."
               },
               "byValue": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
+                "type": "boolean",
                 "description": "Emit `VALUE(name)` wrapper. Default false (pass-by-reference)."
               },
               "default": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Raw ABAP literal — IMPORTING/CHANGING only. Emitted verbatim. Example: \"'X'\", \"0\", \"SPACE\"."
               },
               "optional": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
+                "type": "boolean",
                 "description": "Emit `OPTIONAL` keyword."
               }
             },
@@ -706,24 +562,15 @@
           }
         },
         "serviceDefinition": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: service definition name (SRVD) to bind to"
         },
         "bindingType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: binding type — human-readable values like \"ODataV4-UI\", \"OData V2 - Web API\" are auto-normalized (sets odataVersion + category)."
         },
         "odataVersion": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "V2",
             "V4"
@@ -731,10 +578,7 @@
           "description": "SRVB: OData protocol version (default: V2). Overrides version inferred from bindingType."
         },
         "category": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "0",
             "1"
@@ -742,59 +586,35 @@
           "description": "SRVB: binding category (0=UI, 1=Web API; default: 0). Overrides category inferred from bindingType."
         },
         "version": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: service version number (default: 0001)"
         },
         "lintBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Override server lint-before-write for this call (false skips it). Lint covers PROG/CLAS/INTF/FUNC and DDLS; other types rely on RAP preflight."
         },
         "preflightBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Enable/disable deterministic RAP preflight checks (default true) — TABL/BDEF/DDLX static rules (curr/quan semantics, invalid BDEF enums, DDLX scope on 7.5x)."
         },
         "checkBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Override server check-before-write (default off). When true, runs a SAP syntax check and appends diagnostics to the response — the write is NOT blocked. Off by default (adds a round-trip; intermediate refactor writes legitimately trip transient dependency errors). Activation remains the definitive check."
         },
         "refObjectType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create (required): ADT type+subtype of the documented parent (e.g. \"DDLS/DF\", \"BDEF/BDO\", \"SRVD/SRV\", \"DEVC/K\"). Not CLAS/INTF/PROG (use ABAP Doc for code)."
         },
         "refObjectName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create: name of the parent object the KTD documents (defaults to \"name\")."
         },
         "refObjectDescription": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create: description of the parent object (shown in Eclipse tooltips)."
         },
         "objects": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {
@@ -836,96 +656,54 @@
                 "description": "Object name"
               },
               "source": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "ABAP source code (optional — some objects have no source)"
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object description (defaults to name if omitted)"
               },
               "package": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object-specific package. Overrides top-level package for this item."
               },
               "transport": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object-specific transport request. Overrides top-level transport for this item."
               },
               "dataType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "rowType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "rowTypeKind": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "builtin",
                   "structure"
                 ]
               },
               "length": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "decimals": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "outputLength": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "conversionExit": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "signExists": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "lowercase": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "fixedValues": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -933,16 +711,10 @@
                       "type": "string"
                     },
                     "high": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     },
                     "description": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -951,92 +723,50 @@
                 }
               },
               "valueTable": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "typeKind": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "domain",
                   "predefinedAbapType"
                 ]
               },
               "typeName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "domainName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "shortLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "mediumLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "longLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "headingLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "searchHelp": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "searchHelpParameter": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "setGetParameter": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "defaultComponentName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "changeDocument": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "messages": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -1054,42 +784,27 @@
                 }
               },
               "serviceDefinition": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "bindingType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "odataVersion": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "V2",
                   "V4"
                 ]
               },
               "category": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "0",
                   "1"
                 ]
               },
               "version": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               }
             },
             "required": [

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -268,10 +268,7 @@
           "description": "Write action. create/update/delete: standard object writes. edit_method: replace one method body (type=CLAS, method, source). Class-section surgery (type=CLAS only): edit_class_definition without include= replaces the global DEFINITION block (refuses a diff that would leave the class non-activatable, e.g. a concrete method with no IMPL stub); with include= it whole-replaces a class-local include (CCDEF/CCIMP/macros/testclasses), auto-creating it. add_method inserts a METHODS clause + empty stub (visibility, abstract=true skips the stub); edit_method_signature replaces one METHODS clause (no IMPL change); delete_method removes the clause AND body — WARNING: destructive, discards the method body (to re-section a method use change_method_visibility, NOT delete+add); change_method_visibility moves a method between PUBLIC/PROTECTED/PRIVATE, preserves the body. add_method/edit_method_signature/delete_method/change_method_visibility act on /source/main only. batch_create: create+activate multiple objects (objects array). scaffold_rap_handlers / generate_behavior_implementation: derive RAP behavior-pool handlers from the BDEF (the latter the equivalent of Eclipse's \"Generate Behavior Implementation\")."
         },
         "type": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "PROG",
             "CLAS",
@@ -304,24 +301,15 @@
           "description": "Object type (for create/update/delete/edit_method/edit_class_definition/add_method/edit_method_signature/delete_method/change_method_visibility). Supported on-prem: PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD or KTD (Knowledge Transfer Documents), TABL, TABL/DT, TABL/DS, DOMA, DTEL, MSAG. Class-section surgery actions require type=CLAS. Server-driven objects (8.16+, discovery-gated): DESD, DTSC, CSNM, EVTB, EVTO, COTA — create/update/delete with AFF JSON in \"source\", then SAPActivate."
         },
         "name": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Object name (for create/update/delete/edit_method/edit_class_definition/add_method/edit_method_signature/delete_method/change_method_visibility)."
         },
         "source": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "ABAP source code. create/update: full source body. edit_method: the new method body. edit_class_definition without include=: only the new global CLASS…DEFINITION…ENDCLASS block (no IMPLEMENTATION); with include=: the full replacement body of that include. edit_method_signature: only the new METHODS clause. Not used by add_method/delete_method/change_method_visibility (use `method`/`visibility`)."
         },
         "include": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "definitions",
             "implementations",
@@ -331,17 +319,11 @@
           "description": "CLAS-ONLY. Do NOT send unless type=CLAS AND action is update / edit_method / edit_class_definition. OMIT it entirely for every other type and for delete / batch_create / add_method / edit_method_signature / delete_method / change_method_visibility (those use /source/main). Targets a class-local include: definitions (CCDEF), implementations (CCIMP), macros, testclasses. edit_method auto-detects it from the method specifier (lhc_*/lcl_* → implementations, ltc_* → testclasses), so you rarely pass it; use include=testclasses to create a new local test class. Whole-include writes auto-create a missing include and produce an inactive draft (read with SAPRead version=\"inactive\" before activation)."
         },
         "method": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "edit_method/edit_method_signature/delete_method/change_method_visibility: the method NAME (e.g. \"get_name\", \"zif_order~process\", \"lhc_project~approve_project\"). add_method: the full METHODS clause as ABAP source. Local-class methods auto-route by prefix (lhc_*/lcl_* → implementations, ltc_* → testclasses); use the qualified <localclass>~<method> form when a bare name is ambiguous."
         },
         "visibility": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "public",
             "protected",
@@ -350,101 +332,59 @@
           "description": "For action=add_method: target visibility section to insert into (default \"public\"). For action=change_method_visibility: the TARGET section to move the method to (required). The target section header must already exist in the DEFINITION block — if not, ARC-1 refuses with a hint to use edit_class_definition first."
         },
         "abstract": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For action=add_method: when true, only the METHODS clause is inserted into DEFINITION; no METHOD/ENDMETHOD stub is added to IMPLEMENTATION. Default false (concrete method — DEFINITION + IMPL stub written atomically)."
         },
         "bdefName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For scaffold_rap_handlers: interface BDEF name whose actions/determinations/validations/authorizations define the required handlers (e.g. ZI_TRAVELREQ). For generate_behavior_implementation: optional override (default discovery reads the class rootEntityRef)."
         },
         "autoApply": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For scaffold_rap_handlers: true inserts missing METHODS signatures + empty stubs and writes the class under one lock; false (default) returns a required-vs-missing report without modifying (preview, then re-run with autoApply=true). Not used by generate_behavior_implementation (use dryRun to preview there)."
         },
         "targetAlias": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For scaffold_rap_handlers and generate_behavior_implementation: optional RAP entity alias filter (e.g., Travel, Segment) to scaffold only one handler class. When omitted, all entities declared in the BDEF are scaffolded. Case-insensitive."
         },
         "activate": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For generate_behavior_implementation: true (default) activates the class after writing; false writes source only. The known \"Local classes of CL_ABAP_BEHAVIOR_HANDLER…\" stale-active activation failure does not throw — it returns activation.success=false with a recovery hint."
         },
         "activateAtEnd": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For batch_create only. false (default): per-object inline activation in order. true: write all inactive drafts then one terminal activateBatch so SAP resolves cross-references between siblings — use for interdependent RAP stacks (TABL→DDLS→DCLS→BDEF→SRVD). A write-phase failure still breaks the loop; the terminal activate runs over the already-written subset."
         },
         "dryRun": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "For generate_behavior_implementation: when true, runs discovery + cross-validation + scaffold planning and returns the report without writing or activating. Use this to preview what would change."
         },
         "description": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Object description for create action (defaults to name if omitted). Max 60 chars for most types."
         },
         "package": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Package for new objects (default $TMP). Non-$TMP packages require a transport number."
         },
         "transport": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Transport request number. Required for non-$TMP packages. Use SAPTransport(action=\"list\") to find or SAPTransport(action=\"create\") to create one."
         },
         "group": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted."
         },
         "dataType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA/DTEL: ABAP data type (e.g., CHAR, NUMC, DEC)"
         },
         "rowType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "TTYP create: the row type — a built-in ABAP type (STRING, I, …) or a DDIC structure/type name. Required for TTYP create."
         },
         "rowTypeKind": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "builtin",
             "structure"
@@ -452,52 +392,31 @@
           "description": "TTYP create: row-type mode (auto-detected from rowType if omitted)."
         },
         "length": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA/DTEL: data type length"
         },
         "decimals": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA/DTEL: decimal places"
         },
         "outputLength": {
-          "type": [
-            "number",
-            "null"
-          ],
+          "type": "number",
           "description": "DOMA: output length"
         },
         "conversionExit": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA: conversion exit (e.g., ALPHA)"
         },
         "signExists": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DOMA: signed values allowed"
         },
         "lowercase": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DOMA: lowercase characters allowed"
         },
         "fixedValues": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "DOMA: fixed value ranges",
           "items": {
             "type": "object",
@@ -507,17 +426,11 @@
                 "description": "Low value (required)"
               },
               "high": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "High value for ranges (optional)"
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Value description (optional)"
               }
             },
@@ -527,17 +440,11 @@
           }
         },
         "valueTable": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DOMA: value table reference (e.g., T001)"
         },
         "typeKind": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "domain",
             "predefinedAbapType"
@@ -545,87 +452,51 @@
           "description": "DTEL: type source (domain reference or predefined ABAP type)"
         },
         "typeName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: domain/type name reference (for typeKind=domain)"
         },
         "domainName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: alias for typeName when referencing a domain"
         },
         "shortLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: short field label"
         },
         "mediumLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: medium field label"
         },
         "longLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: long field label"
         },
         "headingLabel": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: heading field label"
         },
         "searchHelp": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: search help name"
         },
         "searchHelpParameter": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: search help parameter"
         },
         "setGetParameter": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: SET/GET parameter ID"
         },
         "defaultComponentName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "DTEL: default component name"
         },
         "changeDocument": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "DTEL: enable change document flag"
         },
         "messages": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "MSAG: message entries for create/update",
           "items": {
             "type": "object",
@@ -646,10 +517,7 @@
           }
         },
         "parameters": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "FUNC: structured signature parameters. ARC-1 builds the IMPORTING/EXPORTING/CHANGING/TABLES/EXCEPTIONS/RAISING clause and splices it into the FM body. When omitted, the supplied source is PUT verbatim.",
           "items": {
             "type": "object",
@@ -671,31 +539,19 @@
                 "description": "Parameter / exception name (uppercased on emit)."
               },
               "type": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "ABAP type expression. Required for IMPORTING/EXPORTING/CHANGING/TABLES; ignored for EXCEPTIONS/RAISING. Examples: \"STRING\", \"I\", \"BAPIRET2\", \"TYPE STANDARD TABLE OF X\", \"LIKE DOKHL-OBJECT\". For TABLES, include the leading TYPE/LIKE keyword."
               },
               "byValue": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
+                "type": "boolean",
                 "description": "Emit `VALUE(name)` wrapper. Default false (pass-by-reference)."
               },
               "default": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Raw ABAP literal — IMPORTING/CHANGING only. Emitted verbatim. Example: \"'X'\", \"0\", \"SPACE\"."
               },
               "optional": {
-                "type": [
-                  "boolean",
-                  "null"
-                ],
+                "type": "boolean",
                 "description": "Emit `OPTIONAL` keyword."
               }
             },
@@ -706,24 +562,15 @@
           }
         },
         "serviceDefinition": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: service definition name (SRVD) to bind to"
         },
         "bindingType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: binding type — human-readable values like \"ODataV4-UI\", \"OData V2 - Web API\" are auto-normalized (sets odataVersion + category)."
         },
         "odataVersion": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "V2",
             "V4"
@@ -731,10 +578,7 @@
           "description": "SRVB: OData protocol version (default: V2). Overrides version inferred from bindingType."
         },
         "category": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "enum": [
             "0",
             "1"
@@ -742,59 +586,35 @@
           "description": "SRVB: binding category (0=UI, 1=Web API; default: 0). Overrides category inferred from bindingType."
         },
         "version": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SRVB: service version number (default: 0001)"
         },
         "lintBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Override server lint-before-write for this call (false skips it). Lint covers PROG/CLAS/INTF/FUNC and DDLS; other types rely on RAP preflight."
         },
         "preflightBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Enable/disable deterministic RAP preflight checks (default true) — TABL/BDEF/DDLX static rules (curr/quan semantics, invalid BDEF enums, DDLX scope on 7.5x)."
         },
         "checkBeforeWrite": {
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "description": "Override server check-before-write (default off). When true, runs a SAP syntax check and appends diagnostics to the response — the write is NOT blocked. Off by default (adds a round-trip; intermediate refactor writes legitimately trip transient dependency errors). Activation remains the definitive check."
         },
         "refObjectType": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create (required): ADT type+subtype of the documented parent (e.g. \"DDLS/DF\", \"BDEF/BDO\", \"SRVD/SRV\", \"DEVC/K\"). Not CLAS/INTF/PROG (use ABAP Doc for code)."
         },
         "refObjectName": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create: name of the parent object the KTD documents (defaults to \"name\")."
         },
         "refObjectDescription": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "SKTD/KTD create: description of the parent object (shown in Eclipse tooltips)."
         },
         "objects": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {
@@ -836,96 +656,54 @@
                 "description": "Object name"
               },
               "source": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "ABAP source code (optional — some objects have no source)"
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object description (defaults to name if omitted)"
               },
               "package": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object-specific package. Overrides top-level package for this item."
               },
               "transport": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "description": "Object-specific transport request. Overrides top-level transport for this item."
               },
               "dataType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "rowType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "rowTypeKind": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "builtin",
                   "structure"
                 ]
               },
               "length": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "decimals": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "outputLength": {
-                "type": [
-                  "number",
-                  "null"
-                ]
+                "type": "number"
               },
               "conversionExit": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "signExists": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "lowercase": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "fixedValues": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -933,16 +711,10 @@
                       "type": "string"
                     },
                     "high": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     },
                     "description": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -951,92 +723,50 @@
                 }
               },
               "valueTable": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "typeKind": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "domain",
                   "predefinedAbapType"
                 ]
               },
               "typeName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "domainName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "shortLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "mediumLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "longLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "headingLabel": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "searchHelp": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "searchHelpParameter": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "setGetParameter": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "defaultComponentName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "changeDocument": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": "boolean"
               },
               "messages": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -1054,42 +784,27 @@
                 }
               },
               "serviceDefinition": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "bindingType": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               },
               "odataVersion": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "V2",
                   "V4"
                 ]
               },
               "category": {
-                "type": [
-                  "string",
-                  "null"
-                ],
+                "type": "string",
                 "enum": [
                   "0",
                   "1"
                 ]
               },
               "version": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": "string"
               }
             },
             "required": [

--- a/tests/unit/handlers/tools.test.ts
+++ b/tests/unit/handlers/tools.test.ts
@@ -256,8 +256,7 @@ describe('Tool Definitions', () => {
     const sapWrite = tools.find((t) => t.name === 'SAPWrite')!;
     const schema = sapWrite.inputSchema as Record<string, any>;
     expect(schema.properties.parameters).toBeDefined();
-    // Optional fields are nullable for GPT/OpenAI strict mode (#360) → type is ['array','null'].
-    expect(schema.properties.parameters.type).toContain('array');
+    expect(schema.properties.parameters.type).toBe('array');
     const item = schema.properties.parameters.items;
     expect(item.properties.kind.enum).toEqual([
       'importing',
@@ -319,8 +318,7 @@ describe('Tool Definitions', () => {
     expect(schema.properties.visibility).toBeDefined();
     expect(schema.properties.visibility.enum).toEqual(['public', 'protected', 'private']);
     expect(schema.properties.abstract).toBeDefined();
-    // Optional fields are nullable for GPT/OpenAI strict mode (#360) → type is ['boolean','null'].
-    expect(schema.properties.abstract.type).toContain('boolean');
+    expect(schema.properties.abstract.type).toBe('boolean');
   });
 
   it('SAPWrite action description mentions class-section surgery (issue #303)', () => {
@@ -343,27 +341,72 @@ describe('Tool Definitions', () => {
     }
   });
 
-  it('SAPWrite optional fields are nullable for GPT/OpenAI strict mode; required stay non-nullable (issue #360)', () => {
+  it('SAPWrite avoids nullable JSON Schema unions for Copilot Eclipse compatibility (issue #520)', () => {
     const tools = getToolDefinitions({ ...DEFAULT_CONFIG, allowWrites: true });
     const sapWrite = tools.find((t) => t.name === 'SAPWrite')!;
     const schema = sapWrite.inputSchema as Record<string, any>;
     const props = schema.properties;
 
-    // Required field stays a plain (non-nullable) string.
     expect(props.action.type).toBe('string');
+    expect(props.dataType.type).toBe('string');
+    expect(props.length.type).toBe('number');
+    expect(props.signExists.type).toBe('boolean');
+    expect(props.odataVersion.type).toBe('string');
+    expect(props.odataVersion.enum).toEqual(['V2', 'V4']);
+    expect(props.odataVersion.enum).not.toContain(null);
 
-    // Optional plain/number/boolean fields become a union with null.
+    const itemProps = props.objects.items.properties;
+    expect(itemProps.type.type).toBe('string');
+    expect(itemProps.name.type).toBe('string');
+    expect(itemProps.source.type).toBe('string');
+
+    const typeArrays: string[] = [];
+    const walk = (node: unknown, path = '$') => {
+      if (!node || typeof node !== 'object') return;
+      const record = node as Record<string, unknown>;
+      if (Array.isArray(record.type)) typeArrays.push(path);
+      for (const [key, value] of Object.entries(record)) walk(value, `${path}.${key}`);
+    };
+    walk(schema);
+    expect(typeArrays).toEqual([]);
+  });
+
+  it('default tool schemas contain no nullable JSON Schema type arrays (issue #520)', () => {
+    const tools = getToolDefinitions({
+      ...DEFAULT_CONFIG,
+      allowWrites: true,
+      allowFreeSQL: true,
+      allowTransportWrites: true,
+      allowGitWrites: true,
+    });
+
+    const typeArrays: string[] = [];
+    const walk = (node: unknown, path = '$') => {
+      if (!node || typeof node !== 'object') return;
+      const record = node as Record<string, unknown>;
+      if (Array.isArray(record.type)) typeArrays.push(path);
+      for (const [key, value] of Object.entries(record)) walk(value, `${path}.${key}`);
+    };
+    for (const tool of tools) walk(tool.inputSchema, tool.name);
+    expect(typeArrays).toEqual([]);
+  });
+
+  it('SAPWrite can opt into nullable optionals for OpenAI strict-mode compatibility (issue #360)', () => {
+    const tools = getToolDefinitions({ ...DEFAULT_CONFIG, allowWrites: true }, undefined, undefined, {
+      nullableOptionals: true,
+    });
+    const sapWrite = tools.find((t) => t.name === 'SAPWrite')!;
+    const schema = sapWrite.inputSchema as Record<string, any>;
+    const props = schema.properties;
+
+    expect(props.action.type).toBe('string');
     expect(props.dataType.type).toEqual(['string', 'null']);
     expect(props.length.type).toEqual(['number', 'null']);
     expect(props.signExists.type).toEqual(['boolean', 'null']);
-
-    // Optional ENUM: null added to `type` ONLY, never to `enum` (OpenAI's documented form).
     expect(props.odataVersion.type).toEqual(['string', 'null']);
     expect(props.odataVersion.enum).toEqual(['V2', 'V4']);
     expect(props.odataVersion.enum).not.toContain(null);
 
-    // Nested batch objects[] items keep their own required keys (type, name) non-nullable,
-    // but optional per-item fields are nullable.
     const itemProps = props.objects.items.properties;
     expect(itemProps.type.type).toBe('string');
     expect(itemProps.name.type).toBe('string');

--- a/tests/unit/server/config.test.ts
+++ b/tests/unit/server/config.test.ts
@@ -37,6 +37,7 @@ describe('parseArgs', () => {
     expect(config.allowTransportWrites).toBe(false);
     expect(config.allowGitWrites).toBe(false);
     expect(config.denyActions).toEqual([]);
+    expect(config.schemaNullableOptionals).toBe('auto');
     expect(config.verbose).toBe(false);
   });
 
@@ -106,6 +107,23 @@ describe('parseArgs', () => {
     process.env.ARC1_MINIMAL_ERRORS = 'true';
     const config = parseArgs([]);
     expect(config.minimalErrors).toBe(true);
+  });
+
+  it('parses ARC1_SCHEMA_NULLABLE_OPTIONALS env var', () => {
+    process.env.ARC1_SCHEMA_NULLABLE_OPTIONALS = 'on';
+    const config = parseArgs([]);
+    expect(config.schemaNullableOptionals).toBe('on');
+  });
+
+  it('--schema-nullable-optionals takes precedence over ARC1_SCHEMA_NULLABLE_OPTIONALS', () => {
+    process.env.ARC1_SCHEMA_NULLABLE_OPTIONALS = 'on';
+    const config = parseArgs(['--schema-nullable-optionals', 'off']);
+    expect(config.schemaNullableOptionals).toBe('off');
+  });
+
+  it('rejects invalid ARC1_SCHEMA_NULLABLE_OPTIONALS values', () => {
+    process.env.ARC1_SCHEMA_NULLABLE_OPTIONALS = 'nullable';
+    expect(() => parseArgs([])).toThrow(/Invalid ARC1_SCHEMA_NULLABLE_OPTIONALS/);
   });
 
   it('--minimal-errors takes precedence over ARC1_MINIMAL_ERRORS env var', () => {
@@ -881,17 +899,21 @@ describe('parseArgs', () => {
     const { sources } = resolveConfig([]);
     expect(sources.allowWrites).toBe('default');
     expect(sources.allowedPackages).toBe('default');
+    expect(sources.schemaNullableOptionals).toBe('default');
   });
 
   it('resolveConfig reports env source for env-set fields', () => {
     process.env.SAP_ALLOW_WRITES = 'true';
+    process.env.ARC1_SCHEMA_NULLABLE_OPTIONALS = 'on';
     const { sources } = resolveConfig([]);
     expect(sources.allowWrites).toEqual({ env: 'SAP_ALLOW_WRITES' });
+    expect(sources.schemaNullableOptionals).toEqual({ env: 'ARC1_SCHEMA_NULLABLE_OPTIONALS' });
   });
 
   it('resolveConfig reports flag source for CLI-set fields', () => {
-    const { sources } = resolveConfig(['--allow-writes', 'true']);
+    const { sources } = resolveConfig(['--allow-writes', 'true', '--schema-nullable-optionals', 'off']);
     expect(sources.allowWrites).toEqual({ flag: '--allow-writes' });
+    expect(sources.schemaNullableOptionals).toEqual({ flag: '--schema-nullable-optionals' });
   });
 
   it('resolveConfig returns both config and sources', () => {
@@ -1157,6 +1179,15 @@ describe('validateConfig', () => {
 
   it('skips client validation when empty (resolveConfig substitutes the default)', () => {
     expect(() => validateConfig({ ...DEFAULT_CONFIG, client: '' })).not.toThrow();
+  });
+
+  it('validateConfig rejects invalid schemaNullableOptionals values', () => {
+    expect(() =>
+      validateConfig({
+        ...DEFAULT_CONFIG,
+        schemaNullableOptionals: 'nullable' as any,
+      }),
+    ).toThrow(/Invalid ARC1_SCHEMA_NULLABLE_OPTIONALS/);
   });
 
   it('throws when HTTP transport has no authentication and no explicit unsafe opt-in', () => {

--- a/tests/unit/server/server.test.ts
+++ b/tests/unit/server/server.test.ts
@@ -20,7 +20,9 @@ import {
   createServer,
   filterToolsByAuthScope,
   formatStartupAuthPreflightToolError,
+  getConfiguredToolDefinitions,
   logAuthSummary,
+  resolveNullableOptionals,
   runStartupAuthPreflight,
   VERSION,
 } from '../../../src/server/server.js';
@@ -46,6 +48,35 @@ describe('MCP Server', () => {
 
   it('has a valid version string', () => {
     expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('resolves schema nullable optionals off by default in auto mode', () => {
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+
+    expect(resolveNullableOptionals(DEFAULT_CONFIG, { name: 'GitHub Copilot', version: '1.0.0' })).toBe(false);
+    expect(debugSpy).toHaveBeenCalledWith('schema nullable optionals auto mode resolved to off', {
+      clientName: 'GitHub Copilot',
+      clientVersion: '1.0.0',
+    });
+
+    debugSpy.mockRestore();
+  });
+
+  it('resolves schema nullable optionals explicit on/off overrides', () => {
+    expect(resolveNullableOptionals({ ...DEFAULT_CONFIG, schemaNullableOptionals: 'on' })).toBe(true);
+    expect(resolveNullableOptionals({ ...DEFAULT_CONFIG, schemaNullableOptionals: 'off' })).toBe(false);
+  });
+
+  it('configured tool definitions honor explicit nullable-optionals mode', () => {
+    const tools = getConfiguredToolDefinitions({
+      ...DEFAULT_CONFIG,
+      allowWrites: true,
+      schemaNullableOptionals: 'on',
+    });
+    const sapWrite = tools.find((tool) => tool.name === 'SAPWrite')!;
+    const schema = sapWrite.inputSchema as Record<string, any>;
+
+    expect(schema.properties.dataType.type).toEqual(['string', 'null']);
   });
 
   it('filters SAPManage actions to read-only set for read-scoped users', () => {
@@ -151,6 +182,34 @@ describe('MCP Server', () => {
     const schema = sap!.inputSchema as Record<string, any>;
     const actionEnum: string[] = schema.properties.action.enum;
     expect(actionEnum).toEqual(['query']);
+  });
+
+  it('passes explicit nullable-optionals mode through tools/list', async () => {
+    const server = createServer({ ...DEFAULT_CONFIG, allowWrites: true, schemaNullableOptionals: 'on' });
+    const handler = requestHandler(server, ListToolsRequestSchema.shape.method.value);
+    const result = await handler({ method: 'tools/list', params: {} }, {});
+    const sapWrite = (result.tools as Array<{ name: string; inputSchema: Record<string, any> }>).find(
+      (tool) => tool.name === 'SAPWrite',
+    );
+
+    expect(sapWrite?.inputSchema.properties.dataType.type).toEqual(['string', 'null']);
+  });
+
+  it('logs nullable-optionals auto clientInfo once during tools/list', async () => {
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    const server = createServer(DEFAULT_CONFIG);
+    const handler = requestHandler(server, ListToolsRequestSchema.shape.method.value);
+
+    await handler({ method: 'tools/list', params: {} }, {});
+    await handler({ method: 'tools/list', params: {} }, {});
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith('schema nullable optionals auto mode clientInfo', {
+      clientName: 'unknown',
+      clientVersion: 'unknown',
+      resolvedNullableOptionals: false,
+    });
+    infoSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Goal

Fix MCP client compatibility for write-enabled ARC-1 tool listings by keeping the default `SAPWrite` JSON Schema portable, while preserving an explicit escape hatch for OpenAI/Azure strict-mode clients that need nullable optional fields.

## What changed

- Adds `ARC1_SCHEMA_NULLABLE_OPTIONALS=auto|off|on` / `--schema-nullable-optionals`.
- Keeps `auto` conservative today: it resolves to `off`, emits a debug resolver log, and logs MCP client info once per server instance on first `tools/list` for future allow-list research.
- Applies nullable optional schema unions only when explicitly enabled, and only to `SAPWrite`.
- Makes MCP `tools/list`, `arc1-cli tools`, and CLI availability checks use the same configured tool-definition helper.
- Keeps runtime null cleanup intact for #360 while preventing default `type: ["x", "null"]` unions that break clients from #520.
- Updates tool schema fixtures, config docs, `.env.example`, and regression tests.

## Root cause

Write-enabled `0.9.21` exposed 95 nullable JSON Schema `type` unions, all inside `SAPWrite`. GitHub Copilot Eclipse rejects that schema shape during tool import, so no ARC-1 tools appear when writes are enabled. Read-only and hyperfocused modes worked because they did not expose those unions.

## Validation

- `npx vitest run tests/unit/handlers/tools.test.ts tests/unit/server/config.test.ts tests/unit/server/server.test.ts tests/unit/cli/cli.test.ts`
- `npx vitest run tests/unit/handlers/zod-jsonschema-parity.test.ts tests/unit/handlers/tool-definitions-snapshot.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run check:sizes`
- `npm test`

Generated schema check:

- default: 0 nullable type unions across all tools
- explicit opt-in: 95 nullable type unions, all in `SAPWrite`
