### PR TITLE
fix: don't crash startup on PP-off overrides, and harden the mta.yaml/mtaext stranding class

### DIFF
--- a/mta-overrides.mtaext.example
+++ b/mta-overrides.mtaext.example
@@ -18,6 +18,12 @@
 # `SAP_BTP_*_DESTINATION` properties below are the only ones that have to
 # be set — the base `mta.yaml` ships with placeholder destination names so
 # deploying without an override fails fast at startup.
+#
+# IMPORTANT — an extension can only OVERRIDE a base property, never remove it.
+# To turn a base-enabled feature OFF you must write the explicit off-value here;
+# commenting the line out or deleting it just falls back to the `mta.yaml` value.
+# (`SAP_FOO: ~` fails the deploy, and `cf unset-env` is undone by the next
+# `cf deploy` — an explicit value is the only durable override.)
 # ──────────────────────────────────────────────────────────────────────
 
 _schema-version: "3.1"
@@ -35,12 +41,17 @@ modules:
       # SAP_BTP_PP_DESTINATION: "my-pp-destination"
 
       # ── Principal propagation behaviour ──────────────────────────────
-      # Enable per-user principal propagation (default in mta.yaml: true)
-      # SAP_PP_ENABLED: "true"
+      # Per-user principal propagation (default in mta.yaml: true). Uncomment
+      # the line below to run every SAP call as the shared destination identity
+      # instead. The base `SAP_PP_STRICT: "true"` can stay as it is — it only
+      # warns once PP is off.
+      # SAP_PP_ENABLED: "false"
 
       # The base MTA uses the recommended strict default: API-key/non-JWT tool
       # calls are rejected. Set false for supported mixed PP/API-key operation;
       # JWT calls use PP and API-key calls use the shared destination identity.
+      # Leaving this at the base "true" while adding ARC1_API_KEYS means those
+      # API-key clients are rejected on every tool call.
       # SAP_PP_STRICT: "false"
 
       # ── Safety / Authorization ───────────────────────────────────────
@@ -140,10 +151,10 @@ modules:
       # SAP language
       # SAP_LANGUAGE: "EN"
 
-      # Skip TLS certificate verification (default in mta.yaml: true, for
-      # on-premise self-signed-cert landscapes). Override to "false" on
-      # landscapes with proper CA-signed certificates.
-      # SAP_INSECURE: "false"
+      # Skip TLS certificate verification (default in mta.yaml: false).
+      # Override to "true" only for on-premise landscapes with self-signed
+      # certificates that you cannot get into the trust store.
+      # SAP_INSECURE: "true"
 
     # ── Route host — pick your public URL (recommended) ──────────────
     # Base mta.yaml sets NO host, so the deploy service assigns a globally

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -759,9 +759,12 @@ export function validateConfig(config: ServerConfig): void {
     throw new Error('SAP_OIDC_ISSUER is required when SAP_OIDC_AUDIENCE is set');
   }
 
+  // Inert, not dangerous — both strict-PP enforcement sites gate on ppEnabled. Warn instead
+  // of crashing: an mtaext cannot unset a base mta.yaml property, so an override that turns
+  // PP off strands SAP_PP_STRICT=true and a hard throw would brick the deployment.
   if (config.ppStrict && !config.ppEnabled) {
-    throw new Error(
-      'SAP_PP_STRICT=true requires SAP_PP_ENABLED=true — strict mode has no effect without principal propagation enabled',
+    console.error(
+      '[warn] SAP_PP_STRICT=true has no effect without SAP_PP_ENABLED=true — ignoring strict mode. Set SAP_PP_ENABLED=true if you meant to enable principal propagation.',
     );
   }
 

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -768,6 +768,16 @@ export function validateConfig(config: ServerConfig): void {
     );
   }
 
