### PR TITLE
test: verify RAP-stack (BDEF/SRVD/SRVB) cloud create on BTP

### DIFF
--- a/docs/research/2026-06-27-btp-rap-create-verification.md
+++ b/docs/research/2026-06-27-btp-rap-create-verification.md
@@ -1,0 +1,110 @@
+# BTP RAP-Stack Create (BDEF / SRVD / SRVB) — Live Verification & Plan
+
+**Date:** 2026-06-27
+**System:** BTP ABAP Environment `H01`, SAP_BASIS **919**, region us10, user `marian@zeis.de` (`SAP_BR_DEVELOPER`).
+**Base:** `origin/main` @ `515b91fd` (PR #522, the cloud-create fix).
+**Companion:** `2026-06-26-btp-object-create-fix.md` (#522 — the create path this builds on).
+**Method:** live ADT POSTs with a real dev JWT, driving ARC-1's create body + content-type through the dist HTTP/CSRF layer.
+
+---
+
+## Goal & premise
+
+The #522 review left item #2: *"RAP create (BDEF/SRVD/SRVB) on BTP is unverified and likely broken — BTP is RAP-first."* This feature pins the real behavior and ships the smallest correct change.
+
+## Verified ADT contracts (SAP source: `~/DEV/arc-1-eclipse-adt/api/01-rap-object-types-and-uris.md`)
+
+| Type | Create collection (POST) | ARC-1 content type (`createContentTypeForType`) | Body builder |
+|------|--------------------------|--------------------------------|--------------|
+| BDEF | `/sap/bc/adt/bo/behaviordefinitions` | `application/vnd.sap.adt.blues.v1+xml` | `blue:blueSource` (BDEF/BDO) |
+| SRVD | `/sap/bc/adt/ddic/srvd/sources` | `application/*` | `srvd:srvdSource` (SRVD/SRV, `srvd:srvdSourceType="S"`) |
+| SRVB | `/sap/bc/adt/businessservices/bindings` | `application/*` (special-cased) | `srvb:serviceBinding` (SRVB/SVB) via `buildServiceBindingXml` |
+
+`abapLanguageVersion` is **not documented** anywhere in the Eclipse ADT api docs or the reference impls (`mcp-abap-adt*`, `vibing-steampunk`) — they are on-prem-shaped. So cloud behavior is **empirical only**.
+
+## How the post-#522 code already treats these types
+
+`buildCreateXml(type, …, cloud=true)` wraps every body in `cloudifyCreateBody` (`src/handlers/write-helpers.ts`), which is **generic**:
+- strips `adtcore:masterSystem="H00"`,
+- strips `adtcore:responsible="…"`,
+- inserts `adtcore:abapLanguageVersion="cloudDevelopment"` after `adtcore:masterLanguage`.
+
+All three RAP bodies carry `masterLanguage`/`responsible` (BDEF/SRVD also `masterSystem`), so cloudify **already rewrites them**. The open question (from the INTF precedent, where `application/*` + cloud language-version → HTTP 500 "ABAP language version is not allowed in this software component"): does adding `abapLanguageVersion` break BDEF/SRVD/SRVB?
+
+## Live findings (BTP 919, this session)
+
+### Deserialize check — POST to structure package `ZLOCAL` (correct body → 409 "structure package"; wrong body → 400/500 earlier)
+
+| Type | +abapLanguageVersion | no abapLanguageVersion |
+|------|----------------------|------------------------|
+| BDEF | 409 structure-package (body OK) | 409 structure-package (body OK) |
+| SRVD | 409 structure-package (body OK) | 409 structure-package (body OK) |
+| SRVB | 409 structure-package (body OK) | 409 structure-package (body OK) |
+
+No 400 deserialize, no 500 language-version at this stage; `abapLanguageVersion` made no difference.
+
+### Full create — POST to writable dev package `ZARC1_TEST` (then deleted)
+
+| Type | +abapLanguageVersion | no abapLanguageVersion |
+|------|----------------------|------------------------|
+| BDEF | **201 CREATED ✅** | **201 CREATED ✅** |
+| SRVD | **201 CREATED ✅** | **201 CREATED ✅** |
+| SRVB | **201 CREATED ✅** (with dummy serviceDefinition ref) | **201 CREATED ✅** |
+
+**All three RAP types create successfully on BTP 919, with and without `abapLanguageVersion`.** The software-component language-version check (that 500'd INTF under `application/*`) does **not** fire for these types — their content types (`blues.v1` for BDEF, `application/*` for SRVD/SRVB) route to STs that accept the cloud body. All 6 probe objects were created and deleted; **no orphans** (verified by search).
+
+### Error-classification observation (adjacent)
+
+Creating a RAP object into a **structure** package returns `409 ExceptionResourceLockConflict` "Structure packages cannot contain development objects" — a **different** exception type than CLAS's `403 ExceptionResourceNoAccess`. Tracing `classifySapDomainError` (`src/adt/errors.ts`, post-#522): the SM12 lock-hint path requires a `lockPattern` match (it doesn't match "structure package"), and the #522 friendly-hint path is gated on `ExceptionResourceNoAccess`. So the RAP case **passes through with SAP's raw (clear) message and no misleading SM12 hint** — *not a bug*, just less friendly than CLAS's "create a regular sub-package" guidance.
+
+## Conclusion (ponytail)
+
+**The create body is already cloud-correct for BDEF/SRVD/SRVB — no production-code change is required to make RAP create work.** The genuine gap from the #522 review is **missing verification/coverage**, not broken code. So:
+
+- **Rung 1 (does the fix need to exist?):** No code fix for the create body. ✋
+- **Deliverable:** regression-locking **tests** + **docs** that this works, so a future cloudify change can't silently break RAP create.
+- **Optional (tiny):** extend #522's structure-package friendly hint to the RAP `ExceptionResourceLockConflict` type for cross-type consistency — safe because it stays guarded by the structure-package markers + `!lockPattern`.
+
+---
+
+## Plan
+
+### Affected files
+| File | Change | Why |
+|------|--------|-----|
+| `tests/unit/handlers/build-create-xml-cloud.test.ts` | Add BDEF/SRVD/SRVB cases: cloud body has **no** `adtcore:responsible`/`masterSystem`, **has** `abapLanguageVersion="cloudDevelopment"`; on-prem body unchanged | Deterministic regression guard for the cloudify contract on RAP types (no live system needed) |
+| `tests/integration/btp-abap.integration.test.ts` | Extend "BTP object-create path": (a) body-acceptance for BDEF/SRVD/SRVB against the structure package (reaches package-assignment, not a 400/500); (b) full create→delete in `TEST_BTP_PACKAGE` when set | Live proof RAP create works on cloud; mirrors the existing CLAS pattern |
+| `docs_page/btp-abap-environment.md` | One line: RAP objects (BDEF/SRVD/SRVB) create is supported on the ABAP Environment | As-shipped user doc |
+| `docs/research/2026-06-27-btp-rap-create-verification.md` | This dossier | Durable evidence |
+| *(optional)* `src/adt/errors.ts` + `tests/unit/adt/errors.test.ts` | Add `ExceptionResourceLockConflict` to the structure-package friendly-hint guard (kept behind the structure-package markers + `!lockPattern`) | Cross-type consistency with #522 G-4 |
+
+### Non-goals
+- No change to `cloudifyCreateBody`/`createContentTypeForType` (already correct for RAP — proven live).
+- No full RAP **activation** test: an empty BDEF/SRVD shell can't activate on any system (needs a real root entity + behavior source + service exposure). That is a RAP-scenario concern, not a create-body concern; the 201-create + deserialize checks are the create-correctness equivalents of #522's CLAS proof.
+- SRVB **update** path on BTP stays a #522 follow-up (out of scope).
+
+### Test commands
+```bash
+npm test -- build-create-xml-cloud          # unit (no SAP)
+# live (needs dev JWT; client_credentials is rejected by ADT):
+TEST_BTP_SERVICE_KEY_FILE=~/.config/arc-1/btp-abap-service-key.json \
+TEST_BTP_ACCESS_TOKEN=<dev-jwt> TEST_BTP_PACKAGE=ZARC1_TEST \
+  npm run test:integration:btp -- -t "object-create path"
+```
+
+### Risk / release
+- Tests + docs → `test:`/`docs:` (no release).
+- Cloud-only; on-prem create bodies are untouched (cloudify is `cloud`-gated).
+
+## Codex review (2026-06-27) — applied
+
+An adversarial Codex pass confirmed **no production-code gap** and found 4 test-quality issues; all addressed in the same commit (tests only):
+
+- **#1 (MEDIUM) structure-package false-green — FIXED.** The body-acceptance assertion allowed `[403, 409]` with loose markers (`/package/`, `/authoriz/`); an unrelated 403 could pass. Tightened to the specific markers `/structure package/` + `/cannot contain development objects/`, and broadened the negative checks (`System expected the element`, `Unsupported Media Type`, `not acceptable`).
+- **#2 (MEDIUM) stale-object risk — FIXED.** Body-check objects now use `generateUniqueName(prefix)` (not a fixed name) and clean up in a `finally` with a `created` flag — so a prior run can't be silently re-deleted in the 409-expected path, masking the probe.
+- **#3 (LOW) `_package` fidelity — FIXED.** The handler (`src/handlers/write/create.ts` `needsPackageParam`) sends `?_package=` only for BDEF (and TABL*); SRVD/SRVB carry the target via the body `packageRef` only. The test now mirrors this per-type (`needsPackage`). **Re-verified live on H01: SRVD/SRVB create→delete green without `_package`.**
+- **#4 (LOW) negative checks — FIXED** alongside #1.
+
+Confirmed *not* real issues: RAP needs no `cloudify`/content-type special-case; `abapLanguageVersion` is harmless on RAP (live-proven); direct-facade test layer matches #522; the SRVB dummy `serviceDefinition` does not mask body shape; three-file schema sync N/A (BDEF/SRVD/SRVB already in `tools.ts`/`schemas.ts`, no surface change).
+
+Post-fix: unit + typecheck + lint green; **live BTP RAP suite 6/6 on H01**; no orphans.

--- a/docs_page/btp-abap-environment.md
+++ b/docs_page/btp-abap-environment.md
@@ -389,7 +389,7 @@ Without this flag, ARC-1 auto-detects the system type on the first `SAPManage pr
 
 ## Writing objects on BTP
 
-Object create/update works on the ABAP Environment (live-verified: `CLAS create → activate → read → delete`). ARC-1 emits the **cloud-correct** create body automatically when the system type is `btp` — it drops the on-prem `adtcore:masterSystem`/`adtcore:responsible` and adds `abapLanguageVersion="cloudDevelopment"`; the object owner is taken from your JWT. Two prerequisites:
+Object create/update works on the ABAP Environment (live-verified: `CLAS create → activate → read → delete`). ARC-1 emits the **cloud-correct** create body automatically when the system type is `btp` — it drops the on-prem `adtcore:masterSystem`/`adtcore:responsible` and adds `abapLanguageVersion="cloudDevelopment"`; the object owner is taken from your JWT. The same cloud-correct body covers the **RAP stack — BDEF, SRVD and SRVB create is live-verified on the ABAP Environment** (they keep their existing content types; no extra handling needed). Two prerequisites:
 
 1. **Enable writes** — `SAP_ALLOW_WRITES=true`.
 2. **Target a real development package** — the booster-provided `ZLOCAL` is a *structure* package that cannot contain development objects, and `$TMP` does not exist on BTP. Create a development **sub-package under `ZLOCAL`** in ADT/Eclipse (e.g. `ZARC1_DEV`, software component `ZLOCAL`), then point the allowlist at it:

--- a/tests/integration/btp-abap.integration.test.ts
+++ b/tests/integration/btp-abap.integration.test.ts
@@ -564,4 +564,137 @@ describeIf('BTP ABAP Environment Integration Tests', () => {
       },
     );
   });
+
+  // ─── BTP-Specific: RAP object-create path (BDEF/SRVD/SRVB) ──────────────
+  //
+  // RAP create bodies are corrected by the same generic cloudify as CLAS/INTF (no adtcore:responsible,
+  // no masterSystem, +abapLanguageVersion="cloudDevelopment"). Live-verified on BTP 919: all three
+  // create (201) with their existing content types — no INTF-style override needed. A structure package
+  // rejects them at package-assignment with 409 "cannot contain development objects" (RAP surfaces
+  // ExceptionResourceLockConflict/409, unlike CLAS's ExceptionResourceNoAccess/403).
+  describe('BTP RAP object-create path (BDEF/SRVD/SRVB)', () => {
+    // needsPackage mirrors the handler (src/handlers/write/create.ts `needsPackageParam`): only BDEF
+    // (and TABL*) get the ?_package= query param; SRVD/SRVB carry the target solely via the body's
+    // packageRef. We exercise the same per-type path the product actually uses.
+    const RAP: {
+      type: string;
+      base: string;
+      prefix: string;
+      needsPackage: boolean;
+      props?: Record<string, unknown>;
+    }[] = [
+      { type: 'BDEF', base: '/sap/bc/adt/bo/behaviordefinitions', prefix: 'ZBD_ARC1_BTP', needsPackage: true },
+      { type: 'SRVD', base: '/sap/bc/adt/ddic/srvd/sources', prefix: 'ZSD_ARC1_BTP', needsPackage: false },
+      {
+        type: 'SRVB',
+        base: '/sap/bc/adt/businessservices/bindings',
+        prefix: 'ZSB_ARC1_BTP',
+        needsPackage: false,
+        props: { serviceDefinition: 'ZSRVD_DUMMY', bindingType: 'ODATA V2 UI', category: '0' },
+      },
+    ];
+    const structurePkg = process.env.TEST_BTP_STRUCTURE_PACKAGE || 'ZLOCAL';
+    const writablePkg = process.env.TEST_BTP_PACKAGE;
+
+    for (const r of RAP) {
+      it(`${r.type} cloud create body is accepted (deserializes past the create ST)`, async () => {
+        const name = generateUniqueName(r.prefix); // unique → never re-deletes a stale object before probing
+        const responsible = await client.getEffectiveUser();
+        const body = buildCreateXml(
+          r.type,
+          name,
+          structurePkg,
+          `ARC-1 BTP ${r.type} body check`,
+          r.props,
+          'EN',
+          responsible,
+          true,
+        );
+        // The cloud body must be ABAP-for-Cloud and carry no responsible (owner comes from the JWT).
+        expect(body).not.toContain('adtcore:responsible');
+        expect(body).toContain('adtcore:abapLanguageVersion="cloudDevelopment"');
+        const objectUrl = `${r.base}/${name.toLowerCase()}`;
+        let created = false;
+        try {
+          await createObject(
+            client.http,
+            client.safety,
+            r.base,
+            body,
+            createContentTypeForType(r.type, true),
+            undefined,
+            r.needsPackage ? structurePkg : undefined,
+            '919',
+            'btp',
+            name,
+          );
+          // structurePkg happened to be writable — a successful create is itself proof the body is
+          // accepted; clean up in finally.
+          created = true;
+        } catch (err) {
+          // Decisive: the cloud body deserialized — it did NOT fail at the create ST, the cloud
+          // language-version check, or content-type negotiation. A structure package then rejects it at
+          // package-assignment with a specific, unambiguous message (a status-only assert could false-green).
+          const msg = err instanceof Error ? err.message : String(err);
+          expect(msg).not.toMatch(/deserializ|transformation program|System expected the element/i);
+          expect(msg).not.toMatch(/language version|Unsupported Media Type|not acceptable/i);
+          expectSapFailureClass(err, [403, 409], [/structure package/i, /cannot contain development objects/i]);
+        } finally {
+          if (created) {
+            // best-effort-cleanup
+            try {
+              await client.http.withStatefulSession(async (session) => {
+                const lock = await lockObject(session, client.safety, objectUrl, 'MODIFY', '919', 'btp');
+                await deleteObject(session, client.safety, objectUrl, lock.lockHandle, lock.corrNr || undefined);
+              });
+            } catch {
+              // leave the object; a follow-up run reuses a fresh unique name
+            }
+          }
+        }
+      });
+    }
+
+    // Full create→delete needs a writable, regular (non-structure) cloud package via TEST_BTP_PACKAGE.
+    // (Activation is out of scope: an empty RAP shell can't activate on any system — it needs a real
+    // root entity + behavior source + service exposure, a RAP-scenario concern, not a create-body one.)
+    for (const r of RAP) {
+      (writablePkg ? it : it.skip)(`${r.type} create → delete in a cloud package`, async () => {
+        const pkg = writablePkg as string;
+        const name = generateUniqueName(r.prefix);
+        const objectUrl = `${r.base}/${name.toLowerCase()}`;
+        const responsible = await client.getEffectiveUser();
+        const body = buildCreateXml(r.type, name, pkg, `ARC-1 BTP ${r.type} create`, r.props, 'EN', responsible, true);
+        let created = false;
+        try {
+          await createObject(
+            client.http,
+            client.safety,
+            r.base,
+            body,
+            createContentTypeForType(r.type, true),
+            undefined,
+            r.needsPackage ? pkg : undefined,
+            '919',
+            'btp',
+            name,
+          );
+          created = true;
+        } finally {
+          if (created) {
+            // best-effort-cleanup
+            try {
+              await client.http.withStatefulSession(async (session) => {
+                const lock = await lockObject(session, client.safety, objectUrl, 'MODIFY', '919', 'btp');
+                await deleteObject(session, client.safety, objectUrl, lock.lockHandle, lock.corrNr || undefined);
+              });
+            } catch {
+              // leave the object; a follow-up run reuses a fresh unique name
+            }
+          }
+        }
+        expect(created).toBe(true);
+      });
+    }
+  });
 });

--- a/tests/unit/handlers/build-create-xml-cloud.test.ts
+++ b/tests/unit/handlers/build-create-xml-cloud.test.ts
@@ -27,6 +27,13 @@ describe('buildCreateXml — cloud mode (G-3)', () => {
       expect(xml).not.toContain('abapLanguageVersion');
       expect(xml).not.toContain('class:final');
     });
+
+    it('BDEF (RAP) keeps masterSystem + responsible and omits the cloud attributes', () => {
+      const xml = buildCreateXml('BDEF', 'ZBD_X', 'ZPKG', 'desc', undefined, 'EN', 'MARIAN', false);
+      expect(xml).toContain('adtcore:masterSystem="H00"');
+      expect(xml).toContain('adtcore:responsible="MARIAN"');
+      expect(xml).not.toContain('abapLanguageVersion');
+    });
   });
 
   describe('cloud (cloud=true)', () => {
@@ -70,6 +77,35 @@ describe('buildCreateXml — cloud mode (G-3)', () => {
       expect(xml).not.toContain('responsible');
       expect(xml).toContain('adtcore:abapLanguageVersion="cloudDevelopment"');
     });
+
+    it('BDEF (RAP behavior definition) drops masterSystem + responsible and adds the cloud language version', () => {
+      const xml = buildCreateXml('BDEF', 'ZBD_X', 'ZPKG', 'desc', undefined, 'EN', 'marian@zeis.de', true);
+      expect(xml).not.toContain('masterSystem');
+      expect(xml).not.toContain('responsible');
+      expect(xml).toContain('adtcore:abapLanguageVersion="cloudDevelopment"');
+    });
+
+    it('SRVD (service definition) drops masterSystem + responsible and adds the cloud language version', () => {
+      const xml = buildCreateXml('SRVD', 'ZSRVD_X', 'ZPKG', 'desc', undefined, 'EN', 'marian@zeis.de', true);
+      expect(xml).not.toContain('masterSystem');
+      expect(xml).not.toContain('responsible');
+      expect(xml).toContain('adtcore:abapLanguageVersion="cloudDevelopment"');
+    });
+
+    it('SRVB (service binding) drops responsible and adds the cloud language version', () => {
+      const xml = buildCreateXml(
+        'SRVB',
+        'ZSB_X',
+        'ZPKG',
+        'desc',
+        { serviceDefinition: 'ZSRVD_X' },
+        'EN',
+        'marian@zeis.de',
+        true,
+      );
+      expect(xml).not.toContain('responsible');
+      expect(xml).toContain('adtcore:abapLanguageVersion="cloudDevelopment"');
+    });
   });
 });
 
@@ -109,6 +145,12 @@ describe('createContentTypeForType — cloud INTF content-type (review fix)', ()
 
   it('does not change CLAS (works with application/* on cloud)', () => {
     expect(createContentTypeForType('CLAS', true)).toBe('application/*');
+  });
+
+  it('needs no cloud override for RAP types (live-verified 919: BDEF/SRVD/SRVB create 201 as-is)', () => {
+    expect(createContentTypeForType('BDEF', true)).toBe('application/vnd.sap.adt.blues.v1+xml');
+    expect(createContentTypeForType('SRVD', true)).toBe('application/*');
+    expect(createContentTypeForType('SRVB', true)).toBe('application/*');
   });
 });
 


### PR DESCRIPTION
## What

Verifies and locks in **RAP-stack object create (BDEF / SRVD / SRVB) on the SAP BTP ABAP Environment** — the "left" item #2 from the #522 review.

## Why / finding

The #522 review flagged RAP create as *"unverified on BTP, likely broken"*. **Live verification on BTP H01 (SAP_BASIS 919) disproves "broken":** the generic `cloudifyCreateBody` added in #522 already emits correct cloud bodies for BDEF/SRVD/SRVB — all three **create (HTTP 201)** in a writable cloud package with their existing content types (BDEF `blues.v1+xml`, SRVD/SRVB `application/*`), with and without `abapLanguageVersion`, no 400 deserialize and no INTF-style 500. So the gap was **coverage, not code** — this PR is **tests + docs only, no `src/` change**.

## Changes
- **unit** (`build-create-xml-cloud.test.ts`): RAP cloudify contract (drops `responsible`/`masterSystem`, adds `abapLanguageVersion`) + content-types stay as-is on cloud; on-prem BDEF body unchanged.
- **integration** (`btp-abap.integration.test.ts`): new `BTP RAP object-create path` — per-type body-acceptance (deserializes past the create ST; a structure package rejects with `409 ExceptionResourceLockConflict`, unlike CLAS's `403`) + full create→delete gated on `TEST_BTP_PACKAGE`. Mirrors the handler's per-type `_package` behavior (`needsPackageParam`: BDEF only).
- **docs**: `btp-abap-environment.md` notes RAP create is verified; research dossier `docs/research/2026-06-27-btp-rap-create-verification.md`.

## Verification
- `typecheck`, `lint`, **4154 unit tests**, `check:sizes`, `validate:policy` — all green.
- **Live BTP H01 (919): RAP integration suite 6/6** (BDEF/SRVD/SRVB body-acceptance + create→delete in `ZARC1_TEST`); no orphan objects left.
- Adversarial **Codex review applied** (tests-only): strict structure-package marker (no status-only false-green), unique names + `finally` cleanup, and `_package` fidelity mirrored to the handler (SRVD/SRVB re-verified live without `_package`).

## Out of scope
RAP **activation** (an empty shell can't activate anywhere — needs a full RAP scenario) and the SRVB **update** path (a #522 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
