### PR TITLE
ci: don't upload Trivy SARIF when the image build never ran

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,11 @@ jobs:
           exit-code: '1'
 
       - name: Upload Trivy SARIF
-        if: always()
+        # always() so a Trivy CVE gate failure (exit-code 1) still uploads findings,
+        # but only when the scan actually produced the SARIF — otherwise an upstream
+        # buildx/build failure (e.g. transient Docker Hub timeout) cascades into a
+        # confusing "Path does not exist: trivy-results.sarif" that masks the real error.
+        if: always() && steps.build.outcome == 'success'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
## What

Release run [28366596932](https://github.com/arc-mcp/arc-1/actions/runs/28366596932) failed: `docker/setup-buildx-action` couldn't pull `moby/buildkit:buildx-stable-1` from Docker Hub (`registry-1.docker.io` timeout). That's transient infra flakiness — re-running the failed jobs publishes the 0.9.23 image fine (npm 0.9.23 had already published).

The annoying part: the failure surfaced as a **confusing** `Path does not exist: trivy-results.sarif` error, because the `Upload Trivy SARIF` step uses `if: always()` and fired even though the build never produced a SARIF.

## Fix

Guard the upload with `steps.build.outcome == 'success'`. The `always()` is still needed so a Trivy **CVE-gate** failure (`exit-code: 1`) keeps uploading findings to the Security tab — but now it won't run when an upstream build step failed and there's no report to upload.

| Scenario | Before | After |
|----------|--------|-------|
| Build fails (Docker Hub timeout) | ❌ "Path does not exist" masks root cause | ⏭️ skipped, real error visible |
| Build ok, Trivy finds HIGH/CRITICAL | ✅ uploads | ✅ uploads |
| Build ok, Trivy clean | ✅ uploads | ✅ uploads |

Not adding retry logic for the Docker Hub pull — first such timeout in recent release history (0.9.22 released fine), so YAGNI. Easy to add `nick-fields/retry` around buildx setup if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)