### PR TITLE
ci: bundle ARC-1 skills inside the .mcpb release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
           cp mcpb-manifest.json mcpb-bundle/manifest.json
           cp icon.png mcpb-bundle/
           cp -r dist mcpb-bundle/dist
+          cp -r skills mcpb-bundle/skills   # ship the ARC-1 agent skills inside the bundle
           cp package.json package-lock.json mcpb-bundle/
           ( cd mcpb-bundle && npm ci --omit=dev --ignore-scripts )
           rm -rf mcpb-bundle/node_modules/better-sqlite3
@@ -131,6 +132,9 @@ jobs:
           VERSION="${VERSION#v}"
           npx --yes "$MCPB" validate mcpb-bundle/manifest.json
           npx --yes "$MCPB" pack mcpb-bundle "arc-1-${VERSION}.mcpb"
+          # Guard: the bundled skills must survive packing (the manifest doesn't list them).
+          unzip -l "arc-1-${VERSION}.mcpb" | grep -q 'skills/generate-rap-service/SKILL.md' \
+            || { echo "::error::Packed MCPB is missing the bundled skills/"; exit 1; }
 
       - name: Attach .mcpb to GitHub Release
         env:

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -11,7 +11,7 @@ This document describes how to publish ARC-1 to various MCP server registries, m
 | [Cline Marketplace](#3-cline-marketplace) | Manual | Ready | Cline VS Code extension marketplace |
 | [VS Code / GitHub Copilot](#4-vs-code--github-copilot) | Via MCP Registry | Automatic | VS Code Extensions `@mcp` gallery |
 | [Cursor Marketplace](#5-cursor-marketplace) | Manual | Ready | Cursor IDE built-in marketplace |
-| [Claude Desktop Extensions](#6-claude-desktop-extensions) | Yes (CI builds + validates + packs .mcpb) | Ready | Claude Desktop Extensions directory |
+| [Claude Desktop Extensions](#6-claude-desktop-extensions) | Yes (CI builds + validates + packs .mcpb) | Ready | Claude Desktop Extensions directory — MCP server + bundled skills |
 | [Claude Code Plugin](#8-claude-code-plugin--marketplace) | Yes (repo is the marketplace) | Ready | `/plugin install` — MCP server + skills |
 
 ## Files in This Repository
@@ -241,6 +241,7 @@ mkdir -p mcpb-bundle
 cp mcpb-manifest.json mcpb-bundle/manifest.json
 cp icon.png mcpb-bundle/
 cp -r dist mcpb-bundle/dist
+cp -r skills mcpb-bundle/skills   # ship the ARC-1 agent skills inside the bundle
 cp package.json package-lock.json mcpb-bundle/
 
 # Install prod deps WITHOUT the native better-sqlite3, so the bundle is pure-JS and

--- a/skills/README.md
+++ b/skills/README.md
@@ -19,8 +19,9 @@ namespaced as `/arc-1:<skill>` (e.g. `/arc-1:generate-rap-service`). Manage it w
 `/reload-plugins` after an update.
 
 > Already running the ARC-1 server another way (Claude Desktop MCPB, `claude mcp add`, or a BTP
-> custom connector)? Use the `skills` CLI below to add just the skills — the plugin is only needed
-> when you also want it to wire up the bundled MCP server.
+> custom connector)? The `.mcpb` bundle now ships these skills under `skills/`; to register them
+> with your agent, use the `skills` CLI below (or copy the folders into your agent's skills path).
+> The plugin is only needed when you also want it to wire up the bundled MCP server.
 
 ## Install the skills via the `skills` CLI (any agent)
 


### PR DESCRIPTION
## What

The `build-mcpb` release job now copies `skills/` into the packed bundle, so the one-click **Claude Desktop (`.mcpb`)** install carries the 22 SAP agent skills alongside the MCP server — parity with the **Claude Code plugin**, which already ships both.

```diff
  cp -r dist mcpb-bundle/dist
+ cp -r skills mcpb-bundle/skills   # ship the ARC-1 agent skills inside the bundle
```

A post-pack guard fails the release if the skills don't survive packing:

```bash
unzip -l "arc-1-${VERSION}.mcpb" | grep -q 'skills/generate-rap-service/SKILL.md' || exit 1
```

## Research findings

- The **MCPB manifest schema has no `skills` field** at any version (checked v0.1–v0.4 in `@anthropic-ai/mcpb@2.1.2`; `latest` is still v0.3). Skills therefore ride as **plain files** inside the bundle, not a manifest-declared capability — this is purely a packaging change, and `mcpb validate` is unaffected.
- `mcpb pack <dir>` zips the **whole directory tree** (respecting `.mcpbignore`), so dropping `skills/` into the staged `mcpb-bundle/` is sufficient to include them.
- Only the 22 product skills under `skills/` are bundled; the repo-dev skills under `.claude/skills/` are excluded (they're not in `mcpb-bundle/`).
- No documented client *auto-activates* skills from an installed `.mcpb` yet, so the `skills/README.md` note keeps `npx skills` / manual copy as the activation path — this PR just makes the artifact self-contained (and future-proofs it).

## Test — full local build of the real bundle

Ran the complete CI flow locally (`npm ci` → `npm run build` → assemble → prune `better-sqlite3` → smoke → `validate` → `pack`):

| Check | Result |
|---|---|
| `mcpb validate` | passes (skills don't affect the manifest) |
| Boot smoke on stdio | passes — `running on stdio` |
| Post-pack skills guard | passes |
| ARC-1 skills in archive | **22/22** under `skills/`, incl. the `references/` subdir |
| Artifact | `arc-1-0.9.27.mcpb`, 9.0 MB packed / 27.4 MB unpacked |

Size impact is negligible — the skills are 568 KB of markdown against a 9 MB bundle.

Incidental observation (pre-existing, not introduced here): `node_modules/dotenv` ships its own `skills/` folder, so two extra `SKILL.md` files have always been present in the bundle. Harmless.

## Files

- `.github/workflows/release.yml` — copy `skills/` into the bundle + post-pack guard
- `docs/publishing-guide.md` — keep the manual repro block + channel table in sync
- `skills/README.md` — MCPB users note now reflects that skills ship in the bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)