### PR TITLE
fix: recognize Windows drive-letter paths in SAP_DENY_ACTIONS

### DIFF
--- a/src/server/deny-actions.ts
+++ b/src/server/deny-actions.ts
@@ -7,7 +7,8 @@
  * admins to be explicit about which tool they're blocking.
  *
  * Source: the env var / CLI value can be either:
- *   - A path (starts with `/`, `./`, `~/`, or `../`) → JSON array of strings from file
+ *   - A path (starts with `/`, `./`, `~/`, `../`, or a Windows drive letter like `C:\`) →
+ *     JSON array of strings from file
  *   - An inline comma-separated list
  *
  * Fails fast: any read error, JSON error, grammar violation, or unknown tool/action
@@ -21,9 +22,13 @@ import { resolve as resolvePath } from 'node:path';
 import { ACTION_POLICY } from '../authz/policy.js';
 
 const PATH_PREFIXES = ['/', './', '~/', '../'] as const;
+// Windows drive-letter absolute path (e.g. C:\deny.json or C:/deny.json). Detected by a fixed
+// regex rather than path.isAbsolute(), which is platform-dependent (posix rules don't recognize
+// drive letters, so it would only detect this on a Windows-hosted server).
+const WINDOWS_ABSOLUTE_PATH_RE = /^[a-zA-Z]:[\\/]/;
 
 function isPathLike(value: string): boolean {
-  return PATH_PREFIXES.some((prefix) => value.startsWith(prefix));
+  return WINDOWS_ABSOLUTE_PATH_RE.test(value) || PATH_PREFIXES.some((prefix) => value.startsWith(prefix));
 }
 
 function expandTilde(p: string): string {

--- a/tests/unit/server/deny-actions.test.ts
+++ b/tests/unit/server/deny-actions.test.ts
@@ -45,6 +45,13 @@ describe('parseDenyActions', () => {
       expect(() => parseDenyActions('/nonexistent/path/deny.json')).toThrow(/cannot read file/);
     });
 
+    it('recognizes a Windows drive-letter absolute path as path-like', () => {
+      // Same proof pattern as the './' case above: if this were misdetected as inline CSV, it
+      // would parse into a single (invalid-grammar) pattern instead of throwing "cannot read file".
+      expect(() => parseDenyActions('C:\\nonexistent\\deny.json')).toThrow(/cannot read file/);
+      expect(() => parseDenyActions('D:/nonexistent/deny.json')).toThrow(/cannot read file/);
+    });
+
     it('throws on invalid JSON', () => {
       const dir = mkdtempSync(join(tmpdir(), 'deny-actions-test-'));
       const file = join(dir, 'deny.json');


### PR DESCRIPTION
isPathLike() only matched /, ./, ~/, ../ prefixes, so a Windows absolute path (e.g. C:\path\to\deny.json) on a Windows-hosted server was misinterpreted as an inline comma-separated pattern list instead of a file path to read.

Fixed with a platform-independent drive-letter regex, not path.isAbsolute() (posix rules don't recognize drive letters, so that check would only detect the path on a Windows host and silently misbehave identically to today on Linux CI/containers).