### PR TITLE
feat: serve RFC 9728 protected-resource metadata in OIDC mode (#630)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,6 +167,11 @@ SAP_TRANSPORT=stdio              # or: http-streamable
 # SAP_OIDC_ISSUER=https://login.microsoftonline.com/TENANT/v2.0
 # SAP_OIDC_AUDIENCE=arc-1
 # SAP_OIDC_CLOCK_TOLERANCE=0
+# Scopes advertised to MCP clients as scopes_supported (IdP scope names, not ARC-1 scopes)
+# SAP_OIDC_SCOPES=api://CLIENT_ID/access_as_user
+# RFC 9728 auto-discovery (default true). Set false for Entra ID if OAuth fails with AADSTS9010010
+# — Entra rejects the RFC 8707 `resource` parameter clients send once metadata exists.
+# SAP_OIDC_DISCOVERY=true
 
 # ── XSUAA (BTP) ──
 # SAP_XSUAA_AUTH=true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches: ['main']
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Image tag (default latest). Use e.g. pr-632 to publish a branch build for testers.'
-        required: false
-        default: 'latest'
 
 jobs:
   # Build Docker images natively per architecture (no QEMU emulation).
@@ -30,15 +25,6 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
-      # `latest` is what every unpinned `docker pull` gets. A dispatch from a
-      # feature branch that forgets the tag input would silently replace it with
-      # an unreleased build, so refuse before anything is pushed.
-      - name: Refuse to publish latest from a non-main ref
-        if: github.ref != 'refs/heads/main' && (inputs.tag == '' || inputs.tag == 'latest')
-        run: |
-          echo "::error::Dispatching from ${{ github.ref }} needs an explicit tag input (e.g. pr-632), not latest."
-          exit 1
-
       - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
@@ -57,7 +43,7 @@ jobs:
         with:
           images: ghcr.io/arc-mcp/arc-1
           tags: |
-            type=raw,value=${{ inputs.tag || 'latest' }}
+            type=raw,value=latest
 
       - name: Build and push by digest
         id: build
@@ -138,7 +124,7 @@ jobs:
         with:
           images: ghcr.io/arc-mcp/arc-1
           tags: |
-            type=raw,value=${{ inputs.tag || 'latest' }}
+            type=raw,value=latest
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: ['main']
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (default latest). Use e.g. pr-632 to publish a branch build for testers.'
+        required: false
+        default: 'latest'
 
 jobs:
   # Build Docker images natively per architecture (no QEMU emulation).
@@ -25,6 +30,15 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
+      # `latest` is what every unpinned `docker pull` gets. A dispatch from a
+      # feature branch that forgets the tag input would silently replace it with
+      # an unreleased build, so refuse before anything is pushed.
+      - name: Refuse to publish latest from a non-main ref
+        if: github.ref != 'refs/heads/main' && (inputs.tag == '' || inputs.tag == 'latest')
+        run: |
+          echo "::error::Dispatching from ${{ github.ref }} needs an explicit tag input (e.g. pr-632), not latest."
+          exit 1
+
       - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
@@ -43,7 +57,7 @@ jobs:
         with:
           images: ghcr.io/arc-mcp/arc-1
           tags: |
-            type=raw,value=latest
+            type=raw,value=${{ inputs.tag || 'latest' }}
 
       - name: Build and push by digest
         id: build
@@ -124,7 +138,7 @@ jobs:
         with:
           images: ghcr.io/arc-mcp/arc-1
           tags: |
-            type=raw,value=latest
+            type=raw,value=${{ inputs.tag || 'latest' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests

--- a/docs/research/issues/630-oidc-protected-resource-metadata.md
+++ b/docs/research/issues/630-oidc-protected-resource-metadata.md
@@ -147,7 +147,17 @@ router does not apply.
 2. **Claude.ai custom connectors + Entra** have a separate, upstream-tracked failure:
    [anthropics/claude-ai-mcp#506](https://github.com/anthropics/claude-ai-mcp/issues/506) — discovery
    succeeds, the user authenticates, then the code is never exchanged at `/token`. Not something ARC-1
-   can fix.
+   can fix. **There is a working escape route**, raised by the reporter on PR #632 and verified against
+   the thread: the **token-broker pattern**
+   ([comment](https://github.com/anthropics/claude-ai-mcp/issues/506#issuecomment-4899697146), posted by
+   `@jvitti93` 2026-07-07, confirmed working by `@brinawebb` the same day) — your own minimal
+   OAuth 2.1 AS in front, federating to Entra privately as a confidential client, so the connector never
+   sees Entra. ARC-1 needs no change (it stays a resource server validating the Entra token the broker
+   attaches), but two ARC-1-specific conditions apply and are now in
+   `docs_page/oauth-jwt-setup.md`: the broker owns discovery (so ARC-1 should run with
+   `SAP_OIDC_DISCOVERY=false`), and the broker must federate the **user's** identity — a
+   `client_credentials` shortcut collapses every MCP user into one identity and silently guts per-user
+   scopes, the audit trail, and Destination principal propagation.
 3. Entra's v2.0 metadata omits `code_challenge_methods_supported` (measured on tenant, `organizations`,
    `common`). SDK 1.29.0 tolerates the absence; a client that follows the 2025-11-25 "MUST refuse" rule
    would not.

--- a/docs/research/issues/630-oidc-protected-resource-metadata.md
+++ b/docs/research/issues/630-oidc-protected-resource-metadata.md
@@ -1,0 +1,220 @@
+# Issue #630 — RFC 9728 protected-resource metadata in OIDC mode
+
+**Status:** Confirmed gap, reproduced live 2026-07-27 on HEAD (`879376d9`, v0.9.27); **implemented** the
+same day (branch `feat/oidc-protected-resource-metadata`). Reporter's diagnosis of the code is accurate.
+Additionally: the shipped docs already claimed this worked — a doc/implementation divergence.
+**Issue:** [arc-mcp/arc-1#630](https://github.com/arc-mcp/arc-1/issues/630) — external reporter (`vateseeb`).
+**Classification:** `feature-request` (small, well-scoped) + `docs-bug` + **MCP spec conformance gap**.
+
+## TL;DR
+
+- In OIDC mode ARC-1 served **no** discovery and its `401` carried **no** `resource_metadata` pointer.
+  XSUAA mode has both. Root cause: everything lives inside the `if (config.xsuaaAuth && …)` branch.
+- The MCP authorization spec (2025-06-18 **and** 2025-11-25) says *"MCP servers **MUST** implement OAuth
+  2.0 Protected Resource Metadata (RFC 9728)"*, so this was a conformance gap, not just a convenience ask.
+- **The finding that shaped the design:** the MCP TS SDK sends the RFC 8707 `resource` parameter **only
+  when PRM exists** (`selectResourceURL` returns `undefined` without it) — and **Microsoft Entra ID rejects
+  that parameter outright**. Measured on a live tenant: `AADSTS9010010`; on `common`: `AADSTS901002: The
+  'resource' request parameter is not supported`. The identical request without `resource` returns the
+  login page. So publishing PRM naively would have *broken* the one client combination that works today
+  (Claude Code + Entra) while fixing the others.
+- Shipped: PRM on by default (spec MUST) + `SAP_OIDC_DISCOVERY=false` as a documented, evidence-backed
+  opt-out + `SAP_OIDC_SCOPES` for the IdP scope names ARC-1 cannot derive.
+
+## Live validation
+
+### A. The reported symptoms — OIDC mode, HEAD before the fix
+
+Local server, `SAP_OIDC_ISSUER=https://login.microsoftonline.com/<tid>/v2.0`,
+`SAP_OIDC_AUDIENCE=api://arc1-demo`, `ARC1_PUBLIC_URL=https://arc1.example.com`:
+
+| Request | Observed |
+|---|---|
+| `GET /.well-known/oauth-protected-resource` | `404 {"error":"Not found. Use /mcp …"}` |
+| `GET /.well-known/oauth-protected-resource/mcp` | `404` |
+| `GET /.well-known/oauth-authorization-server` | `404` |
+| `POST /mcp` (no token) | `401`, `WWW-Authenticate: Bearer error="invalid_token", error_description="Missing Authorization header"` — **no `resource_metadata`** |
+| `POST /mcp` (bogus token) | `401`, `… "Token validation failed: not a valid XSUAA, OIDC, or API key token"` — no pointer |
+
+### B. XSUAA control, same build
+
+```
+GET /.well-known/oauth-protected-resource      → 404          (root path not served there)
+GET /.well-known/oauth-protected-resource/mcp  → 200 {"resource":"https://arc1.example.com/mcp",
+                                                      "authorization_servers":["https://arc1.example.com/"], …}
+POST /mcp → 401  WWW-Authenticate: … resource_metadata="https://arc1.example.com/.well-known/oauth-protected-resource/mcp"
+```
+
+### C. Entra authorization-server behavior (the decisive measurements)
+
+Probes against `login.microsoftonline.com` with a valid S256 challenge:
+
+| Probe | Result |
+|---|---|
+| AS metadata, RFC 8414 insert — `/.well-known/oauth-authorization-server/<tid>/v2.0` | **404** |
+| AS metadata, OIDC append — `/<tid>/v2.0/.well-known/openid-configuration` | **200** |
+| `/authorize` **with** `resource=https://example.com/mcp` (real tenant) | **`AADSTS9010010`** — "The resource parameter provided in the request doesn't match with the requested scopes" |
+| `/authorize` **with** `resource=…` + `scope=api://…/.default` (`common`) | **`AADSTS901002`** — "The 'resource' request parameter is not supported" |
+| `/authorize` **without** `resource` (same tenant, same everything else) | **200** login page |
+| `code_challenge_methods_supported` in Entra v2.0 metadata (tenant, `organizations`, `common`) | **absent** — SDK 1.29.0 tolerates absence; a spec-strict client (2025-11-25 says clients MUST refuse) would not |
+
+The AS-metadata rows prove that advertising the bare `SAP_OIDC_ISSUER` is enough: the SDK client's fallback
+chain ends with the OIDC append form, which is the one Entra answers. The `resource` rows are why the
+opt-out exists.
+
+### D. Post-fix, built `dist/`, same local server
+
+```
+GET /.well-known/oauth-protected-resource/mcp → 200
+  {"resource":"https://arc1.example.com/mcp",
+   "authorization_servers":["https://login.microsoftonline.com/<tid>/v2.0"],
+   "bearer_methods_supported":["header"],"resource_name":"ARC-1 SAP MCP Server",
+   "scopes_supported":["api://arc1-demo/access_as_user"]}
+GET /.well-known/oauth-protected-resource     → 200 (same document, client's root fallback)
+OPTIONS (Origin: https://claude.ai)           → 204 + Access-Control-Allow-Origin: *
+POST  /.well-known/oauth-protected-resource/mcp → 405 (GET/OPTIONS only)
+GET /.well-known/oauth-authorization-server   → 404 (ARC-1 is not the AS — intentional)
+POST /mcp                                     → 401 + resource_metadata="…/.well-known/oauth-protected-resource/mcp"
+SAP_OIDC_DISCOVERY=false                      → both well-known paths 404, 401 carries no pointer
+```
+
+End-to-end with the **real MCP SDK client** functions against the running server (localhost public URL,
+Entra `common` issuer):
+
+```
+1. 401 →  resourceMetadataUrl: http://127.0.0.1:8199/.well-known/oauth-protected-resource/mcp
+2. PRM   →  resource: http://127.0.0.1:8199/mcp | AS: https://login.microsoftonline.com/common/v2.0
+3. RFC 8707 resource param the client will send: http://127.0.0.1:8199/mcp   ← the Entra hazard
+4. AS metadata via issuer → https://login.microsoftonline.com/{tenantid}/v2.0 | authorize=…/oauth2/v2.0/authorize
+5. scope the client will request: api://arc1-demo/access_as_user
+```
+
+## Root cause (pre-fix, `src/server/http.ts`)
+
+- `:364` `if (config.xsuaaAuth && xsuaaCredentials) { … }` held the entire discovery surface —
+  `resourceMetadataUrl` (`:429`) → `requireBearerAuth` (`:430`), prefix-aware well-known overrides
+  (`:647`–`:658`), multi-target PRM routes (`:669`–`:685`), SDK `mcpAuthRouter` (`:694`).
+- `:717`–`:740` (API key / OIDC) mounted only `/mcp` behind `requireBearerAuth`, with no
+  `resourceMetadataUrl` and no well-known route; everything else fell to the catch-all 404 at `:744`.
+
+Nothing regressed — the surface was never built for the non-XSUAA path. XSUAA gets it free because ARC-1
+*is* the authorization server there; in OIDC mode ARC-1 is a pure resource server, so the SDK's auth
+router does not apply.
+
+## Docs divergence found on the way
+
+- `docs_page/oauth-jwt-setup.md:184` — VS Code "will discover the Protected Resource Metadata at …".
+- `docs_page/oauth-jwt-setup.md:282` — "How It Works" step 2 promises the `resource_metadata` challenge.
+- `docs_page/auth-test-process.md:137` — OIDC manual-test recipe curls the endpoint; it 404'd.
+- `docs/research/2026-07-20-mcp-2026-07-28-spec-impact.md:89,105` — records RFC 9728 as "already
+  implemented" (true for XSUAA only).
+
+## What shipped
+
+`src/server/http.ts`, in the API-key/OIDC branch, gated on `oidcIssuer && oidcDiscovery`:
+
+- `buildOidcResourceMetadata()` → `{ resource: "<publicBase>/mcp", authorization_servers: [issuer],
+  bearer_methods_supported: ["header"], resource_name, scopes_supported? }`.
+- `mountOidcResourceMetadata()` serves it through the SDK's own `metadataHandler` (CORS + GET/OPTIONS-only,
+  identical treatment to the XSUAA path) at the RFC 9728 path-insertion URL, at the `ARC1_PUBLIC_URL`
+  prefix variant, and at the root fallback — **in that mount order**, since the root path is a mount
+  prefix that would otherwise swallow `/mcp`. Returns the URL fed to `requireBearerAuth` for both the MCP
+  and UI guards.
+- URLs come from `getAppUrl()` (`ARC1_PUBLIC_URL` / `VCAP_APPLICATION`), never the request `Host` header —
+  a spoofed Host must not be able to point clients at an attacker-controlled IdP. Covered by a test.
+- `SAP_OIDC_DISCOVERY` (default `true`) and `SAP_OIDC_SCOPES` (no default; error if set without an issuer)
+  in `src/server/{config,types}.ts`.
+- `tests/unit/server/http-oidc-metadata.test.ts` — 7 tests over a real `startHttpServer` boot.
+- Docs: `docs_page/oauth-jwt-setup.md` (new "Auto-discovery (RFC 9728)" section + Entra caveat),
+  `docs_page/auth-test-process.md`, `docs_page/configuration-reference.md`, `.env.example`.
+
+### Decisions and what was deliberately not built
+
+| Decision | Why |
+|---|---|
+| PRM **on** by default, opt-out flag | Spec MUST; the failure mode is loud, IdP-specific, and documented with the exact AADSTS codes. Owner's call (2026-07-27). |
+| No `scope` parameter in the 401 challenge (spec 2025-11-25 SHOULD) | The SDK's `requiredScopes` both advertises *and enforces*; Entra scope names are not ARC-1 scopes, so enforcing them would break every request. PRM `scopes_supported` is the client's priority-2 path. Follow-up if a custom challenge is ever worth the code. |
+| No configurable `resource` value | The client validates PRM `resource` against the server origin (`checkResourceAllowed`), so an `api://…` value is rejected client-side — a knob could only offer variants that still don't satisfy Entra. |
+| No `/.well-known/oauth-authorization-server` | ARC-1 is not the AS in this mode; mirroring the IdP's metadata would add a fetch and a staleness failure mode for nothing (measured: clients reach Entra's own metadata from the issuer). |
+| AppRouter untouched | `btp/approuter/xs-app.json` routes only `/` and `/ui`; `/mcp` and `.well-known` are served on the backend route directly. |
+
+## Known limits (state these to the reporter)
+
+1. **Entra + any SDK-based MCP client**: once PRM exists the client sends `resource`, and Entra answers
+   `AADSTS9010010` / `AADSTS901002`. `SAP_OIDC_DISCOVERY=false` restores today's behavior (Claude Code with
+   a manual `authServerMetadataUrl`). There is no server-side value that satisfies both the MCP client's
+   origin check and Entra's registration model.
+2. **Claude.ai custom connectors + Entra** have a separate, upstream-tracked failure:
+   [anthropics/claude-ai-mcp#506](https://github.com/anthropics/claude-ai-mcp/issues/506) — discovery
+   succeeds, the user authenticates, then the code is never exchanged at `/token`. Not something ARC-1
+   can fix.
+3. Entra's v2.0 metadata omits `code_challenge_methods_supported` (measured on tenant, `organizations`,
+   `common`). SDK 1.29.0 tolerates the absence; a client that follows the 2025-11-25 "MUST refuse" rule
+   would not.
+
+So acceptance criteria 1 and 2 from the issue are met unconditionally; criterion 3 is met for IdPs that
+tolerate the `resource` parameter (Keycloak, Okta, Cognito, Auth0 …), and for Entra depends on the two
+upstream constraints above.
+
+## Draft GitHub reply (do not post automatically)
+
+```markdown
+Confirmed and implemented — thanks for the unusually precise report; your reading of `http.ts` matches HEAD.
+
+**Reproduced** on `879376d9` (v0.9.27) with a local OIDC-mode server:
+
+| Request | OIDC mode (before) | XSUAA mode (control, same build) |
+|---|---|---|
+| `GET /.well-known/oauth-protected-resource/mcp` | `404` | `200` + RFC 9728 document |
+| `POST /mcp` without a token | `401`, no `resource_metadata` | `401` **with** `resource_metadata` |
+
+Root cause exactly where you pointed: `resourceMetadataUrl` and every well-known route sit inside the
+`if (config.xsuaaAuth && xsuaaCredentials)` branch (`src/server/http.ts:364`, `:429`, `:647`–`:658`, `:694`);
+the API-key/OIDC branch (`:717`–`:740`) mounted only `/mcp`. Our own docs already promised this behaviour for
+OIDC mode (`docs_page/oauth-jwt-setup.md:184,282`, `docs_page/auth-test-process.md:137`), and the MCP spec makes
+it a MUST for servers — so this was a conformance gap on our side, not a new capability.
+
+**What's now in the PR** — resource-server-only, no token/authorize endpoints, no DCR:
+
+- `/.well-known/oauth-protected-resource/mcp` (RFC 9728 §3.1 path insertion), the root fallback, and the
+  `ARC1_PUBLIC_URL` prefix variant, all served through the MCP SDK's own metadata handler (CORS + GET/OPTIONS).
+- `resource_metadata="…"` on every `401`.
+- `SAP_OIDC_SCOPES` for `scopes_supported`. It can't be derived: `access_as_user` is a name your Entra admin
+  chose, and Keycloak/Okta/Cognito differ — but it can't be dropped either, since the MCP client takes the
+  authorize `scope` from `scopes_supported`. Set it to `api://<client-id>/access_as_user`.
+- No `/.well-known/oauth-authorization-server`: I verified that
+  `https://login.microsoftonline.com/.well-known/oauth-authorization-server/<tenant>/v2.0` 404s while
+  `https://login.microsoftonline.com/<tenant>/v2.0/.well-known/openid-configuration` returns 200, and the MCP
+  SDK's discovery chain ends with that append form. Publishing the raw `SAP_OIDC_ISSUER` is enough.
+
+**One caveat you'll want before you deploy it**, found while validating your proposal against a live Entra
+tenant. The MCP SDK sends the RFC 8707 `resource` parameter **only when protected-resource metadata exists**
+(`selectResourceURL` returns `undefined` otherwise) — which is precisely why Claude Code works against your
+setup today. Entra rejects that parameter:
+
+```
+/authorize …&resource=https://arc1.example.com/mcp   → AADSTS9010010: The resource parameter provided in the
+                                                        request doesn't match with the requested scopes
+/authorize …  (no resource, everything else identical) → 200 (login page)
+```
+
+(on the `common` endpoint the same probe returns `AADSTS901002: The 'resource' request parameter is not supported`.)
+
+There's no server-side value that fixes this: MCP clients reject a `resource` that isn't same-origin with the
+server they called, so an `api://<client-id>` value is impossible. Because of that the PR ships
+`SAP_OIDC_DISCOVERY=false` as a documented escape hatch — it restores exactly today's behaviour (no metadata ⇒
+no `resource` parameter ⇒ your working Claude Code flow) if your tenant hits the error. Default stays on, since
+the spec requires the metadata and IdPs that ignore unknown authorization parameters are the common case.
+
+Also worth knowing for the Claude.ai leg specifically: there's an open upstream issue where a connector behind
+Entra discovers the metadata, the user authenticates, and the authorization code is then never exchanged at
+`/token` — anthropics/claude-ai-mcp#506. That one is outside ARC-1.
+
+If you can test the pre-release build against your tenant with a Claude Desktop / Claude.ai connector, that
+would be very welcome — it's the leg we can't exercise in CI. I'll link the PR here.
+```
+
+## Next step
+
+PR from `feat/oidc-protected-resource-metadata`. If the reporter confirms the Entra `resource` behavior in
+their tenant, consider a docs note under `docs_page/oauth-jwt-setup.md` naming Keycloak/Okta as known-good.

--- a/docs_page/auth-test-process.md
+++ b/docs_page/auth-test-process.md
@@ -134,15 +134,17 @@ npx arc-1 --url http://your-sap:8000 \
 **2. Verify Protected Resource Metadata endpoint:**
 
 ```bash
-curl -s http://localhost:8080/.well-known/oauth-protected-resource | jq .
+curl -s http://localhost:8080/.well-known/oauth-protected-resource/mcp | jq .
 # Expected: JSON with "resource", "authorization_servers", "bearer_methods_supported"
+# (the root path /.well-known/oauth-protected-resource serves the same document;
+#  both are 404 when SAP_OIDC_DISCOVERY=false)
 ```
 
-**3. Verify request without token is rejected:**
+**3. Verify request without token is rejected, and points at the metadata:**
 
 ```bash
-curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/mcp
-# Expected: 401
+curl -s -o /dev/null -D - http://localhost:8080/mcp | grep -i "^HTTP/\|www-authenticate"
+# Expected: 401 + WWW-Authenticate: Bearer …, resource_metadata="http://localhost:8080/.well-known/oauth-protected-resource/mcp"
 ```
 
 **4. Get a real JWT from your IdP:**

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -153,6 +153,8 @@ Full reference: [api-key-setup.md](api-key-setup.md). The single-key `ARC1_API_K
 | `--oidc-issuer` | `SAP_OIDC_ISSUER` | — | OIDC issuer URL (e.g. Entra ID, Auth0). ARC-1 fetches JWKS from `{issuer}/.well-known/openid-configuration` and validates incoming JWTs against it. |
 | `--oidc-audience` | `SAP_OIDC_AUDIENCE` | — | Expected `aud` claim. Tokens whose `aud` doesn't match are rejected. |
 | `--oidc-clock-tolerance` | `SAP_OIDC_CLOCK_TOLERANCE` | `0` | Seconds of clock skew tolerated when checking `exp`/`nbf`/`iat`. Set 30–60 if your auth server and ARC-1 host clocks drift. |
+| `--oidc-discovery` | `SAP_OIDC_DISCOVERY` | `true` | Serve [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) protected-resource metadata at `/.well-known/oauth-protected-resource[/mcp]` and point the `401` `WWW-Authenticate` challenge at it, so MCP clients discover your IdP automatically. **Set `false` for Microsoft Entra ID** if authorization then fails with `AADSTS9010010` / `AADSTS901002`: once metadata exists, MCP clients send the RFC 8707 `resource` parameter, which Entra v2.0 does not accept. Ignored in XSUAA mode (that mode publishes its own metadata) and in API-key-only mode (no authorization server to advertise). |
+| `--oidc-scopes` | `SAP_OIDC_SCOPES` | — | Scopes advertised as `scopes_supported` in the protected-resource metadata, comma or space separated (Entra: `api://<client-id>/access_as_user`). Clients request these at your IdP; omitted from the document when unset. These are **IdP scope names**, unrelated to ARC-1's `read`/`write`/… scopes. Requires `SAP_OIDC_ISSUER`. |
 
 Full reference: [oauth-jwt-setup.md](oauth-jwt-setup.md).
 

--- a/docs_page/oauth-jwt-setup.md
+++ b/docs_page/oauth-jwt-setup.md
@@ -181,10 +181,14 @@ VS Code supports MCP OAuth natively. Configure in `.vscode/mcp.json`:
 ```
 
 VS Code will:
-1. Discover the Protected Resource Metadata at `/.well-known/oauth-protected-resource`
-2. Find the Authorization Server (your IdP)
+1. Discover the Protected Resource Metadata at `/.well-known/oauth-protected-resource/mcp` (root path also served)
+2. Find the Authorization Server (your IdP) from `authorization_servers`
 3. Open browser for OAuth login
 4. Send Bearer tokens automatically
+
+The same discovery serves Claude Desktop / Claude.ai custom connectors and `mcp-remote`, which have no
+manual authorization-server override. Set `SAP_OIDC_SCOPES` so clients know which IdP scope to request —
+see [Auto-discovery](#auto-discovery-rfc-9728) below, including the Entra ID caveat.
 
 ### Microsoft Copilot Studio / Power Automate
 
@@ -275,6 +279,56 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
   https://your-arc1-server.example.com/mcp
 ```
+
+## Auto-discovery (RFC 9728)
+
+With `SAP_OIDC_ISSUER` set, ARC-1 publishes OAuth 2.0 Protected Resource Metadata — the mechanism MCP
+clients use to find your IdP without per-client configuration. ARC-1 stays a pure resource server: it
+advertises *where* the authorization server is and mints no tokens itself.
+
+```bash
+curl -s https://arc1.company.com/.well-known/oauth-protected-resource/mcp | jq .
+```
+```json
+{
+  "resource": "https://arc1.company.com/mcp",
+  "authorization_servers": ["https://login.microsoftonline.com/<tenant-id>/v2.0"],
+  "bearer_methods_supported": ["header"],
+  "resource_name": "ARC-1 SAP MCP Server",
+  "scopes_supported": ["api://<client-id>/access_as_user"]
+}
+```
+
+- The document is served at the RFC 9728 path-insertion URL (`…/oauth-protected-resource/mcp`), at the
+  root fallback, and — behind a base-path proxy — at the `ARC1_PUBLIC_URL` prefix. Every `401` on `/mcp`
+  carries `resource_metadata="…"` pointing at it.
+- URLs come from `ARC1_PUBLIC_URL` (or the CF route), never from the request `Host` header. Set
+  `ARC1_PUBLIC_URL` when ARC-1 sits behind a reverse proxy.
+- `scopes_supported` appears only when you set `SAP_OIDC_SCOPES`. Clients request exactly these scopes at
+  your IdP, so they must be **your IdP's** scope names — ARC-1 cannot derive them from `SAP_OIDC_AUDIENCE`.
+- ARC-1 does **not** serve `/.well-known/oauth-authorization-server`: it is not the authorization server.
+  Clients read your IdP's own metadata from the issuer (Entra answers at
+  `{issuer}/.well-known/openid-configuration`).
+
+### Microsoft Entra ID caveat — `AADSTS9010010`
+
+Once protected-resource metadata exists, MCP clients send the [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)
+`resource` parameter on `/authorize` and `/token` — the MCP spec requires it. **Entra ID v2.0 does not accept
+that parameter** and answers `AADSTS9010010: The resource parameter provided in the request doesn't match with
+the requested scopes` (or `AADSTS901002: The 'resource' request parameter is not supported`). Verified against a
+live tenant: the identical request without `resource` succeeds.
+
+If your Entra sign-in fails that way, turn discovery off:
+
+```bash
+SAP_OIDC_DISCOVERY=false
+```
+
+Clients then send no `resource` parameter, and the manual route works again: point the client at your IdP's
+metadata directly (Claude Code: `authServerMetadataUrl` → `https://login.microsoftonline.com/<tenant-id>/v2.0/.well-known/openid-configuration`).
+Clients without such an override (Claude Desktop / Claude.ai connectors, `mcp-remote`) cannot connect in that
+configuration. IdPs that ignore unknown authorization parameters — the common case — are unaffected; keep the
+default.
 
 ## How It Works
 

