### PR TITLE
fix: pin release npm to 11.x so npm ci builds better-sqlite3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,12 @@ jobs:
           cache: 'npm'
 
       - name: Install npm 11.5+ (required for OIDC trusted publishing)
-        run: |
-          # Workaround for Node.js v22 bundled npm bug (https://github.com/npm/cli/issues/9151)
-          npm install --global npm@11.11.1
-          npm install --global npm@latest
+        # Pin a known-good 11.x: >=11.5 enables OIDC trusted publishing, and `npm ci` still
+        # builds the better-sqlite3 native binding. npm@latest is now 12.x, under which `npm ci`
+        # leaves better_sqlite3.node unbuilt -> the sqlite cache tests fail (blocked 0.9.26).
+        # Installing a pinned version (not the `latest` tag) also sidesteps the Node 22.22.x
+        # bundled-npm self-upgrade bug (https://github.com/npm/cli/issues/9151). Bump deliberately.
+        run: npm install --global npm@11.11.1
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Problem

The npm release is failing. `npm@latest` became **npm 12.0.1** (major bump, landed 2026-07-08). The `publish-npm` job upgrades to it right before `npm ci`, and under npm 12 `npm ci` never builds `better-sqlite3`'s native binding — all 32 SQLite-cache unit tests throw *"Could not locate the bindings file"*, `npm test` exits 1, and the job dies before `npm publish` runs.

Result: **0.9.26 is tagged + GitHub-released but never reached npm** (npm has ...0.9.25).

### Why only the release job
PR CI (`test.yml`) runs a plain `npm ci` on the bundled npm 10.x → binding builds → tests pass. Only `release.yml` upgrades to `npm@latest`. Same Node (22.23.1), same `npm ci`, same `npm test` — the only variable is the npm version.

### Regression timeline
| Event | Date |
|---|---|
| Last green publish (0.9.25) | 2026-07-02 |
| npm 12.0.0 becomes `latest` | 2026-07-08 |
| First release after → fails (0.9.26) | 2026-07-13 |

## Fix

Pin the pre-publish npm to `11.11.1` instead of chasing `npm@latest`:
- `>= 11.5` keeps OIDC trusted publishing working (`npm publish --provenance`)
- an `11.x` still builds native modules during `npm ci`
- a pinned version (not the `latest` tag) also sidesteps the Node 22.22.x bundled-npm self-upgrade bug ([npm/cli#9151](https://github.com/npm/cli/issues/9151))

This is exactly the npm that shipped every release through 0.9.25.

## Note on 0.9.26

This `fix:` bump lets release-please cut **0.9.27**, which will publish cleanly through the fixed workflow. 0.9.26 stays npm-skipped (nobody consumed it) unless you want a one-time manual publish from the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)