### PR TITLE
feat: Add labels to source diffs

### DIFF
--- a/docs/plans/http-forward-proxy-env-support.md
+++ b/docs/plans/http-forward-proxy-env-support.md
@@ -1,0 +1,182 @@
+# COMPAT-06 - Outbound HTTP_PROXY / NO_PROXY support for SAP ADT traffic
+
+## Overview
+
+ARC-1 should honor standard proxy environment variables for outbound SAP ADT requests:
+
+- `HTTP_PROXY` / `http_proxy`
+- `HTTPS_PROXY` / `https_proxy`
+- `NO_PROXY` / `no_proxy`
+
+This is a transport compatibility item for enterprise networks. It is not reverse-proxy support for
+ARC-1's MCP/OAuth/UI HTTP server, and it must not affect the BTP Destination Service / Cloud Connector
+path.
+
+Research: [docs/research/http-forward-proxy-env-support.md](../research/http-forward-proxy-env-support.md).
+
+## Current state
+
+- `docs_page/docker.md` already says ARC-1 respects standard proxy env vars.
+- `src/adt/http.ts` does not currently create an env-proxy dispatcher for non-BTP outbound SAP calls.
+- `src/adt/http.ts` already has a separate BTP proxy path using `undici.Client` with absolute target
+  URLs and SAP-specific proxy headers.
+- Current main handles null-body statuses (`204`, `205`, `304`) in the BTP proxy response
+  reconstruction path. Any new proxy path must preserve that.
+
+## Target state
+
+- Non-BTP outbound SAP calls use standard proxy env vars when configured.
+- BTP `btpProxy` keeps precedence and ignores generic env proxies.
+- Plain `http://` SAP targets can use an HTTP forward proxy without forced `CONNECT` tunneling.
+- `https://` SAP targets still use CONNECT tunneling, preserving end-to-end TLS to SAP.
+- `NO_PROXY` follows undici semantics rather than an ARC-1-specific parser.
+- Existing auth, cookie, CSRF, retry, audit, debug-redaction, and 304 behavior remains unchanged.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `src/adt/http.ts` | Add outbound env-proxy dispatcher or shared forward-proxy helper |
+| `tests/unit/adt/http.test.ts` | Add routing and response reconstruction tests |
+| `docs_page/docker.md` | Clarify outbound-only proxy behavior |
+| `docs_page/configuration-reference.md` | Mention standard proxy env vars in networking notes |
+| `docs_page/security-guide.md` or deployment docs | Warn about proxy visibility for plain HTTP SAP traffic |
+
+## Design constraints
+
+1. **BTP proxy first.** If `config.btpProxy` is present, use the existing BTP connectivity-proxy path and
+   ignore generic `HTTP_PROXY` / `HTTPS_PROXY`.
+2. **Prefer undici primitives.** Use `EnvHttpProxyAgent` / `ProxyAgent` if they express the required
+   behavior. Do not hand-roll env parsing unless required.
+3. **Avoid CONNECT for plain HTTP where possible.** Use undici `proxyTunnel: false` for HTTP endpoints
+   if supported by the installed undici version. HTTPS endpoints still tunnel.
+4. **Preserve TLS behavior.** `SAP_INSECURE=true` must still disable SAP endpoint verification in direct
+   and proxied HTTPS mode, without accidentally weakening unrelated proxy TLS unless explicitly needed.
+5. **Share response reconstruction.** Do not duplicate the BTP proxy's `Response` construction logic.
+   A helper should handle headers and null-body statuses for every `Client.request` based proxy path.
+6. **No new MCP surface.** No tool schema or authz changes.
+
+## Implementation approach
+
+### Task 1: Spike undici dispatcher shape
+
+Files:
+
+- Read: `src/adt/http.ts`
+- Read: installed undici types after `npm ci`
+
+Checklist:
+
+- [ ] Verify `undici@8.5.0` exports `EnvHttpProxyAgent`.
+- [ ] Verify `EnvHttpProxyAgent` accepts `proxyTunnel: false` through its options.
+- [ ] Verify the TypeScript type for endpoint TLS override (`requestTls`) and proxy TLS override
+      (`proxyTls`) so `SAP_INSECURE=true` maps correctly.
+- [ ] Decide whether implementation can be a dispatcher-only change. If yes, avoid any manual
+      `Client.request` forward-proxy path.
+
+### Task 2: Add proxy dispatcher selection
+
+Files:
+
+- Modify: `src/adt/http.ts`
+
+Checklist:
+
+- [ ] Add a small helper such as `hasProxyEnv()` or `createForwardProxyDispatcher(config)`.
+- [ ] In the constructor, keep current behavior:
+      - if `config.btpProxy`, do not set a generic dispatcher;
+      - else if env proxy vars exist, use `EnvHttpProxyAgent`;
+      - else if `config.insecure`, use current direct `Agent`;
+      - else leave dispatcher undefined.
+- [ ] Pass `proxyTunnel: false` for the env proxy dispatcher if type-supported.
+- [ ] Preserve `AbortSignal.timeout(120_000)` at the request call site.
+- [ ] Ensure debug/audit redaction still covers `Proxy-Authorization`.
+
+### Task 3: Add shared response reconstruction only if needed
+
+Files:
+
+- Modify: `src/adt/http.ts`
+- Modify: `tests/unit/adt/http.test.ts`
+
+Checklist:
+
+- [ ] If dispatcher-only implementation is enough, do not add this task's code.
+- [ ] If a manual `Client.request` path is required, extract a helper used by both BTP proxy and the
+      new forward-proxy path:
+      - copy all response headers;
+      - call `resp.body.text()`;
+      - pass `null` to `new Response()` for `204`, `205`, and `304`;
+      - preserve status code and headers.
+- [ ] Keep client close / dispatcher lifecycle explicit and covered by tests.
+
+### Task 4: Unit tests
+
+Files:
+
+- Modify: `tests/unit/adt/http.test.ts`
+
+Minimum tests:
+
+- [ ] No proxy env uses normal `undici.fetch`.
+- [ ] `btpProxy` plus `HTTP_PROXY` uses the BTP proxy path.
+- [ ] `HTTP_PROXY` with HTTP SAP URL uses the env proxy dispatcher or proxy request path.
+- [ ] `NO_PROXY` matching the SAP host bypasses the proxy.
+- [ ] Proxy credentials are configured through undici options or headers without appearing in audit
+      debug fields.
+- [ ] `SAP_INSECURE=true` still creates an appropriate dispatcher when proxy env vars are absent.
+- [ ] Proxied `304` response does not crash and preserves `etag`.
+
+Optional tests if easy:
+
+- [ ] Lowercase env var precedence over uppercase, unless delegated entirely to undici and documented.
+- [ ] `NO_PROXY` port-specific match, unless delegated entirely to undici and documented.
+
+### Task 5: Documentation
+
+Files:
+
+- Modify: `docs_page/docker.md`
+- Modify: `docs_page/configuration-reference.md`
+- Modify: `docs_page/security-guide.md` or `docs_page/deployment.md`
+
+Checklist:
+
+- [ ] State that proxy env vars affect outbound SAP ADT traffic from the ARC-1 process.
+- [ ] State that they do not configure inbound reverse-proxy behavior for `/mcp`, OAuth, or the UI.
+- [ ] State that BTP Destination Service / Cloud Connector deployments should use the BTP destination
+      path, not generic env proxies.
+- [ ] Warn that plain HTTP SAP traffic through a proxy exposes credentials and ABAP source payloads to
+      that proxy.
+- [ ] Recommend HTTPS SAP endpoints for production where available.
+
+### Task 6: Verification
+
+Commands:
+
+- `npx vitest run tests/unit/adt/http.test.ts`
+- `npm run typecheck`
+- `npm run lint`
+- `npm run build`
+
+Optional manual verification:
+
+- Run ARC-1 against a local fake HTTP proxy and a local fake SAP endpoint.
+- Confirm plain HTTP uses absolute-form proxying when `proxyTunnel: false` is active.
+- Confirm `NO_PROXY` bypasses the fake proxy.
+
+## Out of scope
+
+- New ARC-1-specific config names for proxy settings.
+- SOCKS proxy support beyond what undici provides.
+- Proxy support for plugin raw HTTP calls unless those calls already go through the same ADT HTTP
+  layer. Review separately if needed.
+- Any change to BTP Destination Service / Cloud Connector behavior.
+- Creating a PR as part of this research task.
+
+## Exit criteria
+
+- Research document exists and is linked from the roadmap.
+- Roadmap item exists as open `COMPAT-06`.
+- Implementation plan is present in `docs/plans/`.
+- No code changes are made until this plan is explicitly picked up.