--- a/docs_page/oauth-jwt-setup.md
+++ b/docs_page/oauth-jwt-setup.md
@@ -330,6 +330,30 @@ Clients without such an override (Claude Desktop / Claude.ai connectors, `mcp-re
 configuration. IdPs that ignore unknown authorization parameters — the common case — are unaffected; keep the
 default.
 
+#### If you need Claude.ai / Claude Desktop connectors behind Entra today
+
+Entra-backed connectors also hit a separate, client-side failure — discovery and login succeed, then the
+authorization code is never exchanged
+([anthropics/claude-ai-mcp#506](https://github.com/anthropics/claude-ai-mcp/issues/506)). The workaround
+reported and independently confirmed in that thread is the **token-broker pattern**: run your own minimal
+OAuth 2.1 authorization server in front, federating to Entra privately as a confidential client. The
+connector only ever talks to your AS (static pre-registered client, no DCR, `/authorize` + `/token` at the
+host root), so neither the connector bug nor Entra's `resource`/DCR limitations apply.
+
+ARC-1 needs no change for this — it stays a pure resource server validating the Entra token your broker
+attaches. Two ARC-1-specific points if you go that route:
+
+- **Let the broker own discovery.** It is the authorization server the client must be sent to, so it serves
+  the protected-resource metadata; set `SAP_OIDC_DISCOVERY=false` on ARC-1 so a passed-through request can't
+  answer with a document pointing at Entra instead.
+- **Keep the user's identity.** The broker must obtain the Entra token through a user-facing flow. A
+  `client_credentials` shortcut collapses every MCP user into one identity — ARC-1's audit trail, per-user
+  scopes, and Destination principal propagation all key off the token's user, and all of them degrade to a
+  single shared user.
+
+Weigh it against what it is: an extra internet-facing component you build, operate, and secure, holding
+confidential-client credentials for your tenant.
+
 ## How It Works
 
 1. MCP client sends request without token

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -525,6 +525,18 @@ export function resolveConfig(args: string[]): { config: ServerConfig; sources: 
     const parsed = Number.parseInt(clockTolerance, 10);
     config.oidcClockTolerance = Number.isNaN(parsed) ? undefined : parsed;
   }
+  config.oidcDiscovery = resolveBool('oidc-discovery', 'SAP_OIDC_DISCOVERY', true, 'oidcDiscovery');
+  const oidcScopesRaw = getFlag('oidc-scopes') ?? process.env.SAP_OIDC_SCOPES;
+  if (oidcScopesRaw) {
+    // Comma or whitespace separated — OAuth scope strings are space-delimited on the wire.
+    config.oidcScopes = oidcScopesRaw
+      .split(/[,\s]+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    sources.oidcScopes = getFlag('oidc-scopes') !== undefined ? { flag: '--oidc-scopes' } : { env: 'SAP_OIDC_SCOPES' };
+  } else {
+    sources.oidcScopes = 'default';
+  }
   config.xsuaaAuth = resolveBool('xsuaa-auth', 'SAP_XSUAA_AUTH', false, 'xsuaaAuth');
   config.allowHttpNoAuth = resolveBool('allow-http-no-auth', 'ARC1_ALLOW_HTTP_NO_AUTH', false, 'allowHttpNoAuth');
 
@@ -832,6 +844,11 @@ export function validateConfig(config: ServerConfig): void {
   }
   if (config.oidcAudience && !config.oidcIssuer) {
     throw new Error('SAP_OIDC_ISSUER is required when SAP_OIDC_AUDIENCE is set');
+  }
+  if (config.oidcScopes?.length && !config.oidcIssuer) {
+    throw new Error(
+      'SAP_OIDC_ISSUER is required when SAP_OIDC_SCOPES is set — scopes are only advertised in OIDC mode',
+    );
   }
 
   // Inert, not dangerous — both strict-PP enforcement sites gate on ppEnabled. Warn instead

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -725,11 +725,22 @@ export async function startHttpServer(
       // This enables scope enforcement, per-request safety, and principal propagation.
       const { requireBearerAuth } = await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');
       const verifier = await createStandardVerifier(config);
-      const bearerAuth = requireBearerAuth({ verifier: { verifyAccessToken: verifier } });
+
+      // ─── RFC 9728 protected-resource metadata (OIDC mode) ─────────
+      // ARC-1 is a pure resource server here: it publishes WHERE the external
+      // IdP lives and mints no tokens. Skipped for api-key-only mode (no
+      // authorization server to advertise) and when the admin opted out.
+      const resourceMetadataUrl =
+        config.oidcIssuer && config.oidcDiscovery
+          ? await mountOidcResourceMetadata(app, config, bindHost, port)
+          : undefined;
+
+      const bearerAuth = requireBearerAuth({ verifier: { verifyAccessToken: verifier }, resourceMetadataUrl });
       if (uiDeps) {
         const uiBearerAuth = requireBearerAuth({
           verifier: { verifyAccessToken: verifier },
           requiredScopes: ['admin'],
+          resourceMetadataUrl,
         });
         mountUiRoutes(app, uiDeps, uiBearerAuth);
       }
@@ -823,6 +834,76 @@ function buildPackageOidcVerifier(
     ...(config.oidcClockTolerance != null ? { clockToleranceSec: config.oidcClockTolerance } : {}),
     logger: authLibLogger,
   });
+}
+
+// ─── OIDC Protected-Resource Metadata (RFC 9728) ────────────────────
+
+/**
+ * Build the RFC 9728 document ARC-1 publishes in OIDC mode.
+ *
+ * ARC-1 is only the resource server here: `authorization_servers` points at the
+ * external IdP, and clients discover its endpoints themselves (RFC 8414 with the
+ * OIDC-discovery fallbacks — Entra only answers the append form). `resource` is
+ * the canonical MCP endpoint URI; MCP clients reject a document whose `resource`
+ * is not same-origin with the server they called.
+ *
+ * `scopes_supported` is IdP-specific (`api://<client-id>/access_as_user` on Entra,
+ * arbitrary elsewhere) and cannot be derived from `SAP_OIDC_AUDIENCE` — it is
+ * omitted unless the admin sets `SAP_OIDC_SCOPES`.
+ */
+export function buildOidcResourceMetadata(
+  config: ServerConfig,
+  publicBase: string,
+): import('@modelcontextprotocol/sdk/shared/auth.js').OAuthProtectedResourceMetadata {
+  return {
+    resource: `${publicBase}/mcp`,
+    authorization_servers: [config.oidcIssuer as string],
+    bearer_methods_supported: ['header'],
+    resource_name: 'ARC-1 SAP MCP Server',
+    ...(config.oidcScopes?.length ? { scopes_supported: config.oidcScopes } : {}),
+  };
+}
+
+/**
+ * Mount the protected-resource metadata routes and return the URL that belongs in
+ * the `WWW-Authenticate` challenge. Caller gates on `oidcIssuer && oidcDiscovery`.
+ *
+ * URLs come from `getAppUrl()` (ARC1_PUBLIC_URL / VCAP), never from the request
+ * `Host` header, so a spoofed Host cannot redirect clients at an attacker's IdP.
+ * The SDK's `metadataHandler` supplies `cors()` + GET/OPTIONS-only, the same
+ * treatment the XSUAA branch's metadata gets — the document is public by design.
+ */
+export async function mountOidcResourceMetadata(
+  app: express.Application,
+  config: ServerConfig,
+  bindHost: string,
+  port: number,
+): Promise<string> {
+  const { metadataHandler } = await import('@modelcontextprotocol/sdk/server/auth/handlers/metadata.js');
+  const { getAppUrl } = await import('./app-url.js');
+  const parsed = new URL(getAppUrl() ?? `http://${bindHost}:${port}`);
+  const basePath = parsed.pathname.replace(/\/$/, ''); // '' for root, '/arc1' behind a prefix proxy
+  const publicBase = `${parsed.origin}${basePath}`;
+  const metadata = buildOidcResourceMetadata(config, publicBase);
+
+  // Order matters: '/.well-known/oauth-protected-resource' is a mount PREFIX, so
+  // it must come after the '/mcp' route or it would swallow it.
+  app.use('/.well-known/oauth-protected-resource/mcp', metadataHandler(metadata)); // RFC 9728 §3.1 path insertion
+  if (basePath) app.use(`/.well-known/oauth-protected-resource${basePath}/mcp`, metadataHandler(metadata));
+  // Root fallback (spec 2025-11-25 lists it; the SDK client probes sub-path → root).
+  // As a prefix mount it also answers unknown sub-paths — harmless: clients validate
+  // `resource` against the URL they called, and OIDC mode has no other MCP routes.
+  app.use('/.well-known/oauth-protected-resource', metadataHandler(metadata));
+
+  const resourceMetadataUrl = `${publicBase}/.well-known/oauth-protected-resource/mcp`;
+  // Key is `issuer`, not `authorizationServer` — the logger redacts any key
+  // containing "authorization", which would hide the one value operators need.
+  logger.info('OIDC protected-resource metadata enabled', {
+    resource: metadata.resource,
+    issuer: config.oidcIssuer,
+    scopesSupported: config.oidcScopes?.length ?? 0,
+  });
+  return resourceMetadataUrl;
 }
 
 // ─── Standard Mode Verifier ─────────────────────────────────────────

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -85,6 +85,15 @@ export interface ServerConfig {
   oidcAudience?: string;
   /** Clock tolerance in seconds for JWT exp/nbf validation (default: 0 — no tolerance) */
   oidcClockTolerance?: number;
+  /**
+   * Serve RFC 9728 protected-resource metadata in OIDC mode (default: true).
+   * Set false for IdPs that reject the RFC 8707 `resource` parameter MCP clients
+   * send once metadata exists — Microsoft Entra answers `AADSTS9010010`. */
+  oidcDiscovery: boolean;
+  /**
+   * Scopes advertised as `scopes_supported`. IdP-specific (Entra:
+   * `api://<client-id>/access_as_user`), so it cannot be derived; omitted when unset. */
+  oidcScopes?: string[];
   xsuaaAuth: boolean;
   /** Explicit unsafe opt-in for HTTP `/mcp` without API-key, OIDC, or XSUAA auth. */
   allowHttpNoAuth: boolean;
@@ -266,6 +275,7 @@ export const DEFAULT_CONFIG: ServerConfig = {
   systemType: 'auto',
   xsuaaAuth: false,
   allowHttpNoAuth: false,
+  oidcDiscovery: true,
   oauthDcrTtlSeconds: 0, // 0 = never expire; positive opts into expiry (clamped 60s..90d) — see field JSDoc
   btpOAuthCallbackPort: 0,
   multiTargetEndpoints: false,

--- a/tests/unit/server/config.test.ts
+++ b/tests/unit/server/config.test.ts
@@ -1144,6 +1144,15 @@ describe('validateConfig', () => {
     ).toThrow('SAP_OIDC_ISSUER is required when SAP_OIDC_AUDIENCE is set');
   });
 
+  it('throws when oidcScopes is set without oidcIssuer — nothing would advertise them', () => {
+    expect(() =>
+      validateConfig({
+        ...DEFAULT_CONFIG,
+        oidcScopes: ['api://arc-1/access_as_user'],
+      }),
+    ).toThrow('SAP_OIDC_ISSUER is required when SAP_OIDC_SCOPES is set');
+  });
+
   it('accepts config with both oidcIssuer and oidcAudience', () => {
     expect(() =>
       validateConfig({
@@ -1352,6 +1361,25 @@ describe('validateConfig', () => {
   it('parseArgs fails with oidcIssuer but no oidcAudience', () => {
     process.env.SAP_OIDC_ISSUER = 'https://example.com';
     expect(() => parseArgs([])).toThrow('SAP_OIDC_AUDIENCE is required');
+  });
+
+  it('parses SAP_OIDC_SCOPES from comma or whitespace separated values, and defaults discovery on', () => {
+    process.env.SAP_OIDC_ISSUER = 'https://example.com';
+    process.env.SAP_OIDC_AUDIENCE = 'api://arc-1';
+    process.env.SAP_OIDC_SCOPES = 'api://arc-1/access_as_user, api://arc-1/read';
+    expect(parseArgs([]).oidcScopes).toEqual(['api://arc-1/access_as_user', 'api://arc-1/read']);
+    expect(parseArgs([]).oidcDiscovery).toBe(true);
+
+    process.env.SAP_OIDC_SCOPES = 'api://arc-1/access_as_user api://arc-1/read';
+    expect(parseArgs([]).oidcScopes).toEqual(['api://arc-1/access_as_user', 'api://arc-1/read']);
+  });
+
+  it('honors the SAP_OIDC_DISCOVERY opt-out (Entra AADSTS9010010 escape hatch)', () => {
+    process.env.SAP_OIDC_ISSUER = 'https://example.com';
+    process.env.SAP_OIDC_AUDIENCE = 'api://arc-1';
+    process.env.SAP_OIDC_DISCOVERY = 'false';
+    expect(parseArgs([]).oidcDiscovery).toBe(false);
+    expect(parseArgs(['--oidc-discovery', 'true']).oidcDiscovery).toBe(true);
   });
 
   it.each(['100', '000', '999', '010', '001'])('accepts the 3-digit client %s', (client) => {

--- a/tests/unit/server/http-oidc-metadata.test.ts
+++ b/tests/unit/server/http-oidc-metadata.test.ts
@@ -1,0 +1,137 @@
+import { EventEmitter } from 'node:events';
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { startHttpServer } from '../../../src/server/http.js';
+import { DEFAULT_CONFIG } from '../../../src/server/types.js';
+
+const ISSUER = 'https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0';
+
+/**
+ * Boot the real HTTP server without binding a port (listen is stubbed) and hand
+ * the Express app to supertest — same harness as http-multi-target-routes.test.ts.
+ */
+async function boot(overrides: Partial<typeof DEFAULT_CONFIG>, publicUrl?: string): Promise<express.Express> {
+  if (publicUrl) process.env.ARC1_PUBLIC_URL = publicUrl;
+  else process.env.ARC1_PUBLIC_URL = undefined as unknown as string;
+  let app!: express.Express;
+  const listenSpy = vi.spyOn(express.application, 'listen').mockImplementation(function (this: express.Express) {
+    app = this;
+    return new EventEmitter() as never;
+  });
+  try {
+    await startHttpServer(
+      (() => ({ connect: vi.fn() })) as never,
+      {
+        ...DEFAULT_CONFIG,
+        transport: 'http-streamable',
+        httpAddr: '127.0.0.1:0',
+        authRateLimit: 0,
+        mcpHttpRateLimit: 0,
+        ...overrides,
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
+  } finally {
+    listenSpy.mockRestore();
+  }
+  return app;
+}
+
+const OIDC = { oidcIssuer: ISSUER, oidcAudience: 'api://arc1-demo' } as const;
+
+describe('OIDC protected-resource metadata (RFC 9728)', () => {
+  const originalPublicUrl = process.env.ARC1_PUBLIC_URL;
+
+  beforeEach(() => {
+    process.env.ARC1_PUBLIC_URL = undefined as unknown as string;
+  });
+  afterEach(() => {
+    if (originalPublicUrl === undefined) delete process.env.ARC1_PUBLIC_URL;
+    else process.env.ARC1_PUBLIC_URL = originalPublicUrl;
+  });
+
+  it('serves the document at the RFC 9728 path-insertion URL and at the root fallback', async () => {
+    const app = await boot(OIDC, 'https://arc1.example.com');
+
+    for (const path of ['/.well-known/oauth-protected-resource/mcp', '/.well-known/oauth-protected-resource']) {
+      const res = await request(app).get(path);
+      expect(res.status, path).toBe(200);
+      expect(res.body).toEqual({
+        resource: 'https://arc1.example.com/mcp',
+        authorization_servers: [ISSUER],
+        bearer_methods_supported: ['header'],
+        resource_name: 'ARC-1 SAP MCP Server',
+      });
+    }
+  });
+
+  it('points the 401 WWW-Authenticate challenge at the metadata URL', async () => {
+    const app = await boot(OIDC, 'https://arc1.example.com');
+
+    const missing = await request(app).post('/mcp').send({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    expect(missing.status).toBe(401);
+    expect(missing.headers['www-authenticate']).toContain(
+      'resource_metadata="https://arc1.example.com/.well-known/oauth-protected-resource/mcp"',
+    );
+
+    const bogus = await request(app).post('/mcp').set('Authorization', 'Bearer a.b.c').send({});
+    expect(bogus.status).toBe(401);
+    expect(bogus.headers['www-authenticate']).toContain('resource_metadata=');
+  });
+
+  it('advertises scopes_supported only when SAP_OIDC_SCOPES is configured', async () => {
+    const app = await boot({ ...OIDC, oidcScopes: ['api://arc1-demo/access_as_user'] }, 'https://arc1.example.com');
+
+    const res = await request(app).get('/.well-known/oauth-protected-resource/mcp');
+    expect(res.body.scopes_supported).toEqual(['api://arc1-demo/access_as_user']);
+  });
+
+  it('emits prefix-aware URLs and also serves the prefixed path when ARC1_PUBLIC_URL has a base path', async () => {
+    const app = await boot(OIDC, 'https://gateway.example.com/arc1');
+
+    const root = await request(app).get('/.well-known/oauth-protected-resource/mcp');
+    expect(root.body.resource).toBe('https://gateway.example.com/arc1/mcp');
+
+    // A proxy that does NOT strip its base path still finds the document.
+    const prefixed = await request(app).get('/.well-known/oauth-protected-resource/arc1/mcp');
+    expect(prefixed.status).toBe(200);
+    expect(prefixed.body.resource).toBe('https://gateway.example.com/arc1/mcp');
+
+    const unauth = await request(app).post('/mcp').send({});
+    expect(unauth.headers['www-authenticate']).toContain(
+      'resource_metadata="https://gateway.example.com/arc1/.well-known/oauth-protected-resource/mcp"',
+    );
+  });
+
+  it('ignores a spoofed Host header — metadata URLs come from config only', async () => {
+    const app = await boot(OIDC, 'https://arc1.example.com');
+
+    const res = await request(app).get('/.well-known/oauth-protected-resource/mcp').set('Host', 'evil.example.net');
+    expect(res.body.resource).toBe('https://arc1.example.com/mcp');
+    expect(res.body.authorization_servers).toEqual([ISSUER]);
+  });
+
+  it('serves nothing when the admin opts out with SAP_OIDC_DISCOVERY=false', async () => {
+    const app = await boot({ ...OIDC, oidcDiscovery: false }, 'https://arc1.example.com');
+
+    expect((await request(app).get('/.well-known/oauth-protected-resource/mcp')).status).toBe(404);
+    expect((await request(app).get('/.well-known/oauth-protected-resource')).status).toBe(404);
+    // No pointer either: without a document, MCP clients skip the RFC 8707
+    // `resource` parameter — the reason the opt-out exists (Entra AADSTS9010010).
+    const unauth = await request(app).post('/mcp').send({});
+    expect(unauth.status).toBe(401);
+    expect(unauth.headers['www-authenticate']).not.toContain('resource_metadata');
+  });
+
+  it('serves nothing in api-key-only mode — there is no authorization server to advertise', async () => {
+    const app = await boot({ apiKeys: [{ key: 'viewer-key', profile: 'viewer' }] }, 'https://arc1.example.com');
+
+    expect((await request(app).get('/.well-known/oauth-protected-resource/mcp')).status).toBe(404);
+    const unauth = await request(app).post('/mcp').send({});
+    expect(unauth.status).toBe(401);
+    expect(unauth.headers['www-authenticate']).not.toContain('resource_metadata');
+  });
+});


### PR DESCRIPTION
Closes #630.

## Problem

In OIDC mode (`SAP_OIDC_ISSUER` / `SAP_OIDC_AUDIENCE`) ARC-1 exposed no OAuth discovery and its `401` carried no `resource_metadata` pointer, so only clients with a manual authorization-server override could connect — Claude Code yes, Claude Desktop / Claude.ai custom connectors / `mcp-remote` no. The MCP authorization spec makes RFC 9728 a **MUST** for servers, and `docs_page/oauth-jwt-setup.md:184,282` + `docs_page/auth-test-process.md:137` already described the behaviour, so this was a conformance + docs gap rather than a new capability.

Reproduced on `879376d9` before the change:

| Request | OIDC mode (before) | XSUAA mode (control, same build) |
|---|---|---|
| `GET /.well-known/oauth-protected-resource/mcp` | `404` | `200` + RFC 9728 document |
| `POST /mcp` without a token | `401`, no `resource_metadata` | `401` **with** `resource_metadata` |

Root cause: `resourceMetadataUrl` and every well-known route lived inside `if (config.xsuaaAuth && xsuaaCredentials)` (`src/server/http.ts:364`, `:429`, `:647`–`:658`, `:694`); the API-key/OIDC branch mounted only `/mcp`.

## What this does

Resource-server-only discovery — no token/authorize endpoints, no DCR:

- Serves the document at `/.well-known/oauth-protected-resource/mcp` (RFC 9728 §3.1 path insertion), at the root fallback, and at the `ARC1_PUBLIC_URL` prefix variant, through the MCP SDK's own `metadataHandler` (CORS + `GET`/`OPTIONS` only — same treatment the XSUAA path gets).
- Adds `resource_metadata="…"` to every `401` (MCP and UI guards).
- URLs come from `getAppUrl()` (`ARC1_PUBLIC_URL` / `VCAP_APPLICATION`), never the request `Host` header — a spoofed Host must not be able to aim clients at an attacker's IdP. Covered by a test.
- **`SAP_OIDC_SCOPES`** → `scopes_supported`. Cannot be derived (`access_as_user` is an admin-chosen Entra name; other IdPs differ) and cannot be omitted (MCP clients take the authorize `scope` from the document). Omitted when unset; errors if set without an issuer.
- **`SAP_OIDC_DISCOVERY=false`** → opt-out, see below.
- No `/.well-known/oauth-authorization-server`: ARC-1 is not the AS here. Verified that `https://login.microsoftonline.com/.well-known/oauth-authorization-server/<tenant>/v2.0` 404s while `…/<tenant>/v2.0/.well-known/openid-configuration` returns 200, and the SDK client's discovery chain ends with that append form — publishing the bare issuer is enough.

## Why there is an opt-out

Measured against a live Entra tenant while validating the design: MCP clients send the RFC 8707 `resource` parameter **only when protected-resource metadata exists** (`selectResourceURL` returns `undefined` without it) — which is exactly why Claude Code + Entra works today. Entra rejects that parameter:

```
/authorize …&resource=https://arc1.example.com/mcp    → AADSTS9010010 (resource doesn't match requested scopes)
/authorize …  (no resource, otherwise identical)       → 200 login page
```

(`common` endpoint returns `AADSTS901002: The 'resource' request parameter is not supported`.)

No server-side value fixes this — clients reject a `resource` that isn't same-origin with the server they called, so an `api://<client-id>` value is impossible. `SAP_OIDC_DISCOVERY=false` therefore restores today's exact behaviour for affected tenants. Default stays on: the spec requires the metadata, and IdPs that ignore unknown authorization parameters are the common case.

## Verification

- 7 new tests in `tests/unit/server/http-oidc-metadata.test.ts` (real `startHttpServer` boot + supertest): document at all three paths, 401 pointer, `scopes_supported` present/absent, prefix-aware public URL, spoofed-`Host` immunity, opt-out and api-key-only modes mount nothing. 3 new config tests. Full suite: 4657 passing, typecheck/lint/size-ratchet clean.
- Live against the built `dist/`: document served, `OPTIONS` → `204` + `Access-Control-Allow-Origin: *`, `POST` → `405`, `/.well-known/oauth-authorization-server` still `404`, opt-out yields `404` + no pointer.
- End-to-end through the **real MCP SDK client** functions: `401` → `resource_metadata` → PRM → Entra AS metadata resolved from the issuer → scope taken from `scopes_supported`.

## Known limits (documented, not fixable here)

1. Entra + any SDK-based client needs `SAP_OIDC_DISCOVERY=false` if it hits `AADSTS9010010`.
2. Claude.ai connectors behind Entra have an upstream failure where the authorization code is never exchanged — anthropics/claude-ai-mcp#506.
3. Entra's v2.0 metadata omits `code_challenge_methods_supported` (measured on tenant / `organizations` / `common`); SDK 1.29.0 tolerates that, a spec-strict client would not.

Full evidence, decisions and rejected alternatives: `docs/research/issues/630-oidc-protected-resource-metadata.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)