### PR TITLE
docs: expose group param for INCL (FUGR structural-include update) & fix for SAPActivate & SAPTransport

### DIFF
--- a/scripts/ci/check-file-sizes.mjs
+++ b/scripts/ci/check-file-sizes.mjs
@@ -30,13 +30,13 @@ const BUDGETS = {
   // submodules ride the default src budget; keep this tight so the dispatcher can't reabsorb them.
   'src/handlers/write.ts': 360,
   // tools.ts holds every tool's JSON schema. The #520 description trim (write-mode tools/list
-  // 87→66 KB to clear the Copilot-for-Eclipse gateway limit) shrank it; lowered to match. The
-  // CLIENT-SAFETY size guard is scripts/ci/check-tool-schema-budget.ts — trim there before raising this.
-  // +text-pool SAPWrite actions/description (edit_text_symbols/edit_selection_texts).
-  // +1 line: documented `group` for INCL (FUGR structural-include update) in the SAPWrite schema.
-  // +5 lines: `group` param on SAPActivate for FUGR structural-include activation.
-  // +4 lines: `group` param on SAPTransport check/history for FUGR structural includes.
-  'src/handlers/tools.ts': 1724,
+  // 87→66 KB to clear the Copilot-for-Eclipse gateway limit) shrank it; #571 moved the large
+  // SAPWrite description constants out to tool-descriptions.ts, shrinking it further — lowered
+  // to match. The CLIENT-SAFETY size guard is scripts/ci/check-tool-schema-budget.ts — trim there
+  // before raising this. +`group` for INCL (FUGR structural-include update) in the SAPWrite
+  // schema; +`group` param on SAPTransport check/history for FUGR structural includes (the
+  // SAPActivate equivalent shipped independently in #571).
+  'src/handlers/tools.ts': 1699,
   'src/adt/xml-parser.ts': 1650,
   // diagnostics.ts gained the ABAP trace-request engine (#508) + the OData perf probe + CDS Show-SQL (#509)
   // + ST05 SQL-trace control (#510) + clientWait split. Split out a perf/trace module if it grows much further.

--- a/scripts/ci/check-file-sizes.mjs
+++ b/scripts/ci/check-file-sizes.mjs
@@ -35,7 +35,8 @@ const BUDGETS = {
   // +text-pool SAPWrite actions/description (edit_text_symbols/edit_selection_texts).
   // +1 line: documented `group` for INCL (FUGR structural-include update) in the SAPWrite schema.
   // +5 lines: `group` param on SAPActivate for FUGR structural-include activation.
-  'src/handlers/tools.ts': 1720,
+  // +4 lines: `group` param on SAPTransport check/history for FUGR structural includes.
+  'src/handlers/tools.ts': 1724,
   'src/adt/xml-parser.ts': 1650,
   // diagnostics.ts gained the ABAP trace-request engine (#508) + the OData perf probe + CDS Show-SQL (#509)
   // + ST05 SQL-trace control (#510) + clientWait split. Split out a perf/trace module if it grows much further.

--- a/scripts/ci/check-file-sizes.mjs
+++ b/scripts/ci/check-file-sizes.mjs
@@ -33,7 +33,8 @@ const BUDGETS = {
   // 87→66 KB to clear the Copilot-for-Eclipse gateway limit) shrank it; lowered to match. The
   // CLIENT-SAFETY size guard is scripts/ci/check-tool-schema-budget.ts — trim there before raising this.
   // +text-pool SAPWrite actions/description (edit_text_symbols/edit_selection_texts).
-  'src/handlers/tools.ts': 1714,
+  // +1 line: documented `group` for INCL (FUGR structural-include update) in the SAPWrite schema.
+  'src/handlers/tools.ts': 1715,
   'src/adt/xml-parser.ts': 1650,
   // diagnostics.ts gained the ABAP trace-request engine (#508) + the OData perf probe + CDS Show-SQL (#509)
   // + ST05 SQL-trace control (#510) + clientWait split. Split out a perf/trace module if it grows much further.

--- a/scripts/ci/check-file-sizes.mjs
+++ b/scripts/ci/check-file-sizes.mjs
@@ -34,7 +34,8 @@ const BUDGETS = {
   // CLIENT-SAFETY size guard is scripts/ci/check-tool-schema-budget.ts — trim there before raising this.
   // +text-pool SAPWrite actions/description (edit_text_symbols/edit_selection_texts).
   // +1 line: documented `group` for INCL (FUGR structural-include update) in the SAPWrite schema.
-  'src/handlers/tools.ts': 1715,
+  // +5 lines: `group` param on SAPActivate for FUGR structural-include activation.
+  'src/handlers/tools.ts': 1720,
   'src/adt/xml-parser.ts': 1650,
   // diagnostics.ts gained the ABAP trace-request engine (#508) + the OData perf probe + CDS Show-SQL (#509)
   // + ST05 SQL-trace control (#510) + clientWait split. Split out a perf/trace module if it grows much further.

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -807,6 +807,10 @@ export const SAPTransportSchema = z.object({
   user: z.string().optional(),
   status: z.string().optional(),
   type: z.string().optional(),
+  // For "check"/"history" against type=FUNC (auto-resolved via search if omitted) or type=INCL (a
+  // FUGR structural include — required, addresses the include's own group-scoped URI). Ignored
+  // for other types.
+  group: z.string().optional(),
   owner: z.string().optional(),
   // looseOptionalBoolean (not z.boolean()) so GPT/OpenAI clients sending stringified
   // "true"/"false" coerce instead of erroring at validation (CLAUDE.md boolean guidance).

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -516,7 +516,8 @@ export const SAPWriteSchema = z
     package: z.string().optional(),
     transport: z.string().optional(),
     // Required for FUNC create (the parent function-group name); optional for FUNC
-    // update/delete (auto-resolved via search). Ignored for other types.
+    // update/delete (auto-resolved via search). Also used by INCL update to address a
+    // FUGR structural include (see tools.ts description) — ignored for all other types.
     group: z.string().optional(),
     dataType: z.string().optional(),
     rowType: z.string().optional(),

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -704,8 +704,7 @@ export function getToolDefinitions(
           group: {
             type: 'string',
             description:
-              'For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. ' +
-              'For INCL: parent function-group name + action="update", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported.',
+              'FUNC: group name (required for create, else auto-resolved). INCL: group + action=update/edit_unit for a FUGR structural include; omit for standalone.',
           },
           dataType: { type: 'string', description: 'DOMA/DTEL: ABAP data type (e.g., CHAR, NUMC, DEC)' },
           rowType: {
@@ -1568,7 +1567,7 @@ export function getToolDefinitions(
           },
           group: {
             type: 'string',
-            description: 'check/history group: FUNC (auto), INCL (required).',
+            description: 'check/history: FUNC auto, INCL required.',
           },
           pgmid: {
             type: 'string',

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -704,8 +704,8 @@ export function getToolDefinitions(
           group: {
             type: 'string',
             description:
-              'For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. ' +
-              'For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action="update" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported.',
+              'For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. ' +
+              'For INCL: pass the parent function-group name + action="update" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported.',
           },
           dataType: { type: 'string', description: 'DOMA/DTEL: ABAP data type (e.g., CHAR, NUMC, DEC)' },
           rowType: {

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -704,8 +704,8 @@ export function getToolDefinitions(
           group: {
             type: 'string',
             description:
-              'For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. ' +
-              'For INCL: pass the parent function-group name + action="update" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported.',
+              'For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. ' +
+              'For INCL: parent function-group name + action="update", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported.',
           },
           dataType: { type: 'string', description: 'DOMA/DTEL: ABAP data type (e.g., CHAR, NUMC, DEC)' },
           rowType: {
@@ -1565,6 +1565,10 @@ export function getToolDefinitions(
             type: 'string',
             description:
               "Object type for check/history/remove_object actions (PROG, CLAS, DDLS, etc.). Not used by create — the SAP backend infers transport type (K/W/T) from the package's TADIR route on the CreateCorrectionRequest endpoint.",
+          },
+          group: {
+            type: 'string',
+            description: 'check/history group: FUNC (auto), INCL (required).',
           },
           pgmid: {
             type: 'string',

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -704,7 +704,8 @@ export function getToolDefinitions(
           group: {
             type: 'string',
             description:
-              'For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted.',
+              'For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. ' +
+              'For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action="update" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported.',
           },
           dataType: { type: 'string', description: 'DOMA/DTEL: ABAP data type (e.g., CHAR, NUMC, DEC)' },
           rowType: {

--- a/src/handlers/transport.ts
+++ b/src/handlers/transport.ts
@@ -123,6 +123,39 @@ function summarizeTransport(t: TransportRequest) {
   };
 }
 
+/**
+ * Resolve the object URL for check/history, group-aware for FUNC and FUGR-scoped INCL —
+ * mirrors the routing in write.ts/activate.ts (FEAT-18 sibling). Without this, `objectUrlForType`
+ * either throws for FUNC (objectBasePath's deliberate PR #223 guard) or, for INCL, silently
+ * resolves the wrong standalone /programs/includes/ path — the package/transport lookup then
+ * comes back empty and misleadingly reports the object as local (2026-07-14 finding).
+ */
+async function resolveTransportObjectUrl(
+  client: AdtClient,
+  type: string,
+  name: string,
+  group: string | undefined,
+): Promise<string> {
+  const trimmedGroup = String(group ?? '').trim();
+  if (type === 'FUNC') {
+    let g = trimmedGroup;
+    if (!g) {
+      const resolved = await client.resolveFunctionGroup(name);
+      if (!resolved) {
+        throw new Error(`Cannot resolve function group for FM "${name}". Provide the "group" parameter explicitly.`);
+      }
+      g = resolved;
+    }
+    const groupLc = encodeURIComponent(g.toLowerCase());
+    return `/sap/bc/adt/functions/groups/${groupLc}/fmodules/${encodeURIComponent(name.toLowerCase())}`;
+  }
+  if (type === 'INCL' && trimmedGroup) {
+    const groupLc = encodeURIComponent(trimmedGroup.toLowerCase());
+    return `/sap/bc/adt/functions/groups/${groupLc}/includes/${encodeURIComponent(name.toLowerCase())}`;
+  }
+  return objectUrlForType(type, name);
+}
+
 export async function handleSAPTransport(client: AdtClient, args: Record<string, unknown>): Promise<ToolResult> {
   const action = String(args.action ?? '');
 
@@ -391,7 +424,12 @@ export async function handleSAPTransport(client: AdtClient, args: Record<string,
       if (!objectType || !objectName) return errorResult('"type" and "name" are required for "check" action.');
       if (!pkg) return errorResult('"package" is required for "check" action.');
 
-      const objectUrl = objectUrlForType(objectType, objectName);
+      let objectUrl: string;
+      try {
+        objectUrl = await resolveTransportObjectUrl(client, objectType, objectName, args.group as string | undefined);
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
       const info = await getTransportInfo(client.http, client.safety, objectUrl, pkg, 'I');
 
       const summary = info.isLocal
@@ -423,7 +461,12 @@ export async function handleSAPTransport(client: AdtClient, args: Record<string,
         return errorResult('"type" and "name" are required for "history" action.');
       }
 
-      const objectUrl = objectUrlForType(objectType, objectName);
+      let objectUrl: string;
+      try {
+        objectUrl = await resolveTransportObjectUrl(client, objectType, objectName, args.group as string | undefined);
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
       const primary = await getObjectTransports(client.http, client.safety, objectUrl);
       let candidateTransports = primary.candidateTransports;
 

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -358,7 +358,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name + action=\"update\" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported."
+          "description": "For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. For INCL: parent function-group name + action=\"update\", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported."
         },
         "dataType": {
           "type": "string",
@@ -849,7 +849,7 @@
         },
         "group": {
           "type": "string",
-          "description": "FUNC: parent function-group name (auto-resolved if omitted). INCL: required to activate a FUGR structural include. Ignored otherwise."
+          "description": "FUNC: group name (auto-resolved if omitted). INCL: required for a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",
@@ -1551,6 +1551,10 @@
         "type": {
           "type": "string",
           "description": "Object type for check/history/remove_object actions (PROG, CLAS, DDLS, etc.). Not used by create — the SAP backend infers transport type (K/W/T) from the package's TADIR route on the CreateCorrectionRequest endpoint."
+        },
+        "group": {
+          "type": "string",
+          "description": "check/history group: FUNC (auto), INCL (required)."
         },
         "pgmid": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -358,7 +358,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action=\"update\" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported."
+          "description": "For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name + action=\"update\" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported."
         },
         "dataType": {
           "type": "string",
@@ -846,6 +846,10 @@
         "preaudit": {
           "type": "boolean",
           "description": "Request pre-activation audit (default true) — SAP returns warnings/errors before activating. false skips it for speed."
+        },
+        "group": {
+          "type": "string",
+          "description": "FUNC: parent function-group name (auto-resolved if omitted). INCL: required to activate a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -358,7 +358,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted."
+          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action=\"update\" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported."
         },
         "dataType": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -358,7 +358,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. For INCL: parent function-group name + action=\"update\", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported."
+          "description": "FUNC: group name (required for create, else auto-resolved). INCL: group + action=update/edit_unit for a FUGR structural include; omit for standalone."
         },
         "dataType": {
           "type": "string",
@@ -846,10 +846,6 @@
         "preaudit": {
           "type": "boolean",
           "description": "Request pre-activation audit (default true) — SAP returns warnings/errors before activating. false skips it for speed."
-        },
-        "group": {
-          "type": "string",
-          "description": "FUNC: group name (auto-resolved if omitted). INCL: required for a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",
@@ -1554,7 +1550,7 @@
         },
         "group": {
           "type": "string",
-          "description": "check/history group: FUNC (auto), INCL (required)."
+          "description": "check/history: FUNC auto, INCL required."
         },
         "pgmid": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -860,6 +860,10 @@
           "type": "string",
           "description": "Object type for check/history/remove_object actions (PROG, CLAS, DDLS, etc.). Not used by create — the SAP backend infers transport type (K/W/T) from the package's TADIR route on the CreateCorrectionRequest endpoint."
         },
+        "group": {
+          "type": "string",
+          "description": "check/history group: FUNC (auto), INCL (required)."
+        },
         "pgmid": {
           "type": "string",
           "description": "Program ID for remove_object: \"R3TR\" (whole object) or \"LIMU\" (sub-object). Required — object type alone does not determine pgmid."

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -862,7 +862,7 @@
         },
         "group": {
           "type": "string",
-          "description": "check/history group: FUNC (auto), INCL (required)."
+          "description": "check/history: FUNC auto, INCL required."
         },
         "pgmid": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. For INCL: parent function-group name + action=\"update\", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported."
+          "description": "FUNC: group name (required for create, else auto-resolved). INCL: group + action=update/edit_unit for a FUGR structural include; omit for standalone."
         },
         "dataType": {
           "type": "string",
@@ -880,10 +880,6 @@
         "preaudit": {
           "type": "boolean",
           "description": "Request pre-activation audit (default true) — SAP returns warnings/errors before activating. false skips it for speed."
-        },
-        "group": {
-          "type": "string",
-          "description": "FUNC: group name (auto-resolved if omitted). INCL: required for a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",
@@ -1594,7 +1590,7 @@
         },
         "group": {
           "type": "string",
-          "description": "check/history group: FUNC (auto), INCL (required)."
+          "description": "check/history: FUNC auto, INCL required."
         },
         "pgmid": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted."
+          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action=\"update\" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported."
         },
         "dataType": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name + action=\"update\" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported."
+          "description": "For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. For INCL: parent function-group name + action=\"update\", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported."
         },
         "dataType": {
           "type": "string",
@@ -883,7 +883,7 @@
         },
         "group": {
           "type": "string",
-          "description": "FUNC: parent function-group name (auto-resolved if omitted). INCL: required to activate a FUGR structural include. Ignored otherwise."
+          "description": "FUNC: group name (auto-resolved if omitted). INCL: required for a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",
@@ -1591,6 +1591,10 @@
         "type": {
           "type": "string",
           "description": "Object type for check/history/remove_object actions (PROG, CLAS, DDLS, etc.). Not used by create — the SAP backend infers transport type (K/W/T) from the package's TADIR route on the CreateCorrectionRequest endpoint."
+        },
+        "group": {
+          "type": "string",
+          "description": "check/history group: FUNC (auto), INCL (required)."
         },
         "pgmid": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action=\"update\" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported."
+          "description": "For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name + action=\"update\" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported."
         },
         "dataType": {
           "type": "string",
@@ -880,6 +880,10 @@
         "preaudit": {
           "type": "boolean",
           "description": "Request pre-activation audit (default true) — SAP returns warnings/errors before activating. false skips it for speed."
+        },
+        "group": {
+          "type": "string",
+          "description": "FUNC: parent function-group name (auto-resolved if omitted). INCL: required to activate a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. For INCL: parent function-group name + action=\"update\", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported."
+          "description": "FUNC: group name (required for create, else auto-resolved). INCL: group + action=update/edit_unit for a FUGR structural include; omit for standalone."
         },
         "dataType": {
           "type": "string",
@@ -880,10 +880,6 @@
         "preaudit": {
           "type": "boolean",
           "description": "Request pre-activation audit (default true) — SAP returns warnings/errors before activating. false skips it for speed."
-        },
-        "group": {
-          "type": "string",
-          "description": "FUNC: group name (auto-resolved if omitted). INCL: required for a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",
@@ -1594,7 +1590,7 @@
         },
         "group": {
           "type": "string",
-          "description": "check/history group: FUNC (auto), INCL (required)."
+          "description": "check/history: FUNC auto, INCL required."
         },
         "pgmid": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted."
+          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action=\"update\" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported."
         },
         "dataType": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name + action=\"update\" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported."
+          "description": "For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. For INCL: parent function-group name + action=\"update\", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported."
         },
         "dataType": {
           "type": "string",
@@ -883,7 +883,7 @@
         },
         "group": {
           "type": "string",
-          "description": "FUNC: parent function-group name (auto-resolved if omitted). INCL: required to activate a FUGR structural include. Ignored otherwise."
+          "description": "FUNC: group name (auto-resolved if omitted). INCL: required for a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",
@@ -1591,6 +1591,10 @@
         "type": {
           "type": "string",
           "description": "Object type for check/history/remove_object actions (PROG, CLAS, DDLS, etc.). Not used by create — the SAP backend infers transport type (K/W/T) from the package's TADIR route on the CreateCorrectionRequest endpoint."
+        },
+        "group": {
+          "type": "string",
+          "description": "check/history group: FUNC (auto), INCL (required)."
         },
         "pgmid": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action=\"update\" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported."
+          "description": "For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name + action=\"update\" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported."
         },
         "dataType": {
           "type": "string",
@@ -880,6 +880,10 @@
         "preaudit": {
           "type": "boolean",
           "description": "Request pre-activation audit (default true) — SAP returns warnings/errors before activating. false skips it for speed."
+        },
+        "group": {
+          "type": "string",
+          "description": "FUNC: parent function-group name (auto-resolved if omitted). INCL: required to activate a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted."
+          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action=\"update\" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported."
         },
         "dataType": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action=\"update\" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported."
+          "description": "For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name + action=\"update\" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported."
         },
         "dataType": {
           "type": "string",
@@ -880,6 +880,10 @@
         "preaudit": {
           "type": "boolean",
           "description": "Request pre-activation audit (default true) — SAP returns warnings/errors before activating. false skips it for speed."
+        },
+        "group": {
+          "type": "string",
+          "description": "FUNC: parent function-group name (auto-resolved if omitted). INCL: required to activate a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name + action=\"update\" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported."
+          "description": "For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. For INCL: parent function-group name + action=\"update\", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported."
         },
         "dataType": {
           "type": "string",
@@ -883,7 +883,7 @@
         },
         "group": {
           "type": "string",
-          "description": "FUNC: parent function-group name (auto-resolved if omitted). INCL: required to activate a FUGR structural include. Ignored otherwise."
+          "description": "FUNC: group name (auto-resolved if omitted). INCL: required for a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. For INCL: parent function-group name + action=\"update\", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported."
+          "description": "FUNC: group name (required for create, else auto-resolved). INCL: group + action=update/edit_unit for a FUGR structural include; omit for standalone."
         },
         "dataType": {
           "type": "string",
@@ -880,10 +880,6 @@
         "preaudit": {
           "type": "boolean",
           "description": "Request pre-activation audit (default true) — SAP returns warnings/errors before activating. false skips it for speed."
-        },
-        "group": {
-          "type": "string",
-          "description": "FUNC: group name (auto-resolved if omitted). INCL: required for a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. For INCL: parent function-group name + action=\"update\", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported."
+          "description": "FUNC: group name (required for create, else auto-resolved). INCL: group + action=update/edit_unit for a FUGR structural include; omit for standalone."
         },
         "dataType": {
           "type": "string",
@@ -880,10 +880,6 @@
         "preaudit": {
           "type": "boolean",
           "description": "Request pre-activation audit (default true) — SAP returns warnings/errors before activating. false skips it for speed."
-        },
-        "group": {
-          "type": "string",
-          "description": "FUNC: group name (auto-resolved if omitted). INCL: required for a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",
@@ -1594,7 +1590,7 @@
         },
         "group": {
           "type": "string",
-          "description": "check/history group: FUNC (auto), INCL (required)."
+          "description": "check/history: FUNC auto, INCL required."
         },
         "pgmid": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted."
+          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action=\"update\" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported."
         },
         "dataType": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name + action=\"update\" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported."
+          "description": "For FUNC: parent function-group name. Required for create (create the FUGR first); auto-resolved for update/delete if omitted. For INCL: parent function-group name + action=\"update\", to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). No group = standalone include; create/delete of structural includes unsupported."
         },
         "dataType": {
           "type": "string",
@@ -883,7 +883,7 @@
         },
         "group": {
           "type": "string",
-          "description": "FUNC: parent function-group name (auto-resolved if omitted). INCL: required to activate a FUGR structural include. Ignored otherwise."
+          "description": "FUNC: group name (auto-resolved if omitted). INCL: required for a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",
@@ -1591,6 +1591,10 @@
         "type": {
           "type": "string",
           "description": "Object type for check/history/remove_object actions (PROG, CLAS, DDLS, etc.). Not used by create — the SAP backend infers transport type (K/W/T) from the package's TADIR route on the CreateCorrectionRequest endpoint."
+        },
+        "group": {
+          "type": "string",
+          "description": "check/history group: FUNC (auto), INCL (required)."
         },
         "pgmid": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -387,7 +387,7 @@
         },
         "group": {
           "type": "string",
-          "description": "For FUNC: parent function-group name. Required for FUNC create (the FUGR must already exist — create it first via SAPWrite type=FUGR). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name to update an existing FUGR-scoped structural include (the global-data TOP include, a FORM-routine include, PBO/PAI) via action=\"update\" — addresses /functions/groups/{group}/includes/{name}. A bare INCL with no group is a standalone program include. Create/delete of new structural includes is unsupported."
+          "description": "For FUNC: parent function-group name. Required for FUNC create (create the FUGR first). Auto-resolved via search for FUNC update/delete if omitted. For INCL: pass the parent function-group name + action=\"update\" to update an existing FUGR structural include (TOP/form-routine/PBO-PAI). A bare INCL with no group is a standalone program include; create/delete of new structural includes is unsupported."
         },
         "dataType": {
           "type": "string",
@@ -880,6 +880,10 @@
         "preaudit": {
           "type": "boolean",
           "description": "Request pre-activation audit (default true) — SAP returns warnings/errors before activating. false skips it for speed."
+        },
+        "group": {
+          "type": "string",
+          "description": "FUNC: parent function-group name (auto-resolved if omitted). INCL: required to activate a FUGR structural include. Ignored otherwise."
         },
         "objects": {
           "type": "array",

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -884,6 +884,10 @@
           "type": "string",
           "description": "Object type for check/history/remove_object actions (PROG, CLAS, DDLS, etc.). Not used by create — the SAP backend infers transport type (K/W/T) from the package's TADIR route on the CreateCorrectionRequest endpoint."
         },
+        "group": {
+          "type": "string",
+          "description": "check/history group: FUNC (auto), INCL (required)."
+        },
         "pgmid": {
           "type": "string",
           "description": "Program ID for remove_object: \"R3TR\" (whole object) or \"LIMU\" (sub-object). Required — object type alone does not determine pgmid."

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -886,7 +886,7 @@
         },
         "group": {
           "type": "string",
-          "description": "check/history group: FUNC (auto), INCL (required)."
+          "description": "check/history: FUNC auto, INCL required."
         },
         "pgmid": {
           "type": "string",

--- a/tests/unit/adt/client.test.ts
+++ b/tests/unit/adt/client.test.ts
@@ -2233,6 +2233,33 @@ describe('AdtClient', () => {
       expect(pkg).toBe('Z_GATED');
       expect(fetchHeaders(0).Accept).toBe('application/vnd.sap.adt.businessservices.servicebinding.v2+xml');
     });
+
+    it('resolves the package of a FUGR structural include (fincludes) via 406 negotiation retry', async () => {
+      // Live-captured (2026-07-14, object names anonymized): a FORM-routine include under a function
+      // group only renders under the functions.fincludes.v2+xml Accept; a generic GET 406s and names
+      // that type in the error body. resolveObjectPackage is called with no explicit Accept for this
+      // branch (write.ts INCL+group), so it must recover via the client's generic 406 negotiation
+      // retry, then extract the package from containerRef@packageName (the fincludes schema has no
+      // own packageRef).
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          406,
+          '<?xml version="1.0" encoding="utf-8"?><exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><namespace id="com.sap.adt"/><type id="ExceptionResourceNotAcceptable"/><message lang="EN">The message content is not acceptable. Accepted content types: application/vnd.sap.adt.functions.fincludes.v2+xml</message><localizedMessage lang="EN">The message content is not acceptable. Accepted content types: application/vnd.sap.adt.functions.fincludes.v2+xml</localizedMessage><properties><entry key="T100KEY-ID">SADT_RESOURCE</entry><entry key="T100KEY-NO">044</entry><entry key="T100KEY-V1">application/vnd.sap.adt.functions.fincludes.v2+xml</entry></properties></exc:exception>',
+        ),
+      );
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          200,
+          '<?xml version="1.0" encoding="utf-8"?><finclude:abapFunctionGroupInclude abapsource:sourceUri="source/main" adtcore:name="LZFUGR_TESTP01" adtcore:type="FUGR/I" adtcore:version="active" adtcore:description="Include LZFUGR_TESTP01" adtcore:language="EN" xmlns:finclude="http://www.sap.com/adt/functions/fincludes" xmlns:abapsource="http://www.sap.com/adt/abapsource" xmlns:adtcore="http://www.sap.com/adt/core"><adtcore:containerRef adtcore:uri="/sap/bc/adt/functions/groups/zfugr_test" adtcore:type="FUGR/F" adtcore:name="ZFUGR_TEST" adtcore:packageName="ZTEST_PKG"/></finclude:abapFunctionGroupInclude>',
+        ),
+      );
+      const client = createClient();
+      const pkg = await client.resolveObjectPackage('/sap/bc/adt/functions/groups/zfugr_test/includes/lzfugr_testp01');
+      expect(pkg).toBe('ZTEST_PKG');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(fetchHeaders(1).Accept).toBe('application/vnd.sap.adt.functions.fincludes.v2+xml');
+    });
   });
 
   describe('getInactiveObjects', () => {

--- a/tests/unit/handlers/activate.test.ts
+++ b/tests/unit/handlers/activate.test.ts
@@ -824,5 +824,47 @@ describe('SAPActivate handler', () => {
       expect(result.content[0]?.text).toContain('Warnings:');
       expect(result.content[0]?.text).toContain('Consider using CDS view entity');
     });
+
+    // ─── FUGR structural include activation (FEAT-18 sibling) ───
+    // Single-object group-routing is covered by 'activates a function-group structural include
+    // through its parent-group URI' above (#571). These cover the remaining cases: no-group
+    // fallback, batch, and the package-allowlist gate.
+    it('falls back to the standalone /programs/includes/ URI for INCL when no group is given', async () => {
+      await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPActivate', {
+        type: 'INCL',
+        name: 'ZSTANDALONE_INCL',
+      });
+      const lastCallOpts = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]?.[1] as RequestInit;
+      expect(lastCallOpts.body).toContain('/sap/bc/adt/programs/includes/ZSTANDALONE_INCL');
+    });
+
+    it('batch activates a FUGR structural include (INCL) via the group-scoped URI', async () => {
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPActivate', {
+        objects: [{ type: 'INCL', name: 'LZFUGR_TESTP01', group: 'ZFUGR_TEST' }],
+      });
+      expect(result.isError).toBeUndefined();
+      const lastCallOpts = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]?.[1] as RequestInit;
+      expect(lastCallOpts.body).toContain('/sap/bc/adt/functions/groups/zfugr_test/includes/lzfugr_testp01');
+    });
+
+    it('blocks INCL activation in a non-allowed package using the group-scoped package-resolution URL', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          '<finclude:abapFunctionGroupInclude xmlns:adtcore="http://www.sap.com/adt/core" adtcore:name="LZFUGR_TESTP01"><adtcore:containerRef adtcore:name="ZFUGR_TEST" adtcore:packageName="ZRESTRICTED"/></finclude:abapFunctionGroupInclude>',
+          { 'x-csrf-token': 'T' },
+        ),
+      );
+      const result = await handleToolCall(restrictedTmpClient(), DEFAULT_CONFIG, 'SAPActivate', {
+        type: 'INCL',
+        name: 'LZFUGR_TESTP01',
+        group: 'ZFUGR_TEST',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('ZRESTRICTED');
+      expect(result.content[0]?.text).toContain('blocked');
+      expect(mockFetch.mock.calls.some((c) => String(c[0]).includes('/activation'))).toBe(false);
+    });
   });
 });

--- a/tests/unit/handlers/transport.test.ts
+++ b/tests/unit/handlers/transport.test.ts
@@ -633,6 +633,83 @@ describe('SAPTransport + SAPWrite transport behavior', () => {
       expect(result.isError).toBe(true);
       expect(result.content[0]?.text).toContain('"type" and "name" are required');
     });
+
+    // ─── FUGR structural include (INCL) group-routing gap (2026-07-14 finding) ───
+    // Without `group`, check/history silently resolved the wrong standalone
+    // /programs/includes/ URL for a FUGR-scoped include — the lookup then came back
+    // empty and misleadingly reported the object as local. Mirrors the SAPWrite/
+    // SAPActivate FEAT-18-sibling fix.
+    it('history resolves the group-scoped URI for a FUGR structural include (INCL) when group is provided', async () => {
+      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
+        action: 'history',
+        type: 'INCL',
+        name: 'LZFUGR_TESTP01',
+        group: 'ZFUGR_TEST',
+      });
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(parsed.object.uri).toBe('/sap/bc/adt/functions/groups/zfugr_test/includes/lzfugr_testp01');
+    });
+
+    it('history falls back to the standalone /programs/includes/ URI for INCL when no group is given', async () => {
+      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
+        action: 'history',
+        type: 'INCL',
+        name: 'ZSTANDALONE_INCL',
+      });
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(parsed.object.uri).toBe('/sap/bc/adt/programs/includes/ZSTANDALONE_INCL');
+    });
+
+    it('check resolves the group-scoped URI for a FUGR structural include (INCL) when group is provided', async () => {
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          '<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0"><asx:values><DATA><DEVCLASS>ZFUGR_TEST_PKG</DEVCLASS><RECORDING>X</RECORDING></DATA></asx:values></asx:abap>',
+          { 'x-csrf-token': 'T' },
+        ),
+      );
+      const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
+        action: 'check',
+        type: 'INCL',
+        name: 'LZFUGR_TESTP01',
+        group: 'ZFUGR_TEST',
+        package: 'ZFUGR_TEST_PKG',
+      });
+      expect(result.isError).toBeUndefined();
+      const checkCall = mockFetch.mock.calls.find((c) => String(c[0]).includes('/transportchecks'));
+      const checkBody = String((checkCall?.[1] as RequestInit)?.body ?? '');
+      expect(checkBody).toContain('/sap/bc/adt/functions/groups/zfugr_test/includes/lzfugr_testp01');
+    });
+
+    it('history resolves a FUNC via the group-scoped fmodules URI when group is provided', async () => {
+      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
+        action: 'history',
+        type: 'FUNC',
+        name: 'Z_MY_FM',
+        group: 'ZFUGR_TEST',
+      });
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(parsed.object.uri).toBe('/sap/bc/adt/functions/groups/zfugr_test/fmodules/z_my_fm');
+    });
+
+    it('history returns a clear error when FUNC group cannot be resolved', async () => {
+      mockFetch.mockResolvedValue(
+        mockResponse(200, '<?xml version="1.0"?><adtcore:objectReferences/>', { 'x-csrf-token': 'T' }),
+      );
+      const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
+        action: 'history',
+        type: 'FUNC',
+        name: 'Z_UNRESOLVABLE_FM',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('Cannot resolve function group');
+    });
   });
 
   describe('transport error hints', () => {


### PR DESCRIPTION
## Summary

Fixes a group-routing gap for FUGR structural includes (`type=INCL`, e.g. a FORM-routine or TOP
include inside a function group) across three tools. Rebased onto `main` — this PR previously
also touched `SAPActivate`, but that was independently and functionally-identically fixed by
#571 (merged after this branch was created), so that part has been dropped here. See below.

## What's in this PR now

- **SAPWrite** (`type=INCL` + `group`): the write path already worked (FEAT-18/#505), but the
  tool schema never documented `group` for `type=INCL` — only for `type=FUNC`. A caller had no
  way to discover it, and would fall through to the standalone `/programs/includes/` path,
  hitting the package-resolution fail-closed error. Doc/schema-only fix.
- **SAPTransport** (`check`/`history` + `group`): both actions resolved the object URL via
  `objectUrlForType` directly, with no group-aware routing. For `type=FUNC` this threw loudly
  (the existing `objectBasePath` guard from #223); for `type=INCL` it silently resolved the wrong
  standalone path and returned a misleading "no related or candidate transports (likely $TMP /
  local object)" for an object that is, in fact, package-bound with real transport history. Adds
  a `group` param and routes both actions correctly for FUNC (auto-resolved via search if
  omitted) and INCL.
- A few extra `SAPActivate` regression tests that #571 didn't add: the no-group standalone
  fallback, batch activation with `group`, and the package-allowlist gate — kept since they add
  coverage #571's own test didn't include.

## Dropped (superseded by #571)

`activate.ts` INCL routing, `SAPActivateSchema.group` (top-level + `objects[]`), the `tools.ts`
SAPActivate `group` field, and the duplicate single-object activate test — all already shipped
in #571 with equivalent logic and guards.

## Test plan

- [x] `npm test` — full suite green (only pre-existing, unrelated failures present before and
      after this change)
- [x] `npm run typecheck` / `npm run build` — clean
- [x] `npm run check:sizes` — file-size ratchet + tool-schema wire-byte budget both pass
- [x] Live-verified end-to-end on a real SAP system: `SAPWrite type=INCL group=<FUGR>` write,
      then `SAPActivate type=INCL group=<FUGR>` activation, both succeeding against a real
      function-group structural include

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>