### PR TITLE
chore: PR title workflow injection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,12 @@ jobs:
        !startsWith(github.event.pull_request.title, 'chore('))
     steps:
       - name: Tests will run
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "event=${{ github.event_name }}"
-          echo "pr_title=${{ github.event.pull_request.title }}"
+          echo "event=${EVENT_NAME}"
+          echo "pr_title=${PR_TITLE}"
 
   test:
     runs-on: ubuntu-latest

--- a/tests/unit/workflows/test-workflow.test.ts
+++ b/tests/unit/workflows/test-workflow.test.ts
@@ -1,13 +1,36 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
 
 const WORKFLOW = readFileSync(join(import.meta.dirname, '../../../.github/workflows/test.yml'), 'utf8');
+
+type WorkflowStep = {
+  env?: Record<string, unknown>;
+  run?: unknown;
+};
+
+type WorkflowJob = {
+  steps?: WorkflowStep[];
+};
+
+type Workflow = {
+  jobs?: Record<string, WorkflowJob>;
+};
+
+const PARSED_WORKFLOW = parse(WORKFLOW) as Workflow;
 
 function jobBlock(jobName: string): string {
   const match = WORKFLOW.match(new RegExp(`\\n  ${jobName}:\\n([\\s\\S]*?)(?=\\n  [a-zA-Z0-9_-]+:\\n|\\n$)`));
   if (!match) throw new Error(`Job ${jobName} not found`);
   return match[1];
+}
+
+function runScripts(): string[] {
+  return Object.values(PARSED_WORKFLOW.jobs ?? {}).flatMap((job) => {
+    if (!Array.isArray(job.steps)) return [];
+    return job.steps.map((step) => step.run).filter((run): run is string => typeof run === 'string');
+  });
 }
 
 describe('test workflow gate behavior', () => {
@@ -40,6 +63,19 @@ describe('test workflow gate behavior', () => {
     expect(e2eJob).toContain("needs.gate.result == 'success'");
     expect(e2eJob).toContain("needs.test.result == 'success'");
     expect(e2eJob).toContain("needs.sap-run-guard.outputs.current == 'true'");
+  });
+
+  it('does not interpolate untrusted PR titles directly into shell scripts', () => {
+    const scripts = runScripts();
+
+    expect(scripts.length).toBeGreaterThan(0);
+    for (const script of scripts) {
+      expect(script).not.toContain('github.event.pull_request.title');
+    }
+
+    const gateJob = jobBlock('gate');
+    expect(gateJob).toContain('PR_TITLE: $' + '{{ github.event.pull_request.title }}');
+    expect(gateJob).toContain('echo "pr_title=$' + '{PR_TITLE}"');
   });
 
   it('serializes only SAP-heavy jobs repository-wide without cancellation', () => {


### PR DESCRIPTION
## Summary

Fixes SEC-01 by keeping attacker-controlled pull request titles out of GitHub Actions shell script bodies. The gate job still logs the event and PR title, but the values are now passed through step `env` and echoed as shell variables.

## Root Cause

GitHub expression values are rendered into `run:` scripts before Bash executes them. A PR title containing command substitution such as `$(...)` could therefore be executed by the gate debug step.

## Changes

- Move `github.event_name` and `github.event.pull_request.title` into the gate step environment.
- Echo `EVENT_NAME` and `PR_TITLE` from Bash instead of embedding GitHub expressions in the script body.
- Extend the workflow unit test to parse workflow `run:` scripts and reject direct PR-title interpolation there, while preserving legitimate title use in the GitHub `if:` expression.

## Validation

- Reproduced the vulnerable shell boundary locally: rendered `run:` text executes command substitution; environment variables preserve the title as data.
- Confirmed the fixed shell path prints `fix: $(printf SEC01_SHOULD_NOT_RUN)` literally.
- `npx vitest run tests/unit/workflows/test-workflow.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `git diff --check`

Note: local `actionlint` was not installed, and `npx -y actionlint@latest .github/workflows/test.yml` did not expose a runnable binary. The regression test parses the workflow YAML and validates the shell-script boundary directly.
