### PR TITLE
fix(write): omit adtcore:responsible when it cannot be an on-prem user name

### DIFF
--- a/docs/plans/completed/2026-07-29-issue-636-onprem-responsible-char12.md
+++ b/docs/plans/completed/2026-07-29-issue-636-onprem-responsible-char12.md
@@ -1,0 +1,93 @@
+# Plan (DONE) — #636: omit `adtcore:responsible` when it cannot be an on-prem user name
+
+**Evidence base:** [`docs/research/issues/636-onprem-pp-responsible-char12-overflow.md`](../research/issues/636-onprem-pp-responsible-char12-overflow.md)
+— live-verified 2026-07-29 on NW 7.50, S/4HANA 2023 (758), ABAP Platform 2025 (816).
+
+**Status:** delivered 2026-07-29. All tasks done, incl. live create+activate+delete on 7.50 / 758 /
+816 with a PP-shaped identity. One extra guard added during review:
+`tests/unit/adt/create-xml-wellformed.test.ts` (a glued-attribute bug in the BTP package body that
+`toContain` could not see).
+
+## Goal
+
+Object create/update stops failing on on-prem systems reached via BTP Principal Propagation, where
+the XSUAA principal is an email and `adtcore:responsible` maps to `XUBNAME` (`CHAR12`).
+
+## Verified facts this plan rests on
+
+| Fact | Evidence |
+|---|---|
+| Trigger is **length > 12**, not `@`, and the user need not exist | `A@B.DE`→200, `ABCDEFGHIJKLM`→400, `ABCDEFGHIJKL`(nonexistent)→200 on 758 |
+| **11 distinct create STs** reject an over-long value | CLASS_TRANSFORMATION, SEDI_ADT_PROGRAM, SEDI_ADT_INCLUDE, INTF_TRANSFORMATION, SBD_DOMAIN, SBD_DATAELEMENT, SADT_BLUE_SOURCE, SDDIC_ADT_TTYP, SDDIC_ST_ADT_DDLS, SDDIC_ADT_SRVD_ST, SPAK_ST_PACKAGES |
+| Omitting the attribute **succeeds and yields the correct owner** | 10/10 non-DEVC types 200/201; readback `adtcore:responsible="<logged-on user>"` |
+| **`DEVC` is the exception** — omitting → 400, and it validates user *existence* | `""`→400, `ABCDEFGHIJKL`→400, `DDIC`→201 |
+| No on-prem whoami endpoint | `core/systeminformation` 404, `security/users/current` 404, `system/users` = value-help list |
+| Under PP the email arrives via **`config.username`** | `server.ts:344` → `server.ts:404` |
+| Cloud path already strips the attribute | `cloudifyCreateBody`, `write-helpers.ts:358-374` |
+
+## Design
+
+**One predicate.** A value usable as an on-prem `adtcore:responsible` is: non-empty, ≤12 chars, no
+`@`. Everything else normalizes to `''` and the attribute is **omitted**, letting ADT assign the
+logged-on user — which under PP is the correctly propagated one.
+
+Omitting is safe even when the value *would* have been valid (a real user named `A@B` still ends up
+as the object owner, because they are the logged-on user). So the predicate can be strict without
+risk on the omit path.
+
+**`DEVC` opts out** of omission — it requires a real existing user. Its fix is the existing
+`responsible` parameter, un-gated for on-prem, plus a directed error.
+
+**Deliberate extra:** drop the `'DEVELOPER'` fallback. It is a demo-system-only literal that #379
+was filed against, and it is the same defect class (a value that is not a valid user on this
+system). Live-proven that omitting beats it. Called out explicitly in the PR — it is the one
+behavior change beyond the reported symptom.
+
+**Rejected:** adding a `cloud` parameter to `normalizeAdtResponsible` (the reporter's suggestion) —
+`cloudifyCreateBody` already strips the attribute on the BTP path; a second cloud branch would
+duplicate it. Also rejected: auto-learning the on-prem user via the `createdBy` cache — it costs a
+GET per create while cold and is not load-bearing once `responsible` works on-prem.
+
+## Tasks
+
+### 1. `src/adt/ddic-xml.ts` — the predicate
+- Rewrite `normalizeAdtResponsible` to return `''` for empty / `>12` / contains `@`; upper-case otherwise.
+- Rewrite the docstring around the XUBNAME CHAR12 constraint and #636; drop the `DEVELOPER` narrative.
+- The 5 builders (`buildDomainXml`, `buildTableTypeXml`, `buildDataElementXml`, `buildPackageXml`,
+  `buildServiceBindingXml`) interpolate a prebuilt attribute snippet that is `''` when unusable —
+  no empty `adtcore:responsible=""` in any output.
+
+### 2. `src/handlers/write-helpers.ts` — conditional emission
+- `buildCreateXmlBody`: derive `responsibleAttr` once from `responsibleUser`; replace all ~15
+  template sites. No behavior change when the value is valid.
+- Leave `cloudifyCreateBody` alone (its regex already tolerates a missing attribute).
+
+### 3. `src/handlers/manage.ts` — the `DEVC` path
+- On-prem: `responsibleArg || normalizeAdtResponsible(config.username)`.
+- Guard: when the resolved value is unusable, return a directed error naming the `responsible`
+  parameter and explaining the PP case — mirroring the existing BTP message shape.
+
+### 4. `src/handlers/tools.ts` + `schemas.ts` — surface
+- `responsible` description currently says *"BTP only"*; it now also applies to on-prem under PP.
+  Three-file sync: `tools.ts` (JSON Schema), `schemas.ts` (Zod), handler.
+- Regenerate `tests/fixtures/tool-definitions/*.json` (`vitest -u`) and review the diff.
+
+### 5. Tests
+- Flip `ddic-xml.test.ts:191-200` — it currently *asserts* the buggy email passthrough and the
+  `DEVELOPER` default.
+- Add: 13-char and email values omit the attribute; 12-char passes; lower-case still upper-cased.
+- Add: `buildCreateXml` omits the attribute for a PP-shaped email across a source type and a DDIC type.
+- Add: `manage.ts` on-prem package create returns the directed error when `config.username` is an email.
+- Add: metadata **update** path (`update-delete.ts`) omits it too.
+
+### 6. Live verification (mandatory)
+- Create + **activate** a CLAS on 758 with the fixed builder; activation is the definitive check.
+- Re-run the per-type matrix against the built `dist/` and confirm every type now emits no
+  `adtcore:responsible` for an email-shaped user.
+- Repeat the CLAS create on 7.50 and 816.
+
+## Out of scope
+- The PP auth path itself; `config.username` stays the display name (`SAPRead SYSTEM` depends on it).
+- BTP/cloud create and BTP package create — already correct.
+- `DCLS`/`BDEF`/`SRVB`/`DDLX` live coverage — each needs a prerequisite object; they share template
+  families with tested types and are fixed by the same one-line predicate.

--- a/docs/research/issues/636-onprem-pp-responsible-char12-overflow.md
+++ b/docs/research/issues/636-onprem-pp-responsible-char12-overflow.md
@@ -1,0 +1,374 @@
+# Issue #636 — on-prem create fails under Principal Propagation: `adtcore:responsible` overflows XUBNAME (CHAR12)
+
+**Status:** ✅ **Fixed** (see [Resolution](#resolution-shipped)). Root cause validated live
+2026-07-29 on **all three** on-prem releases (NW 7.50, S/4HANA 2023 / 758, ABAP Platform 2025 / 816);
+fix verified the same way. Reporter's diagnosis is
+correct in substance; two mechanism details need correcting, and the blast radius is larger
+than reported.
+
+**Issue:** <https://github.com/arc-mcp/arc-1/issues/636> — reporter `@Antseburov` (external).
+**Ancestor:** #379 / PR #380 (`fix(write): thread logon user into adtcore:responsible`, commit
+`3f8dc126`) — this issue is the mirror-image regression of that fix. Not a duplicate.
+
+---
+
+## TL;DR
+
+ARC-1 emits `adtcore:responsible="<value>"` in every on-prem create body. On-prem that attribute
+deserializes into `XUBNAME`, a **CHAR12** field. Under BTP Principal Propagation to an on-prem
+system, ARC-1 puts the **XSUAA principal (an email, typically 20–40 chars)** into it, so the
+create body fails in the object's simple transformation before anything is created — HTTP 400.
+
+The trigger is **length > 12 only**. It is *not* the `@`, and the user does *not* have to exist.
+
+Fixing it is not a one-liner: for **13 SAPWrite types plus DDIC** the attribute can simply be
+omitted (SAP then assigns the logged-on — i.e. correctly propagated — user), but
+**`SAPManage create_package` rejects an omitted value too**, so it needs a real short user name.
+
+---
+
+## Live validation
+
+All commands issued as raw ADT POSTs (`curl`, basic auth), so the only variable is the
+`adtcore:responsible` attribute. Bodies are byte-identical to what `buildCreateXmlBody`
+produces. Test objects were created in `$TMP` and deleted afterwards.
+
+### 1. Isolating the attribute — `POST /sap/bc/adt/oo/classes`, a4h (S/4HANA 2023, 758)
+
+| # | `adtcore:responsible` | len | Result |
+|---|---|---|---|
+| A | `firstname.lastname@example.com` | 30 | **HTTP 400** `ExceptionInvalidData` — *"An error occurred when deserializing in the simple transformation program CLASS_TRANSFORMATION"*, `XML_OFFSET=466` |
+| B | `MARIAN` (valid user) | 6 | HTTP 200 |
+| C | *attribute omitted entirely* | – | **HTTP 200** |
+| D | `A@B.DE` — has `@`, short | 6 | **HTTP 200** ← the `@` is **not** the trigger |
+| E | `ABCDEFGHIJKLM` — no `@`, long | 13 | **HTTP 400** ← **length is the trigger** |
+| F | `ABCDEFGHIJKL` — no `@`, nonexistent user | 12 | **HTTP 200** ← the user need not exist |
+
+D/E/F are the decisive rows: the boundary is exactly **12 characters**, matching `XUBNAME`
+(`CHAR12`). Row F also shows ADT does not validate user existence for `CLAS` on create.
+
+### 2. Same test across releases — `POST /sap/bc/adt/oo/classes`
+
+| Release | responsible = 30-char email | short user | omitted |
+|---|---|---|---|
+| **NW 7.50** (`npl`) | **400** — *"Data loss occurred when converting firstname.lastname@example.com"* | 200 | **200** |
+| **S/4HANA 2023 / 758** (`a4h`) | **400** — CLASS_TRANSFORMATION | 200 | **200** |
+| **ABAP Platform 2025 / 816** (`a4h-2025`) | **400** — CLASS_TRANSFORMATION | 200 | **200** |
+
+7.50's message is the clearest statement of the root cause: **"Data loss occurred when
+converting …"** — the classic ST field-truncation error. Not release-specific; every on-prem
+release ARC-1 supports is affected.
+
+### 3. Blast radius — other object types, a4h 758
+
+| Type | endpoint | 30-char email | short user | **omitted** |
+|---|---|---|---|---|
+| CLAS | `/oo/classes` | 400 `CLASS_TRANSFORMATION` | 200 | **200** ✅ |
+| PROG | `/programs/programs` | 400 `SEDI_ADT_PROGRAM` | 200 | *(n/t)* |
+| INTF | `/oo/interfaces` | 400 `INTF_TRANSFORMATION` | 200 | *(n/t)* |
+| DOMA | `/ddic/domains` | 400 `SBD_DOMAIN` | 201 | **201** ✅ |
+| **DEVC** | `/packages` | 400 `SPAK_ST_PACKAGES` | 201 | **400** ❌ *"Enter a valid user, not , as the person responsible"* |
+
+**`DEVC` is the exception that shapes the fix.** Package create is the one type that genuinely
+validates `responsible` — omitting it reproduces the exact `[?/049]` error family that #379/PR #380
+was written to fix, just with an empty value. So "always omit" is **not** a safe blanket fix.
+
+### 3b. Per-type omission spike (a4h 758) — decides the fix shape
+
+Run with ARC-1's **own** `buildCreateXml` / `buildPackageXml` (via `dist/`), so each body is
+byte-identical to what ships. Two variants per type: the 30-char email, and the same body with the
+attribute stripped.
+
+| type | simple transformation | email (30) | **omitted** |
+|---|---|---|---|
+| PROG | `SEDI_ADT_PROGRAM` | 400 | **200** ✅ |
+| CLAS | `CLASS_TRANSFORMATION` | 400 | **200** ✅ |
+| INTF | `INTF_TRANSFORMATION` | 400 | **200** ✅ |
+| INCL | `SEDI_ADT_INCLUDE` | 400 | **200** ✅ |
+| DOMA | `SBD_DOMAIN` | 400 | **201** ✅ |
+| DTEL | `SBD_DATAELEMENT` | 400 | **201** ✅ |
+| TABL | `SADT_BLUE_SOURCE` | 400 | **201** ✅ |
+| TTYP | `SDDIC_ADT_TTYP` | 400 | **201** ✅ |
+| DDLS | `SDDIC_ST_ADT_DDLS` | 400 | **201** ✅ |
+| SRVD | `SDDIC_ADT_SRVD_ST` | 400 | **201** ✅ |
+| **DEVC** | `SPAK_ST_PACKAGES` | 400 | **400** ❌ |
+
+**Eleven distinct simple transformations** reject the over-long value — this is a systemic
+attribute-level constraint, not a quirk of one handler. Omission is safe for every type **except
+`DEVC`**.
+
+> Method note: the first spike run reported OMIT failures for INTF/INCL/TABL. Those were artifacts
+> of the spike itself — name collisions with the PROG/CLAS objects created moments earlier, and a
+> DDIC rule (*"Underscore not permitted at 2nd or 3rd position"*) rejecting the generated table
+> name. Re-run with unique, type-legal names: INTF `ZIF_I636B` → 200, INCL `Z_I636BINC` → 200,
+> TABL `ZI636BTAB` → 201. Recorded because a `400`/`422` here reads like a product defect and isn't.
+
+**Not covered:** `DCLS`, `BDEF`, `SRVB`, `DDLX` — each needs a prerequisite object (a CDS entity /
+root view / service definition) to create at all. Each shares a template family with a tested type
+(DCLS/DDLX/BDEF use the same generic source-object template as DDLS; SRVB uses
+`buildServiceBindingXml`, the same builder family as SRVD), and all eleven tested STs behave
+identically, so the fix is uniform by construction. Flagged rather than assumed.
+
+### 3c. `DEVC` validates that the user *exists*
+
+| `responsible` | result |
+|---|---|
+| `ABCDEFGHIJKL` — CHAR12-legal, **nonexistent** | **400** *"Enter a valid user, not ABCDEFGHIJKL, as the person responsible"* |
+| `DDIC` — exists, not the caller | **201** |
+| `MARIAN` — the caller | **201** |
+
+So package create needs a **real, existing** ≤12-char user. It cannot be satisfied by a synthetic
+placeholder, and there is no on-prem whoami to derive it from (§5) — which is why the `responsible`
+parameter has to become usable on-prem.
+
+### 4. What the attribute actually does on-prem (CLAS)
+
+Reading back `ZCL_I636_F_LEN12` (created with `responsible="ABCDEFGHIJKL"`):
+
+```
+<class:abapClass … adtcore:responsible="MARIAN" … adtcore:createdBy="ABCDEFGHIJKL" …>
+  <class:include class:includeType="main" … adtcore:createdBy="ABCDEFGHIJKL"/>
+```
+
+SAP sets the object's real `responsible` from the **logged-on user** regardless of what we send;
+the transmitted value only lands in the class's `createdBy`. And with the attribute **omitted**
+(`ZCL_I636_C_OMITTED`), the object came back `adtcore:responsible="MARIAN"` — the logged-on user.
+Under PP the logged-on user *is* the correctly propagated principal, so omission is not merely
+tolerated, it produces the **right** owner.
+
+### 5. No on-prem "whoami" endpoint
+
+Probed on 758/7.50: `/sap/bc/adt/core/systeminformation` → 404, `/sap/bc/adt/security/users/current`
+→ 404. `/sap/bc/adt/system/users` → 200 but returns a **value-help list of all developers**, not
+the session's identity; `core/discovery` carries no user attribute. So the propagated short user
+cannot be looked up directly — see the fix notes for the proven alternative.
+
+### 6. SAP Notes
+
+No applicable Note. This is a client-side defect (ARC-1 sending an over-long value), not a SAP
+regression. Note **2093502** documents the same generic ST-overflow signature in an unrelated
+context and is useful only as corroboration of the mechanism.
+
+---
+
+## Root cause
+
+Confirmed at HEAD (`c60da36`).
+
+`normalizeAdtResponsible` passes any email through verbatim and has no length bound:
+
+```ts
+// src/adt/ddic-xml.ts:169-174
+export function normalizeAdtResponsible(responsible?: string): string {
+  const r = (responsible ?? '').trim();
+  if (!r) return 'DEVELOPER';
+  // Cloud (BTP) users are email-style and case-sensitive; classic SAP users are upper-case.
+  return r.includes('@') ? r : r.toUpperCase();
+}
+```
+
+The `@`-branch was written for **BTP**, where email-style names are correct. But on the BTP path
+the attribute is stripped from the body anyway (`cloudifyCreateBody`,
+[write-helpers.ts:358-374](../../../src/handlers/write-helpers.ts#L358)), so that branch's only
+live effect today is on **on-prem-reached-via-PP**, exactly where it is wrong.
+
+### Correction 1 — the email arrives via `config.username`, not the `getEffectiveUser()` fallback
+
+The issue states that under PP `config.username` is unset, so
+`create.ts:469 config.username || (await client.getEffectiveUser())` falls through to
+`getEffectiveUser()`. **It does not.** `createPerUserClient` decodes the JWT and assigns it:
+
+```ts
+// src/server/server.ts:344
+displayUsername = payload.user_name ?? payload.email ?? undefined;
+// src/server/server.ts:404 (in applyPerUserAuthTokens)
+adtConfig.username = displayUsername;
+```
+
+So under PP `config.username` **is** set — to the email — and the `||` takes its *first* branch.
+Same outcome, but a fix aimed only at `getEffectiveUser()` would miss the issue entirely.
+
+### Correction 2 — length, not `@`, is the trigger
+
+Rows D/E/F above. The reporter's proposed guard `r.includes('@') || r.length > 12` is *sufficient*
+(every failing value is long), but the `@` half never fires independently on-prem. Keep the length
+check as the load-bearing condition; do not document `@` as the cause.
+
+### Correction 3 — metadata **updates** are affected too, not only creates
+
+The issue says `action="update"` works. That holds for **source** updates only. Metadata updates
+are full-XML-replace and rebuild the same body:
+
+```ts
+// src/handlers/write/update-delete.ts:142
+const responsible = config.username || (await client.getEffectiveUser());
+const body = buildCreateXml(type, name, pkg, description, mergedProps, config.language, responsible, …);
+```
+
+So `SAPWrite(action="update")` on a DDIC/metadata type (DOMA, DTEL, TABL, SRVB, TTYP, …) fails the
+same way under PP.
+
+---
+
+## Affected files
+
+| File | What |
+|---|---|
+| [src/adt/ddic-xml.ts:169](../../../src/adt/ddic-xml.ts#L169) | `normalizeAdtResponsible` — the defect |
+| [src/adt/ddic-xml.ts](../../../src/adt/ddic-xml.ts) | 5 builders emit the attribute: `buildDomainXml`, `buildTableTypeXml`, `buildDataElementXml`, `buildPackageXml`, `buildServiceBindingXml` |
+| [src/handlers/write-helpers.ts:395](../../../src/handlers/write-helpers.ts#L395) + templates | `buildCreateXmlBody` — **13 types** emit it: PROG, CLAS, INTF, INCL, DDLS, DCLS, TABL(/DT,/DS), BDEF, SRVD, SRVB, DDLX, DOMA, TTYP, DTEL (`MSAG`, `FUGR` never did) |
+| [src/handlers/write/create.ts:469](../../../src/handlers/write/create.ts#L469) | single create — call site |
+| [src/handlers/write/create.ts:757](../../../src/handlers/write/create.ts#L757) | `batch_create` — call site |
+| [src/handlers/write/update-delete.ts:142](../../../src/handlers/write/update-delete.ts#L142) | metadata UPDATE — call site (Correction 3) |
+| [src/handlers/manage.ts:134](../../../src/handlers/manage.ts#L134) | `create_package` on-prem uses `config.username` directly — the `DEVC` special case |
+| [src/handlers/tools.ts:1418](../../../src/handlers/tools.ts#L1418) / [schemas.ts:984](../../../src/handlers/schemas.ts#L984) | `responsible` param — currently documented **"BTP only"**; the on-prem PP fix likely needs it on-prem too |
+| tests | `tests/unit/adt/ddic-xml.test.ts:191-200` asserts today's email-passthrough — must be updated, not just extended |
+
+---
+
+## Recommended fix shape
+
+Two parts. The reporter's patch covers part 1 only.
+
+**1. Types where omission is correct (everything except `DEVC`).** Return `''` when the value
+cannot be a valid on-prem user name (`length > 12`) and emit the attribute conditionally. Live-proven
+on 7.50/758/816 to succeed *and* yield the correct owner. Note the reporter's proposed `cloud`
+parameter is **not needed** — `cloudifyCreateBody` already strips the attribute on the BTP path;
+adding a second cloud branch would duplicate that logic. Consider dropping the `'DEVELOPER'`
+fallback in the same change: omitting beats a literal that only exists on SAP demo systems, and it
+retires the #379 bug class permanently rather than relocating it.
+
+**2. `SAPManage create_package` on-prem under PP.** Needs a real ≤12-char XUBNAME; there is no
+whoami endpoint. The proven pattern already exists in this codebase for BTP: create an object, read
+`adtcore:createdBy` back, cache it (`client.noteInternalUser` / `getInternalUser`,
+[create.ts:505-509](../../../src/handlers/write/create.ts#L505), [client.ts:1497](../../../src/adt/client.ts#L1497)).
+On-prem the same trick works because object create **succeeds** with the attribute omitted. Failing
+that, un-gate the existing `responsible` param for on-prem and return a directed error, mirroring
+the current BTP message.
+
+**Regression guard:** the unit test at `ddic-xml.test.ts:197-200` currently *asserts* the buggy
+behavior (`normalizeAdtResponsible('marian@zeis.de')` → passthrough). Any fix must flip it, and
+should add a `DEVC`-omission test so part 2 cannot silently regress into the `[?/049]` error.
+
+## Out of scope
+
+- BTP / ABAP Cloud object create — already correct (`cloudifyCreateBody` strips the attribute).
+- BTP package create — separately solved, see `docs/research/2026-06-27-btp-package-create-solved.md`.
+- The PP auth path itself. The reporter's Cloud Connector X.509 evidence is consistent with
+  everything observed; nothing here indicates an auth defect.
+
+---
+
+## Draft GitHub reply (do not post automatically)
+
+```markdown
+Confirmed — and thank you for an unusually well-researched report. The ICM-trace body and the
+A/B isolation made this fast to validate. Reproduced live on **all three** on-prem releases,
+not just 758.
+
+**Repro (raw ADT POSTs, only `adtcore:responsible` varies), `POST /sap/bc/adt/oo/classes`:**
+
+| `adtcore:responsible` | len | 7.50 | 758 | 816 |
+|---|---|---|---|---|
+| `firstname.lastname@example.com` | 30 | 400 | 400 | 400 |
+| short user | 6 | 200 | 200 | 200 |
+| *omitted* | – | **200** | **200** | **200** |
+
+On 7.50 the message names the mechanism outright: *"Data loss occurred when converting
+firstname.lastname@example.com"* — the ST truncation error. Your CHAR12 diagnosis is right.
+
+**Three refinements from the live runs:**
+
+1. **The trigger is length, not `@`.** `A@B.DE` (6 chars, has `@`) → **200**; `ABCDEFGHIJKLM`
+   (13 chars, no `@`) → **400**; `ABCDEFGHIJKL` (12 chars, not even a real user) → **200**. The
+   boundary is exactly 12. Your guard `includes('@') || length > 12` works, but only the length
+   half ever fires on-prem.
+
+2. **The email arrives via `config.username`, not the `getEffectiveUser()` fallback.** Under PP,
+   `createPerUserClient` decodes the JWT and assigns it as a display name
+   (`server.ts:344` → `server.ts:404 adtConfig.username = displayUsername`), so
+   `create.ts:469` takes its *first* branch. Same outcome — worth flagging because a fix aimed
+   only at `getEffectiveUser()` wouldn't help.
+
+3. **Metadata `update` is affected too.** `update-delete.ts:142` rebuilds the same body for
+   full-XML-replace, so `SAPWrite(action="update")` on DOMA/DTEL/TABL/SRVB/TTYP fails the same
+   way. Source updates are fine, which is what you observed.
+
+**One thing that changes the fix**, and the reason this isn't a one-liner: **`create_package`
+rejects an omitted `responsible` as well.**
+
+| type | 30-char email | short user | omitted |
+|---|---|---|---|
+| CLAS / PROG / INTF / DOMA | 400 | 200 | **200** ✅ |
+| **DEVC** (`/sap/bc/adt/packages`) | 400 `SPAK_ST_PACKAGES` | 201 | **400** — *"Enter a valid user, not , as the person responsible"* |
+
+That's the same `[?/049]` family that #379 was filed for, so blanket-omitting would just move the
+bug. Package create needs a real ≤12-char XUBNAME, and there's no on-prem whoami endpoint
+(`core/systeminformation` and `security/users/current` are both 404; `system/users` returns a
+value-help list of *all* developers). The likely resolution reuses the pattern ARC-1 already has
+for BTP — create an object with the attribute omitted, read `adtcore:createdBy` back, cache it
+(`noteInternalUser`) — which works on-prem precisely because object create succeeds without the
+attribute.
+
+Also worth noting your proposed `cloud` parameter isn't needed: `cloudifyCreateBody`
+(`write-helpers.ts:358-374`) already strips `adtcore:responsible` on the BTP path, so a second
+cloud branch would duplicate that.
+
+Confirmed also that omitting yields the **right** owner, not a blank one — the object came back
+`adtcore:responsible="<logged-on user>"`, which under PP is the correctly propagated principal.
+
+Full dossier with all captured response bodies:
+`docs/research/issues/636-onprem-pp-responsible-char12-overflow.md`. Queued for a fix — the
+scope is 13 `SAPWrite` types plus `SAPManage create_package`, across create, `batch_create`, and
+metadata update.
+```
+
+---
+
+## Resolution (shipped)
+
+Fixed on branch `claude/deep-issue-636-ebea7d`; plan in
+[`docs/plans/2026-07-29-issue-636-onprem-responsible-char12.md`](../../plans/2026-07-29-issue-636-onprem-responsible-char12.md).
+
+`normalizeAdtResponsible` now returns `''` for anything that cannot be an on-prem user name
+(empty, `>12` chars, or containing `@`), and every builder emits the attribute conditionally via
+`adtResponsibleAttr`. `SAPManage create_package` keeps requiring a real user and returns a directed
+error naming the `responsible` parameter.
+
+The `'DEVELOPER'` fallback was dropped in the same change — it is a demo-system-only literal, it is
+the same defect class, and omitting is live-proven better.
+
+**Post-fix live verification** — `config.username` set to `firstname.lastname@example.com` (the PP
+shape) with the session authenticated by cookie, driven through `arc1-cli` so the whole ARC-1 path
+runs, on every supported on-prem release:
+
+| Release | create | **activate** | owner readback | delete |
+|---|---|---|---|---|
+| NW 7.50 (`npl`) | ✅ | ✅ | `DEVELOPER` (that system's logon user) | ✅ |
+| S/4HANA 2023 / 758 (`a4h`) | ✅ | ✅ | `MARIAN` | ✅ |
+| ABAP Platform 2025 / 816 (`a4h-2025`) | ✅ | ✅ | `MARIAN` | ✅ |
+
+`create_package` with the same identity returns the directed error in 2 ms (no SAP round-trip), and
+succeeds when `responsible="MARIAN"` is passed.
+
+> **Verification note.** An earlier round of this check was invalid: a `.env` in the worktree was
+> supplying `SAP_USER`, so `config.username` was a valid short name and the omit path never ran.
+> The runs above set `SAP_USER` to the email with no password (cookies carry the session) and run
+> from a directory with no `.env` — confirmed by `SAPRead(type="SYSTEM")` reporting the email as
+> the user. Recorded because the passing result looked identical either way.
+
+**Bug caught in review, not by tests.** Rewriting the templates initially left the BTP package body
+emitting `adtcore:version="active"adtcore:responsible="…"` — glued attributes, malformed XML. The
+existing test used `toContain('adtcore:responsible="CB9980000000"')`, which matches happily either
+way. Fixed, and `tests/unit/adt/create-xml-wellformed.test.ts` now asserts structurally that no
+generated create body glues two attributes together, across all 14 builder types × cloud/on-prem ×
+responsible present/omitted.
+
+## Recommendation
+
+**Done.** Fixed as described in [Resolution](#resolution-shipped). The `DEVC` design decision went
+to un-gating the `responsible` parameter on-prem (rather than the createdBy-cache), because package
+create validates that the user *exists* and the cache costs a GET per create while cold.
+
+*Validated 2026-07-29 against `npl` (7.50), `a4h` (S/4HANA 2023 / 758), `a4h-2025` (816). All
+test objects created during validation were deleted.*

--- a/docs_page/enterprise-auth.md
+++ b/docs_page/enterprise-auth.md
@@ -194,6 +194,13 @@ The most complete authentication model. Each MCP user's identity flows through t
 MCP Client ──XSUAA/OIDC JWT──► ARC-1 ──user token──► BTP Destination ──► SAP
 ```
 
+> **On-premise: creating packages under principal propagation.** The propagated identity is an
+> email, but an ABAP user name (`XUBNAME`) is only 12 characters. For every object type ARC-1
+> simply omits the "person responsible" from the create body and SAP assigns the propagated user
+> automatically. Package create is the one exception — SAP requires a real, existing user name
+> there — so pass it explicitly: `SAPManage(action="create_package", …, responsible="<your SAP
+> user name>")`. See [#636](https://github.com/arc-mcp/arc-1/issues/636).
+
 ### BTP Destination Service
 
 For BTP deployments connecting to SAP systems through centrally managed destinations. The Destination Service handles connection details, credentials, and optionally per-user token exchange / principal propagation.

--- a/src/adt/ddic-xml.ts
+++ b/src/adt/ddic-xml.ts
@@ -28,7 +28,7 @@ export interface DomainCreateParams {
   valueTable?: string;
   /** ADT master/original language (2-char, e.g. "DE"). Defaults to "EN" when unset. */
   language?: string;
-  /** ADT "person responsible" (logon user). Defaults to "DEVELOPER" when unset. */
+  /** ADT "person responsible" (logon user). Omitted when it cannot be an on-prem user name (#636). */
   responsible?: string;
 }
 
@@ -53,7 +53,7 @@ export interface DataElementCreateParams {
   changeDocument?: boolean;
   /** ADT master/original language (2-char, e.g. "DE"). Defaults to "EN" when unset. */
   language?: string;
-  /** ADT "person responsible" (logon user). Defaults to "DEVELOPER" when unset. */
+  /** ADT "person responsible" (logon user). Omitted when it cannot be an on-prem user name (#636). */
   responsible?: string;
 }
 
@@ -70,7 +70,7 @@ export interface PackageCreateParams {
    * from transportability metadata and keeps literal LOCAL packages off.
    */
   recordChanges?: boolean;
-  /** ADT "person responsible" (logon user). Defaults to "DEVELOPER" when unset. */
+  /** ADT "person responsible" (logon user). Omitted when it cannot be an on-prem user name (#636). */
   responsible?: string;
   /** BTP cloud create: nest under the structure superPackage, SC defaults to ZLOCAL, recordChanges=false,
    *  responsible passed verbatim (the internal ABAP user). Handler-set when systemType=btp. */
@@ -88,7 +88,7 @@ export interface ServiceBindingCreateParams {
   odataVersion?: string;
   /** ADT master/original language (2-char, e.g. "DE"). Defaults to "EN" when unset. */
   language?: string;
-  /** ADT "person responsible" (logon user). Defaults to "DEVELOPER" when unset. */
+  /** ADT "person responsible" (logon user). Omitted when it cannot be an on-prem user name (#636). */
   responsible?: string;
 }
 
@@ -150,27 +150,43 @@ export function normalizeAdtLanguage(language?: string): string {
   return (language ?? '').trim().toUpperCase() || 'EN';
 }
 
+/** On-prem `adtcore:responsible` deserializes into `XUBNAME`, which is CHAR12. */
+const XUBNAME_MAX_LENGTH = 12;
+
 /**
- * Normalize the ADT "person responsible" to the form SAP expects: trimmed and
- * upper-case (on-prem `USR02-BNAME` is upper-case). Defaults to "DEVELOPER"
- * only as a last-resort fallback when no user is configured, preserving the
- * legacy hard-coded value for callers that pass nothing. In practice
- * `config.username` is empty only under cookie-file or OAuth service-key auth
- * (basic auth and principal propagation both supply a real user), so the
- * "DEVELOPER" fallback realistically applies only in those two modes.
+ * Normalize the ADT "person responsible" to the form SAP expects: trimmed and upper-case
+ * (on-prem `USR02-BNAME` is upper-case). Returns `''` when the value cannot be an on-prem user
+ * name, and callers then OMIT the attribute entirely.
  *
- * `adtcore:responsible` must name a user that exists on the target system. The
- * historical hard-coded literal "DEVELOPER" only exists on SAP's own demo
- * systems; on a real system the create fails with
- * `HTTP 400 [?/049] "Enter a valid user, not DEVELOPER, as the person responsible"`.
- * Threading the connection's logon user (ARC-1 passes it as `config.username`)
- * fixes that. Mirrors the `normalizeAdtLanguage` / issue #343 master-language pattern.
+ * Omission is the correct behavior, not a fallback: ADT assigns the logged-on user, which under
+ * principal propagation is exactly the propagated one (live: create without the attribute returns
+ * `adtcore:responsible="<logged-on user>"`). It is safe even for a value that would have been
+ * valid, since a real user is still the logged-on user.
+ *
+ * Why the guard exists (#636): under BTP principal propagation to an on-prem system the principal
+ * is an email, and anything over CHAR12 overflows the field — the create fails in the object's
+ * simple transformation before anything is written (400, e.g. `CLASS_TRANSFORMATION`; on 7.50 the
+ * clearer "Data loss occurred when converting …"). Live-verified across 11 create STs on
+ * 7.50 / 758 / 816 — see docs/research/issues/636-onprem-pp-responsible-char12-overflow.md.
+ *
+ * Note the length is what breaks, not the `@` — `A@B.DE` creates fine — but an email is never a
+ * useful on-prem responsible, so both are rejected. BTP is unaffected: `cloudifyCreateBody` strips
+ * the attribute on the cloud path, and cloud package create uses `normalizeCloudResponsible`.
  */
 export function normalizeAdtResponsible(responsible?: string): string {
   const r = (responsible ?? '').trim();
-  if (!r) return 'DEVELOPER';
-  // Cloud (BTP) users are email-style and case-sensitive; classic SAP users are upper-case.
-  return r.includes('@') ? r : r.toUpperCase();
+  if (!r || r.length > XUBNAME_MAX_LENGTH || r.includes('@')) return '';
+  return r.toUpperCase();
+}
+
+/**
+ * The ` adtcore:responsible="…"` attribute for inline interpolation into a create template, or
+ * `''` when it must be omitted (see above). The leading space belongs to the attribute so an
+ * omitted one leaves no stray whitespace behind.
+ */
+export function adtResponsibleAttr(responsible?: string): string {
+  const user = normalizeAdtResponsible(responsible);
+  return user ? ` adtcore:responsible="${escapeXmlAttr(user)}"` : '';
 }
 
 /**
@@ -208,7 +224,7 @@ function boolToXml(value: boolean | undefined): string {
 
 export function buildDomainXml(params: DomainCreateParams): string {
   const masterLanguage = normalizeAdtLanguage(params.language);
-  const responsible = normalizeAdtResponsible(params.responsible);
+  const responsibleAttr = adtResponsibleAttr(params.responsible);
   const fixedValues = params.fixedValues ?? [];
   const valueTable = params.valueTable?.trim();
   const fixValuesXml =
@@ -234,8 +250,7 @@ export function buildDomainXml(params: DomainCreateParams): string {
              adtcore:name="${escapeXmlAttr(params.name)}"
              adtcore:type="DOMA/DD"
              adtcore:masterLanguage="${masterLanguage}"
-             adtcore:masterSystem="H00"
-             adtcore:responsible="${escapeXmlAttr(responsible)}">
+             adtcore:masterSystem="H00"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(params.package)}"/>
   <doma:content>
     <doma:typeInformation>
@@ -303,7 +318,7 @@ export interface TableTypeCreateParams {
  */
 export function buildTableTypeXml(params: TableTypeCreateParams): string {
   const masterLanguage = normalizeAdtLanguage(params.language);
-  const responsible = normalizeAdtResponsible(params.responsible);
+  const responsibleAttr = adtResponsibleAttr(params.responsible);
   const rowType = params.rowType.trim().toUpperCase();
   // TTYP_BUILTIN_ROW_TYPES is a best-effort heuristic for AUTO-DETECTION ONLY (when the caller omits
   // rowTypeKind). It must not gate an EXPLICIT rowTypeKind: SAP adds built-in types over releases
@@ -334,8 +349,7 @@ export function buildTableTypeXml(params: TableTypeCreateParams): string {
                 adtcore:description="${escapeXmlAttr(params.description)}"
                 adtcore:name="${escapeXmlAttr(params.name)}"
                 adtcore:type="TTYP/DA"
-                adtcore:masterLanguage="${masterLanguage}"
-                adtcore:responsible="${escapeXmlAttr(responsible)}">
+                adtcore:masterLanguage="${masterLanguage}"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(params.package)}"/>
   <ttyp:rowType>${rowTypeXml}</ttyp:rowType>
   <ttyp:initialRowCount>00000</ttyp:initialRowCount>
@@ -450,7 +464,7 @@ export function buildMessageClassXml(params: MessageClassCreateParams): string {
 
 export function buildDataElementXml(params: DataElementCreateParams): string {
   const masterLanguage = normalizeAdtLanguage(params.language);
-  const responsible = normalizeAdtResponsible(params.responsible);
+  const responsibleAttr = adtResponsibleAttr(params.responsible);
   const typeKind = params.typeKind ?? (params.dataType ? 'predefinedAbapType' : 'domain');
   const shortLabel = params.shortLabel ?? '';
   const mediumLabel = params.mediumLabel ?? '';
@@ -465,8 +479,7 @@ export function buildDataElementXml(params: DataElementCreateParams): string {
             adtcore:name="${escapeXmlAttr(params.name)}"
             adtcore:type="DTEL/DE"
             adtcore:masterLanguage="${masterLanguage}"
-            adtcore:masterSystem="H00"
-            adtcore:responsible="${escapeXmlAttr(responsible)}">
+            adtcore:masterSystem="H00"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(params.package)}"/>
   <dtel:dataElement xmlns:dtel="http://www.sap.com/adt/dictionary/dataelements">
     <dtel:typeKind>${escapeXmlAttr(typeKind)}</dtel:typeKind>
@@ -509,9 +522,11 @@ export function buildPackageXml(params: PackageCreateParams): string {
   // Cloud local packages (e.g. under ZLOCAL) are non-transportable → recordChanges defaults false;
   // do NOT let the on-prem non-LOCAL heuristic flip it to true for the ZLOCAL cloud SC.
   const recordChanges = params.recordChanges ?? (cloud ? false : !isLocalSoftwareComponent || transportLayer !== '');
-  const responsible = cloud
-    ? normalizeCloudResponsible(params.responsible)
-    : normalizeAdtResponsible(params.responsible);
+  // Cloud keeps its verbatim internal-user contract (the handler validates it first); on-prem goes
+  // through the CHAR12 guard. Both carry the leading space — see adtResponsibleAttr.
+  const responsibleAttr = cloud
+    ? ` adtcore:responsible="${escapeXmlAttr(normalizeCloudResponsible(params.responsible))}"`
+    : adtResponsibleAttr(params.responsible);
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <pak:package xmlns:pak="http://www.sap.com/adt/packages"
@@ -519,8 +534,7 @@ export function buildPackageXml(params: PackageCreateParams): string {
              adtcore:description="${escapeXmlAttr(params.description)}"
              adtcore:name="${escapeXmlAttr(params.name)}"
              adtcore:type="DEVC/K"
-             adtcore:version="active"
-             adtcore:responsible="${escapeXmlAttr(responsible)}">
+             adtcore:version="active"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(params.name)}"/>
   <pak:attributes pak:packageType="${escapeXmlAttr(packageType)}" pak:recordChanges="${boolToXml(recordChanges)}"/>
   <pak:superPackage adtcore:name="${escapeXmlAttr(superPackage)}"/>
@@ -544,7 +558,7 @@ export function buildServiceBindingXml(params: ServiceBindingCreateParams): stri
   const odataVersion = params.odataVersion?.trim().toUpperCase() || normalized.odataVersion;
   const serviceVersion = params.version?.trim() || '0001';
   const masterLanguage = normalizeAdtLanguage(params.language);
-  const responsible = normalizeAdtResponsible(params.responsible);
+  const responsibleAttr = adtResponsibleAttr(params.responsible);
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <srvb:serviceBinding xmlns:srvb="http://www.sap.com/adt/ddic/ServiceBindings"
@@ -553,8 +567,7 @@ export function buildServiceBindingXml(params: ServiceBindingCreateParams): stri
                      adtcore:name="${escapeXmlAttr(params.name)}"
                      adtcore:type="SRVB/SVB"
                      adtcore:language="${masterLanguage}"
-                     adtcore:masterLanguage="${masterLanguage}"
-                     adtcore:responsible="${escapeXmlAttr(responsible)}">
+                     adtcore:masterLanguage="${masterLanguage}"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(params.package)}"/>
   <srvb:services srvb:name="${escapeXmlAttr(params.name)}">
     <srvb:content srvb:version="${escapeXmlAttr(serviceVersion)}">

--- a/src/handlers/manage.ts
+++ b/src/handlers/manage.ts
@@ -5,7 +5,7 @@
 
 import type { AdtClient } from '../adt/client.js';
 import { createObject, deleteObject, lockObject, unlockObject } from '../adt/crud.js';
-import { buildPackageXml, type PackageCreateParams } from '../adt/ddic-xml.js';
+import { buildPackageXml, normalizeAdtResponsible, type PackageCreateParams } from '../adt/ddic-xml.js';
 import { probeFeatures } from '../adt/features.js';
 import {
   addTileToGroup,
@@ -131,7 +131,13 @@ export async function handleSAPManage(
       // below. Details: docs/research/2026-06-27-btp-package-create-solved.md.
       const systemType = resolveWriteSystemType(config, client);
       const cloud = systemType === 'btp';
-      const responsible = cloud ? responsibleArg || client.getInternalUser() || '' : config.username;
+      // On-prem, unlike every other type, DEVC cannot fall back to omitting adtcore:responsible:
+      // SPAK_ST_PACKAGES rejects an empty value AND validates that the user exists ("Enter a valid
+      // user, not <x>, as the person responsible"). So an unusable logon user (the email-style
+      // principal under PP) must be replaced by an explicit responsible, not dropped (#636).
+      const responsible = cloud
+        ? responsibleArg || client.getInternalUser() || ''
+        : responsibleArg || normalizeAdtResponsible(config.username);
       if (cloud) {
         if (!superPackage) {
           return errorResult(
@@ -146,6 +152,14 @@ export async function handleSAPManage(
               'SAPRead createdBy on an object you own), or create any object first to auto-resolve it.',
           );
         }
+      } else if (!responsible) {
+        return errorResult(
+          'Package create needs a person-responsible that is a valid SAP user name (XUBNAME, max 12 ' +
+            'characters) — unlike other object types, SAP rejects an empty one here. ' +
+            `The connection user (${config.username || 'unset'}) cannot be used. ` +
+            'This is the normal case under principal propagation, where the identity is an email. ' +
+            'Pass responsible="<your SAP user name>".',
+        );
       }
 
       let effectiveTransport = transport || undefined;

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1418,7 +1418,7 @@ export function getToolDefinitions(
         responsible: {
           type: 'string',
           description:
-            'BTP only: the internal ABAP user (XUBNAME, e.g. CB9980000000) for the new package person-responsible. Auto-resolved from prior object creates if omitted; the IAS email is rejected.',
+            'Person-responsible: an existing ABAP user (XUBNAME, max 12 chars); an email is rejected. Defaults to the connection user; pass explicitly under principal propagation. BTP: auto-resolved from prior creates.',
         },
         transportLayer: {
           type: 'string',

--- a/src/handlers/write-helpers.ts
+++ b/src/handlers/write-helpers.ts
@@ -8,6 +8,7 @@
 
 import type { AdtClient } from '../adt/client.js';
 import {
+  adtResponsibleAttr,
   buildDataElementXml,
   buildDomainXml,
   buildMessageClassXml,
@@ -387,12 +388,12 @@ function buildCreateXmlBody(
   // matches the sap-language URL param ARC-1 already sends. Defaults to "EN" when
   // unset, preserving legacy output. See issue #343.
   const masterLanguage = normalizeAdtLanguage(language);
-  // Person responsible for the created object. Derived from the configured logon
-  // user (passed by callers as config.username). The legacy hard-coded "DEVELOPER"
-  // only exists on SAP demo systems, so on a real system it fails with
-  // 400 [?/049] "Enter a valid user, not DEVELOPER, as the person responsible".
-  // Defaults to "DEVELOPER" only when no user is configured. Same threading as #343.
+  // Person responsible for the created object, from the configured logon user (config.username).
+  // Omitted when it cannot be an on-prem user name — notably the email-style principal under
+  // principal propagation, which overflows XUBNAME (CHAR12) and kills the create ST (#636).
+  // ADT then assigns the logged-on user, which under PP is the propagated one.
   const responsibleUser = normalizeAdtResponsible(responsible);
+  const responsibleAttr = adtResponsibleAttr(responsible);
   switch (type) {
     case 'PROG':
       return `<?xml version="1.0" encoding="UTF-8"?>
@@ -402,8 +403,7 @@ function buildCreateXmlBody(
                      adtcore:name="${escapeXmlAttr(name)}"
                      adtcore:type="PROG/P"
                      adtcore:masterLanguage="${masterLanguage}"
-                     adtcore:masterSystem="H00"
-                     adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+                     adtcore:masterSystem="H00"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </program:abapProgram>`;
     case 'CLAS':
@@ -414,8 +414,7 @@ function buildCreateXmlBody(
                  adtcore:name="${escapeXmlAttr(name)}"
                  adtcore:type="CLAS/OC"
                  adtcore:masterLanguage="${masterLanguage}"
-                 adtcore:masterSystem="H00"
-                 adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+                 adtcore:masterSystem="H00"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </class:abapClass>`;
     case 'INTF':
@@ -426,8 +425,7 @@ function buildCreateXmlBody(
                     adtcore:name="${escapeXmlAttr(name)}"
                     adtcore:type="INTF/OI"
                     adtcore:masterLanguage="${masterLanguage}"
-                    adtcore:masterSystem="H00"
-                    adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+                    adtcore:masterSystem="H00"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </intf:abapInterface>`;
     case 'INCL':
@@ -438,8 +436,7 @@ function buildCreateXmlBody(
                      adtcore:name="${escapeXmlAttr(name)}"
                      adtcore:type="PROG/I"
                      adtcore:masterLanguage="${masterLanguage}"
-                     adtcore:masterSystem="H00"
-                     adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+                     adtcore:masterSystem="H00"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </include:abapInclude>`;
     case 'DDLS':
@@ -450,8 +447,7 @@ function buildCreateXmlBody(
                adtcore:name="${escapeXmlAttr(name)}"
                adtcore:type="DDLS/DF"
                adtcore:masterLanguage="${masterLanguage}"
-               adtcore:masterSystem="H00"
-                 adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+               adtcore:masterSystem="H00"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </ddl:ddlSource>`;
     case 'DCLS':
@@ -462,8 +458,7 @@ function buildCreateXmlBody(
                adtcore:name="${escapeXmlAttr(name)}"
                adtcore:type="DCLS/DL"
                adtcore:masterLanguage="${masterLanguage}"
-               adtcore:masterSystem="H00"
-               adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+               adtcore:masterSystem="H00"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </dcl:dclSource>`;
     case 'TABL':
@@ -480,8 +475,7 @@ function buildCreateXmlBody(
                  adtcore:name="${escapeXmlAttr(name)}"
                  adtcore:type="${adtType}"
                  adtcore:masterLanguage="${masterLanguage}"
-                 adtcore:masterSystem="H00"
-                 adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+                 adtcore:masterSystem="H00"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </blue:blueSource>`;
     }
@@ -506,8 +500,7 @@ function buildCreateXmlBody(
                  adtcore:name="${escapeXmlAttr(name)}"
                  adtcore:type="BDEF/BDO"
                  adtcore:masterLanguage="${masterLanguage}"
-                 adtcore:masterSystem="H00"
-                 adtcore:responsible="${escapeXmlAttr(responsibleUser)}">${extTemplate}
+                 adtcore:masterSystem="H00"${responsibleAttr}>${extTemplate}
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </blue:blueSource>`;
     }
@@ -519,8 +512,7 @@ function buildCreateXmlBody(
                  adtcore:name="${escapeXmlAttr(name)}"
                  adtcore:type="SRVD/SRV"
                  adtcore:masterLanguage="${masterLanguage}"
-                 adtcore:masterSystem="H00"
-                 adtcore:responsible="${escapeXmlAttr(responsibleUser)}"
+                 adtcore:masterSystem="H00"${responsibleAttr}
                  srvd:srvdSourceType="S">
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </srvd:srvdSource>`;
@@ -554,8 +546,7 @@ function buildCreateXmlBody(
                  adtcore:name="${escapeXmlAttr(name)}"
                  adtcore:type="DDLX/EX"
                  adtcore:masterLanguage="${masterLanguage}"
-                 adtcore:masterSystem="H00"
-                     adtcore:responsible="${escapeXmlAttr(responsibleUser)}">
+                 adtcore:masterSystem="H00"${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXmlAttr(pkg)}"/>
 </ddlx:ddlxSource>`;
     case 'DOMA': {

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -1376,7 +1376,7 @@
         },
         "responsible": {
           "type": "string",
-          "description": "BTP only: the internal ABAP user (XUBNAME, e.g. CB9980000000) for the new package person-responsible. Auto-resolved from prior object creates if omitted; the IAS email is rejected."
+          "description": "Person-responsible: an existing ABAP user (XUBNAME, max 12 chars); an email is rejected. Defaults to the connection user; pass explicitly under principal propagation. BTP: auto-resolved from prior creates."
         },
         "transportLayer": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -687,7 +687,7 @@
         },
         "responsible": {
           "type": "string",
-          "description": "BTP only: the internal ABAP user (XUBNAME, e.g. CB9980000000) for the new package person-responsible. Auto-resolved from prior object creates if omitted; the IAS email is rejected."
+          "description": "Person-responsible: an existing ABAP user (XUBNAME, max 12 chars); an email is rejected. Defaults to the connection user; pass explicitly under principal propagation. BTP: auto-resolved from prior creates."
         },
         "transportLayer": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -1416,7 +1416,7 @@
         },
         "responsible": {
           "type": "string",
-          "description": "BTP only: the internal ABAP user (XUBNAME, e.g. CB9980000000) for the new package person-responsible. Auto-resolved from prior object creates if omitted; the IAS email is rejected."
+          "description": "Person-responsible: an existing ABAP user (XUBNAME, max 12 chars); an email is rejected. Defaults to the connection user; pass explicitly under principal propagation. BTP: auto-resolved from prior creates."
         },
         "transportLayer": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -1416,7 +1416,7 @@
         },
         "responsible": {
           "type": "string",
-          "description": "BTP only: the internal ABAP user (XUBNAME, e.g. CB9980000000) for the new package person-responsible. Auto-resolved from prior object creates if omitted; the IAS email is rejected."
+          "description": "Person-responsible: an existing ABAP user (XUBNAME, max 12 chars); an email is rejected. Defaults to the connection user; pass explicitly under principal propagation. BTP: auto-resolved from prior creates."
         },
         "transportLayer": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -1416,7 +1416,7 @@
         },
         "responsible": {
           "type": "string",
-          "description": "BTP only: the internal ABAP user (XUBNAME, e.g. CB9980000000) for the new package person-responsible. Auto-resolved from prior object creates if omitted; the IAS email is rejected."
+          "description": "Person-responsible: an existing ABAP user (XUBNAME, max 12 chars); an email is rejected. Defaults to the connection user; pass explicitly under principal propagation. BTP: auto-resolved from prior creates."
         },
         "transportLayer": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -1416,7 +1416,7 @@
         },
         "responsible": {
           "type": "string",
-          "description": "BTP only: the internal ABAP user (XUBNAME, e.g. CB9980000000) for the new package person-responsible. Auto-resolved from prior object creates if omitted; the IAS email is rejected."
+          "description": "Person-responsible: an existing ABAP user (XUBNAME, max 12 chars); an email is rejected. Defaults to the connection user; pass explicitly under principal propagation. BTP: auto-resolved from prior creates."
         },
         "transportLayer": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -711,7 +711,7 @@
         },
         "responsible": {
           "type": "string",
-          "description": "BTP only: the internal ABAP user (XUBNAME, e.g. CB9980000000) for the new package person-responsible. Auto-resolved from prior object creates if omitted; the IAS email is rejected."
+          "description": "Person-responsible: an existing ABAP user (XUBNAME, max 12 chars); an email is rejected. Defaults to the connection user; pass explicitly under principal propagation. BTP: auto-resolved from prior creates."
         },
         "transportLayer": {
           "type": "string",

--- a/tests/unit/adt/create-xml-wellformed.test.ts
+++ b/tests/unit/adt/create-xml-wellformed.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Well-formedness guard for every create-XML builder.
+ *
+ * `toContain('adtcore:responsible="X"')` cannot see two attributes glued together
+ * (`...active"adtcore:responsible="X"`), which is exactly what a mis-spaced interpolation produces.
+ * #636 introduced conditional emission of `adtcore:responsible` across ~15 templates, so assert the
+ * shape structurally instead: every generated body must parse, and no attribute may be glued to the
+ * previous one.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildPackageXml } from '../../../src/adt/ddic-xml.js';
+import { buildCreateXml } from '../../../src/handlers/write-helpers.js';
+
+const GLUED_ATTR = /"[a-zA-Z][\w.-]*:[\w.-]+="/; // `..."` immediately followed by `ns:attr="`
+
+/** Types whose create body buildCreateXml produces directly (source + DDIC families). */
+const TYPES: Array<[string, Record<string, unknown>]> = [
+  ['PROG', {}],
+  ['CLAS', {}],
+  ['INTF', {}],
+  ['INCL', {}],
+  ['DDLS', {}],
+  ['DCLS', {}],
+  ['TABL', {}],
+  ['BDEF', {}],
+  ['SRVD', {}],
+  ['DDLX', {}],
+  ['DOMA', { dataType: 'CHAR', length: 10 }],
+  ['DTEL', { typeKind: 'predefinedAbapType', dataType: 'CHAR', length: 10 }],
+  ['TTYP', { rowType: 'CHAR10', rowTypeKind: 'builtin' }],
+  ['SRVB', { serviceDefinition: 'ZSD' }],
+];
+
+// A usable user (attribute present) and a PP-shaped email (attribute omitted) must BOTH be well
+// formed — the omitted case is the one that regressed formatting.
+describe.each([
+  ['responsible present', 'MARIAN'],
+  ['responsible omitted (PP email)', 'firstname.lastname@example.com'],
+])('create XML is well formed — %s', (_label, responsible) => {
+  it.each(TYPES)('%s', (type, props) => {
+    for (const cloud of [false, true]) {
+      const xml = buildCreateXml(type, 'ZOBJ', '$TMP', 'd', props, 'EN', responsible, cloud);
+      expect(xml, `${type} cloud=${cloud}`).not.toMatch(GLUED_ATTR);
+      expect(xml, `${type} cloud=${cloud}`).not.toContain('responsible=""');
+    }
+  });
+
+  it('buildPackageXml (on-prem and cloud)', () => {
+    for (const cloud of [false, true]) {
+      const xml = buildPackageXml({
+        name: 'ZP',
+        description: 'd',
+        responsible: cloud ? 'CB9980000000' : responsible,
+        cloud,
+        superPackage: cloud ? 'ZLOCAL' : undefined,
+      });
+      expect(xml, `package cloud=${cloud}`).not.toMatch(GLUED_ATTR);
+    }
+  });
+});

--- a/tests/unit/adt/ddic-xml.test.ts
+++ b/tests/unit/adt/ddic-xml.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  adtResponsibleAttr,
   buildDataElementXml,
   buildDomainXml,
   buildMessageClassXml,
@@ -123,19 +124,21 @@ describe('ddic-xml builders', () => {
   });
 
   // Sibling of issue #343, for adtcore:responsible: the created object's "person
-  // responsible" must name a real user on the target system. The legacy hard-coded
-  // "DEVELOPER" only exists on SAP demo systems — on a real system the create fails
-  // with HTTP 400 [?/049] "Enter a valid user, not DEVELOPER, as the person
-  // responsible". ARC-1 threads the connection's logon user (config.username) instead.
+  // responsible" must name a real user on the target system. ARC-1 threads the connection's
+  // logon user (config.username), and OMITS the attribute when that cannot be an on-prem user
+  // name — it deserializes into XUBNAME (CHAR12), so the email-style principal under principal
+  // propagation overflows the field and kills the create ST (#636). ADT then assigns the
+  // logged-on user, which under PP is the propagated one.
   describe('person responsible (adtcore:responsible)', () => {
     it('buildPackageXml emits the configured responsible', () => {
       const xml = buildPackageXml({ name: 'ZTEST', description: 'd', responsible: 'SRAHEMI' });
       expect(xml).toContain('adtcore:responsible="SRAHEMI"');
     });
 
-    it('buildPackageXml defaults responsible to DEVELOPER when unset', () => {
+    it('buildPackageXml omits responsible when unset (never the DEVELOPER demo literal)', () => {
       const xml = buildPackageXml({ name: 'ZTEST', description: 'd' });
-      expect(xml).toContain('adtcore:responsible="DEVELOPER"');
+      expect(xml).not.toContain('adtcore:responsible');
+      expect(xml).not.toContain('DEVELOPER');
     });
 
     it('buildDomainXml emits the configured responsible', () => {
@@ -166,16 +169,16 @@ describe('ddic-xml builders', () => {
       expect(xml).toContain('adtcore:responsible="SRAHEMI"');
     });
 
-    it('defaults responsible to DEVELOPER across DDIC builders when unset', () => {
-      expect(buildDomainXml({ name: 'ZD', description: 'd', package: '$TMP', dataType: 'CHAR', length: 1 })).toContain(
-        'adtcore:responsible="DEVELOPER"',
-      );
-      expect(buildDataElementXml({ name: 'ZE', description: 'd', package: '$TMP' })).toContain(
-        'adtcore:responsible="DEVELOPER"',
+    it('omits responsible across DDIC builders when unset', () => {
+      expect(
+        buildDomainXml({ name: 'ZD', description: 'd', package: '$TMP', dataType: 'CHAR', length: 1 }),
+      ).not.toContain('adtcore:responsible');
+      expect(buildDataElementXml({ name: 'ZE', description: 'd', package: '$TMP' })).not.toContain(
+        'adtcore:responsible',
       );
       expect(
         buildServiceBindingXml({ name: 'ZSB', description: 'd', package: '$TMP', serviceDefinition: 'ZSD' }),
-      ).toContain('adtcore:responsible="DEVELOPER"');
+      ).not.toContain('adtcore:responsible');
     });
 
     it('upper-cases a lower-case responsible', () => {
@@ -183,21 +186,37 @@ describe('ddic-xml builders', () => {
       expect(xml).toContain('adtcore:responsible="SRAHEMI"');
     });
 
-    it('treats a blank responsible as the DEVELOPER default', () => {
+    it('omits a blank responsible', () => {
       const xml = buildPackageXml({ name: 'ZTEST', description: 'd', responsible: '   ' });
-      expect(xml).toContain('adtcore:responsible="DEVELOPER"');
+      expect(xml).not.toContain('adtcore:responsible');
     });
 
-    it('normalizeAdtResponsible trims + upper-cases and defaults to DEVELOPER', () => {
+    it('normalizeAdtResponsible trims + upper-cases, and returns "" when unusable', () => {
       expect(normalizeAdtResponsible('  srahemi ')).toBe('SRAHEMI');
-      expect(normalizeAdtResponsible()).toBe('DEVELOPER');
-      expect(normalizeAdtResponsible('   ')).toBe('DEVELOPER');
+      expect(normalizeAdtResponsible()).toBe('');
+      expect(normalizeAdtResponsible('   ')).toBe('');
     });
 
-    it('normalizeAdtResponsible keeps email-style cloud users case-sensitive (BTP)', () => {
-      // Classic SAP users are upper-case; cloud (BTP) users are case-sensitive emails — never upper-case them.
-      expect(normalizeAdtResponsible('marian@zeis.de')).toBe('marian@zeis.de');
-      expect(normalizeAdtResponsible('  Marian@Zeis.de ')).toBe('Marian@Zeis.de');
+    // #636 — on-prem adtcore:responsible deserializes into XUBNAME (CHAR12). Live-verified on
+    // 7.50/758/816: 12 chars creates, 13 chars fails the create ST ("Data loss occurred when
+    // converting …" on 7.50). Under principal propagation the value is the XSUAA email.
+    it('normalizeAdtResponsible drops a value that cannot be an on-prem user name', () => {
+      expect(normalizeAdtResponsible('firstname.lastname@example.com')).toBe('');
+      expect(normalizeAdtResponsible('marian@zeis.de')).toBe('');
+      expect(normalizeAdtResponsible('ABCDEFGHIJKLM')).toBe(''); // 13 chars — over CHAR12
+      expect(normalizeAdtResponsible('A@B.DE')).toBe(''); // short, but still not a user name
+    });
+
+    it('normalizeAdtResponsible keeps a value exactly at the CHAR12 boundary', () => {
+      expect(normalizeAdtResponsible('ABCDEFGHIJKL')).toBe('ABCDEFGHIJKL'); // 12 chars — creates fine
+      expect(normalizeAdtResponsible('CB9980000000')).toBe('CB9980000000');
+    });
+
+    it('adtResponsibleAttr renders the attribute only when the user is usable', () => {
+      // leading space belongs to the attribute, so omitting it leaves no stray whitespace
+      expect(adtResponsibleAttr('srahemi')).toBe(' adtcore:responsible="SRAHEMI"');
+      expect(adtResponsibleAttr('firstname.lastname@example.com')).toBe('');
+      expect(adtResponsibleAttr()).toBe('');
     });
   });
 
@@ -576,8 +595,8 @@ describe('ddic-xml builders', () => {
       expect(normalizeCloudResponsible('  CB9980000000  ')).toBe('CB9980000000');
       expect(normalizeCloudResponsible()).toBe('');
       expect(normalizeCloudResponsible('')).toBe('');
-      // shared on-prem helper is untouched (regression guard)
-      expect(normalizeAdtResponsible()).toBe('DEVELOPER');
+      // shared on-prem helper is untouched (regression guard): it omits rather than inventing a user
+      expect(normalizeAdtResponsible()).toBe('');
     });
 
     it('on-prem body (cloud unset) keeps the legacy LOCAL default + recordChanges heuristic', () => {

--- a/tests/unit/handlers/manage-context.test.ts
+++ b/tests/unit/handlers/manage-context.test.ts
@@ -9,6 +9,12 @@ import { unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
 import { CachingLayer } from '../../../src/cache/caching-layer.js';
 import { MemoryCache } from '../../../src/cache/memory.js';
 import { DEFAULT_CONFIG } from '../../../src/server/types.js';
+
+// On-prem package create needs a person-responsible that is a real ABAP user: SPAK_ST_PACKAGES
+// rejects an empty one and validates existence (#636). Basic auth always supplies SAP_USER, so
+// these mechanics tests use a config that has one.
+const PKG_CONFIG = { ...DEFAULT_CONFIG, username: 'ADMIN' };
+
 import { mockResponse } from '../../helpers/mock-fetch.js';
 import { AdtClient, createClient, mockFetch } from './setup-undici-mock.js';
 
@@ -81,7 +87,7 @@ describe('SAPManage / SAPContext handlers', () => {
         return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
       });
 
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+      const result = await handleToolCall(createClient(), PKG_CONFIG, 'SAPManage', {
         action: 'create_package',
         name: 'ZPKG_TEST',
         description: 'Test package',
@@ -105,7 +111,7 @@ describe('SAPManage / SAPContext handlers', () => {
         return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
       });
 
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+      const result = await handleToolCall(createClient(), PKG_CONFIG, 'SAPManage', {
         action: 'create_package',
         name: 'ZPKG_TR',
         description: 'Transported package',
@@ -119,7 +125,7 @@ describe('SAPManage / SAPContext handlers', () => {
     });
 
     it('create_package returns error when name is missing', async () => {
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+      const result = await handleToolCall(createClient(), PKG_CONFIG, 'SAPManage', {
         action: 'create_package',
         description: 'Missing name',
       });
@@ -660,7 +666,7 @@ describe('SAPManage / SAPContext handlers', () => {
         return Promise.resolve(mockResponse(200, '<xml/>', { 'x-csrf-token': 'T' }));
       });
 
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+      const result = await handleToolCall(createClient(), PKG_CONFIG, 'SAPManage', {
         action: 'create_package',
         name: 'ZPKG_NEEDS_TR',
         description: 'Transport-required package',
@@ -681,7 +687,7 @@ describe('SAPManage / SAPContext handlers', () => {
         return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
       });
 
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+      const result = await handleToolCall(createClient(), PKG_CONFIG, 'SAPManage', {
         action: 'create_package',
         name: 'ZPKG_FULL',
         description: 'Full options package',
@@ -708,7 +714,7 @@ describe('SAPManage / SAPContext handlers', () => {
         return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
       });
 
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+      const result = await handleToolCall(createClient(), PKG_CONFIG, 'SAPManage', {
         action: 'create_package',
         name: 'ZPKG_NO_RECORD',
         description: 'No recording',
@@ -731,7 +737,7 @@ describe('SAPManage / SAPContext handlers', () => {
         return Promise.resolve(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
       });
 
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+      const result = await handleToolCall(createClient(), PKG_CONFIG, 'SAPManage', {
         action: 'create_package',
         name: 'ZPKG_ZLOCAL',
         description: 'ZLOCAL package',

--- a/tests/unit/handlers/manage-create-package-cloud.test.ts
+++ b/tests/unit/handlers/manage-create-package-cloud.test.ts
@@ -119,7 +119,8 @@ describe('SAPManage create_package — BTP cloud path', () => {
 
   it('on-prem (non-bearer, systemType auto) keeps the legacy LOCAL body — no cloud transform', async () => {
     const client = createClient();
-    const res = await handleToolCall(client, DEFAULT_CONFIG, 'SAPManage', {
+    // On-prem DEVC needs a real person-responsible (#636); basic auth always supplies SAP_USER.
+    const res = await handleToolCall(client, { ...DEFAULT_CONFIG, username: 'ADMIN' }, 'SAPManage', {
       action: 'create_package',
       name: 'ZPKG_OP',
       description: 'd',

--- a/tests/unit/handlers/write-create-batch.test.ts
+++ b/tests/unit/handlers/write-create-batch.test.ts
@@ -1971,10 +1971,30 @@ lv = CONV string( 1 ).`,
         );
       });
 
-      it('defaults responsible to DEVELOPER when no responsible arg is passed', () => {
-        expect(buildCreateXml('PROG', 'ZHELLO', 'ZPACKAGE', 'Hello')).toContain('adtcore:responsible="DEVELOPER"');
-        expect(buildCreateXml('CLAS', 'ZCL', '$TMP', 'C', undefined, 'EN')).toContain(
-          'adtcore:responsible="DEVELOPER"',
+      it('omits responsible when no responsible arg is passed', () => {
+        expect(buildCreateXml('PROG', 'ZHELLO', 'ZPACKAGE', 'Hello')).not.toContain('adtcore:responsible');
+        expect(buildCreateXml('CLAS', 'ZCL', '$TMP', 'C', undefined, 'EN')).not.toContain('adtcore:responsible');
+      });
+
+      // #636 — the email-style principal under principal propagation overflows XUBNAME (CHAR12)
+      // and kills the create ST. Omit it so ADT assigns the logged-on (propagated) user instead.
+      it('omits an email-shaped responsible (principal propagation), across template families', () => {
+        const email = 'firstname.lastname@example.com';
+        for (const type of ['PROG', 'CLAS', 'INTF', 'INCL', 'DDLS', 'SRVD', 'DDLX']) {
+          expect(buildCreateXml(type, 'ZOBJ', '$TMP', 'd', undefined, 'EN', email)).not.toContain(
+            'adtcore:responsible',
+          );
+        }
+        // builder-delegating types (their XML comes from ddic-xml.ts, not the inline templates)
+        expect(buildCreateXml('DOMA', 'ZD', '$TMP', 'd', { dataType: 'CHAR', length: 10 }, 'EN', email)).not.toContain(
+          'adtcore:responsible',
+        );
+        expect(buildCreateXml('DTEL', 'ZE', '$TMP', 'd', {}, 'EN', email)).not.toContain('adtcore:responsible');
+      });
+
+      it('keeps a responsible at the CHAR12 boundary', () => {
+        expect(buildCreateXml('CLAS', 'ZCL', '$TMP', 'C', undefined, 'EN', 'ABCDEFGHIJKL')).toContain(
+          'adtcore:responsible="ABCDEFGHIJKL"',
         );
       });
 

--- a/tests/unit/handlers/write-ddic.test.ts
+++ b/tests/unit/handlers/write-ddic.test.ts
@@ -2249,7 +2249,10 @@ define role ZTEST_DCL {
       expect(dtelCreatePostBody()).toContain('adtcore:responsible="SRAHEMI"');
     });
 
-    it('falls back to DEVELOPER in the create_package POST body when username is unset', async () => {
+    // #636 — DEVC is the one type that cannot fall back to omitting the attribute:
+    // SPAK_ST_PACKAGES rejects an empty value AND validates that the user exists (live 758).
+    // So with no usable connection user, ask for one instead of inventing "DEVELOPER".
+    it('asks for an explicit responsible on create_package when the username is unset', async () => {
       mockFetch.mockReset();
       mockFetch.mockResolvedValue(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
       const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
@@ -2257,8 +2260,40 @@ define role ZTEST_DCL {
         name: 'ZARC1_RESP_DEF',
         description: 'Responsible default test',
       });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('responsible=');
+      expect(result.content[0]?.text).not.toContain('DEVELOPER');
+    });
+
+    it('asks for an explicit responsible on create_package when the username is an email (PP)', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      const result = await handleToolCall(
+        createClient(),
+        { ...DEFAULT_CONFIG, username: 'firstname.lastname@example.com' },
+        'SAPManage',
+        { action: 'create_package', name: 'ZARC1_RESP_PP', description: 'PP package test' },
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('principal propagation');
+    });
+
+    it('uses an explicit responsible on create_package even when the username is an email (PP)', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, '<xml>created</xml>', { 'x-csrf-token': 'T' }));
+      const result = await handleToolCall(
+        createClient(),
+        { ...DEFAULT_CONFIG, username: 'firstname.lastname@example.com' },
+        'SAPManage',
+        {
+          action: 'create_package',
+          name: 'ZARC1_RESP_PP2',
+          description: 'PP package test',
+          responsible: 'MARIAN',
+        },
+      );
       expect(result.isError).toBeUndefined();
-      expect(packageCreatePostBody()).toContain('adtcore:responsible="DEVELOPER"');
+      expect(packageCreatePostBody()).toContain('adtcore:responsible="MARIAN"');
     });
 
     // The metadata-UPDATE call site is full-XML-replace via buildCreateXml, so it


### PR DESCRIPTION
Fixes #636.

## Problem

On-prem `adtcore:responsible` deserializes into `XUBNAME`, which is **CHAR12**. Under BTP principal propagation to an on-prem system the identity is an email, so the value overflows the field and the create fails in the object's simple transformation **before anything is written** — HTTP 400, e.g. `CLASS_TRANSFORMATION`. On 7.50 the message names the mechanism outright: *"Data loss occurred when converting firstname.lastname@example.com"*.

Thanks to @Antseburov for an unusually well-researched report — the ICM-trace body and the A/B isolation made this fast to validate.

## Fix

`normalizeAdtResponsible` returns `''` for anything that cannot be an on-prem user name (empty, `>12` chars, or containing `@`), and every builder emits the attribute conditionally via a new `adtResponsibleAttr`. ADT then assigns the logged-on user — which under PP is the correctly propagated one, so the owner comes out **right**, not merely non-failing.

## What the live spike changed versus the report

- **The trigger is length, not `@`.** `A@B.DE` (6 chars) creates fine; a 13-char non-email does not; a CHAR12-legal user that doesn't exist creates fine. **Eleven distinct create STs** reject the over-long value, so the constraint is attribute-level, not per-handler.
- **The email arrives via `config.username`**, not the `getEffectiveUser()` fallback the issue points at — `server.ts:344` → `server.ts:404` assigns it as a display name under PP. A fix aimed only at `getEffectiveUser()` would have missed it.
- **Metadata `update` is affected too** (`update-delete.ts:142` rebuilds the same body); source updates are fine, which is what the reporter observed.
- **`DEVC` cannot omit it.** `SPAK_ST_PACKAGES` rejects an empty value *and* validates that the user exists (`DDIC` → 201, `ABCDEFGHIJKL` → 400). Blanket-omitting would have relocated the bug into the `[?/049]` family #379 was filed for. So `create_package` keeps requiring a real user and now returns a directed error naming the `responsible` parameter — un-gated for on-prem (it was BTP-only).
- The reporter's suggested `cloud` parameter isn't needed: `cloudifyCreateBody` already strips the attribute on the BTP path.

## Behavior change beyond the reported symptom

Drops the `'DEVELOPER'` fallback. It is a demo-system-only literal, it is the same defect class, and there is no on-prem whoami to replace it with — omitting is live-proven better. **Consequence:** with no `SAP_USER` configured (cookie-file / OAuth-service-key auth), on-prem `create_package` now returns an actionable error instead of sending a name that only exists on SAP demo systems. Object creates in that mode start working rather than failing. Happy to split this out if you'd rather keep it separate.

BTP is otherwise unaffected — cloud package create still uses `normalizeCloudResponsible`.

## Live verification

`config.username` set to `firstname.lastname@example.com` (the PP shape) with the session authenticated by cookie, driven through `arc1-cli` so the whole ARC-1 path runs:

| Release | create | activate | owner readback | delete |
|---|---|---|---|---|
| NW 7.50 (`npl`) | ✅ | ✅ | `DEVELOPER` (that system's logon user) | ✅ |
| S/4HANA 2023 / 758 (`a4h`) | ✅ | ✅ | `MARIAN` | ✅ |
| ABAP Platform 2025 / 816 (`a4h-2025`) | ✅ | ✅ | `MARIAN` | ✅ |

`create_package` with the same identity returns the directed error in 2 ms (no SAP round-trip) and succeeds when `responsible="MARIAN"` is passed. All test objects were deleted.

## Review caught a bug the tests could not

Rewriting the templates initially left the **BTP package body** emitting `adtcore:version="active"adtcore:responsible="…"` — glued attributes, malformed XML. The existing assertion was `toContain('adtcore:responsible="CB9980000000"')`, which matches happily either way. Fixed, and `tests/unit/adt/create-xml-wellformed.test.ts` now asserts structurally that no generated create body glues two attributes together, across all 14 builder types × cloud/on-prem × responsible present/omitted.

## Not covered

`DCLS`, `BDEF`, `SRVB`, `DDLX` were not exercised live — each needs a prerequisite object to create at all. Each shares a template family with a tested type, and all eleven tested STs behave identically, so the one-line predicate covers them by construction. Flagged rather than assumed.

## Gates

`npm test` (4702 passed), `typecheck`, `lint`, `validate:policy`, `check:sizes`, `build` — all green. The schema-budget ratchet initially failed on a too-verbose `responsible` description; the description was tightened rather than the budget raised.

Full dossier: [`docs/research/issues/636-onprem-pp-responsible-char12-overflow.md`](docs/research/issues/636-onprem-pp-responsible-char12-overflow.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)