--- a/docs/plans/version-diff-labels.md
+++ b/docs/plans/version-diff-labels.md
@@ -37,4 +37,5 @@ diff contract in `docs/research/2026-06-15-version-diff-saved-read-action.md`.
 - Existing default behavior remains observable through current tests; new tests cover only the added
   label path.
 - Live SAP testing is not required for the label plumbing because no SAP request/response contract
-  changes and this checkout has no `.env` or `INFRASTRUCTURE.md` live-system recipe.
+  changes. A post-implementation read-only smoke was still run on A4H and recorded in
+  `docs/research/2026-06-27-version-diff-labels.md`.

--- a/docs/plans/version-diff-labels.md
+++ b/docs/plans/version-diff-labels.md
@@ -1,0 +1,40 @@
+# Plan: readable labels for `SAPRead action="diff"`
+
+## Evidence
+
+Use the verified findings in `docs/research/2026-06-27-version-diff-labels.md` and the existing
+diff contract in `docs/research/2026-06-15-version-diff-saved-read-action.md`.
+
+## Implementation
+
+1. Add optional `fromLabel` and `toLabel` fields to the SAPRead Zod schemas and LLM-visible tool
+   schema.
+2. Extend `getVersionDiff` options with `fromLabel`/`toLabel`, preserving the current default labels
+   exactly when labels are omitted.
+3. Thread labels from `handleSAPRead` into `getVersionDiff` and use the same display labels in the
+   one-line `Diff ...` / `No differences ...` messages.
+4. Update `docs_page/tools.md` with parameter rows and examples.
+5. Regenerate tool-definition fixtures.
+
+## Tests
+
+1. Add a handler unit test proving custom labels appear in both the summary and unified diff headers.
+2. Add a handler unit test proving labels also apply to the no-difference message without affecting
+   source resolution.
+3. Add a schema unit test for `fromLabel`/`toLabel`.
+4. Run focused tests:
+   - `npx vitest run tests/unit/adt/source-diff.test.ts tests/unit/handlers/read.test.ts tests/unit/handlers/schemas.test.ts tests/unit/handlers/schema-key-sync.test.ts tests/unit/handlers/tool-definitions-snapshot.test.ts`
+5. Run broader gates:
+   - `npm run typecheck`
+   - `npm run lint`
+   - `npm test`
+
+## Plan Review
+
+- Scope is presentation-only; no ADT calls, safety checks, or revision resolution logic change.
+- Three-file schema sync is covered: `schemas.ts`, `tools.ts`, handler, plus schema-key and snapshot
+  tests.
+- Existing default behavior remains observable through current tests; new tests cover only the added
+  label path.
+- Live SAP testing is not required for the label plumbing because no SAP request/response contract
+  changes and this checkout has no `.env` or `INFRASTRUCTURE.md` live-system recipe.

