### PR TITLE
fix: harden change_package object type matching

### DIFF
--- a/src/handlers/manage.ts
+++ b/src/handlers/manage.ts
@@ -20,6 +20,7 @@ import {
 import { changePackage } from '../adt/refactoring.js';
 import { checkOperation, checkPackage, OperationType } from '../adt/safety.js';
 import { getTransportInfo } from '../adt/transport.js';
+import { parseSearchResults } from '../adt/xml-parser.js';
 import type { CachingLayer } from '../cache/caching-layer.js';
 import type { ServerConfig } from '../server/types.js';
 import { cachedFeatures, setCachedFeatures } from './feature-cache.js';
@@ -268,16 +269,17 @@ export async function handleSAPManage(
         const searchResp = await client.http.get(
           `/sap/bc/adt/repository/informationsystem/search?operation=quickSearch&query=${encodeURIComponent(objectName)}&maxResults=10`,
         );
-        const uriMatch = searchResp.body.match(
-          new RegExp(`adtcore:uri="([^"]*)"[^>]*adtcore:type="${objectType.replace('/', '\\/')}"`, 'i'),
+        const expectedType = objectType.toUpperCase();
+        const searchMatch = parseSearchResults(searchResp.body).find(
+          (ref) => ref.uri && ref.objectType.toUpperCase() === expectedType,
         );
-        if (!uriMatch?.[1]) {
+        if (!searchMatch?.uri) {
           return errorResult(
             `Could not find object "${objectName}" with type "${objectType}" via ADT search. ` +
               `Verify the object exists and the type is correct (e.g., CLAS/OC, DDLS/DF, PROG/P).`,
           );
         }
-        objectUri = uriMatch[1];
+        objectUri = searchMatch.uri;
       }
 
       // SECURITY: gate the object's REAL package (resolved from objectUri via ADT

--- a/tests/unit/handlers/manage-context.test.ts
+++ b/tests/unit/handlers/manage-context.test.ts
@@ -265,6 +265,81 @@ describe('SAPManage / SAPContext handlers', () => {
       expect(executeCall).toBeDefined();
     });
 
+    it('change_package treats objectType as a literal ADT type when resolving objectUri', async () => {
+      const calls: Array<{ method: string; url: string }> = [];
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        calls.push({ method: opts?.method ?? 'GET', url: String(url) });
+        if (String(url).includes('quickSearch')) {
+          return Promise.resolve(
+            mockResponse(
+              200,
+              `<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+                <adtcore:objectReference adtcore:uri="/sap/bc/adt/oo/classes/zvictim" adtcore:type="CLAS/OC" adtcore:name="ZVICTIM" adtcore:packageName="$TMP"/>
+                <adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/ddl/sources/zvictim" adtcore:type="DDLS/DF" adtcore:name="ZVICTIM" adtcore:packageName="$TMP"/>
+              </adtcore:objectReferences>`,
+              { 'x-csrf-token': 'T' },
+            ),
+          );
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+        action: 'change_package',
+        objectName: 'ZVICTIM',
+        objectType: '.*',
+        oldPackage: '$TMP',
+        newPackage: '$TMP',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('Could not find object "ZVICTIM" with type ".*"');
+      expect(calls.some((c) => c.method === 'POST' && c.url.includes('/refactorings'))).toBe(false);
+    });
+
+    it('change_package resolves objectUri from parsed ADT search results regardless of attribute order', async () => {
+      const calls: Array<{ method: string; url: string; body?: string }> = [];
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string; body?: string }) => {
+        calls.push({ method: opts?.method ?? 'GET', url: String(url), body: opts?.body });
+        if (String(url).includes('quickSearch')) {
+          return Promise.resolve(
+            mockResponse(
+              200,
+              `<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+                <adtcore:objectReference adtcore:type="DDLS/DF" adtcore:name="ZARC1_TEST" adtcore:packageName="$TMP" adtcore:uri="/sap/bc/adt/ddic/ddl/sources/zarc1_test"/>
+              </adtcore:objectReferences>`,
+              { 'x-csrf-token': 'T' },
+            ),
+          );
+        }
+        if (String(url).includes('step=preview')) {
+          return Promise.resolve(
+            mockResponse(
+              200,
+              '<generic:genericRefactoring xmlns:generic="http://www.sap.com/adt/refactoring/genericrefactoring"><generic:transport/></generic:genericRefactoring>',
+              { 'x-csrf-token': 'T' },
+            ),
+          );
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+        action: 'change_package',
+        objectName: 'ZARC1_TEST',
+        objectType: 'DDLS/DF',
+        oldPackage: '$TMP',
+        newPackage: '$TMP',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]?.text).toContain('Moved ZARC1_TEST');
+      const previewCall = calls.find((c) => c.method === 'POST' && c.url.includes('step=preview'));
+      expect(previewCall?.body).toContain('/sap/bc/adt/ddic/ddl/sources/zarc1_test');
+    });
+
     it("change_package is blocked by the object's REAL package, not the caller-supplied oldPackage", async () => {
       // The caller lies: oldPackage="ZALLOWED" (in the allowlist) while the object
       // actually lives in ZSECRET. Authorization must gate the package resolved from


### PR DESCRIPTION
## Summary
- Resolve `change_package` object URIs by parsing ADT search results instead of interpolating `objectType` into a `RegExp`.
- Compare ADT object types literally, case-insensitively.
- Add regression coverage for regex metacharacter input and ADT search attributes in a different order.

## Validation
- `npx vitest run tests/unit/handlers/manage-context.test.ts -t change_package`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`
- `npm test`
- `npm run validate:policy`
- `npm run check:sizes`
- `npm run build`
- `npm audit --audit-level=high --omit=optional`

Local note: `npm ci` completed with engine warnings because this machine has Node `v22.18.0`; the package requires `>=22.19`.