### PR TITLE
test: make two CRLF/path-separator assertions portable on Windows

### DIFF
--- a/tests/unit/helpers/skip-discipline.test.ts
+++ b/tests/unit/helpers/skip-discipline.test.ts
@@ -24,8 +24,10 @@ function listTsFiles(dir: string): string[] {
 }
 
 function matchingFiles(pattern: RegExp, excludedFiles: string[] = []): string[] {
+  // relative() returns backslash-separated paths on Windows; excludedFiles are forward-slash
+  // literals, so normalize before comparing.
   return SCAN_DIRS.flatMap(listTsFiles)
-    .map((file) => relative(REPO_ROOT, file))
+    .map((file) => relative(REPO_ROOT, file).replaceAll('\\', '/'))
     .filter((file) => !excludedFiles.includes(file))
     .filter((file) => pattern.test(readFileSync(join(REPO_ROOT, file), 'utf8')))
     .sort();

--- a/tests/unit/workflows/test-workflow.test.ts
+++ b/tests/unit/workflows/test-workflow.test.ts
@@ -3,7 +3,12 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
 
-const WORKFLOW = readFileSync(join(import.meta.dirname, '../../../.github/workflows/test.yml'), 'utf8');
+// Normalize CRLF up front: on a checkout with core.autocrlf=true, this file is CRLF on disk even
+// though the git blob is LF, and jobBlock()'s regex assumes bare \n delimiters.
+const WORKFLOW = readFileSync(join(import.meta.dirname, '../../../.github/workflows/test.yml'), 'utf8').replaceAll(
+  '\r\n',
+  '\n',
+);
 
 type WorkflowStep = {
   env?: Record<string, unknown>;


### PR DESCRIPTION
Both are checkout-dependent, not product bugs:

- test-workflow.test.ts: jobBlock() assumed bare \n delimiters; a Windows checkout (core.autocrlf=true, no .gitattributes) has .github/workflows/test.yml as CRLF on disk even though the git blob is LF, so the regex never matched. Normalize the read content once instead of rewriting the regex.
- skip-discipline.test.ts: matchingFiles() compared a Windows-backslash relative() path against a forward-slash exclusion literal, so the excluded helper file was never actually excluded. Normalize separators before comparing.

Not included here (need a maintainer call, not a quiet test-only fix):
- 5 tests/unit/scripts/*.test.ts files fail to load on this same checkout — root cause is node_modules/vite's bundled hashbang-strip regex (also a bare \n assumption), not our code. Real fix needs a .gitattributes LF rule + renormalization, which is a repo-wide-ish change, not a local test fix.
- chmod(0o600) on FileSink/sqlite cache is a documented Node-on-Windows no-op (verified live: mode reads back 666, world-writable bit set) — audit-log/ cache-db owner-only hardening silently doesn't happen on Windows hosts.
- plugin-loader.ts's world-writable check has no platform guard (unlike the adjacent uid check, which already feature-detects process.getuid), so on Windows every plugin load fails unconditionally — ARC1_PLUGINS is unusable on a Windows-hosted server, not just degraded.