--- a/docs/research/2026-06-27-version-diff-labels.md
+++ b/docs/research/2026-06-27-version-diff-labels.md
@@ -1,0 +1,65 @@
+# Research: readable labels for `SAPRead action="diff"`
+
+Dated 2026-06-27. Scope: extend the existing single-system source diff API with caller-supplied
+display labels for the two patch headers.
+
+## Goal
+
+Let callers replace raw refs in unified-diff headers with human-readable revision context, for
+example:
+
+```diff
+--- ZCL_ORDER (DNT-6-6: Validate discounts, DS7K900123)
++++ ZCL_ORDER (active)
+```
+
+This is useful when a caller already fetched `SAPRead(type="VERSIONS")` and has `versionTitle`,
+`transport`, author, or timestamp metadata. The diff remains the same; only the labels shown in the
+patch header and one-line summary change.
+
+## Verified contract
+
+No new ADT endpoint or SAP behavior is introduced. The existing diff contract remains authoritative:
+`docs/research/2026-06-15-version-diff-saved-read-action.md`.
+
+Key inherited facts:
+
+| Concern | Current verified behavior |
+|---|---|
+| Active/inactive source | `GET <sourceUrl>?version=active|inactive`, raw text |
+| Revision source | `GET .../versions/<timestamp>/<sequence>/content`, raw text |
+| Revision id resolution | Bare ids resolve through the existing `VERSIONS` feed |
+| Server-side diff | None; ARC-1 computes a local unified diff |
+| Release behavior | Existing research marked the `?version=` and revision endpoints release-invariant |
+
+Because labels are local presentation data, there is no response-content behavior to re-probe on SAP
+systems. Existing live checks already cover the source bytes, no-draft guard, revision URI/id
+resolution, and supported-type matrix.
+
+## External input
+
+The fork branch `Prolls:arc-1:feat/compare-source-diff` contains a useful `label1`/`label2` idea for
+readable diff headers. Its implementation targets the pre-consolidation `SAPDiagnose`/`intent.ts`
+path and is superseded by main's `SAPRead action="diff"` implementation. The idea to keep is only
+optional caller labels.
+
+## ARC-1 impact map
+
+| File | Change |
+|---|---|
+| `src/adt/version-diff.ts` | Extend diff options with optional `fromLabel`/`toLabel`; feed labels into `unifiedDiff` |
+| `src/handlers/read.ts` | Read optional labels from tool args and use them in the summary line |
+| `src/handlers/schemas.ts` | Add `fromLabel`/`toLabel` to both SAPRead schemas |
+| `src/handlers/tools.ts` | Expose `fromLabel`/`toLabel` in the LLM-visible SAPRead JSON schema |
+| `docs_page/tools.md` | Document the optional labels |
+| `tests/unit/handlers/read.test.ts` | Assert headers and summary use custom labels |
+| `tests/unit/handlers/schemas.test.ts` | Assert schema accepts labels |
+| `tests/fixtures/tool-definitions/*.json` | Regenerate because the SAPRead tool surface changes |
+
+## Design choice
+
+Use `fromLabel` and `toLabel`, not `label1`/`label2`, so the names align with the existing
+`from`/`to` parameters and avoid introducing a second naming convention.
+
+The labels are optional display strings only. They must not affect source resolution, not trigger any
+extra SAP requests, and not change the existing default labels.

--- a/docs/research/2026-06-27-version-diff-labels.md
+++ b/docs/research/2026-06-27-version-diff-labels.md
@@ -36,6 +36,18 @@ Because labels are local presentation data, there is no response-content behavio
 systems. Existing live checks already cover the source bytes, no-draft guard, revision URI/id
 resolution, and supported-type matrix.
 
+## Live verification
+
+Post-implementation smoke checks were run on 2026-06-27 against the A4H / S/4HANA 2023 live system
+using read-only CLI calls. No credentials or local environment files are part of this branch.
+
+| Scenario | Result |
+|---|---|
+| `SAPRead(type="VERSIONS", name="ZCL_SSI_UNIT_HOOKS", objectType="CLAS")` | Returned revision `00000` with `versionTitle` `ZSSI_IMPORTER extension hooks (Tier 1+2)` |
+| `SAPRead(type="CLAS", name="ZCL_SSI_UNIT_HOOKS", action="diff", from="00000", to="active", fromLabel="ZSSI_IMPORTER extension hooks (Tier 1+2)", toLabel="active")` | Returned `(+2 -28)` and patch headers using the custom labels |
+| `SAPRead(type="CLAS", name="ZCL_SSI_UNIT_HOOKS", action="diff", from="00000", to="active")` | Preserved default summary/header labels: `00000` and `active` |
+| `SAPRead(type="CLAS", name="ZCL_SSI_UNIT_HOOKS", action="diff", from="active", to="active", fromLabel="active baseline", toLabel="active comparison")` | Returned `No differences between active baseline and active comparison for CLAS ZCL_SSI_UNIT_HOOKS.` |
+
 ## External input
 
 The fork branch `Prolls:arc-1:feat/compare-source-diff` contains a useful `label1`/`label2` idea for

