### PR TITLE
feat: add SAPRead lineStart/lineEnd raw line-range read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,8 @@ Terse routing only — full gotchas per row in [docs/dev-guide.md](docs/dev-guid
 | Inactive syntax check / post-save check | `src/adt/devtools.ts`, `src/handlers/write-helpers.ts` (`tryPostSaveSyntaxCheck`) |
 | Method-level surgery | `src/context/method-surgery.ts` — `<localclass>~<method>` specifiers; ambiguous bare names error |
 | SAPRead `grep` (#313) | `src/context/grep.ts`, `src/handlers/read.ts` — rejects `grep`+`method` together |
+| SAPRead `lineStart`/`lineEnd` (raw line-range read) | `src/context/line-range.ts`, `src/handlers/read.ts` — mutually exclusive with `grep`/`method`; 1-based inclusive, `lineEnd` clamped not errored |
+| `edit_unit` (FORM/MODULE splice) / `edit_content` (content-anchored splice) | `src/context/{unit-surgery,content-splice}.ts`, `src/handlers/write/{unit-surgery,content-surgery}.ts`, `src/adt/crud.ts` (`safeUpdateSourceWithTransform`) — both fetch source INSIDE the SAP lock (not before it) via the shared primitive, closing a TOCTOU gap; conditional fetch reuses a cached `{source,etag}` on 304, splices fresh bytes on 200 (anchor match is the drift guard, not a separate error). `edit_content` 0-match-on-oldContent + unique newContent match → idempotent no-op (skips the PUT), not an error |
 | edit_method for CCDEF/CCIMP includes | `src/handlers/write/class-surgery.ts`, `src/handlers/schemas.ts` — auto-detect `lhc_*`/`lcl_*`→implementations, `ltc_*`→testclasses |
 | Class-section surgery (#303) | `src/adt/class-structure.ts`, `src/adt/client.ts`, `src/adt/xml-parser.ts`, `src/handlers/write/class-surgery.ts` — client-side refuse-diff before PUT |
 | SAPSearch tadir_lookup source variants | `src/handlers/search.ts`, `src/adt/client.ts`, `src/authz/policy.ts` — `db`/`both` escalate to sql scope |

--- a/docs_page/tools.md
+++ b/docs_page/tools.md
@@ -29,6 +29,7 @@ Use `SAPRead` when you need exact raw source, one method body, grep output, inac
 | `include` | string | No | For CLAS: `main`, `testclasses`, `definitions`, `implementations`, `macros`. For DDLS: `elements` (extract CDS view elements). |
 | `method` | string | No | For CLAS: method name to read (e.g., `get_name`), or `*` to list all methods |
 | `grep` | string | No | Case-insensitive regex; returns only matching source lines (+3 lines of context, with line numbers) instead of the full object — token-efficient search over source-bearing types (`PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, DCLS, BDEF, SRVD, SRVB, SKTD/KTD, DDLX, TABL, VIEW`). For CLAS, matches are annotated with the owning class/method; combine with `include=` to scope a section, but not with `method=`. Falls back to a literal search when the pattern is not valid regex. |
+| `lineStart` / `lineEnd` | number | No | 1-based, inclusive raw line window (both required together) — returns only those source lines, numbered, instead of the full object. Same source-bearing types as `grep`; `lineEnd` is clamped to the last line rather than erroring. Mutually exclusive with `grep` and `method` (find a line with `grep` or an ATC finding first, then read around it with `lineStart`/`lineEnd`). |
 | `expand_includes` | boolean | No | For FUGR: expand include source inline |
 | `group` | string | No | For FUNC: function group name |
 | `versionUri` | string | No | For VERSION_SOURCE: revision URI from a VERSIONS response (`revisions[].uri`), must start with `/sap/bc/adt/` |
@@ -107,6 +108,7 @@ SAPRead(type="CLAS", name="ZCL_ORDER", method="get_name")    — read a specific
 SAPRead(type="CLAS", name="ZCL_ORDER", grep="select.*from")  — matching lines only, annotated by method
 SAPRead(type="CLAS", name="ZCL_ORDER", include="text_symbols") — maintained text pool (on-prem; see Class text symbols)
 SAPRead(type="PROG", name="ZTEST_REPORT", grep="WRITE")      — search source, returns matches + context
+SAPRead(type="PROG", name="ZTEST_REPORT", lineStart=40, lineEnd=55) — raw line window, e.g. around an ATC finding
 SAPRead(type="DDLS", name="ZI_TRAVEL", include="elements")   — extract CDS view elements
 SAPRead(type="DCLS", name="ZI_TRAVEL_DCL")       — CDS access control source
 SAPRead(type="DDLX", name="ZC_TRAVEL")          — metadata extension with UI annotations

--- a/src/context/line-range.ts
+++ b/src/context/line-range.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure line-range slicing over source text for token-efficient SAPRead reads.
+ *
+ * `readLineRange` returns only lines `lineStart..lineEnd` (1-based, inclusive) with
+ * line-number prefixes, instead of the full object source — the "read the lines an
+ * ATC finding or a prior grep pointed at" half of the read→edit loop. Mirrors
+ * `src/context/grep.ts` in shape and conventions (pure, no I/O, same line-number format).
+ */
+
+export interface LineRangeResult {
+  /** Formatted, LLM-friendly numbered-line listing (or an error message). */
+  output: string;
+  /** True when lineStart/lineEnd are not usable against this source. */
+  invalidRange: boolean;
+}
+
+export interface LineWindowValidation {
+  valid: boolean;
+  /** Present when !valid. */
+  error?: string;
+  /** Present when valid — lineEnd clamped to totalLines. */
+  clampedEnd?: number;
+}
+
+/**
+ * Shared validation for a 1-based, inclusive `[lineStart, lineEnd]` window against a source of
+ * `totalLines` lines. `lineEnd` is clamped to `totalLines` rather than treated as an error, since
+ * callers commonly pass a generous upper bound. Shared by `readLineRange` (read-side) and
+ * `spliceContent` (write-side anchor scoping, `src/context/content-splice.ts`) so the two can't
+ * drift apart on what counts as a valid window.
+ */
+export function validateLineWindow(totalLines: number, lineStart: number, lineEnd: number): LineWindowValidation {
+  if (!Number.isInteger(lineStart) || !Number.isInteger(lineEnd)) {
+    return { valid: false, error: 'lineStart and lineEnd must be integers.' };
+  }
+  if (lineStart < 1) {
+    return { valid: false, error: `lineStart must be >= 1 (got ${lineStart}).` };
+  }
+  if (lineStart > lineEnd) {
+    return { valid: false, error: `lineStart (${lineStart}) must be <= lineEnd (${lineEnd}).` };
+  }
+  if (lineStart > totalLines) {
+    return { valid: false, error: `lineStart (${lineStart}) is past the end of the source (${totalLines} line(s)).` };
+  }
+  return { valid: true, clampedEnd: Math.min(lineEnd, totalLines) };
+}
+
+/**
+ * Slice `source` to the 1-based, inclusive line range `[lineStart, lineEnd]`.
+ *
+ * `lineEnd` is clamped to the last line of the source (noted in the output header)
+ * rather than treated as an error, since callers commonly pass a generous upper
+ * bound. `lineStart` past the end of the source, `lineStart < 1`, or
+ * `lineStart > lineEnd` are reported as an invalid range.
+ */
+export function readLineRange(source: string, lineStart: number, lineEnd: number): LineRangeResult {
+  const lines = source.replace(/\r\n/g, '\n').split('\n');
+  const totalLines = lines.length;
+
+  const validation = validateLineWindow(totalLines, lineStart, lineEnd);
+  if (!validation.valid) {
+    return { output: validation.error!, invalidRange: true };
+  }
+
+  const clampedEnd = validation.clampedEnd!;
+  const clampNote = lineEnd > totalLines ? ` (lineEnd clamped to ${totalLines}, the last line)` : '';
+
+  const out: string[] = [`Lines ${lineStart}-${clampedEnd} of ${totalLines} total${clampNote}:`];
+  for (let i = lineStart; i <= clampedEnd; i++) {
+    out.push(`${String(i).padStart(5)}: ${lines[i - 1]}`);
+  }
+
+  return { output: out.join('\n'), invalidRange: false };
+}

--- a/src/handlers/read.ts
+++ b/src/handlers/read.ts
@@ -16,6 +16,7 @@ import { getVersionDiff } from '../adt/version-diff.js';
 import type { CachingLayer } from '../cache/caching-layer.js';
 import { extractCdsElements } from '../context/cds-deps.js';
 import { grepSource } from '../context/grep.js';
+import { readLineRange } from '../context/line-range.js';
 import { extractMethod, formatMethodListing, listMethods } from '../context/method-surgery.js';
 import { logger } from '../server/logger.js';
 import { type CacheSecurityContext, inactiveListUserKey, invalidateInactiveList } from './cache-security.js';
@@ -243,9 +244,28 @@ export async function handleSAPRead(
     return g.invalidPattern ? errorResult(g.output) : textResult(g.output);
   };
 
+  /** When args.lineStart is set, return only that 1-based inclusive line window instead of full source. */
+  const lineRangeText = (source: string): ToolResult => {
+    const r = readLineRange(source, Number(args.lineStart), Number(args.lineEnd));
+    return r.invalidRange ? errorResult(r.output) : textResult(r.output);
+  };
+
   // Structured format is only supported for CLAS type
   if (args.format === 'structured' && type !== 'CLAS') {
     return errorResult('The "structured" format is only supported for CLAS type. Other types return text format.');
+  }
+
+  // lineStart/lineEnd is a raw-line-window narrowing mode, mutually exclusive with grep
+  // (both are competing narrowing modes; combining them is ambiguous about which wins).
+  if (args.lineStart !== undefined || args.lineEnd !== undefined) {
+    if (args.lineStart === undefined || args.lineEnd === undefined) {
+      return errorResult('Both lineStart and lineEnd are required when using a line-range read.');
+    }
+    if (args.grep) {
+      return errorResult(
+        'Do not combine lineStart/lineEnd with grep. Use grep to find code, then lineStart/lineEnd to read the surrounding raw lines.',
+      );
+    }
   }
 
   switch (type) {
@@ -254,6 +274,7 @@ export async function handleSAPRead(
         client.getProgram(name, { ifNoneMatch, version: effectiveVersion }),
       );
       if (args.grep) return grepText(source);
+      if (args.lineStart !== undefined) return lineRangeText(source);
       return cachedTextResult(source, cacheHit, revalidated, versionWarning);
     }
     case 'CLAS': {
@@ -297,6 +318,39 @@ export async function handleSAPRead(
           ? errorResult(g.output)
           : textResult(`[${name} section=${rawSection ?? 'main'}]\n${g.output}`);
       }
+      // lineStart/lineEnd: return only that raw line window instead of full source.
+      if (args.lineStart !== undefined) {
+        if (args.method) {
+          return errorResult(
+            'Do not combine lineStart/lineEnd with method. Use lineStart/lineEnd for a raw line window, or method="<name>" for a full method read.',
+          );
+        }
+        const rawSection = args.include as string | undefined;
+        const section = rawSection && rawSection.toLowerCase() !== 'main' ? rawSection : undefined;
+        let clasSource: string;
+        if (section) {
+          try {
+            clasSource = (await client.getClassInclude(name, section, { version: effectiveVersion })).source;
+          } catch (err) {
+            if (isNotFoundError(err)) {
+              return textResult(
+                `Include "${section}" is not available for class ${name}. Run lineStart/lineEnd without include= to read from the full class source.`,
+              );
+            }
+            throw err;
+          }
+        } else {
+          clasSource = (
+            await cachedGet('CLAS', name, effectiveVersion, (ifNoneMatch) =>
+              client.getClass(name, undefined, { ifNoneMatch, version: effectiveVersion }),
+            )
+          ).source;
+        }
+        const r = readLineRange(clasSource, Number(args.lineStart), Number(args.lineEnd));
+        return r.invalidRange
+          ? errorResult(r.output)
+          : textResult(`[${name} section=${rawSection ?? 'main'}]\n${r.output}`);
+      }
       // Structured format: return JSON with metadata + decomposed source
       if (args.format === 'structured') {
         const structured = await client.getClassStructured(name);
@@ -338,6 +392,7 @@ export async function handleSAPRead(
         client.getInterface(name, { ifNoneMatch, version: effectiveVersion }),
       );
       if (args.grep) return grepText(source);
+      if (args.lineStart !== undefined) return lineRangeText(source);
       return cachedTextResult(source, cacheHit, revalidated, versionWarning);
     }
     case 'FUNC': {
@@ -377,6 +432,7 @@ export async function handleSAPRead(
         return textResult(JSON.stringify(payload, null, 2));
       }
       if (args.grep) return grepText(source);
+      if (args.lineStart !== undefined) return lineRangeText(source);
       return cachedTextResult(source, cacheHit, revalidated, versionWarning);
     }
     case 'FUGR': {
@@ -405,6 +461,7 @@ export async function handleSAPRead(
         client.getInclude(name, { ifNoneMatch, version: effectiveVersion }),
       );
       if (args.grep) return grepText(source);
+      if (args.lineStart !== undefined) return lineRangeText(source);
       return cachedTextResult(source, cacheHit, revalidated, versionWarning);
     }
     case 'DDLS': {
@@ -426,6 +483,7 @@ export async function handleSAPRead(
         return cachedTextResult(extractCdsElements(ddlSource, name), false, false, versionWarning);
       }
       if (args.grep) return grepText(ddlSource);
+      if (args.lineStart !== undefined) return lineRangeText(ddlSource);
       return cachedTextResult(ddlSource, cacheHit, revalidated, versionWarning);
     }
     case 'DCLS': {
@@ -433,6 +491,7 @@ export async function handleSAPRead(
         client.getDcl(name, { ifNoneMatch, version: effectiveVersion }),
       );
       if (args.grep) return grepText(source);
+      if (args.lineStart !== undefined) return lineRangeText(source);
       return cachedTextResult(source, cacheHit, revalidated, versionWarning);
     }
     case 'BDEF': {
@@ -440,6 +499,7 @@ export async function handleSAPRead(
         client.getBdef(name, { ifNoneMatch, version: effectiveVersion }),
       );
       if (args.grep) return grepText(source);
+      if (args.lineStart !== undefined) return lineRangeText(source);
       return cachedTextResult(source, cacheHit, revalidated, versionWarning);
     }
     case 'SRVD': {
@@ -447,6 +507,7 @@ export async function handleSAPRead(
         client.getSrvd(name, { ifNoneMatch, version: effectiveVersion }),
       );
       if (args.grep) return grepText(source);
+      if (args.lineStart !== undefined) return lineRangeText(source);
       return cachedTextResult(source, cacheHit, revalidated, versionWarning);
     }
     case 'DDLX': {
@@ -455,6 +516,7 @@ export async function handleSAPRead(
           client.getDdlx(name, { ifNoneMatch, version: effectiveVersion }),
         );
         if (args.grep) return grepText(source);
+        if (args.lineStart !== undefined) return lineRangeText(source);
         return cachedTextResult(source, cacheHit, revalidated, versionWarning);
       } catch (err) {
         if (isNotFoundError(err)) {
@@ -481,6 +543,7 @@ export async function handleSAPRead(
         );
         const markdown = decodeKtdText(source);
         if (args.grep) return grepText(markdown);
+        if (args.lineStart !== undefined) return lineRangeText(markdown);
         return cachedTextResult(markdown, cacheHit, revalidated, versionWarning);
       } catch (err) {
         if (isNotFoundError(err)) {
@@ -499,6 +562,7 @@ export async function handleSAPRead(
         client.getTabl(name, { ifNoneMatch, version: effectiveVersion }),
       );
       if (args.grep) return grepText(source);
+      if (args.lineStart !== undefined) return lineRangeText(source);
       return cachedTextResult(source, cacheHit, revalidated, versionWarning);
     }
     case 'VIEW': {
@@ -506,6 +570,7 @@ export async function handleSAPRead(
         client.getView(name, { ifNoneMatch, version: effectiveVersion }),
       );
       if (args.grep) return grepText(source);
+      if (args.lineStart !== undefined) return lineRangeText(source);
       return cachedTextResult(source, cacheHit, revalidated, versionWarning);
     }
     case 'DOMA': {

--- a/src/handlers/schemas.ts
+++ b/src/handlers/schemas.ts
@@ -182,6 +182,10 @@ export const SAPReadSchema = z
     group: z.string().optional(),
     method: z.string().optional(),
     grep: z.string().max(MAX_GREP_PATTERN_LENGTH).optional(),
+    /** 1-based, inclusive start line for a raw line-range read. Requires lineEnd; mutually exclusive with grep. */
+    lineStart: z.coerce.number().int().optional(),
+    /** 1-based, inclusive end line for a raw line-range read. Clamped to the source's last line. */
+    lineEnd: z.coerce.number().int().optional(),
     expand_includes: looseOptionalBoolean,
     format: z.enum(['text', 'structured']).optional(),
     version: z.enum(['active', 'inactive', 'auto']).optional().default('active'),
@@ -219,6 +223,10 @@ export const SAPReadSchemaBtp = z
     group: z.string().optional(),
     method: z.string().optional(),
     grep: z.string().max(MAX_GREP_PATTERN_LENGTH).optional(),
+    /** 1-based, inclusive start line for a raw line-range read. Requires lineEnd; mutually exclusive with grep. */
+    lineStart: z.coerce.number().int().optional(),
+    /** 1-based, inclusive end line for a raw line-range read. Clamped to the source's last line. */
+    lineEnd: z.coerce.number().int().optional(),
     format: z.enum(['text', 'structured']).optional(),
     version: z.enum(['active', 'inactive', 'auto']).optional().default('active'),
     force_refresh: looseOptionalBoolean,

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -477,10 +477,16 @@ export function getToolDefinitions(
             maxLength: MAX_GREP_PATTERN_LENGTH,
             description:
               'Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. ' +
-              'For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section, but do NOT combine with method= (use grep to find, then method= to read). ' +
-              'Works for source-bearing types (CLAS, INTF, DDLS, DCLS, BDEF, SRVD, SRVB, SKTD/KTD, DDLX, TABL' +
-              (btp ? '' : ', PROG, FUNC, FUGR, INCL, VIEW') +
-              '). Falls back to a literal search when the pattern is not valid regex.',
+              'For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section; do NOT combine with method=. ' +
+              'Falls back to a literal search when the pattern is not valid regex.',
+          },
+          lineStart: {
+            type: 'number',
+            description: 'Start line (1-based); pairs with lineEnd, not with grep/method.',
+          },
+          lineEnd: {
+            type: 'number',
+            description: 'End line (1-based); pairs with lineStart.',
           },
           ...(btp
             ? {}

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -85,7 +85,15 @@
         "grep": {
           "type": "string",
           "maxLength": 512,
-          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section, but do NOT combine with method= (use grep to find, then method= to read). Works for source-bearing types (CLAS, INTF, DDLS, DCLS, BDEF, SRVD, SRVB, SKTD/KTD, DDLX, TABL). Falls back to a literal search when the pattern is not valid regex."
+          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section; do NOT combine with method=. Falls back to a literal search when the pattern is not valid regex."
+        },
+        "lineStart": {
+          "type": "number",
+          "description": "Start line (1-based); pairs with lineEnd, not with grep/method."
+        },
+        "lineEnd": {
+          "type": "number",
+          "description": "End line (1-based); pairs with lineStart."
         },
         "format": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -85,7 +85,15 @@
         "grep": {
           "type": "string",
           "maxLength": 512,
-          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section, but do NOT combine with method= (use grep to find, then method= to read). Works for source-bearing types (CLAS, INTF, DDLS, DCLS, BDEF, SRVD, SRVB, SKTD/KTD, DDLX, TABL). Falls back to a literal search when the pattern is not valid regex."
+          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section; do NOT combine with method=. Falls back to a literal search when the pattern is not valid regex."
+        },
+        "lineStart": {
+          "type": "number",
+          "description": "Start line (1-based); pairs with lineEnd, not with grep/method."
+        },
+        "lineEnd": {
+          "type": "number",
+          "description": "End line (1-based); pairs with lineStart."
         },
         "format": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -99,7 +99,15 @@
         "grep": {
           "type": "string",
           "maxLength": 512,
-          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section, but do NOT combine with method= (use grep to find, then method= to read). Works for source-bearing types (CLAS, INTF, DDLS, DCLS, BDEF, SRVD, SRVB, SKTD/KTD, DDLX, TABL, PROG, FUNC, FUGR, INCL, VIEW). Falls back to a literal search when the pattern is not valid regex."
+          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section; do NOT combine with method=. Falls back to a literal search when the pattern is not valid regex."
+        },
+        "lineStart": {
+          "type": "number",
+          "description": "Start line (1-based); pairs with lineEnd, not with grep/method."
+        },
+        "lineEnd": {
+          "type": "number",
+          "description": "End line (1-based); pairs with lineStart."
         },
         "expand_includes": {
           "type": "boolean",

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -99,7 +99,15 @@
         "grep": {
           "type": "string",
           "maxLength": 512,
-          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section, but do NOT combine with method= (use grep to find, then method= to read). Works for source-bearing types (CLAS, INTF, DDLS, DCLS, BDEF, SRVD, SRVB, SKTD/KTD, DDLX, TABL, PROG, FUNC, FUGR, INCL, VIEW). Falls back to a literal search when the pattern is not valid regex."
+          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section; do NOT combine with method=. Falls back to a literal search when the pattern is not valid regex."
+        },
+        "lineStart": {
+          "type": "number",
+          "description": "Start line (1-based); pairs with lineEnd, not with grep/method."
+        },
+        "lineEnd": {
+          "type": "number",
+          "description": "End line (1-based); pairs with lineStart."
         },
         "expand_includes": {
           "type": "boolean",

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -99,7 +99,15 @@
         "grep": {
           "type": "string",
           "maxLength": 512,
-          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section, but do NOT combine with method= (use grep to find, then method= to read). Works for source-bearing types (CLAS, INTF, DDLS, DCLS, BDEF, SRVD, SRVB, SKTD/KTD, DDLX, TABL, PROG, FUNC, FUGR, INCL, VIEW). Falls back to a literal search when the pattern is not valid regex."
+          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section; do NOT combine with method=. Falls back to a literal search when the pattern is not valid regex."
+        },
+        "lineStart": {
+          "type": "number",
+          "description": "Start line (1-based); pairs with lineEnd, not with grep/method."
+        },
+        "lineEnd": {
+          "type": "number",
+          "description": "End line (1-based); pairs with lineStart."
         },
         "expand_includes": {
           "type": "boolean",

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -99,7 +99,15 @@
         "grep": {
           "type": "string",
           "maxLength": 512,
-          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section, but do NOT combine with method= (use grep to find, then method= to read). Works for source-bearing types (CLAS, INTF, DDLS, DCLS, BDEF, SRVD, SRVB, SKTD/KTD, DDLX, TABL, PROG, FUNC, FUGR, INCL, VIEW). Falls back to a literal search when the pattern is not valid regex."
+          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section; do NOT combine with method=. Falls back to a literal search when the pattern is not valid regex."
+        },
+        "lineStart": {
+          "type": "number",
+          "description": "Start line (1-based); pairs with lineEnd, not with grep/method."
+        },
+        "lineEnd": {
+          "type": "number",
+          "description": "End line (1-based); pairs with lineStart."
         },
         "expand_includes": {
           "type": "boolean",

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -99,7 +99,15 @@
         "grep": {
           "type": "string",
           "maxLength": 512,
-          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section, but do NOT combine with method= (use grep to find, then method= to read). Works for source-bearing types (CLAS, INTF, DDLS, DCLS, BDEF, SRVD, SRVB, SKTD/KTD, DDLX, TABL, PROG, FUNC, FUGR, INCL, VIEW). Falls back to a literal search when the pattern is not valid regex."
+          "description": "Regex pattern (case-insensitive) to search within the object source. Returns only matching lines with 1-based line numbers and ±3 context lines, instead of the full source — token-efficient. For CLAS, matches are annotated with the owning class/method; combine with include= to scope a section; do NOT combine with method=. Falls back to a literal search when the pattern is not valid regex."
+        },
+        "lineStart": {
+          "type": "number",
+          "description": "Start line (1-based); pairs with lineEnd, not with grep/method."
+        },
+        "lineEnd": {
+          "type": "number",
+          "description": "End line (1-based); pairs with lineStart."
         },
         "expand_includes": {
           "type": "boolean",

--- a/tests/unit/context/line-range.test.ts
+++ b/tests/unit/context/line-range.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for the pure readLineRange helper.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readLineRange } from '../../../src/context/line-range.js';
+
+const SOURCE = `REPORT zfoo.
+DATA lv_count TYPE i.
+START-OF-SELECTION.
+  SELECT * FROM mara INTO TABLE @DATA(lt_mara).
+  LOOP AT lt_mara INTO DATA(ls_mara).
+    WRITE ls_mara-matnr.
+  ENDLOOP.
+  SELECT SINGLE maktx FROM makt INTO @DATA(lv_text).
+  WRITE lv_text.`;
+
+describe('readLineRange', () => {
+  it('returns the requested lines with a header and 1-based numbering', () => {
+    const r = readLineRange(SOURCE, 3, 5);
+    expect(r.invalidRange).toBe(false);
+    expect(r.output).toContain('Lines 3-5 of 9 total:');
+    expect(r.output).toContain('    3: START-OF-SELECTION.');
+    expect(r.output).toContain('    4:   SELECT * FROM mara INTO TABLE @DATA(lt_mara).');
+    expect(r.output).toContain('    5:   LOOP AT lt_mara INTO DATA(ls_mara).');
+    expect(r.output).not.toContain('    2:');
+    expect(r.output).not.toContain('    6:');
+  });
+
+  it('supports a single-line range', () => {
+    const r = readLineRange(SOURCE, 1, 1);
+    expect(r.invalidRange).toBe(false);
+    expect(r.output).toContain('Lines 1-1 of 9 total:');
+    expect(r.output).toContain('    1: REPORT zfoo.');
+  });
+
+  it('clamps lineEnd past the end of the source and notes the clamp', () => {
+    const r = readLineRange(SOURCE, 8, 100);
+    expect(r.invalidRange).toBe(false);
+    expect(r.output).toContain('Lines 8-9 of 9 total (lineEnd clamped to 9, the last line):');
+    expect(r.output).toContain('    9:   WRITE lv_text.');
+  });
+
+  it('normalizes CRLF source', () => {
+    const crlf = SOURCE.replace(/\n/g, '\r\n');
+    const r = readLineRange(crlf, 1, 2);
+    expect(r.invalidRange).toBe(false);
+    expect(r.output).toContain('    1: REPORT zfoo.');
+    expect(r.output).toContain('    2: DATA lv_count TYPE i.');
+  });
+
+  it('rejects lineStart < 1', () => {
+    const r = readLineRange(SOURCE, 0, 3);
+    expect(r.invalidRange).toBe(true);
+    expect(r.output).toMatch(/lineStart must be >= 1/);
+  });
+
+  it('rejects lineStart > lineEnd', () => {
+    const r = readLineRange(SOURCE, 5, 3);
+    expect(r.invalidRange).toBe(true);
+    expect(r.output).toMatch(/lineStart \(5\) must be <= lineEnd \(3\)/);
+  });
+
+  it('rejects lineStart past the end of the source', () => {
+    const r = readLineRange(SOURCE, 50, 60);
+    expect(r.invalidRange).toBe(true);
+    expect(r.output).toMatch(/lineStart \(50\) is past the end of the source \(9 line\(s\)\)/);
+  });
+
+  it('rejects non-integer inputs', () => {
+    const r = readLineRange(SOURCE, 1.5, 3);
+    expect(r.invalidRange).toBe(true);
+    expect(r.output).toMatch(/must be integers/);
+  });
+});

--- a/tests/unit/handlers/read.test.ts
+++ b/tests/unit/handlers/read.test.ts
@@ -235,6 +235,162 @@ describe('SAPRead handler', () => {
       });
     });
 
+    describe('lineStart/lineEnd', () => {
+      const PROG_SRC =
+        'REPORT zfoo.\nDATA lv TYPE i.\nlv = 1.\nlv = 2.\nlv = 3.\nSELECT * FROM mara INTO TABLE @lt.\nWRITE lv.';
+
+      it('PROG lineStart/lineEnd returns only that line window, not the whole source', async () => {
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValue(mockResponse(200, PROG_SRC, { 'x-csrf-token': 't' }));
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+          type: 'PROG',
+          name: 'ZFOO',
+          lineStart: 3,
+          lineEnd: 4,
+        });
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0]?.text).toContain('Lines 3-4 of 7 total');
+        expect(result.content[0]?.text).toContain('lv = 1.');
+        expect(result.content[0]?.text).toContain('lv = 2.');
+        expect(result.content[0]?.text).not.toContain('REPORT zfoo');
+        expect(result.content[0]?.text).not.toContain('SELECT * FROM mara');
+      });
+
+      it('requires both lineStart and lineEnd', async () => {
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+          type: 'PROG',
+          name: 'ZFOO',
+          lineStart: 3,
+        });
+        expect(result.isError).toBe(true);
+        expect(result.content[0]?.text).toContain('Both lineStart and lineEnd are required');
+      });
+
+      it('rejects lineStart/lineEnd combined with grep', async () => {
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+          type: 'PROG',
+          name: 'ZFOO',
+          lineStart: 1,
+          lineEnd: 2,
+          grep: 'x',
+        });
+        expect(result.isError).toBe(true);
+        expect(result.content[0]?.text).toContain('Do not combine lineStart/lineEnd with grep');
+      });
+
+      it('an out-of-range lineStart returns an error, not the full source', async () => {
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValue(mockResponse(200, PROG_SRC, { 'x-csrf-token': 't' }));
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+          type: 'PROG',
+          name: 'ZFOO',
+          lineStart: 50,
+          lineEnd: 60,
+        });
+        expect(result.isError).toBe(true);
+        expect(result.content[0]?.text).toContain('past the end of the source');
+      });
+
+      it('CLAS lineStart/lineEnd reads from the raw main section, annotated with the section label', async () => {
+        const clasSrc = [
+          'CLASS zcl_test DEFINITION PUBLIC.',
+          '  PUBLIC SECTION.',
+          '    METHODS read.',
+          'ENDCLASS.',
+          'CLASS zcl_test IMPLEMENTATION.',
+          '  METHOD read.',
+          '    SELECT * FROM mara INTO TABLE @lt.',
+          '  ENDMETHOD.',
+          'ENDCLASS.',
+        ].join('\n');
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValue(mockResponse(200, clasSrc, { 'x-csrf-token': 't' }));
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+          type: 'CLAS',
+          name: 'ZCL_TEST',
+          lineStart: 7,
+          lineEnd: 7,
+        });
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0]?.text).toContain('section=main');
+        expect(result.content[0]?.text).toContain('SELECT * FROM mara');
+      });
+
+      it('CLAS lineStart/lineEnd + method returns a combine error', async () => {
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+          type: 'CLAS',
+          name: 'ZCL_TEST',
+          lineStart: 1,
+          lineEnd: 2,
+          method: 'read',
+        });
+        expect(result.isError).toBe(true);
+        expect(result.content[0]?.text).toContain('Do not combine lineStart/lineEnd with method');
+      });
+
+      it('CLAS lineStart/lineEnd + include reads the raw section', async () => {
+        const testSrc = [
+          'CLASS ltcl_test DEFINITION FOR TESTING.',
+          '  PRIVATE SECTION.',
+          '    METHODS first_test FOR TESTING.',
+          'ENDCLASS.',
+          'CLASS ltcl_test IMPLEMENTATION.',
+          '  METHOD first_test.',
+          '    cl_abap_unit_assert=>assert_true( abap_true ).',
+          '  ENDMETHOD.',
+          'ENDCLASS.',
+        ].join('\n');
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValue(mockResponse(200, testSrc, { 'x-csrf-token': 't' }));
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+          type: 'CLAS',
+          name: 'ZCL_TEST',
+          lineStart: 7,
+          lineEnd: 7,
+          include: 'testclasses',
+        });
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0]?.text).toContain('section=testclasses');
+        expect(result.content[0]?.text).toContain('assert_true');
+        const inclCall = mockFetch.mock.calls.find((c: any[]) => String(c[0]).includes('/includes/testclasses'));
+        expect(inclCall).toBeDefined();
+      });
+
+      it('works on a non-CLAS source type (BDEF)', async () => {
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValue(
+          mockResponse(200, 'define behavior for ZI_Foo\n{\n  create;\n  update;\n  delete;\n}', {
+            'x-csrf-token': 't',
+          }),
+        );
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+          type: 'BDEF',
+          name: 'ZI_FOO',
+          lineStart: 3,
+          lineEnd: 3,
+        });
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0]?.text).toContain('create;');
+      });
+
+      it('works on a DDIC source type (TABL)', async () => {
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValue(
+          mockResponse(200, 'define structure zfoo {\n  field1 : abap.int4;\n  matnr : matnr;\n}', {
+            'x-csrf-token': 't',
+          }),
+        );
+        const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+          type: 'TABL',
+          name: 'ZFOO',
+          lineStart: 3,
+          lineEnd: 3,
+        });
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0]?.text).toContain('matnr');
+      });
+    });
+
     it('reads active version with draft warning when inactive list contains the object', async () => {
       mockFetch.mockReset();
       mockFetch


### PR DESCRIPTION
Adds an optional 1-based, inclusive lineStart/lineEnd window to SAPRead, returning only that raw line range instead of the full object source — useful for reading around a known line (e.g. an ATC finding) without paying for the whole file. Mutually exclusive with grep/method for now; lineEnd is clamped to the source's last line rather than erroring.