### PR TITLE
docs: document XSUAA session-cookie trap for invalid_scope

### DIFF
--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -106,6 +106,15 @@ cf logs arc1-mcp-server --recent | grep XSUAA
 4. Add your BTP user (email address)
 5. Save
 
+**Assign before you hand out the MCP URL.** The assignment creates the shadow user, so it works for users who have never logged in — use the **Users** tab above, or:
+
+```bash
+btp assign security/role-collection "ARC-1 Admin (<space>)" \
+  --subaccount <subaccount-id> --to-user <email> --of-idp <origin-key>
+```
+
+Order matters. If the user logs in first, that failed login leaves a cached XSUAA session behind, and every retry keeps returning `invalid_scope` after you grant the role — until they clear their browser cookies. A self-service rollout ("here's the URL, try it") produces that order by default, so it hits essentially every user once. See [`invalid_scope`](#insufficient-scope-invalid_scope) if you are already in that state.
+
 ## Step 4: Verify OAuth Discovery
 
 ```bash
@@ -372,7 +381,31 @@ Ensure the XSUAA service is bound: `cf services` should show `arc1-xsuaa` bound 
 ### "Insufficient scope" / "invalid_scope"
 The user doesn't have the required role collection assigned. Go to BTP Cockpit → Security → Role Collections and assign the appropriate collection to the user.
 
-**IdP matters:** If the subaccount has a custom IAS tenant (trust configuration shows `sap.custom`), role collections must be assigned with the correct IdP origin. Assigning via `sap.default` when the user logs in via `sap.custom` will result in `invalid_scope`.
+If the collection **is** already assigned and you still get `invalid_scope`, it is one of three things, in the order worth checking.
+
+**1. Stale XSUAA session cookie — the common one.** After an admin assigns a role collection, XSUAA keeps returning `invalid_scope` because the browser still holds an XSUAA SSO session created *before* the grant. XSUAA answers from that session's cached authorities and never re-reads role collections.
+
+Fix: delete the browser cookies for the XSUAA domain (`<identityzone>.authentication.<region>.hana.ondemand.com` — in Edge, `edge://settings/content/all` → search `authentication` → delete). Read the exact domain from the `url` field of the XSUAA binding: **Cockpit → Application → Service Bindings → arc1-xsuaa → Credentials**. No waiting period; the next login works immediately.
+
+Two things that do **not** work, both tried:
+
+- **`<xsuaa-url>/logout` is a dead end.** Without a `redirect` param it renders SAP's "Uh oh. Something went amiss." and does not reliably drop the session.
+- **Resetting the MCP client's token cache** (e.g. VS Code's MCP auth reset) changes nothing — the poisoned session lives in the browser, not the client.
+
+Diagnostic, in `cf logs <app-name> --recent`:
+
+```
+GET /authorize?...                         302
+GET /oauth/callback?error=invalid_scope    400   ← <200ms later
+```
+
+`/authorize` → `/oauth/callback?error=invalid_scope` in under ~200 ms with no IAS login form in between is a cached session, not a missing role collection — a genuine grant problem costs a full interactive login first. Corollary: if a retry never shows a login form, the cookie is still there.
+
+**2. Role collection with no roles.** Deleting and recreating an XSUAA service instance orphans its role collections — collections are subaccount-scoped and survive the instance, their roles do not. A later `cf deploy` will not re-link them, because the `role-collections` config in `mta.yaml` only creates collections whose names don't already exist.
+
+Check **Cockpit → Security → Role Collections → "ARC-1 Admin (<space>)" → Roles**: it must list role `MCPAdmin` with Application Identifier `arc1-mcp-<space>!t<idx>`. An empty **Roles** tab is the tell. Fix: delete the role collection in the cockpit, `cf deploy` again, re-assign.
+
+**3. Wrong IdP origin.** If the subaccount has a custom IAS tenant (trust configuration shows `sap.custom`), role collections must be assigned with the correct IdP origin. Assigning via `sap.default` when the user logs in via `sap.custom` will result in `invalid_scope`. Platform IdP users (origin `<tenant>-platform`) are for cockpit and CLI access only — a role collection assigned there does nothing for application logon.
 
 ### "Invalid client_id" (Copilot Studio)
 DCR registrations are in-memory and lost on restart. Switch to **Manual** OAuth mode (see above) to avoid this.


### PR DESCRIPTION
## Why

The `invalid_scope` troubleshooting entry only covered the IdP-origin cause. An admin who had **already** assigned the role collection — correctly, under the right IdP — had nothing to go on, and the ARC-1 error page tells them to do the thing they just did.

This has now cost two multi-hour field debugs (2026-06-01 and 2026-07-15, different subaccounts) with the identical root cause: a **stale XSUAA SSO session**. The browser holds a session created *before* the grant, and XSUAA answers from that session's cached authorities without ever re-reading role collections.

Both times, the obvious fix made it worse — `<xsuaa-url>/logout` renders SAP's "Uh oh. Something went amiss." and does **not** drop the session, so it reads as "cache ruled out" when it isn't.

## What changed

**[Step 3](https://github.com/arc-mcp/arc-1/blob/claude/hopeful-wescoff-099273/docs_page/xsuaa-setup.md) — prevention.** Assign the role collection *before* handing out the MCP URL, with the `btp assign` one-liner that creates the shadow user for a never-logged-in user. The trap only fires in the try-first-then-assign order, which is exactly what a self-service rollout produces — so it hits essentially every self-onboarding user once.

**Troubleshooting — cure.** The entry keeps its original opener, then branches into three causes for when the collection *is* already assigned:

1. **Stale session cookie** (the common one) — fix is deleting cookies for the XSUAA domain. Explicitly flags the two non-fixes that burn the most time: `/logout`, and resetting the MCP client's token cache (the poisoned session lives in the browser, not the client).
2. **Role collection with no roles** — recreating an XSUAA instance strands the collection's roles, and `cf deploy` won't re-link a name that already exists. Empty **Roles** tab is the tell.
3. **Wrong IdP origin** — the pre-existing note, extended with platform-IdP users (`<tenant>-platform`), which are cockpit/CLI only and grant nothing for application logon.

Plus the `cf logs` diagnostic that settles it in one glance: `/authorize` → `/oauth/callback?error=invalid_scope` in under ~200 ms **with no IAS login form** is a cached session, not a missing grant.

## Notes

- Docs-only, `docs:` prefix — no release.
- The Step 3 → troubleshooting anchor is `#insufficient-scope-invalid_scope` (single hyphen). Python-Markdown's slugify collapses the double space; the GitHub-style `--` form would 404 on the published site. Verified against the actual slugify rather than by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)