### PR TITLE
fix(security): patch and monitor BTP AppRouter dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 # Dependabot configuration for ARC-1.
 # Documented in docs/plans/2026-05-08-dependency-security-tier1-foundation.md (SEC-11).
-# Three ecosystems: npm (production code), github-actions (CI), docker (base image).
+# Three ecosystems: npm (root package + BTP AppRouter), github-actions (CI), docker (base image).
 # Schedule: weekly. Security advisories are handled separately by Dependabot's
 # security-updates feature (enabled in repo Settings → Advanced Security).
 
@@ -56,6 +56,24 @@ updates:
       # Bump @types/node major in the same PR that bumps engines.node.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+
+  # The optional BTP UI AppRouter has an independent package-lock.json. Keep it
+  # explicit so version and security updates cannot fall through the root-only scan.
+  - package-ecosystem: "npm"
+    directory: "/btp/approuter"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "marianfoo"
 
   # ─── GitHub Actions ──────────────────────────────────────────────────────
   - package-ecosystem: "github-actions"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,11 @@ jobs:
       - name: Security audit (npm audit)
         run: npm audit --audit-level=high --omit=optional
 
+      # The optional BTP UI AppRouter has an independent lockfile and is not
+      # included in the root npm audit above.
+      - name: Security audit (BTP AppRouter)
+        run: npm audit --prefix btp/approuter --audit-level=high --omit=optional
+
       - name: Lint
         run: npm run lint
 

--- a/btp/approuter/package-lock.json
+++ b/btp/approuter/package-lock.json
@@ -11,7 +11,7 @@
         "@sap/approuter": "22.0.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -279,9 +279,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -358,19 +359,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -536,11 +538,16 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cookie": {
@@ -1920,18 +1927,6 @@
       },
       "engines": {
         "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",

--- a/btp/approuter/package.json
+++ b/btp/approuter/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "engines": {
-    "node": ">=20"
+    "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
     "start": "node node_modules/@sap/approuter/approuter.js"
@@ -12,6 +12,8 @@
     "@sap/approuter": "22.0.3"
   },
   "overrides": {
+    "axios": "1.18.0",
+    "body-parser": "2.3.0",
     "ws": "^8.17.1"
   }
 }