--- a/docs/research/http-forward-proxy-env-support.md
+++ b/docs/research/http-forward-proxy-env-support.md
@@ -1,0 +1,300 @@
+# HTTP_PROXY / NO_PROXY support for outbound SAP ADT traffic
+
+**Date:** 2026-06-27
+**Status:** Research complete, implementation deferred
+**Related branch reviewed:** `kalelkim/feature/kalelkim`
+**Roadmap item:** [COMPAT-06](../../docs_page/roadmap.md#compat-06)
+**Plan:** [docs/plans/http-forward-proxy-env-support.md](../plans/http-forward-proxy-env-support.md)
+
+## Summary
+
+ARC-1 should support standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables for
+outbound SAP ADT requests made by `src/adt/http.ts`, but the fork patch should not be merged as-is.
+
+The use case is not browser-to-ARC-1 traffic. It is the ARC-1 server process reaching SAP from an
+enterprise network that requires an outbound proxy. This is most relevant for local laptops, Docker
+containers, CI runners, or self-hosted ARC-1 servers inside locked-down corporate networks. BTP Cloud
+Foundry deployments that use Destination Service and Cloud Connector should continue to use ARC-1's
+existing BTP connectivity-proxy path instead.
+
+The right implementation is a small transport-layer compatibility item:
+
+- Keep `btpProxy` precedence exactly as-is.
+- Use undici's own proxy primitives where possible, not a custom environment parser.
+- For plain `http://` SAP targets behind a corporate proxy, avoid `CONNECT` when possible.
+- Preserve current response reconstruction behavior, especially null-body statuses `204`, `205`, and
+  `304`.
+- Add explicit unit tests before enabling this path.
+
+## Who would use it
+
+### Likely users
+
+1. **Local developer laptop behind a corporate proxy**
+   - A developer runs `npx arc-1` or a git checkout locally.
+   - Direct access to `http://sap-host:5xx00/sap/bc/adt/...` is blocked.
+   - Company tooling already exposes `HTTP_PROXY` and `NO_PROXY`.
+
+2. **Docker container in a corporate network**
+   - ARC-1 runs as `docker run ghcr.io/arc-mcp/arc-1`.
+   - The container cannot route directly to SAP, but can route through a proxy.
+   - `docs_page/docker.md` already tells operators to pass proxy env vars.
+
+3. **CI or integration test runners**
+   - Test infrastructure runs outside the SAP network segment.
+   - The runner can reach SAP only through an internal forward proxy.
+
+4. **Self-hosted VM/server**
+   - ARC-1 is installed on a company VM.
+   - Egress is governed by an HTTP proxy or inspection gateway.
+
+### Unlikely or wrong users
+
+1. **BTP Cloud Foundry with Destination Service + Cloud Connector**
+   - ARC-1 already has a separate BTP connectivity-proxy implementation (`btpProxy`) with
+     `Proxy-Authorization`, `SAP-Connectivity-Authentication`, and optional Location ID handling.
+   - Environment proxy support must not override that path.
+
+2. **Browser or MCP clients calling ARC-1**
+   - `HTTP_PROXY` here is not reverse-proxy support for `/mcp`, OAuth, or the web UI.
+   - It only affects ARC-1's outbound SAP ADT HTTP client.
+
+3. **Public internet deployments**
+   - If `SAP_URL` is public and HTTPS, a corporate forward proxy may still be useful.
+   - If `SAP_URL` is plain HTTP over the internet, that is a separate and higher-severity TLS problem.
+
+## Current ARC-1 behavior
+
+`src/adt/http.ts` currently has three transport modes:
+
+1. **BTP connectivity proxy**
+   - Configured through `config.btpProxy`.
+   - Uses `undici.Client` directly against the proxy origin and sends the full target URL as the
+     request path.
+   - This is intentionally not undici `ProxyAgent`, because the BTP connectivity proxy path relies on
+     standard HTTP proxying plus SAP-specific headers.
+
+2. **Direct fetch with optional TLS-insecure dispatcher**
+   - For non-BTP connections, ARC-1 calls npm `undici.fetch()`.
+   - If `SAP_INSECURE=true`, ARC-1 installs an `Agent({ connect: { rejectUnauthorized: false } })`
+     dispatcher.
+
+3. **No explicit env-proxy dispatcher**
+   - Despite `docs_page/docker.md` saying proxy environment variables are respected, `src/adt/http.ts`
+     does not currently create an `EnvHttpProxyAgent` or parse proxy env vars.
+   - Depending on Node version and runtime flags, Node's global `fetch()` may support env proxies, but
+     ARC-1 imports and calls npm `undici.fetch()` with its own dispatcher path. Relying on Node global
+     behavior is therefore too implicit.
+
+## External source findings
+
+### Node.js
+
+Node's enterprise-network guide says proxy settings are commonly supplied as `HTTP_PROXY`,
+`HTTPS_PROXY`, and `NO_PROXY`, and Node supports them when `NODE_USE_ENV_PROXY=1` or
+`--use-env-proxy` is enabled. It also states support applies to `fetch()` only on sufficiently recent
+Node releases. Source:
+
+- https://nodejs.org/learn/http/enterprise-network-configuration
+
+Important consequence for ARC-1:
+
+- ARC-1's `package.json` currently allows Node `>=22.19`.
+- Node's documented env-proxy support for `fetch()` starts later than that minimum.
+- ARC-1 should not require users to set `NODE_USE_ENV_PROXY=1` or rely on Node global behavior when it
+  already owns the undici dispatcher path.
+
+### undici `EnvHttpProxyAgent`
+
+undici documents `EnvHttpProxyAgent` as stable. It reads lowercase and uppercase proxy variables,
+supports `no_proxy` / `NO_PROXY`, and can be used as a per-request dispatcher. It also documents the
+important precedence rule that lowercase env vars take precedence over uppercase when both are set.
+Source:
+
+- https://github.com/nodejs/undici/blob/main/docs/docs/api/EnvHttpProxyAgent.md
+
+Important consequence for ARC-1:
+
+- Prefer `EnvHttpProxyAgent` over hand-written env parsing.
+- Do not implement a weaker `NO_PROXY` parser unless undici cannot support the needed mode.
+- Tests should cover lowercase-over-uppercase precedence indirectly or document that this is delegated
+  to undici.
+
+### undici `ProxyAgent`
+
+undici documents `ProxyAgent` as stable. It states that secure `https:` endpoints use an HTTP
+`CONNECT` tunnel. It also exposes `proxyTunnel: false`; for plain `http:` endpoints behind an HTTP
+proxy, this sends the absolute request URI to the proxy instead of tunneling, matching curl behavior.
+Secure connections always use a tunnel even when this option is false. Source:
+
+- https://github.com/nodejs/undici/blob/main/docs/docs/api/ProxyAgent.md
+
+Important consequence for ARC-1:
+
+- The fork's core insight is valid: some corporate proxies block `CONNECT` to plain SAP ICM HTTP ports.
+- The implementation should probably use undici's `proxyTunnel: false` rather than duplicating the BTP
+  proxy request implementation.
+- `https://` SAP endpoints still require tunneling. That is correct because TLS must terminate at SAP,
+  not at the proxy.
+
+## Benefits
+
+1. **Makes existing Docker documentation true**
+   - `docs_page/docker.md` already tells operators that ARC-1 respects proxy env vars.
+   - Implementing the transport path removes a documentation/code mismatch.
+
+2. **Works in enterprise network topologies**
+   - Many corporate networks block direct outbound connections from developer machines, CI, and
+     containers.
+   - Standard env vars are the operator-friendly interface.
+
+3. **Avoids a known CONNECT failure mode**
+   - Some forward proxies allow normal HTTP proxy requests but block `CONNECT` to non-443 ports.
+   - SAP ICM commonly uses ports such as `50000`, `54000`, or `8000`.
+   - For plain `http://` SAP targets, absolute-URI proxying can work where tunneling fails.
+
+4. **Low product-surface impact**
+   - No MCP schema changes.
+   - No new user-facing tool permissions.
+   - No SAP ADT behavior changes.
+
+5. **Improves local and CI reproducibility**
+   - Operators can pass the same env vars used by curl, npm, Docker, or corporate shell profiles.
+
+## Risks
+
+### Security risks
+
+1. **Plain HTTP SAP traffic through a proxy exposes credentials and content**
+   - If `SAP_URL` is `http://`, the proxy can see Basic auth headers, cookies, CSRF tokens, paths,
+     request bodies, and response bodies.
+   - This is already true for direct plain HTTP traffic on the network, but proxy support can make it
+     easier to route sensitive traffic through a managed inspection point.
+   - Production guidance should prefer HTTPS SAP endpoints where possible.
+
+2. **Proxy env var injection can redirect SAP traffic**
+   - A malicious `HTTP_PROXY` value in the ARC-1 process environment can route all outbound SAP traffic
+     through an attacker-controlled host.
+   - This is an operator/runtime hardening issue, not an LLM user-controlled input path.
+
+3. **Proxy credentials in env vars are sensitive**
+   - `HTTP_PROXY=http://user:pass@proxy:3128` stores credentials in process environment.
+   - Environments can leak through process inspection, crash reports, CI logs, or poor support dumps.
+   - ARC-1 debug logging already redacts `Proxy-Authorization`, but it should not log proxy URIs with
+     embedded credentials.
+
+4. **`NO_PROXY` mistakes change data path**
+   - A missing SAP hostname in `NO_PROXY` may send internal traffic through a proxy.
+   - An overly broad `NO_PROXY=*` may bypass a required security control.
+
+### Reliability risks
+
+1. **Transport-mode interactions**
+   - Direct fetch, BTP connectivity proxy, TLS-insecure mode, bearer tokens, CSRF, cookie jars, retries,
+     and conditional GETs all meet in `src/adt/http.ts`.
+   - A proxy implementation must preserve the existing behavior across all modes.
+
+2. **Null-body response handling**
+   - Main currently handles `204`, `205`, and `304` specially in the BTP proxy path because the Fetch
+     `Response` constructor rejects a non-null body for null-body statuses.
+   - A forward-proxy path must share that same reconstruction helper.
+
+3. **Connection pooling and lifecycle**
+   - The fork opens a new `undici.Client` for every proxied request.
+   - That is simple but less efficient than an agent/dispatcher and increases moving parts.
+   - Prefer an agent/dispatcher if it can express the needed behavior.
+
+4. **Lowercase/uppercase env precedence**
+   - Hand-rolled parsers often get proxy env precedence and `NO_PROXY` matching wrong.
+   - undici already documents these rules.
+
+## Evaluation of the fork patch
+
+The fork patch in `kalelkim/feature/kalelkim` is useful as evidence of the need, but not as mergeable
+code.
+
+### Good ideas
+
+- It keeps BTP `btpProxy` first.
+- It targets only plain `http://` SAP targets for absolute-URI proxying.
+- It recognizes `HTTP_PROXY` and `NO_PROXY`.
+- It supports Basic proxy auth from `user:pass@proxy`.
+
+### Problems
+
+- It duplicates `undici.Client` response reconstruction instead of sharing a helper.
+- It does not inherit current main's 204/205/304 null-body handling.
+- Its `NO_PROXY` parser is narrower than undici's documented behavior:
+  - no space-separated entries,
+  - no `*.example.com` wildcard,
+  - no optional `:port` matching,
+  - no lowercase-over-uppercase precedence.
+- It creates a new proxy client for every request.
+- It adds Korean fork-local comments to production code.
+- It has no tests.
+
+## Recommended implementation direction
+
+Use undici dispatcher primitives first:
+
+1. In `AdtHttpClient` construction, when `config.btpProxy` is absent, configure a non-BTP outbound
+   dispatcher if proxy env vars are present.
+2. Prefer `EnvHttpProxyAgent` with options forwarded to `ProxyAgent`, including `proxyTunnel: false`,
+   if supported by the installed undici version.
+3. If `SAP_INSECURE=true`, preserve current TLS behavior:
+   - direct mode: keep `Agent({ connect: { rejectUnauthorized: false } })`;
+   - proxied HTTPS SAP target: set the equivalent endpoint TLS option for the proxy agent
+     (`requestTls` in undici terminology), and verify with unit tests/types.
+4. If undici's agent cannot express one necessary case, add a small shared helper for `Client.request`
+   response reconstruction and use it in both BTP and forward-proxy code paths.
+
+Non-goal:
+
+- Do not create a new ARC-1-specific config surface unless standard env vars prove insufficient.
+
+## Acceptance criteria
+
+1. BTP connectivity proxy remains unchanged and wins over env proxies.
+2. Non-BTP direct connections without proxy env vars behave exactly as today.
+3. `HTTP_PROXY` / `http_proxy` routes plain `http://` SAP targets through the proxy.
+4. `NO_PROXY` / `no_proxy` bypasses the proxy using undici semantics.
+5. HTTPS SAP targets continue to tunnel, preserving end-to-end TLS to SAP.
+6. `SAP_INSECURE=true` still works for direct and proxied HTTPS SAP targets.
+7. `204`, `205`, and `304` responses work through proxy paths.
+8. Proxy auth is supported without logging credentials.
+9. Unit tests cover the routing matrix.
+
+## Test matrix
+
+Minimum unit tests in `tests/unit/adt/http.test.ts`:
+
+| Scenario | Expected behavior |
+|----------|-------------------|
+| No proxy env | Uses `undici.fetch`, not `Client`/proxy dispatcher |
+| `btpProxy` + `HTTP_PROXY` | Uses BTP proxy path, ignores env proxy |
+| `HTTP_PROXY` + HTTP SAP URL | Routes through proxy |
+| `HTTP_PROXY` + `NO_PROXY` matching SAP host | Bypasses proxy |
+| lowercase and uppercase env set | Lowercase wins, or test delegates to undici |
+| `HTTP_PROXY` with credentials | Sends proxy auth through agent option, not leaked in audit |
+| Proxied response status 304 | Returns status 304 and empty body without Response constructor error |
+| `SAP_INSECURE=true` + HTTPS SAP URL | TLS verification disabled only for the SAP endpoint as today |
+
+Optional integration test:
+
+- A local fake proxy server that asserts absolute-form request target for plain `http://` SAP URL.
+- Keep it unit-level unless the fake proxy adds too much test flake.
+
+## Documentation updates needed if implemented
+
+- `docs_page/docker.md`: clarify that proxy env vars affect ARC-1 outbound SAP traffic, not inbound
+  MCP/OAuth/UI traffic.
+- `docs_page/configuration-reference.md`: add a networking note for `HTTP_PROXY`, `HTTPS_PROXY`, and
+  `NO_PROXY` even though they are standard env vars, not ARC-1-specific config.
+- `docs_page/security-guide.md` or deployment docs: warn that plain HTTP SAP traffic through a proxy
+  exposes credentials and source payloads to that proxy.
+
+## Decision
+
+Implement later as `COMPAT-06`, with a fresh patch rather than a cherry-pick from the fork. The feature
+is worth doing because it unblocks enterprise networks and aligns docs with behavior, but it sits below
+core SAP feature work because it affects only deployments that require outbound proxies.

--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -1,6 +1,6 @@
 # ARC-1 Roadmap
 
-**Last Updated:** 2026-06-26
+**Last Updated:** 2026-06-27 (COMPAT-06 outbound `HTTP_PROXY` / `NO_PROXY` support researched and added as an open compatibility item)
 
 **Project:** ARC-1 (ABAP Relay Connector) — MCP Server for SAP ABAP Systems
 **Repository:** https://github.com/arc-mcp/arc-1
@@ -91,6 +91,7 @@ SORT RULES for this table — DO NOT BREAK when adding rows:
 | [OPS-02](#ops-02) | Health Check Enhancements | P2 | XS | Ops |
 | [DOC-03](#doc-03) | SAP Community Blog Post | P2 | S | Docs |
 | [COMPAT-04](#compat-04) | BTP transport omission in safeUpdateSource() — verify only | P2 | XS | Compatibility |
+| [COMPAT-06](#compat-06) | Outbound `HTTP_PROXY` / `NO_PROXY` support for SAP ADT traffic from ARC-1 | P2 | S | Compatibility |
 | [FEAT-05](#feat-05) | Code Refactoring (Rename, Extract) | P3 | L | Features |
 | [FEAT-07](#feat-07) | TLS/HTTPS for HTTP Streamable | P3 | S | Features |
 | ~~[FEAT-65](#feat-65)~~ | ~~TTYP (Table Type) read/write~~ — **✅ Completed 2026-06-25 (PR #504)**: read + create (built-in & structure rows; POST shell → follow-up PUT sets the real row type), live-verified 758 + 816 | P3 | M | Features |
@@ -294,6 +295,8 @@ These bugs affect real-world deployments and were confirmed by cross-project com
 - **BUG-01: SAPActivate phantom success + CLI/server alignment (NW 7.50)** (S) — **In flight via PR [#179](https://github.com/arc-mcp/arc-1/pull/179)** (samibouge, 2026-04-22). Five independent bugs produced a silent no-op that reported success for an inactive class. See the [BUG-01 detail block](#bug-01).
 
 - <a id="compat-04"></a>~~**COMPAT-04: BTP transport omission in safeUpdateSource()**~~ — **Likely NOT applicable to ARC-1.** fr0ster's bug was per-handler transport wiring (`UpdateInterface` missing what `UpdateClass` had). ARC-1's centralized `safeUpdateSource()` handles ALL types with `effectiveTransport = transport ?? (lock.corrNr || undefined)` — the pattern already correctly omits `corrNr` when undefined. **Verify** with BTP Cloud INTF update integration test. Source: fr0ster commit c2b8006 + issue #61. [Eval](../docs/compare/fr0ster/evaluations/c2b8006-dump-simplify-updateintf-fix.md)
+
+- <a id="compat-06"></a>**COMPAT-06: Outbound HTTP_PROXY / NO_PROXY support for SAP ADT traffic** (S) - ARC-1's ADT client should honor standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` env vars for non-BTP outbound SAP calls. This is mainly for local, Docker, CI, and self-hosted enterprise networks where direct SAP egress is blocked by a corporate forward proxy. Keep BTP Destination Service / Cloud Connector precedence, prefer undici `EnvHttpProxyAgent` / `ProxyAgent` over hand-rolled env parsing, avoid `CONNECT` for plain `http://` SAP targets where undici supports `proxyTunnel: false`, and preserve 204/205/304 response handling. Research: [docs/research/http-forward-proxy-env-support.md](../docs/research/http-forward-proxy-env-support.md). Plan: [docs/plans/http-forward-proxy-env-support.md](../docs/plans/http-forward-proxy-env-support.md).
 
 ### Phase B: Core Value Features (P1)
 7. ~~**FEAT-37** DCL (Access Control) Read/Write (S)~~ — **completed 2026-04-15**

--- a/docs_page/tools.md
+++ b/docs_page/tools.md
@@ -23,6 +23,8 @@ Use `SAPRead` when you need exact raw source, one method body, grep output, inac
 | `action` | string | No | `"diff"` — return a unified diff between two source versions on this system (only the hunks, not two full sources), using `from`/`to`. Source types only: `PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, DCLS, BDEF, SRVD, DDLX, TABL` (CDS views are `DDLS`; classic DDIC `VIEW` is unsupported — it has no plain-text source). Note: SAP only snapshots a version on transport *release*, so `from`/`to` revision ids are sparse — `active` vs `inactive` (pending unactivated changes) is the most reliable use. |
 | `from` | string | No | For `action="diff"`: OLD side — `"active"` (default), `"inactive"`, a revision id (from a VERSIONS response), or a full `/sap/bc/adt/` revision URI. |
 | `to` | string | No | For `action="diff"`: NEW side — defaults to `"inactive"`. Same accepted values as `from`. |
+| `fromLabel` | string | No | For `action="diff"`: optional display label for the OLD side in the summary and patch header, e.g. `DNT-6-6: Validate discounts (DS7K900123)`. Does not affect source resolution. |
+| `toLabel` | string | No | For `action="diff"`: optional display label for the NEW side in the summary and patch header, e.g. `active` or `inactive draft`. Does not affect source resolution. |
 | `format` | string | No | Output format: `"text"` (default) or `"structured"` (CLAS only, see below) |
 | `include` | string | No | For CLAS: `main`, `testclasses`, `definitions`, `implementations`, `macros`. For DDLS: `elements` (extract CDS view elements). |
 | `method` | string | No | For CLAS: method name to read (e.g., `get_name`), or `*` to list all methods |
@@ -123,6 +125,7 @@ SAPRead(type="VERSIONS", name="ZCL_X", include="definitions") — list revisions
 SAPRead(type="VERSION_SOURCE", versionUri="/sap/bc/adt/programs/programs/ZARC1_TEST_REPORT/source/main/versions/20260410185851/00000/content") — fetch source at one revision
 SAPRead(type="CLAS", name="ZCL_ORDER", action="diff")                       — diff active vs your inactive draft (pending changes)
 SAPRead(type="CLAS", name="ZCL_ORDER", action="diff", from="00001", to="active") — diff a revision against the active version
+SAPRead(type="CLAS", name="ZCL_ORDER", action="diff", from="00001", to="active", fromLabel="DNT-6-6 (DS7K900123)", toLabel="active") — readable diff headers
 SAPRead(type="TRAN", name="SE38")                — transaction metadata
 SAPRead(type="SOBJ", name="BUS2032")             — list BOR object methods
 SAPRead(type="BSP")                              — list all BSP/UI5 apps

--- a/src/adt/version-diff.ts
+++ b/src/adt/version-diff.ts
@@ -38,6 +38,8 @@ const DIFF_SUPPORTED_TYPES = [
 interface DiffOptions {
   include?: string;
   group?: string;
+  fromLabel?: string;
+  toLabel?: string;
 }
 
 /**
@@ -79,7 +81,9 @@ export async function getVersionDiff(
     resolveDiffSource(client, type, name, to, resolved, revList),
   ]);
 
-  return unifiedDiff(fromSrc, toSrc, `${name} (${from})`, `${name} (${to})`);
+  const fromDisplay = opts.fromLabel ?? from;
+  const toDisplay = opts.toLabel ?? to;
+  return unifiedDiff(fromSrc, toSrc, `${name} (${fromDisplay})`, `${name} (${toDisplay})`);
 }
 
 /** Resolve one diff ref to raw source text. */

--- a/src/handlers/read.ts
+++ b/src/handlers/read.ts
@@ -131,15 +131,23 @@ export async function handleSAPRead(
     if (!name) return errorResult('SAPRead action="diff" requires a "name".');
     const from = typeof args.from === 'string' && args.from ? args.from : 'active';
     const to = typeof args.to === 'string' && args.to ? args.to : 'inactive';
+    const fromLabel = typeof args.fromLabel === 'string' && args.fromLabel ? args.fromLabel : undefined;
+    const toLabel = typeof args.toLabel === 'string' && args.toLabel ? args.toLabel : undefined;
+    const fromDisplay = fromLabel ?? from;
+    const toDisplay = toLabel ?? to;
     try {
       const r = await getVersionDiff(client, type, name, from, to, {
         include: typeof args.include === 'string' ? args.include : undefined,
         group: typeof args.group === 'string' ? args.group : undefined,
+        fromLabel,
+        toLabel,
       });
       if (r.identical) {
-        return textResult(`No differences between ${from} and ${to} for ${type} ${name}.`);
+        return textResult(`No differences between ${fromDisplay} and ${toDisplay} for ${type} ${name}.`);
       }
-      return textResult(`Diff ${type} ${name}: ${from} → ${to}  (+${r.added} -${r.removed})\n\n${r.diff}`);
+      return textResult(
+        `Diff ${type} ${name}: ${fromDisplay} → ${toDisplay}  (+${r.added} -${r.removed})\n\n${r.diff}`,
+      );
     } catch (err) {
       if (isNotFoundError(err)) {
         return errorResult(

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -160,6 +160,10 @@ export const SAPReadSchema = z
     from: z.string().optional(),
     /** For action="diff": NEW side — defaults to "inactive". Same accepted values as from. */
     to: z.string().optional(),
+    /** For action="diff": optional display label for the OLD side. */
+    fromLabel: z.string().optional(),
+    /** For action="diff": optional display label for the NEW side. */
+    toLabel: z.string().optional(),
     include: z.string().optional(),
     group: z.string().optional(),
     method: z.string().optional(),
@@ -193,6 +197,10 @@ export const SAPReadSchemaBtp = z
     from: z.string().optional(),
     /** For action="diff": NEW side — defaults to "inactive". Same accepted values as from. */
     to: z.string().optional(),
+    /** For action="diff": optional display label for the OLD side. */
+    fromLabel: z.string().optional(),
+    /** For action="diff": optional display label for the NEW side. */
+    toLabel: z.string().optional(),
     include: z.string().optional(),
     group: z.string().optional(),
     method: z.string().optional(),

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -474,6 +474,16 @@ export function getToolDefinitions(
             description:
               'action="diff" NEW side (default "inactive" = pending unactivated changes). Same values as from.',
           },
+          fromLabel: {
+            type: 'string',
+            description:
+              'action="diff" optional display label for the OLD side in the summary and patch header, e.g. "DNT-6-6: Validate discounts (DS7K900123)". Does not affect source resolution.',
+          },
+          toLabel: {
+            type: 'string',
+            description:
+              'action="diff" optional display label for the NEW side in the summary and patch header, e.g. "active" or "inactive draft". Does not affect source resolution.',
+          },
           include: {
             type: 'string',
             description:

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -62,6 +62,14 @@
           "type": "string",
           "description": "action=\"diff\" NEW side (default \"inactive\" = pending unactivated changes). Same values as from."
         },
+        "fromLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the OLD side in the summary and patch header, e.g. \"DNT-6-6: Validate discounts (DS7K900123)\". Does not affect source resolution."
+        },
+        "toLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the NEW side in the summary and patch header, e.g. \"active\" or \"inactive draft\". Does not affect source resolution."
+        },
         "include": {
           "type": "string",
           "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -62,6 +62,14 @@
           "type": "string",
           "description": "action=\"diff\" NEW side (default \"inactive\" = pending unactivated changes). Same values as from."
         },
+        "fromLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the OLD side in the summary and patch header, e.g. \"DNT-6-6: Validate discounts (DS7K900123)\". Does not affect source resolution."
+        },
+        "toLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the NEW side in the summary and patch header, e.g. \"active\" or \"inactive draft\". Does not affect source resolution."
+        },
         "include": {
           "type": "string",
           "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -76,6 +76,14 @@
           "type": "string",
           "description": "action=\"diff\" NEW side (default \"inactive\" = pending unactivated changes). Same values as from."
         },
+        "fromLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the OLD side in the summary and patch header, e.g. \"DNT-6-6: Validate discounts (DS7K900123)\". Does not affect source resolution."
+        },
+        "toLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the NEW side in the summary and patch header, e.g. \"active\" or \"inactive draft\". Does not affect source resolution."
+        },
         "include": {
           "type": "string",
           "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -76,6 +76,14 @@
           "type": "string",
           "description": "action=\"diff\" NEW side (default \"inactive\" = pending unactivated changes). Same values as from."
         },
+        "fromLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the OLD side in the summary and patch header, e.g. \"DNT-6-6: Validate discounts (DS7K900123)\". Does not affect source resolution."
+        },
+        "toLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the NEW side in the summary and patch header, e.g. \"active\" or \"inactive draft\". Does not affect source resolution."
+        },
         "include": {
           "type": "string",
           "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -76,6 +76,14 @@
           "type": "string",
           "description": "action=\"diff\" NEW side (default \"inactive\" = pending unactivated changes). Same values as from."
         },
+        "fromLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the OLD side in the summary and patch header, e.g. \"DNT-6-6: Validate discounts (DS7K900123)\". Does not affect source resolution."
+        },
+        "toLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the NEW side in the summary and patch header, e.g. \"active\" or \"inactive draft\". Does not affect source resolution."
+        },
         "include": {
           "type": "string",
           "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -76,6 +76,14 @@
           "type": "string",
           "description": "action=\"diff\" NEW side (default \"inactive\" = pending unactivated changes). Same values as from."
         },
+        "fromLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the OLD side in the summary and patch header, e.g. \"DNT-6-6: Validate discounts (DS7K900123)\". Does not affect source resolution."
+        },
+        "toLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the NEW side in the summary and patch header, e.g. \"active\" or \"inactive draft\". Does not affect source resolution."
+        },
         "include": {
           "type": "string",
           "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -76,6 +76,14 @@
           "type": "string",
           "description": "action=\"diff\" NEW side (default \"inactive\" = pending unactivated changes). Same values as from."
         },
+        "fromLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the OLD side in the summary and patch header, e.g. \"DNT-6-6: Validate discounts (DS7K900123)\". Does not affect source resolution."
+        },
+        "toLabel": {
+          "type": "string",
+          "description": "action=\"diff\" optional display label for the NEW side in the summary and patch header, e.g. \"active\" or \"inactive draft\". Does not affect source resolution."
+        },
         "include": {
           "type": "string",
           "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."

--- a/tests/unit/handlers/read.test.ts
+++ b/tests/unit/handlers/read.test.ts
@@ -2045,6 +2045,29 @@ ENDCLASS.`;
       expect((text.match(/METHOD a\./g) ?? []).length).toBe(1);
     });
 
+    it('uses custom display labels in the diff summary and patch headers', async () => {
+      mockFetch.mockImplementation((url: unknown) =>
+        Promise.resolve(mockResponse(200, String(url).includes('version=inactive') ? INACTIVE_SRC : ACTIVE_SRC)),
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'CLAS',
+        name: 'ZCL_X',
+        action: 'diff',
+        from: 'active',
+        to: 'inactive',
+        fromLabel: 'DNT-6-6 (DS7K900123)',
+        toLabel: 'inactive draft',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const text = result.content[0]!.text;
+      expect(text).toContain('Diff CLAS ZCL_X: DNT-6-6 (DS7K900123) → inactive draft');
+      expect(text).toContain('--- ZCL_X (DNT-6-6 (DS7K900123))');
+      expect(text).toContain('+++ ZCL_X (inactive draft)');
+      expect(text).not.toContain('Diff CLAS ZCL_X: active → inactive');
+    });
+
     it('reports "No differences" when both sides are identical (e.g. no draft)', async () => {
       mockFetch.mockImplementation(() => Promise.resolve(mockResponse(200, ACTIVE_SRC)));
       const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
@@ -2054,6 +2077,25 @@ ENDCLASS.`;
       });
       expect(result.isError).toBeUndefined();
       expect(result.content[0]?.text).toBe('No differences between active and inactive for CLAS ZCL_X.');
