### PR TITLE
fix: reload rotated cookie file before the 401 retry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,7 +314,7 @@ Every code change requires tests. Skip taxonomy: `docs/testing-skip-policy.md`.
   [MCP hub](https://github.com/arc-mcp/mcp-hub) or a new ADR/security review.
 - **Per-user auth never inherits shared credentials** — `buildAdtConfig(..., { perUser: true })` strips username/password/cookies; any new Layer B field must respect the flag.
 - **All ADT endpoints have safety guards** — no unguarded `http.{get,post,put,delete}`.
-- **Cookie hot-reload**: `SAP_COOKIE_FILE` re-read on persistent 401; `SAP_COOKIE_STRING` cannot hot-reload.
+- **Cookie hot-reload**: `SAP_COOKIE_FILE` re-read before the 401 retry, and again on the next request after a persistent 401; `SAP_COOKIE_STRING` cannot hot-reload.
 - **Error types**: `AdtApiError` / `AdtSafetyError` / `AdtNetworkError`; `dispatch.ts` formats them with LLM-friendly hints.
 - **Stateful sessions** for lock→modify→unlock; CSRF auto-managed (`src/adt/http.ts`).
 - **ADT locks never cross an MCP round-trip** — `lock→modify→unlock` completes inside ONE synchronous tool call; never elicit inside a lock block, never expose writes as async MCP Tasks holding a lock ([ADR-0006](docs/adr/0006-mcp-legacy-era-until-triggers.md)).

--- a/docs_page/cli-guide.md
+++ b/docs_page/cli-guide.md
@@ -172,7 +172,7 @@ Open a browser, log into SAP, and write a Netscape-format cookie file usable as 
 arc1-cli extract-cookies --url https://host:44300 --output ~/.config/arc-1/cookies.txt
 ```
 
-When the running ARC-1 process is configured with `SAP_COOKIE_FILE` pointing to the same file, the next SAP call automatically reloads the fresh cookies — **no restart needed**. The reload is lazy: it fires on the next outgoing request after a persistent 401, so just re-extract and the next tool invocation picks up the new session.
+When the running ARC-1 process is configured with `SAP_COOKIE_FILE` pointing to the same file, the next SAP call automatically reloads the fresh cookies — **no restart needed**. The reload fires twice over: once inside the 401 retry, so a call already in flight when you re-extract can recover in place, and again on the next outgoing request after a persistent 401. Either way, just re-extract — no restart, and at worst the following tool invocation picks up the new session.
 
 `SAP_COOKIE_STRING` does not support hot-reload — that env var is read once at startup. Use `SAP_COOKIE_FILE` if you want the no-restart refresh path.
 

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -615,6 +615,24 @@ export class AdtHttpClient {
         // Clear session to force fresh authentication
         this.resetSession();
 
+        // Cookie auth: re-read the cookie file BEFORE the retry, not after.
+        //
+        // Cookie files are rotated out-of-band — by an operator re-running
+        // `arc1-cli extract-cookies`, or by a scheduled refresh job. Until now
+        // the reload only happened lazily on the NEXT request (see the
+        // `cookiesCleared` branch in the request preamble), so a rotated file
+        // could not rescue the call that observed the expiry: it failed, and
+        // only the following call picked up the fresh cookies. Reloading here
+        // lets the retry succeed against an already-refreshed file.
+        //
+        // When the file has NOT been refreshed this reloads the same dead
+        // cookies and the retry fails exactly as before — the persistent-401
+        // branch below still clears them and marks the client for reload.
+        if (this.isCookieAuthMode()) {
+          this.clearCookiesAndMark();
+          this.reloadCookiesFromSource();
+        }
+
         // Re-apply auth credentials
         this.applyAuthHeader(headers);
         if (this.config.bearerTokenProvider) {

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -615,23 +615,12 @@ export class AdtHttpClient {
         // Clear session to force fresh authentication
         this.resetSession();
 
-        // Cookie auth: re-read the cookie file BEFORE the retry, not after.
-        //
-        // Cookie files are rotated out-of-band — by an operator re-running
-        // `arc1-cli extract-cookies`, or by a scheduled refresh job. Until now
-        // the reload only happened lazily on the NEXT request (see the
-        // `cookiesCleared` branch in the request preamble), so a rotated file
-        // could not rescue the call that observed the expiry: it failed, and
-        // only the following call picked up the fresh cookies. Reloading here
-        // lets the retry succeed against an already-refreshed file.
-        //
-        // When the file has NOT been refreshed this reloads the same dead
-        // cookies and the retry fails exactly as before — the persistent-401
-        // branch below still clears them and marks the client for reload.
-        if (this.isCookieAuthMode()) {
-          this.clearCookiesAndMark();
-          this.reloadCookiesFromSource();
-        }
+        // Pick up an out-of-band rotated cookie file so the call that observes the
+        // expiry can recover; the lazy `cookiesCleared` reload stays the fallback.
+        // `cookieFile`, not `isCookieAuthMode()` — cookieString has nothing to re-read,
+        // and reloadCookiesFromSource keeps config.cookies on a missing/empty file, so
+        // the retry still replays the ticket we have.
+        if (this.config.cookieFile) this.reloadCookiesFromSource();
 
         // Re-apply auth credentials
         this.applyAuthHeader(headers);

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -1900,6 +1900,40 @@ describe('AdtHttpClient', () => {
       expect((client as any).config.cookies).toEqual({ MYSAPSSO2: 'fresh-value' });
     });
 
+    it('reloads a rotated cookie file before the 401 retry, so the retry recovers in place', async () => {
+      const fs = require('node:fs');
+      tmpFile = writeNetscapeCookieFile({ MYSAPSSO2: 'dead-value' });
+
+      // First GET → 401. The cookie file is rotated out-of-band while that
+      // request is in flight (an operator re-running `arc1-cli extract-cookies`,
+      // or a scheduled refresh job). The retry must pick the rotated ticket up
+      // instead of replaying the dead one and spending the call.
+      mockFetch.mockImplementationOnce(() => {
+        fs.writeFileSync(
+          tmpFile,
+          '# Netscape HTTP Cookie File\nsap.example.com\tFALSE\t/\tFALSE\t0\tMYSAPSSO2\tfresh-value\n',
+        );
+        return Promise.resolve(mockResponse(401, 'Unauthorized'));
+      });
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { MYSAPSSO2: 'dead-value' },
+        cookieFile: tmpFile,
+      });
+
+      await client.get('/sap/bc/adt/discovery');
+
+      const retryHeaders = fetchHeaders(1);
+      expect(retryHeaders.Cookie).toContain('MYSAPSSO2=fresh-value');
+      expect(retryHeaders.Cookie).not.toContain('dead-value');
+      // Recovered within the same call — nothing left marked for a later reload.
+      expect((client as any).cookiesCleared).toBe(false);
+    });
+
     it('warns and skips reload when only cookieString is configured (no cookieFile)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
 

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -1934,6 +1934,47 @@ describe('AdtHttpClient', () => {
       expect((client as any).cookiesCleared).toBe(false);
     });
 
+    it('cookieString-only: a session-timeout 401 still retries with the configured ticket', async () => {
+      // No file to re-read, so the pre-retry reload must not touch config.cookies —
+      // otherwise an ordinary work-process timeout (ticket still valid) becomes a
+      // permanent auth failure instead of the retry it exists to be.
+      mockFetch.mockResolvedValueOnce(mockResponse(401, 'Unauthorized'));
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { MYSAPSSO2: 'still-valid' },
+        cookieString: 'MYSAPSSO2=still-valid',
+      });
+
+      await client.get('/sap/bc/adt/discovery');
+
+      expect(fetchHeaders(1).Cookie).toContain('MYSAPSSO2=still-valid');
+      expect((client as any).config.cookies).toEqual({ MYSAPSSO2: 'still-valid' });
+    });
+
+    it('cookieFile unreadable at retry time: the retry keeps the in-memory ticket', async () => {
+      // A file caught mid-rotation (truncate-then-write) or simply missing must
+      // leave config.cookies alone — reloadCookiesFromSource is safe-on-failure and
+      // the retry has to fall back to replaying the ticket it already has.
+      mockFetch.mockResolvedValueOnce(mockResponse(401, 'Unauthorized'));
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
+
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        username: undefined,
+        password: undefined,
+        cookies: { MYSAPSSO2: 'still-valid' },
+        cookieFile: '/tmp/arc1-cookie-file-that-does-not-exist.txt',
+      });
+
+      await client.get('/sap/bc/adt/discovery');
+
+      expect(fetchHeaders(1).Cookie).toContain('MYSAPSSO2=still-valid');
+    });
+
     it('warns and skips reload when only cookieString is configured (no cookieFile)', async () => {
       mockFetch.mockResolvedValueOnce(mockResponse(200, 'ok'));
 


### PR DESCRIPTION
## Problem

Cookie files rotate out-of-band — an operator re-running `arc1-cli extract-cookies`, or a scheduled refresh job. When the in-memory ticket expires, today's flow is:

1. Request → `401`
2. `resetSession()` → retry with the **same** in-memory cookies → `401` again
3. Persistent 401 → `clearCookiesAndMark()`
4. **Next** request → lazy `reloadCookiesFromSource()` → succeeds

The call that observes the expiry can therefore never be rescued, even when a freshly rotated cookie file is already sitting on disk. One tool call is spent per expiry cycle, and the caller gets an authentication error that was avoidable. With SSO-ticket lifetimes measured in hours, this surfaces as a recurring "first call after a while always fails".

## Change

Reload from the cookie source inside the 401 retry branch, before the retry fetch (`src/adt/http.ts`).

- File **was** rotated → the retry succeeds and the call recovers in place.
- File **was not** rotated → the same dead cookies are reloaded and the retry fails exactly as before; the persistent-401 branch below still clears them and marks the client for a later reload.

No path is removed — one success path is added. The block is guarded by `isCookieAuthMode()`, so Basic and Bearer flows are untouched, and it runs after `resetSession()` so the subsequent CSRF fetch for modifying requests uses the reloaded cookies.

## Test

New case in the existing `cookie hot-reload` block of `tests/unit/adt/http.test.ts`: the mocked fetch rewrites the cookie file as it returns the first 401 (simulating out-of-band rotation mid-flight), then asserts the retry carries the rotated ticket, never the dead one, and that `cookiesCleared` is left false — i.e. the call recovered in place rather than deferring to the next one.

All 140 tests in that file pass.
