### PR TITLE
refactor: emit compact JSON from tool results

### DIFF
--- a/docs/plans/2026-07-17-token-optimization-plan.md
+++ b/docs/plans/2026-07-17-token-optimization-plan.md
@@ -278,7 +278,15 @@ that proves the conflict is absent; a polluted `batch_create` still passes (item
 
 ---
 
-## P6 — Serialization hygiene (do LAST, only after P1)
+## P6 — Serialization hygiene — SHIPPED (PR 2)
+
+> **Status 2026-07-17: done.** One `toolJson()` helper; 86 sites across 11 handler modules via a
+> bounded codemod. Measured live on already-bounded results: where-used 11,856 → 8,781 (−26%),
+> transport 5,689 → 3,581 (−37%), DEVC 5,372 → 4,404 (−18%), search 2,922 → 2,472 (−15%).
+> **Field pruning rejected on measurement:** dropping empty strings adds only 7.6% over compaction
+> alone, and dropping `""`/`0`/`false` removes `isResult:false` (which separates a real where-used
+> hit from a structural tree node) and `line:0` (meaning "no line info") — absent ≠ false.
+> The "gate on an eval" caveat below stands: accuracy was reasoned about, not A/B tested.
 
 **Verified but small.** 77 `JSON.stringify(x, null, 2)` sites across `src/handlers/`.
 

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -1497,12 +1497,14 @@ export class AdtClient {
     if (u && !u.includes('@')) this.internalUser = u;
   }
 
-  /** Get system info as structured JSON (user, system details from discovery XML) */
+  /** Get system info as structured JSON (user, system details from discovery XML).
+   *  Compact: this string is returned verbatim to the LLM by SAPRead(type="SYSTEM"). Cannot use
+   *  handlers' toolJson() here — adt/ must not depend on handlers/. */
   async getSystemInfo(): Promise<string> {
     checkOperation(this.safety, OperationType.Read, 'GetSystemInfo');
     const resp = await this.http.get('/sap/bc/adt/core/discovery');
     const info = parseSystemInfo(resp.body, await this.getEffectiveUser());
-    return JSON.stringify(info, null, 2);
+    return JSON.stringify(info);
   }
 
   /** Get installed SAP components */

--- a/src/adt/xml-parser.ts
+++ b/src/adt/xml-parser.ts
@@ -1006,7 +1006,7 @@ export function buildApiReleasePutBody(getXml: string, contract: string, state: 
  * We extract the key fields into a JSON summary:
  * - name, description, OData version (V2/V4), binding type (UI/Web API)
  * - service definition reference, publish status, contract
- */
+ * Compact JSON — returned verbatim to the LLM as SAPRead(type="SRVB").source.*/
 export function parseServiceBinding(xml: string): string {
   const parsed = parseXml(xml);
   const sb = (parsed.serviceBinding ?? {}) as Record<string, unknown>;
@@ -1045,7 +1045,7 @@ export function parseServiceBinding(xml: string): string {
     changedBy: String(sb['@_changedBy'] ?? ''),
   };
 
-  return JSON.stringify(result, null, 2);
+  return JSON.stringify(result);
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -135,18 +135,21 @@ program
   .addOption(outputOption)
   .action(async (type: string, name: string, opts: { flat?: boolean; sourceVersion?: string; output: OutputMode }) => {
     const args: Record<string, unknown> = { type: type.toUpperCase(), name };
-    if (opts.flat) args.flat = true;
+    // `--flat` predates `format`; it means "raw source, not decomposed sections" = format:"text",
+    // which is already the default. It used to be sent as a phantom `flat` arg that no handler read
+    // and Zod silently stripped — now that the schemas are strict, send the real parameter.
+    if (opts.flat) args.format = 'text';
     if (opts.sourceVersion) args.version = opts.sourceVersion;
     process.exit(await runToolCall('SAPRead', args, opts.output));
   });
 
-// `source` kept as an alias of `read` with flat=true to preserve legacy CLI behavior.
+// `source` kept as an alias of `read --flat` to preserve legacy CLI behavior.
 program
   .command('source <type> <name>')
   .description('Alias of `read --flat` (legacy)')
   .addOption(outputOption)
   .action(async (type: string, name: string, opts: { output: OutputMode }) => {
-    process.exit(await runToolCall('SAPRead', { type: type.toUpperCase(), name, flat: true }, opts.output));
+    process.exit(await runToolCall('SAPRead', { type: type.toUpperCase(), name, format: 'text' }, opts.output));
   });
 
 program

--- a/src/handlers/context.ts
+++ b/src/handlers/context.ts
@@ -23,7 +23,7 @@ import { logger } from '../server/logger.js';
 import { type CacheSecurityContext, contextCacheForDependencyPayloads } from './cache-security.js';
 import { cachedFeatures } from './feature-cache.js';
 import { normalizeObjectType, objectUrlForType } from './object-types.js';
-import { errorResult, type ToolResult, textResult } from './shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from './shared.js';
 import { lookupLiveUsages, resolveWhereUsedUri } from './where-used.js';
 
 // ─── SAPContext Handler ───────────────────────────────────────────────
@@ -83,18 +83,14 @@ export async function handleSAPContext(
       }
       if (matches.length > 1) {
         return errorResult(
-          JSON.stringify(
-            {
-              error: `Object name "${name.toUpperCase()}" is ambiguous. Retry with type.`,
-              candidates: matches.slice(0, 20).map((match) => ({
-                type: normalizeObjectType(match.objectType),
-                name: match.objectName,
-                uri: match.uri,
-              })),
-            },
-            null,
-            2,
-          ),
+          toolJson({
+            error: `Object name "${name.toUpperCase()}" is ambiguous. Retry with type.`,
+            candidates: matches.slice(0, 20).map((match) => ({
+              type: normalizeObjectType(match.objectType),
+              name: match.objectName,
+              uri: match.uri,
+            })),
+          }),
         );
       }
       const match = matches[0]!;
@@ -105,25 +101,21 @@ export async function handleSAPContext(
     const usageMax = args.maxResults === undefined ? undefined : Number(args.maxResults);
     const lookup = await lookupLiveUsages(client, resolvedUri, undefined, usageMax);
     return textResult(
-      JSON.stringify(
-        {
-          name: name.toUpperCase(),
-          resolvedObject,
-          // usageCount is the TOTAL, not the page size — a truncated page must not under-report
-          // the blast radius of a change.
-          usageCount: lookup.total,
-          shown: lookup.results.length,
-          truncated: lookup.truncated,
-          ...(lookup.truncated
-            ? { hint: `Showing ${lookup.results.length} of ${lookup.total} usages. Raise maxResults (max 1000).` }
-            : {}),
-          usages: lookup.results,
-          source: 'live',
-          fallbackUsed: lookup.fallbackUsed,
-        },
-        null,
-        2,
-      ),
+      toolJson({
+        name: name.toUpperCase(),
+        resolvedObject,
+        // usageCount is the TOTAL, not the page size — a truncated page must not under-report
+        // the blast radius of a change.
+        usageCount: lookup.total,
+        shown: lookup.results.length,
+        truncated: lookup.truncated,
+        ...(lookup.truncated
+          ? { hint: `Showing ${lookup.results.length} of ${lookup.total} usages. Raise maxResults (max 1000).` }
+          : {}),
+        usages: lookup.results,
+        source: 'live',
+        fallbackUsed: lookup.fallbackUsed,
+      }),
     );
   }
 
@@ -350,7 +342,7 @@ export async function handleSAPContext(
       ...(warnings.length > 0 ? { warnings } : {}),
     };
 
-    return textResult(JSON.stringify(response, null, 2));
+    return textResult(toolJson(response));
   }
 
   if (action === 'structure') {
@@ -359,7 +351,7 @@ export async function handleSAPContext(
     }
 
     const result = await buildStructureHierarchy(client, name);
-    return textResult(JSON.stringify(result, null, 2));
+    return textResult(toolJson(result));
   }
 
   // Get source — either provided or fetched from SAP

--- a/src/handlers/context.ts
+++ b/src/handlers/context.ts
@@ -5,12 +5,13 @@
 
 import {
   buildSiblingExtensionFinding,
+  type CdsImpactDownstream,
   classifyCdsImpact,
   deriveSiblingStem,
   isSiblingNameMatch,
   type SiblingExtensionCandidate,
 } from '../adt/cds-impact.js';
-import type { AdtClient, SourceReadResult } from '../adt/client.js';
+import { type AdtClient, clampSearchResults, type SourceReadResult } from '../adt/client.js';
 import { findWhereUsed } from '../adt/codeintel.js';
 import { decodeKtdText } from '../adt/ddic-xml.js';
 import { AdtApiError, isNotFoundError } from '../adt/errors.js';
@@ -30,6 +31,42 @@ import { lookupLiveUsages, resolveWhereUsedUri } from './where-used.js';
 
 const DEFAULT_SIBLING_MAX_CANDIDATES = 4;
 const HARD_MAX_SIBLING_MAX_CANDIDATES = 10;
+
+/** Per-bucket cap for action="impact". Applied per bucket, not across the whole result, so a
+ *  crowded `abapConsumers` cannot hide a single decisive `bdefs` entry. */
+const DEFAULT_IMPACT_BUCKET = 50;
+
+/** Bucket keys of CdsImpactDownstream (everything except `summary`). */
+const IMPACT_BUCKETS = [
+  'projectionViews',
+  'bdefs',
+  'serviceDefinitions',
+  'serviceBindings',
+  'accessControls',
+  'metadataExtensions',
+  'abapConsumers',
+  'tables',
+  'documentation',
+  'other',
+] as const;
+
+/** Slice every downstream bucket to `limit`, reporting which were cut. `summary` is untouched: it
+ *  is computed pre-slice and is what makes a capped answer honest about the real blast radius. */
+function boundImpactBuckets(
+  downstream: CdsImpactDownstream,
+  limit: number,
+): { boundedDownstream: CdsImpactDownstream; truncatedBuckets: string[] } {
+  const truncatedBuckets: string[] = [];
+  const boundedDownstream = { ...downstream };
+  for (const bucket of IMPACT_BUCKETS) {
+    const entries = downstream[bucket];
+    if (entries.length > limit) {
+      truncatedBuckets.push(`${bucket} (${entries.length})`);
+      boundedDownstream[bucket] = entries.slice(0, limit);
+    }
+  }
+  return { boundedDownstream, truncatedBuckets };
+}
 
 function parseSiblingMaxCandidates(value: unknown): number {
   const parsed = Number(value ?? DEFAULT_SIBLING_MAX_CANDIDATES);
@@ -327,16 +364,31 @@ export async function handleSAPContext(
     const upstreamCount =
       upstream.tables.length + upstream.views.length + upstream.associations.length + upstream.compositions.length;
 
+    // Bound each downstream bucket. A widely-consumed base view has a huge blast radius, and this
+    // path classifies the FULL where-used tree. `downstream.summary` is computed before slicing, so
+    // the reported total/direct/indirect stay honest — a truncated bucket must never shrink the
+    // blast radius a caller sees.
+    const impactLimit = clampSearchResults(args.maxResults as number | undefined, DEFAULT_IMPACT_BUCKET);
+    const { boundedDownstream, truncatedBuckets } = boundImpactBuckets(downstream, impactLimit);
+
     const response = {
       name,
       type: 'DDLS',
       upstream,
-      downstream,
+      downstream: boundedDownstream,
       summary: {
         upstreamCount,
         downstreamTotal: downstream.summary.total,
         downstreamDirect: downstream.summary.direct,
       },
+      ...(truncatedBuckets.length > 0
+        ? {
+            truncatedBuckets,
+            hint:
+              `Bucket(s) ${truncatedBuckets.join(', ')} were capped at ${impactLimit} entries each; ` +
+              `summary counts remain complete. Raise maxResults (max 1000) to see more.`,
+          }
+        : {}),
       ...(consistencyHints.length > 0 ? { consistencyHints } : {}),
       ...(siblingExtensionAnalysis ? { siblingExtensionAnalysis } : {}),
       ...(warnings.length > 0 ? { warnings } : {}),

--- a/src/handlers/diagnose.ts
+++ b/src/handlers/diagnose.ts
@@ -44,7 +44,7 @@ import type {
 } from '../adt/types.js';
 import { isBtpSystem } from './feature-cache.js';
 import { classIncludeUrl, normalizeObjectType, objectUrlForType, sourceUrlForType } from './object-types.js';
-import { errorResult, type ToolResult, textResult } from './shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from './shared.js';
 
 export async function handleSAPDiagnose(client: AdtClient, args: Record<string, unknown>): Promise<ToolResult> {
   const action = String(args.action ?? '');
@@ -65,26 +65,26 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
         objectUrl,
         Object.keys(opts).length > 0 ? opts : undefined,
       );
-      return textResult(JSON.stringify(result, null, 2));
+      return textResult(toolJson(result));
     }
     case 'unittest': {
       const objectUrl = objectUrlForType(type, name);
       const coverage = args.coverage === true;
       const result = await runUnitTests(client.http, client.safety, objectUrl, { coverage });
       // Default (no coverage) keeps the historical array output; coverage requested → {tests, coverage}.
-      if (!coverage) return textResult(JSON.stringify(result.tests, null, 2));
+      if (!coverage) return textResult(toolJson(result.tests));
       const out: Record<string, unknown> = { tests: result.tests };
       if (result.coverage) out.coverage = result.coverage;
       else
         out.coverageNote =
           'Coverage unavailable on this system (the coverage-measurement endpoint or measurement result was not available).';
-      return textResult(JSON.stringify(out, null, 2));
+      return textResult(toolJson(out));
     }
     case 'atc': {
       const objectUrl = objectUrlForType(type, name);
       const variant = args.variant as string | undefined;
       const result = await runAtcCheck(client.http, client.safety, objectUrl, variant);
-      return textResult(JSON.stringify(result, null, 2));
+      return textResult(toolJson(result));
     }
     case 'cds_testcases': {
       // SAP-suggested ABAP Unit test cases for a CDS entity (CDS Test Double Framework).
@@ -110,7 +110,7 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
           'then implement one FOR TESTING method per case (insert_test_data for the doubled sources, ' +
           'assert with cl_abap_unit_assert). AI testdata/testmethod generation is not exposed.',
       };
-      return textResult(JSON.stringify(payload, null, 2));
+      return textResult(toolJson(payload));
     }
     case 'object_state': {
       if (!name || !type) return errorResult('"name" and "type" are required for "object_state" action.');
@@ -126,7 +126,7 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
           : [{ section: 'main', uri: sourceUrlForType(type, name) }];
 
       const result = await getObjectState(client.http, client.safety, { type, name, sections });
-      return textResult(JSON.stringify(result, null, 2));
+      return textResult(toolJson(result));
     }
     case 'quickfix': {
       const source = args.source as string | undefined;
@@ -148,7 +148,7 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
         line,
         column,
       );
-      return textResult(JSON.stringify(proposals, null, 2));
+      return textResult(toolJson(proposals));
     }
     case 'apply_quickfix': {
       const source = args.source as string | undefined;
@@ -184,7 +184,7 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
         line,
         column,
       );
-      return textResult(JSON.stringify(deltas, null, 2));
+      return textResult(toolJson(deltas));
     }
     case 'dumps': {
       const id = args.id as string | undefined;
@@ -213,13 +213,13 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
         if (includeFullText) {
           payload.formattedText = detail.formattedText;
         }
-        return textResult(JSON.stringify(payload, null, 2));
+        return textResult(toolJson(payload));
       }
 
       const user = args.user as string | undefined;
       const maxResults = args.maxResults ? Number(args.maxResults) : undefined;
       const dumps = await listDumps(client.http, client.safety, { user, maxResults });
-      return textResult(JSON.stringify(dumps, null, 2));
+      return textResult(toolJson(dumps));
     }
     case 'traces': {
       const id = args.id as string | undefined;
@@ -229,15 +229,15 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
         switch (analysis) {
           case 'hitlist': {
             const hitlist = await getTraceHitlist(client.http, client.safety, id);
-            return textResult(JSON.stringify(hitlist, null, 2));
+            return textResult(toolJson(hitlist));
           }
           case 'statements': {
             const statements = await getTraceStatements(client.http, client.safety, id);
-            return textResult(JSON.stringify(statements, null, 2));
+            return textResult(toolJson(statements));
           }
           case 'dbAccesses': {
             const dbAccesses = await getTraceDbAccesses(client.http, client.safety, id);
-            return textResult(JSON.stringify(dbAccesses, null, 2));
+            return textResult(toolJson(dbAccesses));
           }
           default:
             return errorResult(`Unknown trace analysis type: ${analysis}. Supported: hitlist, statements, dbAccesses`);
@@ -245,7 +245,7 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
       }
       // List traces
       const traces = await listTraces(client.http, client.safety);
-      return textResult(JSON.stringify(traces, null, 2));
+      return textResult(toolJson(traces));
     }
     case 'trace_start': {
       const opts: TraceRequestCreateOptions = {};
@@ -259,27 +259,23 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
       if (args.description !== undefined) opts.description = String(args.description);
       const request = await createTraceRequest(client.http, client.safety, client.username, client.sapClient, opts);
       return textResult(
-        JSON.stringify(
-          {
-            armed: true,
-            request,
-            next: 'Reproduce the slow action (e.g. the OData call) as this user PROMPTLY — an http request captures the user\'s very next matching HTTP call, so avoid other ARC-1 calls in between (they would consume it). Then SAPDiagnose(action="traces") with no id to list recorded traces, find the new trace id, and read it with analysis="dbAccesses". Note: for an HTTP/OData trace, dbAccesses lists the tables the request touched but SAP returns no per-statement SQL text/timing here (hitlist/statements are usually empty); for the actual slow SQL + duration + plan use ST05 in SAP GUI. The profiler trace is richest for dialog/report/RFC traces of ABAP-side code.',
-          },
-          null,
-          2,
-        ),
+        toolJson({
+          armed: true,
+          request,
+          next: 'Reproduce the slow action (e.g. the OData call) as this user PROMPTLY — an http request captures the user\'s very next matching HTTP call, so avoid other ARC-1 calls in between (they would consume it). Then SAPDiagnose(action="traces") with no id to list recorded traces, find the new trace id, and read it with analysis="dbAccesses". Note: for an HTTP/OData trace, dbAccesses lists the tables the request touched but SAP returns no per-statement SQL text/timing here (hitlist/statements are usually empty); for the actual slow SQL + duration + plan use ST05 in SAP GUI. The profiler trace is richest for dialog/report/RFC traces of ABAP-side code.',
+        }),
       );
     }
     case 'trace_requests': {
       const user = (args.traceUser as string | undefined) ?? (args.user as string | undefined) ?? client.username;
       const requests = await listTraceRequests(client.http, client.safety, user);
-      return textResult(JSON.stringify(requests, null, 2));
+      return textResult(toolJson(requests));
     }
     case 'trace_cancel': {
       const id = args.id as string | undefined;
       if (!id) return errorResult('trace_cancel requires "id" (from trace_start or trace_requests).');
       await deleteTraceRequest(client.http, client.safety, id);
-      return textResult(JSON.stringify({ cancelled: true, id }, null, 2));
+      return textResult(toolJson({ cancelled: true, id }));
     }
     case 'system_messages': {
       const user = args.user as string | undefined;
@@ -287,7 +283,7 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
       const from = args.from as string | undefined;
       const to = args.to as string | undefined;
       const messages = await listSystemMessages(client.http, client.safety, { user, maxResults, from, to });
-      return textResult(JSON.stringify(messages, null, 2));
+      return textResult(toolJson(messages));
     }
     case 'gateway_errors': {
       if (isBtpSystem()) {
@@ -306,11 +302,11 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
 
       if (detailUrl || id) {
         const detail = await getGatewayErrorDetail(client.http, client.safety, { detailUrl, id, errorType });
-        return textResult(JSON.stringify(detail, null, 2));
+        return textResult(toolJson(detail));
       }
 
       const errors = await listGatewayErrors(client.http, client.safety, { user, maxResults, from, to });
-      return textResult(JSON.stringify(errors, null, 2));
+      return textResult(toolJson(errors));
     }
     case 'odata_perf': {
       const url = String(args.url ?? '').trim();
@@ -320,7 +316,7 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
         );
       }
       const perf = await probeODataPerformance(client.http, client.safety, url);
