### PR TITLE
ci: harden release workflow — pin mcp-publisher, drop non-gating coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,18 +52,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Sole test gate for the release: release-please opens its PR with the default
+      # GITHUB_TOKEN, so test.yml never runs on it (GITHUB_TOKEN events don't trigger
+      # workflows) — nothing else tests the released commit. Do not remove.
+      # Coverage is dropped here: it's non-gating and no one reads it at publish time.
       - name: Run tests
         run: npm test
-
-      # Coverage — informational only, does not block release
-      - name: Run coverage (informational)
-        run: npm run test:coverage
-        continue-on-error: true
-
-      - name: Coverage summary
-        if: always()
-        run: node scripts/ci/coverage-summary.mjs
-        continue-on-error: true
 
       - name: Build
         run: npm run build
@@ -156,8 +150,12 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install mcp-publisher
+        # Pin the release (not `latest/download`) so a new mcp-publisher can't silently
+        # change publish behavior mid-release. Bump deliberately, like the actions above.
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.0
         run: |
-          curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          curl -sL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
       - name: Authenticate to MCP Registry (GitHub OIDC)
         run: ./mcp-publisher login github-oidc


### PR DESCRIPTION
Follow-up to #568. Long-term hardening of the release path against the "a floating external version silently broke publishing" class of failure.

## #3 — Pin the last floating version in the release-critical path
`publish-mcp-registry` fetched mcp-publisher from `releases/latest/download/…`. Pinned to **v1.8.0**. Now every tool the release depends on is version- or SHA-pinned (actions, `npm@11.11.1`, MCPB CLI, mcp-publisher) — no `@latest` left where a bump can't be caught before release. Bump deliberately, like the SHA-pinned actions.

## #2 — Drop non-gating coverage from `publish-npm`
Removed the two coverage steps (`Run coverage (informational)` + `Coverage summary`). They're `continue-on-error` (never gate a release) and nobody reads coverage at publish time — pure weight and log noise.

**Kept `npm test`** — and this is the important correction to the original plan. I verified that release-please opens its `chore(main): release` PR with the default `GITHUB_TOKEN`, and GitHub does not trigger workflow files (`test.yml`) on `GITHUB_TOKEN` events. Checked release PR #553: only CodeQL ran, no `test`/`gate`/`mta-validate`. So **`npm test` in `publish-npm` is the release's *only* test gate** — removing it would ship an untested artifact. It stays, now with a comment saying so.

## Not done here (needs a decision)
The cleanest robustness win — test the release *before* the tag is cut instead of during publish — requires giving release-please a GitHub App / PAT token so its PR triggers `test.yml`. That's a secret + setup, so I left it out. Without it, a broken build still fails *after* the tag/GitHub Release exist (the 0.9.26 symptom), even though npm itself is never published broken (publish is gated by `npm test` in the same job). Say the word if you want the token route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)