### PR TITLE
docs: follow OS light/dark preference on the docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,13 +11,16 @@ theme:
   name: material
   custom_dir: docs/overrides
   palette:
-    - scheme: default
+    # `media` = follow the OS light/dark setting on first visit; the toggle then pins a choice.
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
       primary: deep orange
       accent: amber
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - scheme: slate
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
       primary: deep orange
       accent: amber
       toggle:


### PR DESCRIPTION
## Problem

The Material palette in `mkdocs.yml` had no `media` keys, so the docs site always opened in **light mode** regardless of the visitor's OS setting. Dark mode was reachable only by clicking the toggle.

## Fix

Tag each palette entry with its `prefers-color-scheme` media query. Material's bundled JS reads those and picks the matching entry on first load — no custom CSS or JS needed.

```yaml
- media: '(prefers-color-scheme: light)'
  scheme: default
- media: '(prefers-color-scheme: dark)'
  scheme: slate
```

The toggle still overrides the OS setting and persists the choice across pages (`localStorage['/.__palette']`), exactly as before.

## Verification

Built locally with mkdocs-material 9.7.5 (inside CI's `>=9.5,<10` range) and driven in a browser under both OS settings:

| OS setting | First load | Toggle |
|---|---|---|
| dark | slate (dark) ✅ | → default, persisted ✅ |
| light | default (light) ✅ | → slate, persisted ✅ |

Both verified with `localStorage` cleared, i.e. a genuine first visit.

## Notes

- `docs:` prefix — no release triggered.
- Skipped the third "auto / system preference" toggle state that Material also supports. It adds a state to the toggle for the ability to return to auto after an explicit override; say the word if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)