### PR TITLE
docs: cryptography + secret-hygiene inventory in security model

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -289,7 +289,33 @@ if the change is *in* one of them.
 
 ---
 
-## 8. References
+## 8. Cryptography and key handling
+
+ARC-1 uses only vetted primitives from Node's `node:crypto` and the platform TLS stack —
+**no hand-rolled cryptography, and no custom RNG for any security decision.**
+
+| Purpose | Primitive | Where |
+|---|---|---|
+| OAuth PKCE | **S256** — SHA-256 over a `randomBytes(32)` verifier | [`src/adt/oauth.ts`](../src/adt/oauth.ts) |
+| OAuth `state` / nonce | `randomBytes(32)` (base64url) | [`src/adt/oauth.ts`](../src/adt/oauth.ts) |
+| DCR `client_id` + auth `state` | HMAC (HKDF-derived, domain-separated key), constant-time verify | [`@arc-mcp/xsuaa-auth`](https://github.com/arc-mcp/xsuaa-auth) — see §7 |
+| JWT signature | asymmetric, verified vs kid-matched JWKS; `none` / HS↔RS confusion rejected | [`@arc-mcp/xsuaa-auth`](https://github.com/arc-mcp/xsuaa-auth), wired via [`src/server/http.ts`](../src/server/http.ts) |
+| Cache key / ETag / content hash | SHA-256 | [`src/cache/cache.ts`](../src/cache/cache.ts), [`src/adt/diagnostics.ts`](../src/adt/diagnostics.ts) |
+| Audit event id | `crypto.randomUUID()` | [`src/server/sinks/btp-auditlog.ts`](../src/server/sinks/btp-auditlog.ts) |
+| Transport | platform TLS; certificate validation **on by default** — `SAP_INSECURE` opt-out is logged as a warning | [`src/adt/http.ts`](../src/adt/http.ts) |
+
+**Key & secret handling.** Secrets (SAP credentials, XSUAA `clientsecret`, the DCR signing
+secret, BTP service-key fields) come only from env / service-key / destination config — never
+hardcoded — and are never persisted at rest in the cache DB or logs (invariant **I4**).
+Accidental hardcoded-credential leaks are prevented by **GitHub secret scanning with push
+protection** (enabled on this repo): a matching secret is blocked at `git push`, and anything
+already committed raises a Security-tab alert. The related "hidden interfaces" concern is bounded
+separately: CodeQL SAST runs on every push (GitHub default setup — JS/TS, Actions, Python), and
+the LLM-visible tool surface is frozen byte-for-byte by `tests/fixtures/tool-definitions/`.
+
+---
+
+## 9. References
 - Operator hardening: [`docs_page/security-guide.md`](../docs_page/security-guide.md)
 - Scopes, profiles, deny-actions: [`docs_page/authorization.md`](../docs_page/authorization.md)
 - Auth coexistence matrix: [`docs_page/enterprise-auth.md`](../docs_page/enterprise-auth.md)


### PR DESCRIPTION
## What

Adds a discoverable **§8 "Cryptography and key handling"** to `docs/security-model.md` — an inventory reviewers and auditors can point to:

- Every crypto primitive in use (PKCE S256, SHA-256 hashing, HMAC DCR `client_id`/state, `randomUUID`, platform TLS) with source pointers — all `node:crypto`, **no custom crypto**.
- Key/secret handling: env/service-key sourced, never hardcoded, never at rest in the cache DB or logs (invariant I4).

Closes a documentation gap — the primitives were already vetted; only a written inventory was missing. References renumbered §8 → §9.

## Secret scanning is native (no workflow)

An earlier revision of this PR added a Trivy secret-scan workflow; it's been **dropped in favor of the stronger native controls**, now enabled on the repo:

- **GitHub secret scanning + push protection** — blocks a matching secret at `git push` (prevention, not CI-time detection), using GitHub's maintained partner-pattern set. Supersedes a custom scanner.
- **CodeQL** (default setup) covers SAST; **dependency-review** + the Trivy image scan cover deps/CVEs.
- The `main` ruleset now requires `test`, CodeQL `Analyze`, and `dependency-review` to pass before merge.

Docs-only; `docs:` → no release.