### PR TITLE
fix: answer tools/list immediately instead of blocking on startup discovery

### DIFF
--- a/docs/research/2026-07-19-cline-tools-list-timeout.md
+++ b/docs/research/2026-07-19-cline-tools-list-timeout.md
@@ -1,0 +1,70 @@
+# Cline shows "Tools (0)" for ARC-1 — tools/list timeout race
+
+**Status:** Root cause confirmed via raw stdio capture. Fix: respond to `tools/list` immediately,
+push `notifications/tools/list_changed` once startup feature discovery completes.
+
+## Symptom
+
+In Cline (VS Code extension), the ARC-1 MCP server entry shows as connected (green) but the tool
+list stays empty ("Tools (0)"), even after:
+- restarting the process (fresh PID confirmed via `Win32_Process`)
+- reloading the VS Code window
+- reducing the tool count to 1 via `ARC1_TOOL_MODE=hyperfocused`
+
+A structurally near-identical sibling server (`ABAP_MCP`, same machine, same SAP lab host, also
+`node` + stdio + local `dist/index.js`) worked fine in the same Cline instance (13 tools), which
+ruled out Cline itself, PATH/env, and network/credentials as the cause.
+
+## Root cause
+
+`src/server/server.ts` (`createServer`, `ListToolsRequestSchema` handler) blocks the `tools/list`
+response until the startup feature-discovery probe finishes, capped at 10 seconds:
+
+```ts
+server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
+  if (startupProbePromise) {
+    await Promise.race([startupProbePromise, new Promise((resolve) => setTimeout(resolve, 10_000))]);
+  }
+  ...
+```
+
+Confirmed via a stdio MITM wrapper spliced between Cline and the real server process (raw
+JSON-RPC, timestamps in UTC):
+
+```
+07:10:03.488  Client → Server: initialize
+07:10:07.273  Server → Client: initialize result            (+3.79s)
+07:10:07.274  Client → Server: tools/list
+07:10:12.289  Client → Server: notifications/cancelled       reason="MCP error -32001: Request timed out"  (+5.01s after tools/list)
+07:10:15.559  Server stderr:  "Authorization probe: object search access is available"   (discovery only NOW finishing)
+```
+
+**Cline cancels `tools/list` after ~5 seconds.** ARC-1's feature-discovery probe against a real
+(non-localhost) SAP system routinely takes longer than that — here the probe was still running at
++8.3s past the `tools/list` request, well past Cline's patience and even past ARC-1's own 10s cap
+would have allowed it to reach. Since the wait sits in the shared code path before tool-list
+construction, this affects standard **and** hyperfocused mode identically (hyperfocused only
+changes what happens *after* the wait, so a 1-tool response is delayed exactly as much as the
+12-tool one).
+
+ABAP_MCP has no equivalent blocking wait — its `tools/list` answers immediately regardless of SAP
+reachability, which is why it never showed this symptom.
+
+## Fix
+
+Chosen approach (of two considered): stop blocking `tools/list` on the probe. Respond immediately
+with the best-effort/default tool set, declare `capabilities.tools.listChanged = true`, and emit
+`notifications/tools/list_changed` once the startup probe resolves so clients that support live
+refresh re-fetch the discovery-adjusted list shortly after. (Alternative considered: just lower the
+10s cap to ~2s — simpler, but still a race against unknown client timeouts and loses the
+discovery-adjusted list on any slow SAP system rather than delivering it slightly late via
+notification.)
+
+## Diagnostic method (for future reference)
+
+A throwaway Node.js MITM script was pointed to by the Cline config in place of the real command; it
+spawned the real `dist/index.js` as a child process, piped stdin/stdout through unmodified, and
+logged every chunk with a timestamp to a file. This captured the exact wire-level JSON-RPC exchange
+between Cline and ARC-1 without needing the user to interpret Cline's UI — the log alone was
+sufficient to pinpoint the exact timeout race. Both the wrapper script and its log were scratch
+artifacts, deleted after use (not committed).

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -693,7 +693,7 @@ export function createServer(
 ): Server {
   const server = new Server(
     { name: 'arc-1', version: VERSION },
-    { capabilities: { tools: {} }, instructions: SERVER_INSTRUCTIONS },
+    { capabilities: { tools: { listChanged: true } }, instructions: SERVER_INSTRUCTIONS },
   );
   const apiKeyProvenanceVerifier = createConfiguredApiKeyVerifier(config);
 
@@ -714,12 +714,12 @@ export function createServer(
 
   // Register tool listing — filtered by user's scopes when auth is active
   server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
-    // Wait for the startup probe (if provided), but with a timeout so a slow/unreachable
-    // SAP system doesn't stall the MCP connection setup. If the probe doesn't finish in
-    // time, fall back to the default tool set (textSearch unknown = show source_code).
-    if (startupProbePromise) {
-      await Promise.race([startupProbePromise, new Promise((resolve) => setTimeout(resolve, 10_000))]);
-    }
+    // Never block tools/list on the startup feature-discovery probe: some MCP clients
+    // (observed: Cline) cancel tools/list around ~5s, well under how long discovery can take
+    // against a real (non-localhost) SAP system. Answer immediately with whatever is cached
+    // right now (undefined on the very first call = default/on-prem-superset tool set), and
+    // rely on the tools/list_changed notification below to nudge clients to re-fetch once
+    // discovery actually finishes. See docs/research/2026-07-19-cline-tools-list-timeout.md.
     const features = getCachedFeatures();
     const clientVersion = server.getClientVersion();
     if (config.schemaNullableOptionals === 'auto' && !schemaNullableAutoClientInfoLogged) {
@@ -897,6 +897,23 @@ export function createServer(
     );
     return { ...result } as Record<string, unknown>;
   });
+
+  // Nudge already-connected clients to re-fetch tools/list once startup feature discovery
+  // finishes, so the discovery-adjusted list (BTP vs on-prem enums, SAPGit visibility, ...)
+  // still arrives — just later, instead of delaying the first tools/list response for it.
+  // Guarded: for HTTP, createServer() is called per-session via a factory (see
+  // createAndStartServer) and connect() may not have happened yet when this fires; a missed
+  // notification there is harmless because that session's own first tools/list will already
+  // reflect the (by-then-resolved) discovery state directly.
+  if (startupProbePromise) {
+    startupProbePromise
+      .then(() => server.sendToolListChanged())
+      .catch((err) => {
+        logger.debug('Skipped tools/list_changed notification after startup probe', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  }
 
   return server;
 }

--- a/tests/unit/server/server.test.ts
+++ b/tests/unit/server/server.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { BTPConfig } from '@arc-mcp/xsuaa-auth/btp';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -213,6 +213,65 @@ describe('MCP Server', () => {
       resolvedNullableOptionals: false,
     });
     infoSpy.mockRestore();
+  });
+
+  it('answers tools/list immediately without waiting for the startup probe', async () => {
+    // Regression test: some MCP clients (observed: Cline) cancel tools/list around ~5s,
+    // well under how long startup feature discovery can take against a real SAP system.
+    // See docs/research/2026-07-19-cline-tools-list-timeout.md.
+    const neverResolves = new Promise<void>(() => {});
+    const server = createServer(DEFAULT_CONFIG, undefined, undefined, undefined, undefined, neverResolves);
+    const handler = requestHandler(server, ListToolsRequestSchema.shape.method.value);
+
+    const result = await Promise.race([
+      handler({ method: 'tools/list', params: {} }, {}),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('tools/list did not answer promptly')), 200)),
+    ]);
+
+    expect((result as { tools: unknown[] }).tools.length).toBeGreaterThan(0);
+  });
+
+  it('declares tools.listChanged and notifies clients once the startup probe resolves', async () => {
+    let resolveProbe: () => void = () => {};
+    const startupProbePromise = new Promise<void>((resolve) => {
+      resolveProbe = resolve;
+    });
+    const sendSpy = vi.spyOn(Server.prototype, 'sendToolListChanged').mockResolvedValue(undefined);
+
+    const server = createServer(DEFAULT_CONFIG, undefined, undefined, undefined, undefined, startupProbePromise);
+    const capabilities = (server as unknown as { _capabilities: { tools?: { listChanged?: boolean } } })._capabilities;
+
+    expect(capabilities.tools).toEqual({ listChanged: true });
+    expect(sendSpy).not.toHaveBeenCalled();
+
+    resolveProbe();
+    await vi.waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1));
+
+    sendSpy.mockRestore();
+  });
+
+  it('does not crash when sendToolListChanged fails (e.g. not yet connected)', async () => {
+    let resolveProbe: () => void = () => {};
+    const startupProbePromise = new Promise<void>((resolve) => {
+      resolveProbe = resolve;
+    });
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+
+    // No transport connected: the real sendToolListChanged() throws 'Not connected'.
+    createServer(DEFAULT_CONFIG, undefined, undefined, undefined, undefined, startupProbePromise);
+    resolveProbe();
+
+    await vi.waitFor(() =>
+      expect(debugSpy).toHaveBeenCalledWith(
+        'Skipped tools/list_changed notification after startup probe',
+        expect.objectContaining({ error: expect.stringContaining('Not connected') }),
+      ),
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- `tools/list` previously blocked for up to 10s waiting on the startup feature-discovery probe. Some MCP clients (observed: Cline) cancel `tools/list` around ~5s, so the request was cancelled every time and the tool list never populated ("Tools (0)").
- `tools/list` now answers immediately using the currently cached feature state (falling back to the safe on-prem-superset default on the very first call).
- The server declares `capabilities.tools.listChanged` and emits `notifications/tools/list_changed` once discovery finishes, so clients that support live refresh still pick up the discovery-adjusted tool list shortly after.
- Root cause captured via a raw stdio MITM capture between Cline and the server process: `docs/research/2026-07-19-cline-tools-list-timeout.md`.

## Test plan
- [x] `npm test` (added/updated coverage in `tests/unit/server/server.test.ts`)
- [x] `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)