--- a/docs_page/security-guide.md
+++ b/docs_page/security-guide.md
@@ -437,8 +437,8 @@ ARC-1 ships as an [npm package](https://www.npmjs.com/package/arc-1) and a [Dock
 
 | Control | Workflow | Severity gate |
 |---|---|---|
-| Dependabot — npm + GitHub Actions + Docker | `.github/dependabot.yml` | weekly + same-day security advisories |
-| `npm audit` PR gate | `.github/workflows/test.yml` (`Security audit (npm audit)` step) | fails on `high` / `critical` |
+| Dependabot — root npm + BTP AppRouter npm + GitHub Actions + Docker | `.github/dependabot.yml` | weekly + same-day security advisories |
+| `npm audit` PR gates | `.github/workflows/test.yml` (root + `btp/approuter`) | fail on `high` / `critical` |
 | GitHub Dependency Review (PR diff) | `.github/workflows/dependency-review.yml` | fails on `high`; license allow/deny lists |
 | CodeQL SAST (JavaScript/TypeScript) | GitHub Default Setup | findings on Security tab; PR check fails on `High or higher` |
 | Trivy container scan — dev push | `.github/workflows/docker.yml` | non-gating; SARIF uploaded to Security tab |

--- a/tests/unit/server/approuter-config.test.ts
+++ b/tests/unit/server/approuter-config.test.ts
@@ -2,6 +2,21 @@ import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
 
 describe('BTP UI AppRouter config', () => {
+  it('pins patched transitive dependencies on an AppRouter-supported Node release', async () => {
+    const packageJson = JSON.parse(await readFile('btp/approuter/package.json', 'utf8')) as {
+      engines: { node: string };
+      overrides: Record<string, string>;
+    };
+    const packageLock = JSON.parse(await readFile('btp/approuter/package-lock.json', 'utf8')) as {
+      packages: Record<string, { version?: string }>;
+    };
+
+    expect(packageJson.engines.node).toBe('^22.0.0 || ^24.0.0');
+    expect(packageJson.overrides).toMatchObject({ axios: '1.18.0', 'body-parser': '2.3.0' });
+    expect(packageLock.packages['node_modules/axios']?.version).toBe('1.18.0');
+    expect(packageLock.packages['node_modules/body-parser']?.version).toBe('2.3.0');
+  });
+
   it('requires admin scope for all UI routes', async () => {
     const xsApp = JSON.parse(await readFile('btp/approuter/xs-app.json', 'utf8')) as {
       routes: Array<Record<string, unknown>>;

--- a/tests/unit/workflows/dependabot.test.ts
+++ b/tests/unit/workflows/dependabot.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+type DependabotUpdate = {
+  'package-ecosystem'?: string;
+  directory?: string;
+};
+
+type DependabotConfig = {
+  updates?: DependabotUpdate[];
+};
+
+describe('Dependabot configuration', () => {
+  it('monitors both independent npm lockfiles', () => {
+    const source = readFileSync(join(import.meta.dirname, '../../../.github/dependabot.yml'), 'utf8');
+    const config = parse(source) as DependabotConfig;
+    const npmDirectories = (config.updates ?? [])
+      .filter((update) => update['package-ecosystem'] === 'npm')
+      .map((update) => update.directory);
+
+    expect(npmDirectories).toEqual(expect.arrayContaining(['/', '/btp/approuter']));
+  });
+});

--- a/tests/unit/workflows/test-workflow.test.ts
+++ b/tests/unit/workflows/test-workflow.test.ts
@@ -39,6 +39,7 @@ describe('test workflow gate behavior', () => {
 
     expect(testJob).not.toContain('needs: gate');
     expect(testJob).toContain('npm audit --audit-level=high --omit=optional');
+    expect(testJob).toContain('npm audit --prefix btp/approuter --audit-level=high --omit=optional');
     expect(testJob).toContain('npm run lint');
     expect(testJob).toContain('npm run typecheck');
     expect(testJob).toContain('npm test');


### PR DESCRIPTION
## Summary

Patches the independent BTP UI AppRouter dependency graph and makes it part of ARC-1's ongoing dependency controls.

GitHub reported 11 open Dependabot alerts in `btp/approuter/package-lock.json`: one high-severity Axios advisory, nine additional Axios advisories, and one low-severity body-parser advisory.

## Root cause

The AppRouter has its own package manifest and lockfile, but both automated controls were root-only:

- `.github/dependabot.yml` monitored npm directory `/` only.
- `.github/workflows/test.yml` ran `npm audit` against the root lockfile only.

`@sap/approuter` 22.0.3 pins the affected transitive releases exactly, and no newer AppRouter release is currently available.

## Changes

- Override Axios 1.16.1 with patched 1.18.0.
- Override body-parser 2.2.2 with patched 2.3.0.
- Align the AppRouter package's Node range with `@sap/approuter` 22's supported Node 22/24 releases.
- Add a separate high-severity `npm audit` CI gate for `btp/approuter`.
- Add `/btp/approuter` to weekly and security Dependabot coverage.
- Add tests that lock both npm directories into Dependabot coverage, lock the CI audit command, and verify the AppRouter's patched resolutions.
- Update the supply-chain security guide to describe both npm graphs.

## Verification

- `npm ci --prefix btp/approuter`
- `npm audit --prefix btp/approuter --audit-level=high --omit=optional`: 0 vulnerabilities
- Full AppRouter audit metadata: 0 low / moderate / high / critical vulnerabilities
- `npm ls --prefix btp/approuter axios body-parser @sap/approuter --all`
- AppRouter module load smoke test
- Targeted Vitest: 9 tests passed
- `npm run typecheck`
- `npm run lint`
- YAML parsing test for `.github/dependabot.yml`

The root npm graph remains at 0 vulnerabilities.