+    });
+
+    it('uses custom display labels in the no-difference message', async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(mockResponse(200, ACTIVE_SRC)));
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'CLAS',
+        name: 'ZCL_X',
+        action: 'diff',
+        from: 'active',
+        to: 'inactive',
+        fromLabel: 'released transport',
+        toLabel: 'current active',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toBe(
+        'No differences between released transport and current active for CLAS ZCL_X.',
+      );
     });
 
     it('resolves a bare revision id via the VERSIONS feed', async () => {

--- a/tests/unit/handlers/schemas.test.ts
+++ b/tests/unit/handlers/schemas.test.ts
@@ -31,6 +31,34 @@ describe('SAPReadSchema', () => {
     if (result.success) expect(result.data.version).toBe('active');
   });
 
+  it('accepts diff display labels', () => {
+    const result = SAPReadSchema.safeParse({
+      type: 'CLAS',
+      name: 'ZCL_TEST',
+      action: 'diff',
+      from: '00001',
+      to: 'active',
+      fromLabel: 'DNT-6-6 (DS7K900123)',
+      toLabel: 'active',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fromLabel).toBe('DNT-6-6 (DS7K900123)');
+      expect(result.data.toLabel).toBe('active');
+    }
+
+    expect(
+      SAPReadSchemaBtp.safeParse({
+        type: 'CLAS',
+        name: 'ZCL_TEST',
+        action: 'diff',
+        fromLabel: 'inactive draft',
+        toLabel: 'active',
+      }).success,
+    ).toBe(true);
+  });
+
   it('accepts server-driven object types (DESD/EVTB/COTA — 816)', () => {
     expect(SAPReadSchema.safeParse({ type: 'DESD', name: 'DEMO_CDS_LOGICL_EXTERNL_SCHEMA' }).success).toBe(true);
     expect(SAPReadSchema.safeParse({ type: 'EVTB', name: 'S_BUSINESSPARTNER_CHANGE' }).success).toBe(true);


### PR DESCRIPTION
## Summary

Adds optional `fromLabel` and `toLabel` parameters to `SAPRead action="diff"` so callers can show readable transport/revision context in the diff summary and unified-diff headers without changing source resolution.

## Details

- Threads labels through the existing `getVersionDiff`/`unifiedDiff` path.
- Keeps the existing `from`/`to` defaults and source-fetch behavior unchanged when labels are omitted.
- Updates SAPRead schemas, LLM-visible tool definitions, docs, snapshots, and unit coverage.
- Adds a short research note and reviewed plan for the deep-feature workflow, including live smoke evidence.

## Validation

- `npx vitest run tests/unit/adt/source-diff.test.ts tests/unit/handlers/read.test.ts tests/unit/handlers/schemas.test.ts tests/unit/handlers/schema-key-sync.test.ts tests/unit/handlers/tool-definitions-snapshot.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run validate:policy`
- `npm run check:sizes`
- `npm test`
- `npm run build`
- `git diff --check`

## Live SAP Smoke

Read-only CLI checks against A4H / S/4HANA 2023:

- `SAPRead(type="VERSIONS", name="ZCL_SSI_UNIT_HOOKS", objectType="CLAS")` returned revision `00000` with `versionTitle` `ZSSI_IMPORTER extension hooks (Tier 1+2)`.
- Labeled `SAPRead action="diff"` from `00000` to `active` returned `(+2 -28)` and patch headers using `ZSSI_IMPORTER extension hooks (Tier 1+2)` / `active`.
- Unlabeled `SAPRead action="diff"` from `00000` to `active` preserved default summary/header labels `00000` / `active`.
- Labeled `active` to `active` diff returned: `No differences between active baseline and active comparison for CLAS ZCL_SSI_UNIT_HOOKS.`