+  // The mirror-image stranding: an mtaext that turns XSUAA off and adds API keys, but leaves
+  // the base SAP_PP_ENABLED/SAP_PP_STRICT stranded, passes validation (API keys satisfy
+  // hasHttpAuth) and logs a healthy `per-user` scope while server.ts rejects every API-key
+  // call for lacking a JWT. Loud at startup beats 100% of traffic failing silently.
+  if (config.ppEnabled && config.ppStrictExplicit && config.ppStrict && config.apiKeys?.length) {
+    console.error(
+      '[warn] SAP_PP_STRICT=true rejects every non-JWT call, so the configured ARC1_API_KEYS clients cannot call any tool. Set SAP_PP_STRICT=false for mixed PP/API-key operation, or SAP_PP_ENABLED=false to run fully shared.',
+    );
+  }
+
   const hasHttpAuth = !!(config.apiKeys?.length || config.oidcIssuer || config.xsuaaAuth);
   if (config.transport === 'http-streamable' && !hasHttpAuth && !config.allowHttpNoAuth) {
     throw new Error(

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -357,7 +357,9 @@ async function createPerUserClient(
   // This enables a dual-destination approach:
   // - SAP_BTP_DESTINATION = BasicAuth destination (shared client, startup resolution)
   // - SAP_BTP_PP_DESTINATION = PrincipalPropagation destination (per-user, runtime)
-  const destName = process.env.SAP_BTP_PP_DESTINATION ?? process.env.SAP_BTP_DESTINATION;
+  // `||`, not `??`: blanking is the only way an mtaext can neutralize a base property, so
+  // an empty SAP_BTP_PP_DESTINATION must fall back instead of failing every PP request.
+  const destName = process.env.SAP_BTP_PP_DESTINATION || process.env.SAP_BTP_DESTINATION;
   if (!destName) {
     throw new Error('SAP_BTP_PP_DESTINATION or SAP_BTP_DESTINATION is required for principal propagation');
   }
@@ -771,7 +773,7 @@ export function createServer(
     const isJwt = !isApiKey && typeof token === 'string' && token.split('.').length === 3;
     if (config.ppEnabled && isJwt) {
       const ppUser = (extra.authInfo?.extra?.userName ?? extra.authInfo?.clientId) as string | undefined;
-      const ppDest = process.env.SAP_BTP_PP_DESTINATION ?? process.env.SAP_BTP_DESTINATION ?? '';
+      const ppDest = process.env.SAP_BTP_PP_DESTINATION || process.env.SAP_BTP_DESTINATION || '';
       if (!btpConfig) {
         const errMsg = 'BTP runtime configuration is unavailable for principal propagation';
         logger.emitAudit({

--- a/tests/unit/server/config.test.ts
+++ b/tests/unit/server/config.test.ts
@@ -206,6 +206,21 @@ describe('parseArgs', () => {
     expect(config.ppStrictExplicit).toBe(true);
   });
 
+  // An mtaext override turns PP off but cannot unset the base mta.yaml
+  // SAP_PP_STRICT=true — startup must not crash on the stranded no-op.
+  it('starts up when PP is disabled while SAP_PP_STRICT=true is left over', () => {
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      process.env.SAP_PP_ENABLED = 'false';
+      process.env.SAP_PP_STRICT = 'true';
+      const config = parseArgs([]);
+      expect(config.ppEnabled).toBe(false);
+      expect(stderrSpy.mock.calls.flat().join(' ')).toContain('SAP_PP_STRICT=true has no effect');
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
   it('defaults allowGitWrites to false without explicit configuration', () => {
     const config = parseArgs([]);
     expect(config.allowGitWrites).toBe(false);
@@ -1053,14 +1068,20 @@ describe('validateConfig', () => {
     expect(() => validateConfig({ ...DEFAULT_CONFIG })).not.toThrow();
   });
 
-  it('throws when ppStrict is true without ppEnabled', () => {
-    expect(() =>
-      validateConfig({
-        ...DEFAULT_CONFIG,
-        ppStrict: true,
-        ppEnabled: false,
-      }),
-    ).toThrow('SAP_PP_STRICT=true requires SAP_PP_ENABLED=true');
+  it('warns but does not throw when ppStrict is true without ppEnabled', () => {
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      expect(() =>
+        validateConfig({
+          ...DEFAULT_CONFIG,
+          ppStrict: true,
+          ppEnabled: false,
+        }),
+      ).not.toThrow();
+      expect(stderrSpy.mock.calls.flat().join(' ')).toContain('SAP_PP_STRICT=true has no effect');
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
   it('accepts ppStrict with ppEnabled', () => {

--- a/tests/unit/server/mta-descriptor.test.ts
+++ b/tests/unit/server/mta-descriptor.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Proves the SHIPPED BTP descriptor actually resolves through the real config parser.
+ *
+ * An MTA extension descriptor can only OVERRIDE a base `mta.yaml` property, never remove it
+ * (the spec allows deletion via optional+overwritable+null; multiapps-controller never
+ * implemented it — SAP/cloud-mta-build-tool#1164). `SAP_FOO: ~` fails the deploy and
+ * `cf unset-env` is undone by the next `cf deploy`, so writing an explicit value in the
+ * mtaext is an operator's ONLY durable override.
+ *
+ * That makes every base-enabled property a stranding hazard: turning its partner off leaves
+ * it behind in the merged descriptor. Shipping `SAP_PP_STRICT: "true"` next to
+ * `SAP_PP_ENABLED: "true"` is exactly how a `SAP_PP_ENABLED: "false"` override once crashed
+ * every CF instance at startup.
+ *
+ * The other mta.yaml tests (tests/unit/plugin/plugin-manifest.test.ts) assert property
+ * VALUES. These assert the descriptor BOOTS — base as shipped, and under the realistic
+ * overrides operators actually write.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parse } from 'yaml';
+import { parseArgs } from '../../../src/server/config.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/** The env every CF instance boots with: the app module's `properties` block, verbatim. */
+function baseDescriptorEnv(): Record<string, string> {
+  const mta = parse(readFileSync(join(ROOT, 'mta.yaml'), 'utf8')) as Record<string, any>;
+  const appModule = (mta.modules as Array<Record<string, any>>).find((m) => m.name === 'arc1-mcp-server');
+  expect(appModule, 'arc1-mcp-server module missing from mta.yaml').toBeDefined();
+  return appModule?.properties as Record<string, string>;
+}
+
+/** Base ∪ mtaext, the way multiapps-controller merges it: override wins, nothing is removed. */
+function resolveWithOverrides(overrides: Record<string, string> = {}) {
+  for (const [key, value] of Object.entries({ ...baseDescriptorEnv(), ...overrides })) {
+    process.env[key] = String(value);
+  }
+  return parseArgs([]);
+}
+
+describe('shipped mta.yaml resolves through the config parser', () => {
+  const savedEnv = { ...process.env };
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('SAP_') || key.startsWith('ARC1_')) delete process.env[key];
+    }
+    stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    process.env = { ...savedEnv };
+  });
+
+  // The base descriptor legitimately warns about ARC1_DCR_SIGNING_SECRET — it is a
+  // per-landscape secret that cannot live in a tracked descriptor (cf set-env supplies it).
+  const warnings = () => stderrSpy.mock.calls.flat().join(' ');
+  const ppWarnings = () =>
+    stderrSpy.mock.calls
+      .flat()
+      .filter((line) => String(line).includes('SAP_PP_'))
+      .join(' ');
+
+  it('boots as shipped, with strict PP actually enforced', () => {
+    const config = resolveWithOverrides();
+
+    expect(config.transport).toBe('http-streamable');
+    expect(config.ppEnabled).toBe(true);
+    // ppStrictExplicit is the load-bearing half: both enforcement sites in server.ts require
+    // it, so an unset SAP_PP_STRICT would derive ppStrict=true and enforce nothing. This is
+    // why mta.yaml keeps the redundant-looking explicit "true".
+    expect(config.ppStrict).toBe(true);
+    expect(config.ppStrictExplicit).toBe(true);
+    expect(ppWarnings()).toBe('');
+  });
+
+  it('boots with PP turned off by an override, stranding the base SAP_PP_STRICT', () => {
+    const config = resolveWithOverrides({ SAP_PP_ENABLED: 'false' });
+
+    expect(config.ppEnabled).toBe(false);
+    expect(warnings()).toContain('SAP_PP_STRICT=true has no effect');
+  });
+
+  it('warns when an override adds API keys while the base strict PP stays stranded', () => {
+    // XSUAA off + API keys passes validation (API keys satisfy hasHttpAuth) and logs a
+    // healthy `per-user` scope, while server.ts rejects every API-key call for lacking a JWT.
+    const config = resolveWithOverrides({ SAP_XSUAA_AUTH: 'false', ARC1_API_KEYS: 'k1:admin' });
+
+    expect(config.ppEnabled).toBe(true);
+    expect(warnings()).toContain('rejects every non-JWT call');
+  });
+
+  it('boots for mixed PP/API-key operation, the documented SAP_PP_STRICT=false topology', () => {
+    const config = resolveWithOverrides({
+      SAP_XSUAA_AUTH: 'false',
+      SAP_PP_STRICT: 'false',
+      ARC1_API_KEYS: 'k1:admin',
+    });
+
+    expect(config.ppStrict).toBe(false);
+    expect(ppWarnings()).toBe('');
+  });
+
+  it('falls back to the basic destination when an override blanks the PP destination', () => {
+    // Blanking is an mtaext's only way to neutralize a base property, so the PP destination
+    // lookup in server.ts must treat '' as absent and fall back — `??` would not.
+    resolveWithOverrides({ SAP_BTP_PP_DESTINATION: '', SAP_BTP_DESTINATION: 'my-destination' });
+
+    expect(process.env.SAP_BTP_PP_DESTINATION || process.env.SAP_BTP_DESTINATION).toBe('my-destination');
+  });
+});

--- a/tests/unit/server/mta-descriptor.test.ts
+++ b/tests/unit/server/mta-descriptor.test.ts
@@ -64,7 +64,7 @@ describe('shipped mta.yaml resolves through the config parser', () => {
   const ppWarnings = () =>
     stderrSpy.mock.calls
       .flat()
-      .filter((line) => String(line).includes('SAP_PP_'))
+      .filter((line: unknown) => String(line).includes('SAP_PP_'))
       .join(' ');
 
   it('boots as shipped, with strict PP actually enforced', () => {


### PR DESCRIPTION
## Problem

Turning principal propagation off in a BTP deployment crashes the app at startup:

```
Error: SAP_PP_STRICT=true requires SAP_PP_ENABLED=true — strict mode has no effect without principal propagation enabled
    at validateConfig (file:///home/vcap/app/dist/server/config.js:647:15)
```

…even though the operator only set `SAP_PP_ENABLED: "false"` and left `SAP_PP_STRICT` commented out. Reproduced locally with that exact env pair, matching the reported stack.

## Root cause — and the class behind it

The base [mta.yaml](mta.yaml#L116-L119) ships `SAP_PP_STRICT: "true"` next to `SAP_PP_ENABLED: "true"`. **An MTA extension can only override a base property, never remove it**, so commenting it out in the `.mtaext` did nothing and the merged descriptor still deployed `SAP_PP_ENABLED=false` + `SAP_PP_STRICT=true`.

Researched the mechanism rather than assuming it. The MTA spec (§9) says deletion *should* work via `optional` + `overwritable` + null — but multiapps-controller never implemented it (`PropertiesUtil.mergeExtensionProperties` only ever `put`s; a maintainer confirms in [SAP/cloud-mta-build-tool#1164](https://github.com/SAP/cloud-mta-build-tool/issues/1164)). Both obvious escapes are dead ends too: `SAP_FOO: ~` fails the deploy outright, and `cf unset-env` is undone by the very next `cf deploy`.

So writing an **explicit value in the mtaext is an operator's only durable override** — which gives the design rule this PR enforces: *every base-enabled property needs a documented off-value that the code accepts.*

## Changes

**1. `SAP_PP_STRICT` + PP off → warn, don't throw.** The combination is inert: both strict-PP enforcement sites already gate on `ppEnabled` ([server.ts:241](src/server/server.ts#L241), [server.ts:825](src/server/server.ts#L825)), exactly as the thrown message itself conceded. Crashing protected nothing while making an explicit, legitimate "PP off" undeployable.

**2. The mirror-image stranding — worse, because it's silent.** An override that turns XSUAA off and adds API keys strands the base PP pair. Validation passes ([config.ts:771](src/server/config.ts#L771) — API keys satisfy `hasHttpAuth`), startup logs a healthy `per-user` scope, and `server.ts` then rejects **every** API-key tool call for lacking a JWT. A hundred percent of traffic fails with no crash and no warning. Now warns at startup.

**3. `??` → `||` in the PP destination fallback.** Blanking is the only way to neutralize a base property, and `'' ?? x` returns `''`, so blanking `SAP_BTP_PP_DESTINATION` failed every PP request with `SAP_BTP_PP_DESTINATION or SAP_BTP_DESTINATION is required` while the basic destination was correctly set. The comment directly above it already promised the fallback `??` prevented. Per-request, so it deployed green and broke only when users connected.

**4. mtaext template.** The PP block offered `# SAP_PP_ENABLED: "true"` — a no-op uncomment, leaving an operator who wants PP *off* with no line to uncomment. That is the exact journey that produced this bug. Added the off-line, the "an extension cannot unset" rule, and fixed a claim that `SAP_INSECURE` defaults to `true` (mta.yaml ships `"false"` — the template told operators TLS verification was off when it's on).

## What this deliberately does *not* change

`mta.yaml` keeps its explicit `SAP_PP_STRICT: "true"`. I first dropped it as redundant and **the `plugin-manifest` invariant test caught that as a real regression**: both enforcement sites also require `ppStrictExplicit`, which is only true when the var is set *explicitly*. Removing it would have silently stopped PP-enabled BTP deployments from rejecting non-JWT calls, falling API-key requests back to the shared technical user. The new descriptor test now pins `ppStrictExplicit` with that reasoning attached.

## Tests

[tests/unit/server/mta-descriptor.test.ts](tests/unit/server/mta-descriptor.test.ts) retires the class: it resolves the **shipped descriptor through the real config parser** — base, and under the overrides operators actually write (PP off, XSUAA off + API keys, mixed mode, blanked PP destination). Nothing previously proved `mta.yaml` could boot at all; the existing tests assert property *values*, not that they resolve.

It found a real one on its first run: the base descriptor warns about `ARC1_DCR_SIGNING_SECRET`. That's by design (a per-landscape secret can't live in a tracked descriptor), so the assertions are scoped to the stranding class.

Full suite: 4321 passed. The 2 failures in `tests/unit/lint/` are **pre-existing on `main`** (verified via `git stash`) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)