-      return textResult(JSON.stringify(perf, null, 2));
+      return textResult(toolJson(perf));
     }
     case 'cds_sql': {
       if (!name) {
@@ -329,11 +325,11 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
         );
       }
       const cdsSql = await getCdsCreateStatements(client.http, client.safety, name);
-      return textResult(JSON.stringify(cdsSql, null, 2));
+      return textResult(toolJson(cdsSql));
     }
     case 'sql_trace_state': {
       const states = await getSqlTraceState(client.http, client.safety);
-      return textResult(JSON.stringify(states, null, 2));
+      return textResult(toolJson(states));
     }
     case 'set_sql_trace_state': {
       if (args.sqlOn === undefined) {
@@ -345,21 +341,17 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
       const traceUser = args.user !== undefined ? String(args.user) : undefined;
       const states = await setSqlTraceState(client.http, client.safety, { sqlOn, traceUser });
       return textResult(
-        JSON.stringify(
-          {
-            states,
-            next: sqlOn
-              ? 'SQL trace armed. Reproduce the slow request, then call SAPDiagnose(action="sql_trace_directory") for the SQL Trace Analysis link, or read the generated SQL with SAPDiagnose(action="cds_sql").'
-              : 'SQL trace disarmed.',
-          },
-          null,
-          2,
-        ),
+        toolJson({
+          states,
+          next: sqlOn
+            ? 'SQL trace armed. Reproduce the slow request, then call SAPDiagnose(action="sql_trace_directory") for the SQL Trace Analysis link, or read the generated SQL with SAPDiagnose(action="cds_sql").'
+            : 'SQL trace disarmed.',
+        }),
       );
     }
     case 'sql_trace_directory': {
       const dir = await getSqlTraceDirectory(client.http, client.safety);
-      return textResult(JSON.stringify(dir, null, 2));
+      return textResult(toolJson(dir));
     }
     case 'authorization_trace': {
       const user = String(args.user ?? '').trim() || undefined;
@@ -369,7 +361,7 @@ export async function handleSAPDiagnose(client: AdtClient, args: Record<string, 
 
       try {
         const result = await getAuthorizationTrace(client, { user, authObject, onlyFailures, maxResults });
-        return textResult(JSON.stringify(result, null, 2));
+        return textResult(toolJson(result));
       } catch (err) {
         if (err instanceof AdtApiError && /Cannot find '/i.test(err.message)) {
           return errorResult(

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -45,7 +45,7 @@ import { handleSAPQuery } from './query.js';
 import { handleSAPRead } from './read.js';
 import { getToolSchema } from './schemas.js';
 import { handleSAPSearch } from './search.js';
-import { errorResult, hasSqlParserSignature, type ToolResult } from './shared.js';
+import { errorResult, hasSqlParserSignature, type ToolResult, toolJson } from './shared.js';
 import { handleSAPTransport } from './transport.js';
 import { handleSAPWrite } from './write.js';
 import { formatZodError } from './zod-errors.js';
@@ -589,7 +589,7 @@ export async function handleToolCall(
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify({
+            text: toolJson({
               error: 'rate_limited',
               retryAfter,
               message: `Rate limit exceeded (${decision.limitPerMinute}/min per user). Retry after ${retryAfter} seconds.`,

--- a/src/handlers/git.ts
+++ b/src/handlers/git.ts
@@ -35,7 +35,7 @@ import {
 } from '../adt/gcts.js';
 import { getActionPolicy } from '../authz/policy.js';
 import { cachedFeatures } from './feature-cache.js';
-import { errorResult, type ToolResult, textResult } from './shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from './shared.js';
 
 // ─── SAPGit Handler ──────────────────────────────────────────────────
 
@@ -292,5 +292,5 @@ export async function handleSAPGit(
   }
 
   const payload = backend === 'gcts' || backend === 'abapgit' ? { backend, result } : result;
-  return textResult(JSON.stringify(payload, null, 2));
+  return textResult(toolJson(payload));
 }

--- a/src/handlers/lint.ts
+++ b/src/handlers/lint.ts
@@ -13,7 +13,7 @@ import {
 import { buildLintConfig, listRulesFromConfig, type RuleOverrides } from '../lint/config-builder.js';
 import { detectFilename, lintAbapSource, lintAndFix } from '../lint/lint.js';
 import type { ServerConfig } from '../server/types.js';
-import { errorResult, type ToolResult, textResult } from './shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from './shared.js';
 import { buildLintConfigOptions } from './write-helpers.js';
 
 // Some SAPLint actions run offline (@abaplint/core), others call SAP ADT formatter APIs.
@@ -34,7 +34,7 @@ export async function handleSAPLint(
       const filename = detectFilename(source, name);
       const lintConfig = buildLintConfig(configOptions);
       const issues = lintAbapSource(source, filename, lintConfig);
-      return textResult(JSON.stringify(issues, null, 2));
+      return textResult(toolJson(issues));
     }
     case 'lint_and_fix': {
       const source = String(args.source ?? '');
@@ -43,7 +43,7 @@ export async function handleSAPLint(
       const filename = detectFilename(source, name);
       const lintConfig = buildLintConfig(configOptions);
       const result = lintAndFix(source, filename, lintConfig);
-      return textResult(JSON.stringify(result, null, 2));
+      return textResult(toolJson(result));
     }
     case 'list_rules': {
       const lintConfig = buildLintConfig(configOptions);
@@ -53,19 +53,15 @@ export async function handleSAPLint(
       const effectiveAbapRelease = configOptions.abapRelease ?? 'unknown';
       const syntax = lintConfig.get().syntax as { version?: string } | undefined;
       return textResult(
-        JSON.stringify(
-          {
-            preset: configOptions.systemType === 'btp' ? 'cloud' : 'onprem',
-            abapVersion: effectiveAbapRelease,
-            syntaxVersion: syntax?.version ?? 'unknown',
-            enabledRules: enabled.length,
-            disabledRules: disabled.length,
-            rules: enabled,
-            disabledRuleNames: disabled.map((r) => r.rule),
-          },
-          null,
-          2,
-        ),
+        toolJson({
+          preset: configOptions.systemType === 'btp' ? 'cloud' : 'onprem',
+          abapVersion: effectiveAbapRelease,
+          syntaxVersion: syntax?.version ?? 'unknown',
+          enabledRules: enabled.length,
+          disabledRules: disabled.length,
+          rules: enabled,
+          disabledRuleNames: disabled.map((r) => r.rule),
+        }),
       );
     }
     case 'format': {
@@ -76,7 +72,7 @@ export async function handleSAPLint(
     }
     case 'get_formatter_settings': {
       const settings = await getPrettyPrinterSettings(client.http, client.safety);
-      return textResult(JSON.stringify(settings, null, 2));
+      return textResult(toolJson(settings));
     }
     case 'set_formatter_settings': {
       const indentation = args.indentation as boolean | undefined;
@@ -90,7 +86,7 @@ export async function handleSAPLint(
         style: style ?? current.style,
       };
       await setPrettyPrinterSettings(client.http, client.safety, next);
-      return textResult(JSON.stringify(next, null, 2));
+      return textResult(toolJson(next));
     }
     default:
       return errorResult(

--- a/src/handlers/manage.ts
+++ b/src/handlers/manage.ts
@@ -45,7 +45,7 @@ export async function handleSAPManage(
     case 'features': {
       if (!cachedFeatures) {
         return textResult(
-          JSON.stringify({ message: 'No features probed yet. Use action="probe" to probe the SAP system first.' }),
+          toolJson({ message: 'No features probed yet. Use action="probe" to probe the SAP system first.' }),
         );
       }
       return textResult(toolJson(cachedFeatures));
@@ -455,7 +455,7 @@ export async function handleSAPManage(
 
     case 'cache_stats': {
       if (!cachingLayer) {
-        return textResult(JSON.stringify({ enabled: false, message: 'Object cache is disabled (ARC1_CACHE=none).' }));
+        return textResult(toolJson({ enabled: false, message: 'Object cache is disabled (ARC1_CACHE=none).' }));
       }
       const stats = cachingLayer.stats();
       return textResult(

--- a/src/handlers/manage.ts
+++ b/src/handlers/manage.ts
@@ -25,7 +25,7 @@ import type { CachingLayer } from '../cache/caching-layer.js';
 import type { ServerConfig } from '../server/types.js';
 import { cachedFeatures, setCachedFeatures } from './feature-cache.js';
 import { inferObjectType, normalizeObjectType, objectUrlForTypeRaw } from './object-types.js';
-import { errorResult, type ToolResult, textResult } from './shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from './shared.js';
 import { enforceAllowedPackageForObjectUrl, resolveWriteSystemType } from './write-helpers.js';
 
 // ─── SAPManage Handler ────────────────────────────────────────────────
@@ -48,7 +48,7 @@ export async function handleSAPManage(
           JSON.stringify({ message: 'No features probed yet. Use action="probe" to probe the SAP system first.' }),
         );
       }
-      return textResult(JSON.stringify(cachedFeatures, null, 2));
+      return textResult(toolJson(cachedFeatures));
     }
 
     case 'set_api_state': {
@@ -94,7 +94,7 @@ export async function handleSAPManage(
       const lead = result.changed
         ? `Set API release contract ${contract} of ${objectUri} to ${endState}`
         : `API release contract ${contract} of ${objectUri} is already ${endState} (no change)`;
-      return textResult(`${lead}${vis ? ` (visible in ${vis})` : ''}.\n\n${JSON.stringify(result, null, 2)}`);
+      return textResult(`${lead}${vis ? ` (visible in ${vis})` : ''}.\n\n${toolJson(result)}`);
     }
 
     case 'create_package': {
@@ -381,7 +381,7 @@ export async function handleSAPManage(
       if (!domainId) return errorResult('"domainId" is required for flp_create_catalog action.');
       if (!title) return errorResult('"title" is required for flp_create_catalog action.');
       const catalog = await createCatalog(client.http, client.safety, domainId, title);
-      return textResult(JSON.stringify(catalog, null, 2));
+      return textResult(toolJson(catalog));
     }
 
     case 'flp_create_group': {
@@ -393,7 +393,7 @@ export async function handleSAPManage(
       if (!groupId) return errorResult('"groupId" is required for flp_create_group action.');
       if (!title) return errorResult('"title" is required for flp_create_group action.');
       const group = await createGroup(client.http, client.safety, groupId, title);
-      return textResult(JSON.stringify(group, null, 2));
+      return textResult(toolJson(group));
     }
 
     case 'flp_create_tile': {
@@ -426,7 +426,7 @@ export async function handleSAPManage(
         subtitle: typeof tile.subtitle === 'string' ? tile.subtitle : undefined,
         info: typeof tile.info === 'string' ? tile.info : undefined,
       });
-      return textResult(JSON.stringify(tileInstance, null, 2));
+      return textResult(toolJson(tileInstance));
     }
 
     case 'flp_add_tile_to_group': {
@@ -440,7 +440,7 @@ export async function handleSAPManage(
       if (!catalogId) return errorResult('"catalogId" is required for flp_add_tile_to_group action.');
       if (!tileInstanceId) return errorResult('"tileInstanceId" is required for flp_add_tile_to_group action.');
       const result = await addTileToGroup(client.http, client.safety, groupId, catalogId, tileInstanceId);
-      return textResult(JSON.stringify(result, null, 2));
+      return textResult(toolJson(result));
     }
 
     case 'flp_delete_catalog': {
@@ -459,15 +459,11 @@ export async function handleSAPManage(
       }
       const stats = cachingLayer.stats();
       return textResult(
-        JSON.stringify(
-          {
-            enabled: true,
-            ...stats,
-            inactiveListCache: cachingLayer.inactiveLists.stats(),
-          },
-          null,
-          2,
-        ),
+        toolJson({
+          enabled: true,
+          ...stats,
+          inactiveListCache: cachingLayer.inactiveLists.stats(),
+        }),
       );
     }
 
@@ -505,7 +501,7 @@ export async function handleSAPManage(
         }
         setCachedFeatures(probed);
       }
-      return textResult(JSON.stringify(probed, null, 2));
+      return textResult(toolJson(probed));
     }
 
     default:

--- a/src/handlers/navigate.ts
+++ b/src/handlers/navigate.ts
@@ -8,7 +8,7 @@ import { findDefinition, getCompletion } from '../adt/codeintel.js';
 import { AdtApiError } from '../adt/errors.js';
 import { isOperationAllowed, OperationType } from '../adt/safety.js';
 import type { ClassHierarchy } from '../adt/types.js';
-import { errorResult, type ToolResult, textResult } from './shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from './shared.js';
 import { lookupLiveUsages, resolveWhereUsedUri } from './where-used.js';
 
 // ─── SAPNavigate Handler ─────────────────────────────────────────────
@@ -40,7 +40,7 @@ export async function handleSAPNavigate(client: AdtClient, args: Record<string, 
       if (!result) {
         return textResult('No definition found at this position.');
       }
-      return textResult(JSON.stringify(result, null, 2));
+      return textResult(toolJson(result));
     }
     case 'references': {
       if (!uri) {
@@ -57,28 +57,24 @@ export async function handleSAPNavigate(client: AdtClient, args: Record<string, 
         return textResult('No references found.');
       }
       return textResult(
-        JSON.stringify(
-          {
-            total,
-            shown: results.length,
-            truncated,
-            ...(truncated
-              ? {
-                  hint:
-                    `Showing ${results.length} of ${total} references. Narrow with objectType ` +
-                    `(e.g. "CLAS/OC") or raise maxResults (max 1000).`,
-                }
-              : {}),
-            references: results,
-          },
-          null,
-          2,
-        ),
+        toolJson({
+          total,
+          shown: results.length,
+          truncated,
+          ...(truncated
+            ? {
+                hint:
+                  `Showing ${results.length} of ${total} references. Narrow with objectType ` +
+                  `(e.g. "CLAS/OC") or raise maxResults (max 1000).`,
+              }
+            : {}),
+          references: results,
+        }),
       );
     }
     case 'completion': {
       const proposals = await getCompletion(client.http, client.safety, uri, line, column, source);
-      return textResult(JSON.stringify(proposals, null, 2));
+      return textResult(toolJson(proposals));
     }
     case 'hierarchy': {
       const className = String(args.name ?? '').toUpperCase();
@@ -142,7 +138,7 @@ export async function handleSAPNavigate(client: AdtClient, args: Record<string, 
         }
 
         const result: ClassHierarchy = { className: safeName, superclass, interfaces, subclasses };
-        return textResult(JSON.stringify(result, null, 2));
+        return textResult(toolJson(result));
       } catch (err) {
         if (err instanceof AdtApiError && err.statusCode === 404) {
           return errorResult('Cannot query SEOMETAREL — table may not be accessible on this system.');

--- a/src/handlers/query.ts
+++ b/src/handlers/query.ts
@@ -6,7 +6,7 @@ import type { AdtClient } from '../adt/client.js';
 import { AdtApiError, extractUnknownColumn, formatUnknownColumnHint } from '../adt/errors.js';
 import type { DataPreviewMeta } from '../adt/xml-parser.js';
 import { classifySapQueryParserError, maskSqlStringLiterals } from './query-errors.js';
-import { errorResult, type ToolResult, textResult } from './shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from './shared.js';
 
 const SAPQUERY_IN_LIST_CHUNK_SIZE = 8;
 
@@ -195,7 +195,7 @@ export async function handleSAPQuery(client: AdtClient, args: Record<string, unk
     out.rowsReturned = data.rows.length;
     out.columns = data.columns;
     out.rows = data.rows;
-    return textResult(JSON.stringify(out, null, 2));
+    return textResult(toolJson(out));
   } catch (err) {
     if (err instanceof AdtApiError && err.isNotFound) {
       // Try to extract table name from SQL and suggest similar names

--- a/src/handlers/read.ts
+++ b/src/handlers/read.ts
@@ -21,7 +21,7 @@ import { logger } from '../server/logger.js';
 import { type CacheSecurityContext, inactiveListUserKey, invalidateInactiveList } from './cache-security.js';
 import { cachedFeatures, isBtpSystem } from './feature-cache.js';
 import { inferObjectType, normalizeObjectType, objectUrlForTypeRaw } from './object-types.js';
-import { errorResult, type ToolResult, textResult } from './shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from './shared.js';
 
 const BTP_HINTS: Record<string, string> = {
   PROG: 'Executable programs (reports) are not available on BTP ABAP Environment. Use CLAS with IF_OO_ADT_CLASSRUN for console applications.',
@@ -189,7 +189,7 @@ export async function handleSAPRead(
       );
     }
     const sdo = await getServerDrivenObject(client.http, client.safety, type, name);
-    return textResult(JSON.stringify(sdo, null, 2));
+    return textResult(toolJson(sdo));
   }
 
   // Class text symbols (Textelemente): include=text_symbols reads a class's maintained text symbols
@@ -300,7 +300,7 @@ export async function handleSAPRead(
       // Structured format: return JSON with metadata + decomposed source
       if (args.format === 'structured') {
         const structured = await client.getClassStructured(name);
-        return textResult(JSON.stringify(structured, null, 2));
+        return textResult(toolJson(structured));
       }
       const methodParam = args.method as string | undefined;
       if (methodParam && !args.include) {
@@ -374,7 +374,7 @@ export async function handleSAPRead(
           source,
           signature: grouped,
         };
-        return textResult(JSON.stringify(payload, null, 2));
+        return textResult(toolJson(payload));
       }
       if (args.grep) return grepText(source);
       return cachedTextResult(source, cacheHit, revalidated, versionWarning);
@@ -398,7 +398,7 @@ export async function handleSAPRead(
         return textResult(parts.join('\n\n'));
       }
       const fg = await client.getFunctionGroup(name);
-      return textResult(JSON.stringify(fg, null, 2));
+      return textResult(toolJson(fg));
     }
     case 'INCL': {
       const { source, cacheHit, revalidated } = await cachedGet('INCL', name, effectiveVersion, (ifNoneMatch) =>
@@ -510,19 +510,19 @@ export async function handleSAPRead(
     }
     case 'DOMA': {
       const domain = await client.getDomain(name);
-      return textResult(JSON.stringify(domain, null, 2));
+      return textResult(toolJson(domain));
     }
     case 'DTEL': {
       const dtel = await client.getDataElement(name);
-      return textResult(JSON.stringify(dtel, null, 2));
+      return textResult(toolJson(dtel));
     }
     case 'TTYP': {
       const ttyp = await client.getTableType(name);
-      return textResult(JSON.stringify(ttyp, null, 2));
+      return textResult(toolJson(ttyp));
     }
     case 'AUTH': {
       const authField = await client.getAuthorizationField(name);
-      return textResult(JSON.stringify(authField, null, 2));
+      return textResult(toolJson(authField));
     }
     case 'FTG2':
     case 'FEATURE_TOGGLE': {
@@ -536,11 +536,11 @@ export async function handleSAPRead(
         });
       }
       const toggle = await client.getFeatureToggle(name);
-      return textResult(JSON.stringify(toggle, null, 2));
+      return textResult(toolJson(toggle));
     }
     case 'ENHO': {
       const enhancement = await client.getEnhancementImplementation(name);
-      return textResult(JSON.stringify(enhancement, null, 2));
+      return textResult(toolJson(enhancement));
     }
     case 'VERSIONS': {
       const include = typeof args.include === 'string' ? args.include : undefined;
@@ -561,7 +561,7 @@ export async function handleSAPRead(
 
       try {
         const revisions = await client.getRevisions(objectType, name, { include, group });
-        return textResult(JSON.stringify(revisions, null, 2));
+        return textResult(toolJson(revisions));
       } catch (err) {
         if (isNotFoundError(err)) {
           return textResult(
@@ -604,7 +604,7 @@ export async function handleSAPRead(
           // SQL failed (e.g., TSTC not found on BTP) — still return metadata
         }
       }
-      return textResult(JSON.stringify(tran, null, 2));
+      return textResult(toolJson(tran));
     }
     case 'API_STATE': {
       // Determine object type for URL construction — use explicit objectType, infer from name, or error
@@ -618,12 +618,12 @@ export async function handleSAPRead(
       // Use raw URI (no name encoding) — getApiReleaseState encodes the full URI as a single path segment
       const objectUri = objectUrlForTypeRaw(inferredType, name);
       const releaseState = await client.getApiReleaseState(objectUri);
-      return textResult(JSON.stringify(releaseState, null, 2));
+      return textResult(toolJson(releaseState));
     }
     case 'TABLE_CONTENTS': {
       const maxRows = Number(args.maxRows ?? 100);
       const data = await client.getTableContents(name, maxRows, args.sqlFilter as string | undefined);
-      return textResult(JSON.stringify(data, null, 2));
+      return textResult(toolJson(data));
     }
     case 'TABLE_QUERY': {
       const maxRows = Number(args.maxRows ?? 100);
@@ -633,7 +633,7 @@ export async function handleSAPRead(
         : undefined;
       try {
         const data = await client.runTableQuery(name, { columns, where, maxRows });
-        return textResult(JSON.stringify(data, null, 2));
+        return textResult(toolJson(data));
       } catch (err) {
         // Self-correct an unknown-column error (a bad entry in `columns`/`where`) by listing the
         // table's real columns (best-effort).
@@ -687,18 +687,18 @@ export async function handleSAPRead(
       if (methods.rows.length === 0) {
         return errorResult(`No BOR methods found for object type "${name}". Verify the BOR object type name.`);
       }
-      return textResult(JSON.stringify(methods, null, 2));
+      return textResult(toolJson(methods));
     }
     case 'DEVC': {
       const maxResults = args.maxResults != null ? Number(args.maxResults) : undefined;
       const contents = await client.getPackageContents(name, maxResults);
-      return textResult(JSON.stringify(contents, null, 2));
+      return textResult(toolJson(contents));
     }
     case 'SYSTEM':
       return textResult(await client.getSystemInfo());
     case 'COMPONENTS': {
       const components = await client.getInstalledComponents();
-      return textResult(JSON.stringify(components, null, 2));
+      return textResult(toolJson(components));
     }
     case 'MESSAGES':
     case 'MSAG': {
@@ -713,7 +713,7 @@ export async function handleSAPRead(
       }
       try {
         const mcInfo = await client.getMessageClassInfo(name);
-        return textResult(JSON.stringify(mcInfo, null, 2));
+        return textResult(toolJson(mcInfo));
       } catch {
         // Fall back to legacy endpoint if messageclass endpoint unavailable
         return textResult(await client.getMessages(name));
@@ -734,17 +734,17 @@ export async function handleSAPRead(
       if (!name) {
         // List all BSP apps (optional search via query param not used here since name is empty)
         const apps = await client.listBspApps();
-        return textResult(JSON.stringify(apps, null, 2));
+        return textResult(toolJson(apps));
       }
       if (!include) {
         // Browse root structure of the app
-        return textResult(JSON.stringify(await client.getBspAppStructure(name), null, 2));
+        return textResult(toolJson(await client.getBspAppStructure(name)));
       }
       // If include contains a dot, treat as file read; otherwise browse subfolder
       if (include.includes('.')) {
         return textResult(await client.getBspFileContent(name, include));
       }
-      return textResult(JSON.stringify(await client.getBspAppStructure(name, `/${include}`), null, 2));
+      return textResult(toolJson(await client.getBspAppStructure(name, `/${include}`)));
     }
     case 'BSP_DEPLOY': {
       if (cachedFeatures?.ui5repo && !cachedFeatures.ui5repo.available) {
@@ -760,11 +760,11 @@ export async function handleSAPRead(
       if (!info) {
         return textResult(`App "${name}" not found in ABAP Repository.`);
       }
-      return textResult(JSON.stringify(info, null, 2));
+      return textResult(toolJson(info));
     }
     case 'INACTIVE_OBJECTS': {
       const objects = await client.getInactiveObjects();
-      return textResult(JSON.stringify({ count: objects.length, objects }, null, 2));
+      return textResult(toolJson({ count: objects.length, objects }));
     }
     default:
       return errorResult(

--- a/src/handlers/search.ts
+++ b/src/handlers/search.ts
@@ -9,7 +9,7 @@ import { classifyTextSearchError } from '../adt/features.js';
 import type { AdtObjectLookupResult, AdtSearchResult } from '../adt/types.js';
 import { cachedFeatures } from './feature-cache.js';
 import { normalizeObjectType } from './object-types.js';
-import { errorResult, type ToolResult, textResult } from './shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from './shared.js';
 
 // ─── Search Helpers ─────────────────────────────────────────────────
 
@@ -164,7 +164,7 @@ export async function handleSAPSearch(client: AdtClient, args: Record<string, un
     if (splitBrain.length > 0) payload.splitBrain = splitBrain;
     if (warnings.length > 0) payload.warnings = warnings;
 
-    return textResult(JSON.stringify(payload, null, 2));
+    return textResult(toolJson(payload));
   }
 
   if (searchType === 'source_code') {
@@ -179,7 +179,7 @@ export async function handleSAPSearch(client: AdtClient, args: Record<string, un
     const packageName = args.packageName as string | undefined;
     try {
       const results = await client.searchSource(rawQuery, maxResults, objectType, packageName);
-      return textResult(JSON.stringify(results, null, 2));
+      return textResult(toolJson(results));
     } catch (err) {
       if (err instanceof AdtApiError) {
         const permanentCodes = [401, 403, 404, 501];
@@ -215,7 +215,7 @@ export async function handleSAPSearch(client: AdtClient, args: Record<string, un
     }
     return textResult(hint);
   }
-  return textResult(transliterationNote + JSON.stringify(results, null, 2));
+  return textResult(transliterationNote + toolJson(results));
 }
 
 function extractLookupNames(query: string, rawNames: unknown): string[] {

--- a/src/handlers/shared.ts
+++ b/src/handlers/shared.ts
@@ -19,6 +19,22 @@ export function errorResult(message: string): ToolResult {
   return { content: [{ type: 'text', text: message }], isError: true };
 }
 
+/**
+ * Serialize a tool result for the LLM. Compact, not pretty-printed.
+ *
+ * Two-space indentation plus newlines cost 15-37% of every JSON result — measured post-bounding:
+ * where-used 11,856 -> 8,781 tokens, transport list 5,689 -> 3,581, SAPSearch 2,922 -> 2,472,
+ * DEVC listing 5,372 -> 4,404. The output is still JSON (models are trained on it), so this is
+ * whitespace only — NOT a token-optimized notation like TOON, which trades single-digit savings
+ * for up to -36pp accuracy (arXiv 2605.29676).
+ *
+ * Use for every LLM-facing JSON payload. Human-facing output (audit previews, CLI rendering) is
+ * formatted at its own layer, so nothing readable is lost.
+ */
+export function toolJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
 /** True when an error body carries an Open-SQL parser/grammar signature (SAPQuery + error hints). */
 export function hasSqlParserSignature(text: string): boolean {
   const normalized = text.toLowerCase();

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -455,8 +455,8 @@ export function getToolDefinitions(
           include: {
             type: 'string',
             description:
-              'For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. ' +
-              'For DDLS: use include="elements" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. ' +
+              'For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. ' +
+              'For DDLS: use include="elements" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. ' +
               'For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses).',
           },
           group: {
@@ -1006,7 +1006,7 @@ export function getToolDefinitions(
         },
         maxResults: {
           type: 'number',
-          description: 'references: max entries (default 100, max 1000). "total" always reports the unfiltered count.',
+          description: 'references: max entries (default 100, max 1000). "total" counts every match of the filter.',
         },
         line: { type: 'number', description: 'Line number (1-based)' },
         column: { type: 'number', description: 'Column number (1-based)' },
@@ -1087,11 +1087,11 @@ export function getToolDefinitions(
         '- "apply_quickfix": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n' +
         '- "dumps": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n' +
         '- "traces": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n' +
-        '- "trace_start": arm a profiler trace for the NEXT matching execution, then reproduce and read via "traces" (write scope; defaults: next HTTP request, SQL on; optional traceUser/processType/maxExecutions/expiresHours/sqlTrace/…).\n' +
+        '- "trace_start": arm a profiler trace for the NEXT matching execution, then reproduce and read via "traces" (write scope; defaults: next HTTP request, SQL on).\n' +
         '- "trace_requests": list armed trace requests. "trace_cancel": cancel one by id (write scope).\n' +
         '- "system_messages": list SM02 messages. "gateway_errors": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n' +
         '- "odata_perf": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n' +
-        '- "authorization_trace": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC (optional user/authObject/onlyFailures/maxResults). Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n' +
+        '- "authorization_trace": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n' +
         '- "cds_sql": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n' +
         '- "sql_trace_state" / "set_sql_trace_state" (sqlOn; needs SAP_ALLOW_WRITES) / "sql_trace_directory": ST05 SQL-trace control.\n' +
         'Quickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.',
@@ -1702,6 +1702,12 @@ export function getToolDefinitions(
     const annotations = TOOL_ANNOTATIONS[tool.name];
     if (annotations) tool.annotations = { ...annotations };
   }
+
+  // Advertise the strictness the runtime enforces: the Zod schemas are `.strict()`, and JSON Schema
+  // means the opposite when `additionalProperties` is absent. Stamped centrally so a new tool cannot
+  // forget it, TOP-LEVEL ONLY — nested `objects[]` items stay lenient, matching `.strict()`, which
+  // does not cascade (batch_create relies on that; #360).
+  for (const tool of tools) (tool.inputSchema as Record<string, unknown>).additionalProperties = false;
 
   return tools;
 }

--- a/src/handlers/transport.ts
+++ b/src/handlers/transport.ts
@@ -27,7 +27,7 @@ import {
 import type { InactiveObject, ObjectTransportHistory, TransportReleaseReport, TransportRequest } from '../adt/types.js';
 import { logger } from '../server/logger.js';
 import { objectUrlForType } from './object-types.js';
-import { errorResult, type ToolResult, textResult } from './shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from './shared.js';
 
 /** Default page size for `list`. Object lists dominate the payload, so the backlog sets the cost. */
 const DEFAULT_TRANSPORT_RESULTS = 50;
@@ -145,23 +145,19 @@ export async function handleSAPTransport(client: AdtClient, args: Record<string,
       const truncated = transports.length > limit;
       const payload = args.summary === false ? page : page.map(summarizeTransport);
       return textResult(
-        JSON.stringify(
-          {
-            total: transports.length,
-            shown: page.length,
-            truncated,
-            ...(truncated
-              ? {
-                  hint:
-                    `Showing ${page.length} of ${transports.length} transports. Narrow with user/status, ` +
-                    `or raise maxResults (max 1000).`,
-                }
-              : {}),
-            transports: payload,
-          },
-          null,
-          2,
-        ),
+        toolJson({
+          total: transports.length,
+          shown: page.length,
+          truncated,
+          ...(truncated
+            ? {
+                hint:
+                  `Showing ${page.length} of ${transports.length} transports. Narrow with user/status, ` +
+                  `or raise maxResults (max 1000).`,
+              }
+            : {}),
+          transports: payload,
+        }),
       );
     }
     case 'get': {
@@ -169,7 +165,7 @@ export async function handleSAPTransport(client: AdtClient, args: Record<string,
       if (!id) return errorResult('Transport ID is required for "get" action.');
       const transport = await getTransport(client.http, client.safety, id);
       if (!transport) return textResult(`Transport ${id} not found.`);
-      return textResult(JSON.stringify(transport, null, 2));
+      return textResult(toolJson(transport));
     }
     case 'create': {
       const description = String(args.description ?? '');
@@ -296,7 +292,7 @@ export async function handleSAPTransport(client: AdtClient, args: Record<string,
           ? `${layers.length} transport layer(s); ${routed.length} carry a target. Pass one as transportLayer= on create.`
           : `${layers.length} transport layer(s), but none expose a consolidation target — created requests will be local on this system.`
         : 'No transport layers are defined on this system — every request will be local.';
-      return textResult(JSON.stringify({ transportLayers: layers, summary }, null, 2));
+      return textResult(toolJson({ transportLayers: layers, summary }));
     }
     case 'targets': {
       // Discovery: list valid values for create's `target` (Transportziel / TR_TARGET) via the
@@ -326,7 +322,7 @@ export async function handleSAPTransport(client: AdtClient, args: Record<string,
       const summary = targets.length
         ? `${targets.length} valid transport target(s). Pass one as target= on create.`
         : 'No transport targets are configured on this system (so created requests are local).';
-      return textResult(JSON.stringify({ transportTargets: targets, summary }, null, 2));
+      return textResult(toolJson({ transportTargets: targets, summary }));
     }
     case 'release': {
       const id = String(args.id ?? '');
@@ -431,19 +427,15 @@ export async function handleSAPTransport(client: AdtClient, args: Record<string,
           : `Package "${pkg}" does not require transport recording.`;
 
       return textResult(
-        JSON.stringify(
-          {
-            package: pkg,
-            transportRequired: !info.isLocal && info.recording,
-            isLocal: info.isLocal,
-            deliveryUnit: info.deliveryUnit,
-            existingTransports: info.existingTransports,
-            ...(info.lockedTransport ? { lockedTransport: info.lockedTransport } : {}),
-            summary,
-          },
-          null,
-          2,
-        ),
+        toolJson({
+          package: pkg,
+          transportRequired: !info.isLocal && info.recording,
+          isLocal: info.isLocal,
+          deliveryUnit: info.deliveryUnit,
+          existingTransports: info.existingTransports,
+          ...(info.lockedTransport ? { lockedTransport: info.lockedTransport } : {}),
+          summary,
+        }),
       );
     }
     case 'history': {
@@ -486,7 +478,7 @@ export async function handleSAPTransport(client: AdtClient, args: Record<string,
         summary,
       };
 
-      return textResult(JSON.stringify(history, null, 2));
+      return textResult(toolJson(history));
     }
     default:
       return errorResult(

--- a/src/handlers/where-used.ts
+++ b/src/handlers/where-used.ts
@@ -25,10 +25,11 @@ export interface LiveUsageLookup {
   fallbackUsed: boolean;
 }
 
-/** Match a result's ADT type against a filter: "CLAS" matches "CLAS/OC", "CLAS/OC" matches exactly. */
+/** Match a result's ADT type against a filter: "CLAS" matches "CLAS/OC", "CLAS/OC" matches exactly.
+ *  Trimmed — a padded `" CLAS "` would otherwise match nothing and read as "no references found". */
 function matchesObjectType(resultType: string, filter: string): boolean {
-  const type = resultType.toUpperCase();
-  const wanted = filter.toUpperCase();
+  const type = resultType.trim().toUpperCase();
+  const wanted = filter.trim().toUpperCase();
   return type === wanted || type.startsWith(`${wanted}/`);
 }
 
@@ -83,7 +84,10 @@ export async function lookupLiveUsages(
     await augmentInterfaceImplementers(client, uri, objectType, results as WhereUsedResult[]);
   }
 
-  const filtered = objectType ? results.filter((result) => matchesObjectType(result.type, objectType)) : results;
+  // A whitespace-only filter means "no filter", not "match the empty type" — the latter would match
+  // nothing and surface as a bare "No references found".
+  const filter = objectType?.trim() ? objectType : undefined;
+  const filtered = filter ? results.filter((result) => matchesObjectType(result.type, filter)) : results;
   const limit = clampSearchResults(maxResults, DEFAULT_USAGE_RESULTS);
   return {
     results: filtered.slice(0, limit),

--- a/src/handlers/write/rap.ts
+++ b/src/handlers/write/rap.ts
@@ -12,7 +12,7 @@ import {
 } from '../../adt/rap-handlers.js';
 import { cachedFeatures } from '../feature-cache.js';
 import { classIncludeUrl } from '../object-types.js';
-import { errorResult, type ToolResult, textResult } from '../shared.js';
+import { errorResult, type ToolResult, textResult, toolJson } from '../shared.js';
 import { mergePreWriteWarnings, type PreWriteLintResult, runPreWriteLint } from '../write-helpers.js';
 import type { SapWriteContext } from './context.js';
 
@@ -120,7 +120,7 @@ export async function writeActionScaffoldRapHandlers(ctx: SapWriteContext): Prom
   };
 
   if (!autoApply || (missing.length === 0 && missingImplementationStubs.length === 0)) {
-    return textResult(JSON.stringify({ ...summary, applied: false }, null, 2));
+    return textResult(toolJson({ ...summary, applied: false }));
   }
 
   // Pure RAP transformation planning lives in rap-handlers.ts. Keep this
@@ -142,23 +142,19 @@ export async function writeActionScaffoldRapHandlers(ctx: SapWriteContext): Prom
         ? `No source changes were applied because handler class skeleton(s) ${unresolvedHandlerClasses.join(', ')} were not found in main, definitions, or implementations. Create the local handler class skeleton(s) first (for example with the ADT quick fix "Create local handler class"), then rerun with autoApply=true.`
         : undefined;
     return textResult(
-      JSON.stringify(
-        {
-          ...summary,
-          applied: false,
-          hint: unresolvedHint,
-          applyResult: {
-            skeletons: scaffoldPlan.skeletons,
-            main: scaffoldPlan.signatures.main,
-            definitions: scaffoldPlan.signatures.definitions,
-            implementations: scaffoldPlan.signatures.implementations,
-            implementationStubs: scaffoldPlan.implementationStubs,
-            unresolved: scaffoldPlan.unresolved,
-          },
+      toolJson({
+        ...summary,
+        applied: false,
+        hint: unresolvedHint,
+        applyResult: {
+          skeletons: scaffoldPlan.skeletons,
+          main: scaffoldPlan.signatures.main,
+          definitions: scaffoldPlan.signatures.definitions,
+          implementations: scaffoldPlan.signatures.implementations,
+          implementationStubs: scaffoldPlan.implementationStubs,
+          unresolved: scaffoldPlan.unresolved,
         },
-        null,
-        2,
-      ),
+      }),
     );
   }
 
@@ -237,22 +233,18 @@ export async function writeActionScaffoldRapHandlers(ctx: SapWriteContext): Prom
     lintWarningsDefinitions?.warnings,
     lintWarningsImplementations?.warnings,
   );
-  const details = JSON.stringify(
-    {
-      ...summary,
-      applied: true,
-      applyResult: {
-        skeletons: scaffoldPlan.skeletons,
-        main: scaffoldPlan.signatures.main,
-        definitions: scaffoldPlan.signatures.definitions,
-        implementations: scaffoldPlan.signatures.implementations,
-        implementationStubs: scaffoldPlan.implementationStubs,
-        unresolved: scaffoldPlan.unresolved,
-      },
+  const details = toolJson({
+    ...summary,
+    applied: true,
+    applyResult: {
+      skeletons: scaffoldPlan.skeletons,
+      main: scaffoldPlan.signatures.main,
+      definitions: scaffoldPlan.signatures.definitions,
+      implementations: scaffoldPlan.signatures.implementations,
+      implementationStubs: scaffoldPlan.implementationStubs,
+      unresolved: scaffoldPlan.unresolved,
     },
-    null,
-    2,
-  );
+  });
   return warnings ? textResult(`${msg}\n\n${warnings}\n\n${details}`) : textResult(`${msg}\n\n${details}`);
 }
 
@@ -294,6 +286,6 @@ export async function writeActionGenerateBehaviorImplementation(ctx: SapWriteCon
   // `isRapGenerateResultSuccess` for the success/error contract (Codex review on PR #260, P1).
   // The structured JSON is preserved in both branches so the caller can still see what
   // was discovered, written, and what activation reported.
-  const json = JSON.stringify(result, null, 2);
+  const json = toolJson(result);
   return isRapGenerateResultSuccess(result) ? textResult(json) : errorResult(json);
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -672,7 +672,8 @@ const SERVER_INSTRUCTIONS = [
   '- One method: SAPRead(type="CLAS", method="name"). Survey signatures: method="*".',
   '- Finding a string: SAPRead(grep="pattern") instead of reading the whole object.',
   '- Blast radius of a CDS change: SAPContext(action="impact").',
-  'List-returning actions are paged and report a true "total" — trust it over the page length.',
+  'Where-used, usages, impact and transport lists are paged: they report a complete "total"/summary',
+  'alongside a capped page — trust that count, not the page length. Other list actions are unpaged.',
   '',
   'One SAP system per instance: there is no system/destination selector, by design.',
 ].join('\n');

--- a/tests/e2e/cache.e2e.test.ts
+++ b/tests/e2e/cache.e2e.test.ts
@@ -191,6 +191,10 @@ describe('E2E Cache Tests', () => {
     expect(parsed.source).toBe('live');
     expect(parsed.resolvedObject).toMatchObject({ type: 'CLAS', name: 'ZCL_ARC1_TEST' });
     expect(parsed.usages).toBeInstanceOf(Array);
-    expect(parsed.usageCount).toBe(parsed.usages.length);
+    // usageCount is the TOTAL match count, not the page size — it only equals usages.length when
+    // the result was not truncated. `shown` is the page length.
+    expect(parsed.shown).toBe(parsed.usages.length);
+    expect(parsed.usageCount).toBeGreaterThanOrEqual(parsed.usages.length);
+    if (!parsed.truncated) expect(parsed.usageCount).toBe(parsed.usages.length);
   });
 });

--- a/tests/e2e/navigate.e2e.test.ts
+++ b/tests/e2e/navigate.e2e.test.ts
@@ -74,7 +74,7 @@ describe('E2E SAPNavigate — Where-Used Analysis', () => {
         );
         return;
       }
-      const refs = JSON.parse(text);
+      const refs = JSON.parse(text).references;
       expect(refs.length).toBeGreaterThanOrEqual(1);
       // ZCL_ARC1_TEST implements this interface — must appear in results
       const classRef = refs.find((r: { name: string }) => r.name === 'ZCL_ARC1_TEST');
@@ -94,7 +94,7 @@ describe('E2E SAPNavigate — Where-Used Analysis', () => {
         skipTest(ctx, 'Where-used index empty for ZCL_ARC1_TEST on this system');
         return;
       }
-      const refs = JSON.parse(text);
+      const refs = JSON.parse(text).references;
       expect(Array.isArray(refs)).toBe(true);
       if (refs.length > 0) {
         expect(refs[0]).toHaveProperty('uri');
@@ -115,7 +115,7 @@ describe('E2E SAPNavigate — Where-Used Analysis', () => {
         skipTest(ctx, 'Where-used index empty for ZIF_ARC1_TEST on this system');
         return;
       }
-      const refs = JSON.parse(text);
+      const refs = JSON.parse(text).references;
       expect(refs.length).toBeGreaterThanOrEqual(1);
       const first = refs[0];
       // Scope-based API returns enriched fields
@@ -169,7 +169,7 @@ describe('E2E SAPNavigate — Where-Used Analysis', () => {
         name: 'CL_ABAP_CHAR_UTILITIES',
       });
       const text = expectToolSuccess(result);
-      const refs = JSON.parse(text);
+      const refs = JSON.parse(text).references;
       expect(refs.length).toBeGreaterThan(0);
       const first = refs[0];
       expect(first).toHaveProperty('uri');
@@ -190,7 +190,7 @@ describe('E2E SAPNavigate — Where-Used Analysis', () => {
         name: 'BUKRS',
       });
       const text = expectToolSuccessOrSkip(ctx, result);
-      const refs = JSON.parse(text);
+      const refs = JSON.parse(text).references;
       expect(refs.length).toBeGreaterThan(0);
       console.log(`    BUKRS domain has ${refs.length} references`);
     });
@@ -202,7 +202,7 @@ describe('E2E SAPNavigate — Where-Used Analysis', () => {
         name: 'BUKRS',
       });
       const text = expectToolSuccessOrSkip(ctx, result);
-      const refs = JSON.parse(text);
+      const refs = JSON.parse(text).references;
       expect(refs.length).toBeGreaterThan(0);
       console.log(`    BUKRS data element has ${refs.length} references`);
     });
@@ -219,7 +219,7 @@ describe('E2E SAPNavigate — Where-Used Analysis', () => {
         objectType: 'PROG/P',
       });
       const text = expectToolSuccess(result);
-      const refs = JSON.parse(text);
+      const refs = JSON.parse(text).references;
       // The objectTypeFilter is sent in the request body, but some SAP systems
       // ignore it and return all types. We just verify we got results back.
       if (Array.isArray(refs)) {

--- a/tests/e2e/navigate.slow.e2e.test.ts
+++ b/tests/e2e/navigate.slow.e2e.test.ts
@@ -35,7 +35,7 @@ describe('E2E SAPNavigate — Slow Where-Used Analysis', () => {
       name: 'BAPIRET2',
     });
     const text = expectToolSuccess(result);
-    const refs = JSON.parse(text);
+    const refs = JSON.parse(text).references;
     expect(refs.length).toBeGreaterThan(0);
     console.log(`    BAPIRET2 has ${refs.length} references`);
   });
@@ -48,7 +48,7 @@ describe('E2E SAPNavigate — Slow Where-Used Analysis', () => {
       name: 'T000',
     });
     const text = expectToolSuccessOrSkip(ctx, result);
-    const refs = JSON.parse(text);
+    const refs = JSON.parse(text).references;
     expect(refs.length).toBeGreaterThan(0);
     console.log(`    T000 table has ${refs.length} references`);
   });
@@ -61,7 +61,7 @@ describe('E2E SAPNavigate — Slow Where-Used Analysis', () => {
       objectType: 'CLAS/OC',
     });
     const text = expectToolSuccess(result);
-    const refs = JSON.parse(text);
+    const refs = JSON.parse(text).references;
     if (Array.isArray(refs)) {
       expect(refs.length).toBeGreaterThan(0);
       const clasCount = refs.filter((r: { type: string }) => r.type === 'CLAS/OC').length;

--- a/tests/e2e/saptransport.e2e.test.ts
+++ b/tests/e2e/saptransport.e2e.test.ts
@@ -37,8 +37,9 @@ describe('E2E SAPTransport Tests', () => {
   const createdTransportablePrograms = new Set<string>();
 
   async function listArc1DraftTransportIds(): Promise<Set<string>> {
-    const result = await callTool(client, 'SAPTransport', { action: 'list', status: 'D' });
-    const transports = JSON.parse(expectToolSuccess(result)) as TransportListEntry[];
+    // maxResults=1000 so cleanup still sees every ARC-1 draft: `list` pages at 50 by default.
+    const result = await callTool(client, 'SAPTransport', { action: 'list', status: 'D', maxResults: 1000 });
+    const transports = (JSON.parse(expectToolSuccess(result)) as { transports: TransportListEntry[] }).transports;
     return new Set(
       transports
         .filter(isArc1TestTransport)
@@ -187,13 +188,17 @@ describe('E2E SAPTransport Tests', () => {
       });
       const text = expectToolSuccess(result);
 
-      // Response should be valid JSON array
-      const transports = JSON.parse(text);
-      expect(Array.isArray(transports)).toBe(true);
-      console.log(`    Listed ${transports.length} transports`);
-      if (transports.length > 0) {
-        // Verify structure of first entry
-        expect(transports[0]).toHaveProperty('id');
+      // Paged envelope: {total, shown, truncated, transports:[...]}. `total` is the full backlog,
+      // `transports` the capped page; summary mode is the default, so entries carry objectCount
+      // instead of object lists.
+      const payload = JSON.parse(text);
+      expect(Array.isArray(payload.transports)).toBe(true);
+      expect(payload.shown).toBe(payload.transports.length);
+      expect(payload.total).toBeGreaterThanOrEqual(payload.shown);
+      console.log(`    Listed ${payload.shown} of ${payload.total} transports`);
+      if (payload.transports.length > 0) {
+        expect(payload.transports[0]).toHaveProperty('id');
+        expect(payload.transports[0]).toHaveProperty('objectCount');
       }
     });
 

--- a/tests/evals/scenarios/navigate.ts
+++ b/tests/evals/scenarios/navigate.ts
@@ -24,7 +24,13 @@ export const SCENARIOS: EvalScenario[] = [
       },
     ],
     mockResponses: {
-      SAPNavigate: JSON.stringify([{ uri: '/sap/bc/adt/programs/programs/ZTEST/source/main', line: 15, column: 5 }]),
+      // references returns the paged envelope, not a bare array.
+      SAPNavigate: JSON.stringify({
+        total: 1,
+        shown: 1,
+        truncated: false,
+        references: [{ uri: '/sap/bc/adt/programs/programs/ZTEST/source/main', line: 15, column: 5 }],
+      }),
       SAPSearch: JSON.stringify([{ objectName: 'ZTEST', objectType: 'PROG/P', line: 15 }]),
     },
   },

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -72,7 +72,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
         },
         "group": {
           "type": "string",
@@ -167,7 +167,8 @@
       },
       "required": [
         "type"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -227,7 +228,8 @@
           "type": "string",
           "description": "For source_code search: filter by package name"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -797,7 +799,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -871,7 +874,8 @@
           },
           "description": "Batch items; use for 2+ objects."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -912,7 +916,7 @@
         },
         "maxResults": {
           "type": "number",
-          "description": "references: max entries (default 100, max 1000). \"total\" always reports the unfiltered count."
+          "description": "references: max entries (default 100, max 1000). \"total\" counts every match of the filter."
         },
         "line": {
           "type": "number",
@@ -929,7 +933,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -952,7 +957,8 @@
       },
       "required": [
         "sql"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -1005,7 +1011,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1014,7 +1021,7 @@
   },
   {
     "name": "SAPDiagnose",
-    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on; optional traceUser/processType/maxExecutions/expiresHours/sqlTrace/…).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC (optional user/authObject/onlyFailures/maxResults). Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
+    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1237,7 +1244,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1309,7 +1317,8 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -1489,7 +1498,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1583,7 +1593,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1708,7 +1719,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -72,7 +72,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
         },
         "group": {
           "type": "string",
@@ -167,7 +167,8 @@
       },
       "required": [
         "type"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -222,7 +223,8 @@
           ],
           "description": "For tadir_lookup only: data source for the lookup. \"adt\" (default) uses the ADT info-system endpoint — workbench-resolvable objects only. \"db\" issues SQL against table TADIR — also surfaces orphan/ghost rows from aborted create-delete cycles (requires sql scope and SAP_ALLOW_FREE_SQL=true). \"both\" runs both paths and adds a \"splitBrain\" array listing names where the two sources disagree, plus a \"warnings\" array explaining each divergence (requires sql scope)."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -262,7 +264,7 @@
         },
         "maxResults": {
           "type": "number",
-          "description": "references: max entries (default 100, max 1000). \"total\" always reports the unfiltered count."
+          "description": "references: max entries (default 100, max 1000). \"total\" counts every match of the filter."
         },
         "line": {
           "type": "number",
@@ -279,7 +281,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -332,7 +335,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -341,7 +345,7 @@
   },
   {
     "name": "SAPDiagnose",
-    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on; optional traceUser/processType/maxExecutions/expiresHours/sqlTrace/…).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC (optional user/authObject/onlyFailures/maxResults). Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
+    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -564,7 +568,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -636,7 +641,8 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -807,7 +813,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -895,7 +902,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1012,7 +1020,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -86,7 +86,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
         },
         "group": {
           "type": "string",
@@ -185,7 +185,8 @@
       },
       "required": [
         "type"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -245,7 +246,8 @@
           "type": "string",
           "description": "For source_code search: filter by package name"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -831,7 +833,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -905,7 +908,8 @@
           },
           "description": "Batch items; use for 2+ objects."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -946,7 +950,7 @@
         },
         "maxResults": {
           "type": "number",
-          "description": "references: max entries (default 100, max 1000). \"total\" always reports the unfiltered count."
+          "description": "references: max entries (default 100, max 1000). \"total\" counts every match of the filter."
         },
         "line": {
           "type": "number",
@@ -963,7 +967,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -986,7 +991,8 @@
       },
       "required": [
         "sql"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -1039,7 +1045,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1048,7 +1055,7 @@
   },
   {
     "name": "SAPDiagnose",
-    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on; optional traceUser/processType/maxExecutions/expiresHours/sqlTrace/…).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC (optional user/authObject/onlyFailures/maxResults). Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
+    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1271,7 +1278,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1349,7 +1357,8 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -1529,7 +1538,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1623,7 +1633,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -86,7 +86,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
         },
         "group": {
           "type": "string",
@@ -185,7 +185,8 @@
       },
       "required": [
         "type"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -245,7 +246,8 @@
           "type": "string",
           "description": "For source_code search: filter by package name"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -831,7 +833,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -905,7 +908,8 @@
           },
           "description": "Batch items; use for 2+ objects."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -946,7 +950,7 @@
         },
         "maxResults": {
           "type": "number",
-          "description": "references: max entries (default 100, max 1000). \"total\" always reports the unfiltered count."
+          "description": "references: max entries (default 100, max 1000). \"total\" counts every match of the filter."
         },
         "line": {
           "type": "number",
@@ -963,7 +967,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -986,7 +991,8 @@
       },
       "required": [
         "sql"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -1039,7 +1045,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1048,7 +1055,7 @@
   },
   {
     "name": "SAPDiagnose",
-    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on; optional traceUser/processType/maxExecutions/expiresHours/sqlTrace/…).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC (optional user/authObject/onlyFailures/maxResults). Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
+    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1271,7 +1278,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1349,7 +1357,8 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -1529,7 +1538,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1623,7 +1633,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1748,7 +1759,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -86,7 +86,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
         },
         "group": {
           "type": "string",
@@ -185,7 +185,8 @@
       },
       "required": [
         "type"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -245,7 +246,8 @@
           "type": "string",
           "description": "For source_code search: filter by package name"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -831,7 +833,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -905,7 +908,8 @@
           },
           "description": "Batch items; use for 2+ objects."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -946,7 +950,7 @@
         },
         "maxResults": {
           "type": "number",
-          "description": "references: max entries (default 100, max 1000). \"total\" always reports the unfiltered count."
+          "description": "references: max entries (default 100, max 1000). \"total\" counts every match of the filter."
         },
         "line": {
           "type": "number",
@@ -963,7 +967,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -986,7 +991,8 @@
       },
       "required": [
         "sql"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -1039,7 +1045,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1048,7 +1055,7 @@
   },
   {
     "name": "SAPDiagnose",
-    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on; optional traceUser/processType/maxExecutions/expiresHours/sqlTrace/…).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC (optional user/authObject/onlyFailures/maxResults). Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
+    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1271,7 +1278,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1349,7 +1357,8 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -1529,7 +1538,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1654,7 +1664,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -86,7 +86,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
         },
         "group": {
           "type": "string",
@@ -185,7 +185,8 @@
       },
       "required": [
         "type"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -245,7 +246,8 @@
           "type": "string",
           "description": "For source_code search: filter by package name"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -831,7 +833,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -905,7 +908,8 @@
           },
           "description": "Batch items; use for 2+ objects."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -946,7 +950,7 @@
         },
         "maxResults": {
           "type": "number",
-          "description": "references: max entries (default 100, max 1000). \"total\" always reports the unfiltered count."
+          "description": "references: max entries (default 100, max 1000). \"total\" counts every match of the filter."
         },
         "line": {
           "type": "number",
@@ -963,7 +967,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -986,7 +991,8 @@
       },
       "required": [
         "sql"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -1039,7 +1045,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1048,7 +1055,7 @@
   },
   {
     "name": "SAPDiagnose",
-    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on; optional traceUser/processType/maxExecutions/expiresHours/sqlTrace/…).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC (optional user/authObject/onlyFailures/maxResults). Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
+    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1271,7 +1278,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1349,7 +1357,8 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -1529,7 +1538,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1623,7 +1633,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1748,7 +1759,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -86,7 +86,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. Not all classes have these sections — missing ones return a note instead of an error. For DDLS: use include=\"elements\" to get a structured field list extracted from the CDS DDL source — shows key fields, aliases, associations, and expression types (calculated, case, cast). Useful for understanding CDS entity structure without parsing raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
         },
         "group": {
           "type": "string",
@@ -185,7 +185,8 @@
       },
       "required": [
         "type"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -240,7 +241,8 @@
           ],
           "description": "For tadir_lookup only: data source for the lookup. \"adt\" (default) uses the ADT info-system endpoint — workbench-resolvable objects only. \"db\" issues SQL against table TADIR — also surfaces orphan/ghost rows from aborted create-delete cycles (requires sql scope and SAP_ALLOW_FREE_SQL=true). \"both\" runs both paths and adds a \"splitBrain\" array listing names where the two sources disagree, plus a \"warnings\" array explaining each divergence (requires sql scope)."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -280,7 +282,7 @@
         },
         "maxResults": {
           "type": "number",
-          "description": "references: max entries (default 100, max 1000). \"total\" always reports the unfiltered count."
+          "description": "references: max entries (default 100, max 1000). \"total\" counts every match of the filter."
         },
         "line": {
           "type": "number",
@@ -297,7 +299,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -350,7 +353,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -359,7 +363,7 @@
   },
   {
     "name": "SAPDiagnose",
-    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on; optional traceUser/processType/maxExecutions/expiresHours/sqlTrace/…).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC (optional user/authObject/onlyFailures/maxResults). Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
+    "description": "Run diagnostics on ABAP objects and analyze runtime errors. Actions:\n- \"syntax\": syntax-check (name+type; optional version; optional source = pre-write dry-run, nothing written).\n- \"unittest\": run ABAP Unit tests (name+type).\n- \"atc\": run ATC checks (name+type; optional variant).\n- \"cds_testcases\": SAP-suggested ABAP Unit test cases for a CDS entity (name; read-only; SAP_BASIS 8.16+).\n- \"object_state\": compare active and inactive source versions without fetching both (name+type; CLAS compares all includes). Returns ETags, hashes, divergence flags.\n- \"quickfix\": get quick-fix proposals at a position (name+type+source+line; optional column, sourceUri).\n- \"apply_quickfix\": apply one proposal, return text deltas, no write (name+type+source+line+proposalUri+proposalUserContent; pass proposalUserContent through exactly, may be empty).\n- \"dumps\": list/read ST22 short dumps (no id = list; id = read; includeFullText, sections).\n- \"traces\": list/analyze profiler traces (id+analysis: hitlist=hot spots, statements=call tree, dbAccesses=DB stats).\n- \"trace_start\": arm a profiler trace for the NEXT matching execution, then reproduce and read via \"traces\" (write scope; defaults: next HTTP request, SQL on).\n- \"trace_requests\": list armed trace requests. \"trace_cancel\": cancel one by id (write scope).\n- \"system_messages\": list SM02 messages. \"gateway_errors\": list /IWFND/ERROR_LOG (on-prem; detailUrl or id+errorType for detail).\n- \"odata_perf\": diagnose why an OData call is slow (url = host-relative path from the Network tab); returns the sap-statistics timing split (DB/ABAP/framework/auth) + a verdict. Read-only; needs allowDataPreview.\n- \"authorization_trace\": read the on-prem STUSERTRACE authorization trace from SUAUTHVALTRC Read-only; needs SAP_ALLOW_DATA_PREVIEW.\n- \"cds_sql\": show the native SQL a CDS view compiles to (name; read-only; may be absent on old releases).\n- \"sql_trace_state\" / \"set_sql_trace_state\" (sqlOn; needs SAP_ALLOW_WRITES) / \"sql_trace_directory\": ST05 SQL-trace control.\nQuickfix workflow: syntax/ATC → quickfix → apply_quickfix → write via SAPWrite. Full action reference: docs_page SAPDiagnose.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -582,7 +586,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -660,7 +665,8 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": true
@@ -831,7 +837,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -919,7 +926,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,
@@ -1036,7 +1044,8 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "additionalProperties": false
     },
     "annotations": {
       "readOnlyHint": false,

--- a/tests/unit/handlers/manage-context.test.ts
+++ b/tests/unit/handlers/manage-context.test.ts
@@ -1165,6 +1165,44 @@ ENDCLASS.`;
       expect(payload.usages[0].name).toBe('ZCL_CALLER');
     });
 
+    it('reports usageCount as the TOTAL, not the returned page', async () => {
+      // The safety property behind bounding: "what breaks if I change this?" must not be answered
+      // with the page size. Under-reporting a blast radius is a wrong answer, not a terse one.
+      const rows = Array.from(
+        { length: 120 },
+        (_, i) => `<usageReferences:referencedObject uri="/sap/bc/adt/oo/classes/zcl_c${i}" isResult="true">
+      <usageReferences:adtObject adtcore:name="ZCL_C${i}" adtcore:type="CLAS/OC" xmlns:adtcore="http://www.sap.com/adt/core">
+        <adtcore:packageRef adtcore:name="$TMP"/>
+      </usageReferences:adtObject>
+    </usageReferences:referencedObject>`,
+      ).join('\n');
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          200,
+          `<?xml version="1.0" encoding="utf-8"?>
+<usageReferences:usageReferenceResult xmlns:usageReferences="http://www.sap.com/adt/ris/usageReferences">
+  <usageReferences:referencedObjects>${rows}</usageReferences:referencedObjects>
+</usageReferences:usageReferenceResult>`,
+        ),
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPContext', {
+        action: 'usages',
+        type: 'CLAS',
+        name: 'ZCL_TARGET',
+        maxResults: 5,
+      });
+
+      const payload = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(payload.usageCount).toBe(120);
+      expect(payload.shown).toBe(5);
+      expect(payload.truncated).toBe(true);
+      expect(payload.usages).toHaveLength(5);
+      expect(payload.hint).toContain('120');
+    });
+
     it('resolves a unique name-only usages request through ADT lookup', async () => {
       mockFetch.mockReset();
       mockFetch.mockResolvedValueOnce(
@@ -1380,6 +1418,55 @@ ENDCLASS.`;
       expect(parsed.downstream.projectionViews.map((item: { name: string }) => item.name)).toContain('ZI_ARC1_PROJ');
       expect(parsed.downstream.bdefs.map((item: { name: string }) => item.name)).toContain('ZI_ARC1_ROOT');
       expect(parsed.summary.downstreamTotal).toBeGreaterThanOrEqual(2);
+    });
+
+    it('bounds impact buckets while keeping the summary total complete', async () => {
+      // Regression: impact accepted maxResults and silently ignored it, classifying and returning
+      // the FULL where-used tree — the exact bug bounding exists to kill. The summary must stay
+      // complete: an under-reported blast radius is a wrong answer to "what breaks if I change this".
+      mockFetch.mockReset();
+      const rows = Array.from(
+        { length: 80 },
+        (
+          _,
+          i,
+        ) => `<usageReferences:referencedObject uri="/sap/bc/adt/ddic/ddl/sources/zi_p${i}" isResult="true" canHaveChildren="false" usageInformation="gradeDirect">
+      <usageReferences:adtObject adtcore:name="ZI_P${i}" adtcore:type="DDLS/DF" xmlns:adtcore="http://www.sap.com/adt/core"/>
+    </usageReferences:referencedObject>`,
+      ).join('\n');
+      const whereUsedXml = `<?xml version="1.0" encoding="utf-8"?>
+<usageReferences:usageReferenceResult xmlns:usageReferences="http://www.sap.com/adt/ris/usageReferences">
+  <usageReferences:referencedObjects>${rows}</usageReferences:referencedObjects>
+</usageReferences:usageReferenceResult>`;
+
+      mockFetch.mockImplementation((url: string | URL) => {
+        const urlStr = String(url);
+        if (urlStr.includes('/sap/bc/adt/ddic/ddl/sources/Z_MY_VIEW/source/main')) {
+          return Promise.resolve(
+            mockResponse(200, 'define view entity Z_MY_VIEW as select from zmytab { key zmytab.id }', {
+              'x-csrf-token': 'T',
+            }),
+          );
+        }
+        if (urlStr.includes('/repository/informationsystem/usageReferences?uri=')) {
+          return Promise.resolve(mockResponse(200, whereUsedXml, { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPContext', {
+        action: 'impact',
+        type: 'DDLS',
+        name: 'Z_MY_VIEW',
+        siblingCheck: false,
+        maxResults: 10,
+      });
+
+      const parsed = JSON.parse(result.content[0]!.text);
+      expect(parsed.downstream.projectionViews).toHaveLength(10);
+      expect(parsed.summary.downstreamTotal).toBe(80);
+      expect(parsed.truncatedBuckets).toContain('projectionViews (80)');
+      expect(parsed.hint).toContain('summary counts remain complete');
     });
 
     it('returns guidance error when impact is requested for non-DDLS type', async () => {

--- a/tests/unit/handlers/search-navigate.test.ts
+++ b/tests/unit/handlers/search-navigate.test.ts
@@ -1224,6 +1224,19 @@ describe('SAPSearch / SAPQuery / SAPGit / SAPNavigate handlers', () => {
         expect(parsed.total).toBe(1);
         expect(parsed.references[0].type).toBe('CLAS/OC');
       });
+
+      it('tolerates a padded objectType instead of silently matching nothing', async () => {
+        const parsed = await bulkRefs({ objectType: '  CLAS/OC  ', maxResults: 5 });
+        expect(parsed.total).toBe(1);
+        expect(parsed.references[0].name).toBe('ZCL_X');
+      });
+
+      it('treats a whitespace-only objectType as no filter', async () => {
+        // Otherwise it would filter on the empty type, match nothing, and read as "No references
+        // found" — a wrong answer dressed as an empty one.
+        const parsed = await bulkRefs({ objectType: '   ' });
+        expect(parsed.total).toBe(251);
+      });
     });
 
     it('returns error when neither uri nor type+name provided for references', async () => {

--- a/tests/unit/handlers/shared.test.ts
+++ b/tests/unit/handlers/shared.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { errorResult, textResult, toolJson } from '../../../src/handlers/shared.js';
+
+describe('toolJson', () => {
+  it('emits compact JSON — no pretty-print whitespace', () => {
+    const json = toolJson({ total: 2, refs: [{ name: 'A' }, { name: 'B' }] });
+    expect(json).toBe('{"total":2,"refs":[{"name":"A"},{"name":"B"}]}');
+    expect(json).not.toContain('\n');
+    expect(json).not.toContain('  ');
+  });
+
+  it('stays valid, round-trippable JSON', () => {
+    const value = { a: 1, b: [1, 2], c: { d: null }, e: 'x"y', f: 'ü' };
+    expect(JSON.parse(toolJson(value))).toEqual(value);
+  });
+
+  it('is materially smaller than pretty-printed output', () => {
+    // The whole point: 2-space indent + newlines cost 15-37% of every JSON result.
+    // Measured live post-bounding: where-used 11,856 -> 8,781 tokens, transport 5,689 -> 3,581.
+    const rows = Array.from({ length: 100 }, (_, i) => ({
+      uri: `/sap/bc/adt/oo/classes/zcl_${i}`,
+      type: 'CLAS/OC',
+      name: `ZCL_${i}`,
+      line: 0,
+      column: 0,
+      packageName: '$TMP',
+    }));
+    const compact = toolJson({ total: 100, references: rows }).length;
+    const pretty = JSON.stringify({ total: 100, references: rows }, null, 2).length;
+    expect(compact).toBeLessThan(pretty * 0.8);
+  });
+
+  it('preserves falsy values that carry meaning', () => {
+    // Pruning ""/0/false was rejected: isResult:false distinguishes a real where-used hit from a
+    // structural tree node, and line:0 means "no line info". Absent would not mean the same thing.
+    const json = toolJson({ isResult: false, line: 0, snippet: '' });
+    expect(JSON.parse(json)).toEqual({ isResult: false, line: 0, snippet: '' });
+  });
+});
+
+describe('textResult / errorResult', () => {
+  it('wraps text in the MCP content shape', () => {
+    expect(textResult('hi')).toEqual({ content: [{ type: 'text', text: 'hi' }] });
+  });
+
+  it('flags errors with isError', () => {
+    expect(errorResult('bad')).toEqual({ content: [{ type: 'text', text: 'bad' }], isError: true });
+  });
+});


### PR DESCRIPTION
**Stacked on #583** — base is `feat/token-optimization-bounding`, since this touches the same handler modules. Review/merge #583 first; the base retargets to `main` automatically.

Plan: [`docs/plans/2026-07-17-token-optimization-plan.md`](docs/plans/2026-07-17-token-optimization-plan.md).

## What

Every JSON tool result was pretty-printed with 2-space indent. The model gains nothing from indentation, and it costs 15–37% of the payload.

Measured **live, after #583's bounding** — so these are savings on already-bounded results, not a paper win:

| Result | Before | After |
|---|---|---|
| `SAPNavigate(references)` | 11,856 tok | **8,781 (−26%)** |
| `SAPTransport(list)` | 5,689 tok | **3,581 (−37%)** |
| `SAPRead(DEVC)` | 5,372 tok | **4,404 (−18%)** |
| `SAPSearch` | 2,922 tok | **2,472 (−15%)** |

One `toolJson()` helper in `shared.ts`; 86 call sites across 11 handler modules.

## Why this is safe

It is **whitespace only** — the output is still JSON, which models are trained on. It is explicitly **not** a token-optimized notation like TOON: the only controlled study ([arXiv 2605.29676](https://arxiv.org/html/2605.29676v1)) finds those trade 2–18% savings for up to **−36pp accuracy**, with parallel tool calls collapsing to near zero.

The codemod was **bounded** per AGENTS.md Playbook §6: it only rewrites a `JSON.stringify` call whose argument list it fully parsed and confirmed to be exactly `(X, null, 2)`, tracking string/template literals so parens inside strings cannot fool the paren balancer. Anything unparseable was left alone — nothing was.

Human-facing output is unaffected: audit previews and CLI rendering format at their own layer.

## Field pruning evaluated and rejected

| where-used (100 refs) | tokens |
|---|---|
| pretty (before) | 11,856 |
| **compact (this PR)** | **8,781 (−26%)** |
| + drop empty strings | 7,881 (−34%) |
| + drop `""`/`0`/`false` | 6,649 (−44%) |

Empty-string pruning adds only 7.6% over compaction for a recursive transform on every result. Falsy pruning adds more but removes `isResult:false` — which distinguishes a real where-used hit from a structural tree node — and `line:0`, which means "no line info". **Absent does not mean the same thing as false.** Not worth the semantics for 10%.

## Honest caveat

My plan said to gate this on an accuracy eval. I reasoned about accuracy (still JSON, not a notation change, models parse compact JSON routinely) but did **not** A/B test it against a fixture set. If you want that before merging, say so — this is the one change in the series whose downside is argued rather than measured. The revert unit is this PR alone, which is why it's separate.

## The abaplint failures were never real

I previously reported "2 pre-existing failures" from `@abaplint/core` drift. **That diagnosis was wrong** — there is no drift. The lockfile correctly pins 2.119.65 and matches `package.json`. This worktree simply had no `node_modules` and resolved up to the parent checkout, which sits on an older commit with 2.119.37 installed. After `npm ci`:

**0 failed, 4330 passed.** CI was never affected and no fix was needed, so there is no abaplint change in this PR.

## Testing

- Full suite green: **0 failed, 4330 passed**. Typecheck 0 errors, policy, biome, schema budget, build all pass.
- 6 new tests in `shared.test.ts`, **mutation-checked**: reverting `toolJson` to pretty-print fails 2 of them.
- One test pins that falsy values survive, so a future "prune empty fields" change has to argue with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)