### PR TITLE
fix: serve just-activated source on next read without force_refresh

### DIFF
--- a/scripts/ci/check-file-sizes.mjs
+++ b/scripts/ci/check-file-sizes.mjs
@@ -38,9 +38,9 @@ const BUDGETS = {
   // + ST05 SQL-trace control (#510) + clientWait split. Split out a perf/trace module if it grows much further.
   'src/adt/diagnostics.ts': 1845,
   // The ADT client facade aggregates every read/write op; set_api_state (#506) + runQueryWithMetrics
-  // (SAPQuery metrics) + getEffectiveUser (BTP JWT-derived user, G-5) pushed it past the default.
-  // Keep tight headroom.
-  'src/adt/client.ts': 1585,
+  // (SAPQuery metrics) + getEffectiveUser (BTP JWT-derived user, G-5) + getSourceAtObjectUrl
+  // (post-activation cache promotion) pushed it past the default. Keep tight headroom.
+  'src/adt/client.ts': 1600,
 };
 
 const DEFAULT_SRC = 1500;

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -417,6 +417,16 @@ export class AdtClient {
     return this.fetchSource(`/sap/bc/adt/programs/programs/${encodeURIComponent(name)}/source/main`, opts);
   }
 
+  /** Read the `/source/main` body under an object's base ADT URL (version-aware).
+   *  Type-agnostic: the caller supplies the already-resolved object URL. Used by SAPActivate
+   *  to capture the inactive draft so it can be promoted to the active cache slot after a
+   *  successful activation (the active version equals the draft byte-for-byte for source
+   *  objects), sidestepping the backend's read-after-activate consistency lag. */
+  async getSourceAtObjectUrl(objectBaseUrl: string, opts?: SourceReadOptions): Promise<SourceReadResult> {
+    checkOperation(this.safety, OperationType.Read, 'GetSource');
+    return this.fetchSource(`${objectBaseUrl}/source/main`, opts);
+  }
+
   /** Get class source code (main include by default) */
   async getClass(name: string, include?: string, opts?: SourceReadOptions): Promise<SourceReadResult> {
     checkOperation(this.safety, OperationType.Read, 'GetClass');

--- a/src/cache/caching-layer.ts
+++ b/src/cache/caching-layer.ts
@@ -63,9 +63,29 @@ export interface CacheActivityEntry {
   detail?: string;
 }
 
+/** How long after a successful activation the active source cache is treated as authoritative.
+ *  During this window the active read is served from the promoted draft WITHOUT revalidating
+ *  against SAP, and the "unactivated draft" note is suppressed — both defeat the backend's
+ *  read-after-activate consistency lag (observed on BTP/Steampunk) that otherwise serves a
+ *  stale/empty shell until force_refresh. Must comfortably exceed the inactive-list TTL (60s)
+ *  so a list re-fetched mid-lag cannot outlive it. Cleared early by any write/force_refresh
+ *  (which route through invalidate()). ponytail: fixed window; a backend that lags >2min would
+ *  need a real consistency signal instead. Residual gap: a non-invalidating mutator (SAPGit
+ *  pull / SAPTransport import) to the same object within the window is masked until it expires —
+ *  rare and gated; use force_refresh to see such an external change immediately. */
+const ACTIVATION_FRESH_MS = 120_000;
+
+interface ActivationFreshness {
+  until: number;
+  /** Whether a draft source was promoted into the active slot (vs. only note-suppression). */
+  promoted: boolean;
+}
+
 export class CachingLayer {
   readonly cache: Cache;
   readonly inactiveLists = new InactiveListCache();
+  /** (TYPE:NAME) → activation freshness, set by markActivated() after a successful SAPActivate. */
+  private readonly recentlyActivated = new Map<string, ActivationFreshness>();
   private warmupDone = false;
   private readonly activityEntries: CacheActivityEntry[] = [];
   private readonly activityCounts: Partial<Record<CacheActivityEvent, number>> = {};
@@ -101,6 +121,27 @@ export class CachingLayer {
     opts: { version?: 'active' | 'inactive' } = {},
   ): Promise<{ source: string; hit: boolean; revalidated: boolean }> {
     const version = opts.version ?? 'active';
+
+    // Post-activation consistency guard: right after a successful activation the active
+    // version equals the draft we promoted into cache, but the backend's active /source/main
+    // can briefly still serve the pre-activation (empty) shell. Serve the promoted source
+    // directly — no revalidation — until the freshness window expires. See ACTIVATION_FRESH_MS.
+    if (version === 'active' && this.isActivationFresh(objectType, objectName)) {
+      const promoted = this.cache.getSource(objectType, objectName, 'active');
+      if (promoted) {
+        this.recordActivity('source_hit', {
+          objectType,
+          objectName,
+          version,
+          hash: promoted.hash,
+          sourceLength: promoted.source.length,
+          etagPresent: !!promoted.etag,
+          detail: 'post-activation source (consistency guard)',
+        });
+        return { source: promoted.source, hit: true, revalidated: false };
+      }
+    }
+
     const cached = this.cache.getSource(objectType, objectName, version);
     if (!cached) {
       this.recordActivity('source_miss', {
@@ -275,7 +316,66 @@ export class CachingLayer {
     logger.debug(`[cache] invalidate ${objectType}:${objectName}:${version}`);
     const removed = this.countSourceEntries(objectType, objectName, version);
     this.cache.invalidateSource(objectType, objectName, version);
+    // Any explicit invalidation (write, delete, force_refresh) means "give me the truth" —
+    // drop the post-activation freshness guard so a fresh draft/read is never masked by it.
+    this.recentlyActivated.delete(activationKey(objectType, objectName));
     this.recordActivity('source_invalidate', { objectType, objectName, version, removed });
+  }
+
+  // ─── Post-Activation Freshness ────────────────────────────────────
+
+  /**
+   * Record a successful activation so the next active read returns the just-activated source
+   * without being clobbered by a lagging backend (see ACTIVATION_FRESH_MS).
+   *
+   * When `promotedSource` is provided it is written to the active slot (and the inactive draft
+   * dropped) — this is the authoritative content for source objects, whose active version equals
+   * the draft byte-for-byte. When omitted (draft unavailable / non-source type) only the
+   * "unactivated draft" note is suppressed; the active source falls back to a normal fetch.
+   */
+  markActivated(objectType: string, objectName: string, promotedSource?: string): void {
+    if (promotedSource !== undefined) {
+      this.cache.putSource(objectType, objectName, promotedSource, { version: 'active' });
+      this.cache.invalidateSource(objectType, objectName, 'inactive');
+    }
+    const now = Date.now();
+    // Opportunistic sweep so the map can't accumulate expired entries on a long-lived server
+    // (activations are infrequent, so the O(n) cost is negligible).
+    for (const [k, v] of this.recentlyActivated) {
+      if (now >= v.until) this.recentlyActivated.delete(k);
+    }
+    this.recentlyActivated.set(activationKey(objectType, objectName), {
+      until: now + ACTIVATION_FRESH_MS,
+      promoted: promotedSource !== undefined,
+    });
+    this.recordActivity('source_refresh', {
+      objectType,
+      objectName,
+      version: 'active',
+      sourceLength: promotedSource?.length,
+      detail: promotedSource !== undefined ? 'promoted activated draft' : 'activation (note-suppress only)',
+    });
+  }
+
+  /** Whether the object was activated within the freshness window (used to suppress the draft note). */
+  wasRecentlyActivated(objectType: string, objectName: string): boolean {
+    return this.activationFreshness(objectType, objectName) !== undefined;
+  }
+
+  /** Whether a promoted active source should be served without revalidation. */
+  private isActivationFresh(objectType: string, objectName: string): boolean {
+    return this.activationFreshness(objectType, objectName)?.promoted === true;
+  }
+
+  private activationFreshness(objectType: string, objectName: string): ActivationFreshness | undefined {
+    const key = activationKey(objectType, objectName);
+    const entry = this.recentlyActivated.get(key);
+    if (!entry) return undefined;
+    if (Date.now() >= entry.until) {
+      this.recentlyActivated.delete(key);
+      return undefined;
+    }
+    return entry;
   }
 
   // ─── Reverse Dependencies (Pre-warmer only) ───────────────────────
@@ -340,4 +440,9 @@ export class CachingLayer {
     }
     this.activityCounts[event] = (this.activityCounts[event] ?? 0) + 1;
   }
+}
+
+/** Key for the post-activation freshness map (version-independent: one entry per object). */
+function activationKey(objectType: string, objectName: string): string {
+  return `${objectType.toUpperCase()}:${objectName.toUpperCase()}`;
 }

--- a/src/handlers/activate.ts
+++ b/src/handlers/activate.ts
@@ -27,6 +27,68 @@ import {
 
 // ─── SAPActivate Handler ─────────────────────────────────────────────
 
+/** Source-text object types whose active /source/main equals the inactive draft byte-for-byte
+ *  after activation, so the draft can be promoted into the active cache slot. DDIC/server-driven
+ *  and binding (SRVB) types are excluded — they round-trip differently and best-effort capture
+ *  would just fall back to plain invalidation anyway. */
+const ACTIVATE_PROMOTE_TYPES = new Set([
+  'CLAS',
+  'INTF',
+  'PROG',
+  'INCL',
+  'FUNC',
+  'DDLS',
+  'DCLS',
+  'BDEF',
+  'SRVD',
+  'DDLX',
+]);
+
+/** Best-effort: read the inactive draft (the about-to-be-active content) BEFORE activation, so it
+ *  can be promoted into the active cache after success. Reading the stable draft now — rather than
+ *  the post-activation active version — sidesteps the backend read-after-activate consistency lag.
+ *  Returns undefined on any failure or empty body (caller then falls back to plain invalidation). */
+async function captureDraftForPromotion(
+  client: AdtClient,
+  type: string,
+  objectUrl: string,
+): Promise<string | undefined> {
+  if (!ACTIVATE_PROMOTE_TYPES.has(type)) return undefined;
+  try {
+    const { source } = await client.getSourceAtObjectUrl(objectUrl, { version: 'inactive' });
+    return typeof source === 'string' && source.trim() !== '' ? source : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Update the cache after a successful activation: promote the captured draft into the active slot
+ *  when available, otherwise drop stale entries. Either way mark the object freshly-activated so the
+ *  next read isn't masked by the backend's read-after-activate lag (stale active source / sticky
+ *  "unactivated draft" note).
+ *
+ *  Under principal propagation the freshness guard + note-suppression are keyed by object (not by
+ *  user), so they must NOT be shared across identities — one user's activation would otherwise hide
+ *  another user's own draft. PP clients fall back to plain invalidation (the source-cache body is
+ *  already process-shared, but the active version is global so that stays correct). The lag-defeating
+ *  promotion applies to single-identity servers (stdio / shared service user / bearer token), which
+ *  is how the bug reproduces. */
+function applyActivationToCache(
+  cachingLayer: CachingLayer | undefined,
+  type: string,
+  name: string,
+  draft: string | undefined,
+  perUserClient: boolean,
+): void {
+  if (!cachingLayer) return;
+  if (perUserClient) {
+    cachingLayer.invalidate(type, name, 'all');
+    return;
+  }
+  if (draft === undefined) cachingLayer.invalidate(type, name, 'all');
+  cachingLayer.markActivated(type, name, draft);
+}
+
 export async function handleSAPActivate(
   client: AdtClient,
   args: Record<string, unknown>,
@@ -151,6 +213,9 @@ export async function handleSAPActivate(
   const type = normalizeObjectType(String(args.type ?? ''));
   const preaudit = args.preaudit !== undefined ? Boolean(args.preaudit) : undefined;
   const activateOpts = preaudit !== undefined ? { preaudit } : undefined;
+  // Post-activation cache promotion + freshness guard are object-keyed (not user-keyed); disable
+  // them for per-user (principal-propagation) clients. See applyActivationToCache.
+  const perUserClient = cacheSecurity.isPerUserClient;
 
   if (args.objects && Array.isArray(args.objects)) {
     const rawObjects = args.objects as Array<Record<string, unknown>>;
@@ -201,14 +266,20 @@ export async function handleSAPActivate(
       await enforceAllowedPackageForObjectUrl(client, o.url, `Activation of ${o.type} '${o.name}'`);
     }
 
+    // Capture each object's inactive draft before the batch flips them to active.
+    const drafts =
+      cachingLayer && !perUserClient
+        ? await Promise.all(objects.map((o) => captureDraftForPromotion(client, o.type, o.url)))
+        : [];
+
     const result = await activateBatch(client.http, client.safety, objects, activateOpts);
     const names = objects.map((o) => o.name).join(', ');
     const batchStatuses = buildBatchActivationStatuses(objects, result);
     const statusDetails = formatBatchActivationStatuses(batchStatuses);
 
     if (result.success) {
-      for (const object of objects) {
-        cachingLayer?.invalidate(object.type, object.name, 'all');
+      for (const [i, object] of objects.entries()) {
+        applyActivationToCache(cachingLayer, object.type, object.name, drafts[i], perUserClient);
       }
       invalidateInactiveList(cachingLayer, client, cacheSecurity);
       return textResult(`Successfully activated ${objects.length} objects: ${names}.${statusDetails}`);
@@ -281,10 +352,13 @@ export async function handleSAPActivate(
     isServerDrivenObjectType(type) ? serverDrivenBlueContentType(type) : undefined,
   );
 
+  // Capture the inactive draft before activation flips it to active (see captureDraftForPromotion).
+  const draft = cachingLayer && !perUserClient ? await captureDraftForPromotion(client, type, objectUrl) : undefined;
+
   const result = await activate(client.http, client.safety, objectUrl, { ...activateOpts, name });
 
   if (result.success) {
-    cachingLayer?.invalidate(type, name, 'all');
+    applyActivationToCache(cachingLayer, type, name, draft, perUserClient);
     invalidateInactiveList(cachingLayer, client, cacheSecurity);
     return textResult(`Successfully activated ${type} ${name}.${formatActivationMessages(result)}`);
   }

--- a/src/handlers/read.ts
+++ b/src/handlers/read.ts
@@ -90,6 +90,15 @@ export async function resolveVersionAndDraftInfo(
     }
   }
 
+  // A just-activated object can briefly still appear in the (eventually-consistent) inactive
+  // worklist; don't surface a stale "unactivated draft" note (or resolve 'auto' to the now-gone
+  // inactive version) for it. Cleared by any subsequent write/force_refresh. See ACTIVATION_FRESH_MS.
+  // Skipped for per-user (principal-propagation) clients: the freshness flag is object-keyed, so
+  // honoring it cross-user could hide another user's genuine draft (inactive list is per-user keyed).
+  if (draft && !cacheSecurity.isPerUserClient && cachingLayer?.wasRecentlyActivated(type, name)) {
+    draft = undefined;
+  }
+
   if (requestedVersion === 'auto') {
     return { effectiveVersion: draft ? 'inactive' : 'active', draft };
   }

--- a/tests/unit/cache/caching-layer.test.ts
+++ b/tests/unit/cache/caching-layer.test.ts
@@ -463,4 +463,88 @@ describe('CachingLayer', () => {
       expect(stats.edgeCount).toBe(1);
     });
   });
+
+  // ─── Post-Activation Freshness Guard ─────────────────────────────────
+  // Regression for the "stale active read after SAPActivate" bug: on an eventually-consistent
+  // backend (BTP/Steampunk) the active /source/main can briefly still serve the pre-activation
+  // shell. markActivated() promotes the just-activated draft and the guard serves it without
+  // revalidating, so the next active read returns the real source WITHOUT force_refresh.
+  describe('post-activation freshness', () => {
+    const STALE = 'CLASS zcl_x. " empty pre-activation shell\nENDCLASS.';
+    const REAL = 'CLASS zcl_x.\n  METHOD hello.\n    r = `hi`.\n  ENDMETHOD.\nENDCLASS.';
+
+    it('serves the promoted draft as active without calling the (lagging) fetcher', async () => {
+      // Pre-activation read cached the empty shell with an etag.
+      cache.putSource('CLAS', 'ZCL_X', STALE, { version: 'active', etag: 'e0' });
+      // Activation promotes the captured draft.
+      layer.markActivated('CLAS', 'ZCL_X', REAL);
+
+      // A backend that still serves the stale shell on the post-activate read.
+      const laggingFetcher = vi
+        .fn()
+        .mockResolvedValue({ source: STALE, etag: 'e0', notModified: false, statusCode: 200 });
+
+      const result = await layer.getSource('CLAS', 'ZCL_X', laggingFetcher, { version: 'active' });
+      expect(result).toEqual({ source: REAL, hit: true, revalidated: false });
+      expect(laggingFetcher).not.toHaveBeenCalled();
+      // Inactive slot is dropped on promotion (the draft is now active).
+      expect(layer.getCachedSourceWithEtag('CLAS', 'ZCL_X', 'inactive')).toBeNull();
+    });
+
+    it('flags the object as recently activated (drives draft-note suppression)', () => {
+      expect(layer.wasRecentlyActivated('CLAS', 'ZCL_X')).toBe(false);
+      layer.markActivated('CLAS', 'ZCL_X', REAL);
+      expect(layer.wasRecentlyActivated('CLAS', 'ZCL_X')).toBe(true);
+      expect(layer.wasRecentlyActivated('CLAS', 'ZCL_OTHER')).toBe(false);
+      // Case-insensitive, like the source cache keys.
+      expect(layer.wasRecentlyActivated('clas', 'zcl_x')).toBe(true);
+    });
+
+    it('clears freshness on invalidate (write / force_refresh resets to backend truth)', async () => {
+      cache.putSource('CLAS', 'ZCL_X', STALE, { version: 'active', etag: 'e0' });
+      layer.markActivated('CLAS', 'ZCL_X', REAL);
+      layer.invalidate('CLAS', 'ZCL_X', 'all');
+
+      expect(layer.wasRecentlyActivated('CLAS', 'ZCL_X')).toBe(false);
+      const fetcher = vi.fn().mockResolvedValue({ source: REAL, etag: 'e1', notModified: false, statusCode: 200 });
+      const result = await layer.getSource('CLAS', 'ZCL_X', fetcher, { version: 'active' });
+      expect(fetcher).toHaveBeenCalledOnce();
+      expect(result.source).toBe(REAL);
+    });
+
+    it('without a promoted draft, suppresses the note but still fetches the active source', async () => {
+      layer.markActivated('CLAS', 'ZCL_Y'); // note-suppress only (no draft captured)
+      expect(layer.wasRecentlyActivated('CLAS', 'ZCL_Y')).toBe(true);
+
+      const fetcher = vi.fn().mockResolvedValue({ source: REAL, etag: 'e1', notModified: false, statusCode: 200 });
+      const result = await layer.getSource('CLAS', 'ZCL_Y', fetcher, { version: 'active' });
+      expect(fetcher).toHaveBeenCalledOnce();
+      expect(result.source).toBe(REAL);
+    });
+
+    it('only guards active reads, not inactive', async () => {
+      layer.markActivated('CLAS', 'ZCL_X', REAL);
+      const fetcher = vi.fn().mockResolvedValue({ source: 'draft', etag: 'e1', notModified: false, statusCode: 200 });
+      await layer.getSource('CLAS', 'ZCL_X', fetcher, { version: 'inactive' });
+      expect(fetcher).toHaveBeenCalledOnce();
+    });
+
+    it('expires after the freshness window so reads revalidate again', async () => {
+      vi.useFakeTimers();
+      try {
+        cache.putSource('CLAS', 'ZCL_X', REAL, { version: 'active' });
+        layer.markActivated('CLAS', 'ZCL_X', REAL);
+        expect(layer.wasRecentlyActivated('CLAS', 'ZCL_X')).toBe(true);
+
+        vi.advanceTimersByTime(120_001);
+        expect(layer.wasRecentlyActivated('CLAS', 'ZCL_X')).toBe(false);
+
+        const fetcher = vi.fn().mockResolvedValue({ source: REAL, etag: 'e1', notModified: false, statusCode: 200 });
+        await layer.getSource('CLAS', 'ZCL_X', fetcher, { version: 'active' });
+        expect(fetcher).toHaveBeenCalledOnce();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });

--- a/tests/unit/handlers/read.test.ts
+++ b/tests/unit/handlers/read.test.ts
@@ -263,6 +263,65 @@ describe('SAPRead handler', () => {
       expect(result.content[0]?.text).toContain('CLASS zcl_test');
     });
 
+    it('suppresses the draft note for a just-activated object (single-identity client)', async () => {
+      mockFetch.mockReset();
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse(
+            200,
+            `<?xml version="1.0"?><ioc:inactiveObjects xmlns:ioc="http://www.sap.com/abapxml/inactiveCtsObjects" xmlns:adtcore="http://www.sap.com/adt/core"><ioc:entry><ioc:object ioc:user="admin" ioc:deleted="false"><ioc:ref adtcore:uri="/sap/bc/adt/oo/classes/zcl_test" adtcore:type="CLAS/OC" adtcore:name="ZCL_TEST"/></ioc:object></ioc:entry></ioc:inactiveObjects>`,
+          ),
+        )
+        .mockResolvedValueOnce(mockResponse(200, 'CLASS zcl_test DEFINITION. ENDCLASS.', { etag: 'e1' }));
+      const layer = new CachingLayer(new MemoryCache());
+      // Simulate a successful activation moments ago; the inactive worklist is still lagging.
+      layer.markActivated('CLAS', 'ZCL_TEST');
+
+      const result = await handleToolCall(
+        createClient(),
+        DEFAULT_CONFIG,
+        'SAPRead',
+        { type: 'CLAS', name: 'ZCL_TEST' },
+        undefined,
+        undefined,
+        layer,
+        false, // isPerUserClient — single-identity client
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).not.toContain('unactivated draft');
+      expect(result.content[0]?.text).toContain('CLASS zcl_test');
+    });
+
+    it('does NOT suppress another user draft note under principal propagation', async () => {
+      mockFetch.mockReset();
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse(
+            200,
+            `<?xml version="1.0"?><ioc:inactiveObjects xmlns:ioc="http://www.sap.com/abapxml/inactiveCtsObjects" xmlns:adtcore="http://www.sap.com/adt/core"><ioc:entry><ioc:object ioc:user="admin" ioc:deleted="false"><ioc:ref adtcore:uri="/sap/bc/adt/oo/classes/zcl_test" adtcore:type="CLAS/OC" adtcore:name="ZCL_TEST"/></ioc:object></ioc:entry></ioc:inactiveObjects>`,
+          ),
+        )
+        .mockResolvedValueOnce(mockResponse(200, 'CLASS zcl_test DEFINITION. ENDCLASS.', { etag: 'e1' }));
+      const layer = new CachingLayer(new MemoryCache());
+      // Another identity activated ZCL_TEST; the object-keyed flag must NOT hide THIS user's draft.
+      layer.markActivated('CLAS', 'ZCL_TEST');
+
+      const result = await handleToolCall(
+        createClient(),
+        DEFAULT_CONFIG,
+        'SAPRead',
+        { type: 'CLAS', name: 'ZCL_TEST' },
+        undefined,
+        undefined,
+        layer,
+        true, // isPerUserClient — per-user (principal propagation) client
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('unactivated draft');
+    });
+
     it('continues active source reads when inactive object listing is unavailable', async () => {
       mockFetch.mockReset();
       mockFetch


### PR DESCRIPTION
## Problem

After `SAPActivate` succeeds, a subsequent `SAPRead(version=active)` could return the **stale pre-activation shell** plus a sticky **"unactivated draft" note**, until `force_refresh` was used. Live-reproduced on **BTP / ABAP 919** for CLAS and INTF.

## Root cause

Not a cache-invalidation miss — `activate.ts` already invalidated the source + inactive-list caches correctly (verified: process-singleton cache, case-insensitive keys, `'all'` clears both versions, Memory + Sqlite). The real cause is the **backend's read-after-activate eventual consistency**: on BTP/Steampunk the active `/source/main` read and the inactive worklist lag a few seconds after activation. ARC-1 invalidated, then the *immediately following* read re-fetched the still-lagging data and re-cached it (active source until the next write; inactive list for its 60s TTL) — so the staleness **stuck** until `force_refresh`, which only "works" because more time has elapsed (it runs the identical invalidation).

**a4h on-prem (S/4 2023) is immediately consistent and does not reproduce** — confirming this is backend-timing, not a cache bug. (Pre-existing; not BTP-specific in principle — any lagging backend hits it. Filed separately from #522 as intended.)

## Fix

Make the cache authoritative from what we know at activation, instead of re-reading a lagging backend.

- **`SAPActivate` captures the inactive draft *before* activating**, then on success **promotes it into the active cache slot** — the active version equals the draft byte-for-byte for source objects (`src/handlers/activate.ts`, new `client.getSourceAtObjectUrl`).
- **`CachingLayer` post-activation freshness guard** (120s, `markActivated`/`wasRecentlyActivated`): the active read is served from the promoted source **without revalidation**, and the stale draft note is suppressed. Cleared by any write/`force_refresh` (which route through `invalidate()`); expired entries are swept opportunistically.
- **Disabled for per-user (principal-propagation) clients** — the guard/note-suppression are object-keyed, so honoring them cross-user could hide *another* user's own draft (the inactive list stays per-user keyed). PP clients keep the old invalidate behavior.
- **Scoped** to source-text types (`CLAS/INTF/PROG/INCL/FUNC/DDLS/DCLS/BDEF/SRVD/DDLX`); DDIC/SRVB fall back to plain invalidation.

## Verification

- **Unit** (`tests/unit/cache/caching-layer.test.ts`, `tests/unit/handlers/read.test.ts`): guard serves the promoted source without calling a lagging fetcher; note suppression; invalidate-clears-guard; TTL expiry; **PP gating does not hide another user's draft**. Full suite green (4160).
- **Live (a4h)**: drove the real handlers + a shared cache, then **poisoned the backend after activate** (active read → empty, inactive list → still listing the draft). `SAPRead(active)` returned the real source with **no draft note**, and the poisoned active fetcher was **never called** (guard served from cache). `force_refresh` still resets to backend truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)