### PR TITLE
fix: never block tools/list on startup feature discovery

### DIFF
--- a/docs/research/pull-requests/589-cline-tools-list-timeout.md
+++ b/docs/research/pull-requests/589-cline-tools-list-timeout.md
@@ -1,0 +1,132 @@
+# `tools/list` blocked on startup discovery — review of PR #589 and the shipped fix
+
+**Reported by:** @DimiDR in https://github.com/arc-mcp/arc-1/pull/589 (cross-repo fork)
+**Reviewed + reimplemented:** 2026-07-29/30 against `origin/main` @ `3811587a`
+
+@DimiDR's diagnosis was correct and their root-cause capture (a raw stdio MITM between Cline and the
+server) is what made this findable. Their patch is not what shipped: it dropped a tool, and it
+predated #579/#606 so it no longer merged. This documents both.
+
+---
+
+## The defect (independently reproduced)
+
+`tools/list` awaited the startup feature probe behind a 10s cap. Clients cancel on their own
+schedule — Cline at ~5s — so against a slow system the client got nothing and showed "Tools (0)".
+
+Reproduced on `main` with a blackholed SAP host:
+
+```
++0.30s ==> tools/list
++10.44s <== tools/list (11 tools)     ← the cap, exactly
+```
+
+---
+
+## Why PR #589's patch was not merged as-is
+
+It answered `tools/list` immediately and emitted `tools/list_changed`. Right shape, two problems.
+
+**1. The immediate answer silently dropped SAPGit.** The PR's comment claimed the unprobed path
+yields the "on-prem-superset tool set". It did not — `SAPGit` was registered *only* when the probe
+had already reported a backend, so the first list was a **subset**. Measured on a4h (758):
+
+| | first `tools/list` | tools | SAPGit |
+|---|---|---|---|
+| `main` | 1.89s | 12 | ✅ |
+| PR #589 | 0.33s | **11** | ❌ |
+
+Recovery depended entirely on `tools/list_changed`, which major clients do not implement
+([Claude Code](https://github.com/anthropics/claude-code/issues/13646),
+[Codex](https://github.com/openai/codex/issues/10105),
+[Gemini CLI](https://github.com/google-gemini/gemini-cli/issues/13850)). For those users the tool
+would simply never appear — trading 1.5s of latency for a permanently missing capability.
+
+An exhaustive surface diff (tool names + every enum value, on-prem and BTP, standard and
+hyperfocused) showed `SAPGit` plus its 17 action/backend enum values were the *only* loss — and that
+hyperfocused mode was already correct, because it had its own copy of the visibility rule that
+handled the unknown case. Standard mode's copy did not. **The bug was two copies of one rule.**
+
+**2. Stale.** Branched before #579 (multi-target) and #606 (server name); `createServer()` had since
+moved to an options object. Real conflict in `server.ts`, and its three tests used the old
+positional signature.
+
+Gates on the PR's own base did pass as claimed: typecheck ✅, lint ✅, 4345 tests ✅.
+
+---
+
+## What shipped instead
+
+Design principle: **the tool surface must be complete without the network.** Discovery may only ever
+*narrow* it. A tool wrongly shown costs one failed call with a typed hint; a tool wrongly hidden is
+unreachable for the whole session.
+
+1. **`tools/list` never awaits the probe** (`src/server/server.ts`) — removes the race against every
+   client's timeout, not just Cline's.
+2. **Unknown features ⇒ superset, by construction.** The duplicated git-visibility rule is now one
+   function, `isGitToolVisible()` in `src/handlers/tool-registry.ts`, used by both standard and
+   hyperfocused mode. Unknown resolves to visible unless the admin set the feature `off`.
+3. **`capabilities.tools.listChanged` + `notifications/tools/list_changed`** on probe completion, so
+   clients that support it converge to the narrowed list. **stdio only** — the HTTP transport builds
+   a fresh `Server` per request (`serveMcpRequest`), so no instance outlives a request to deliver
+   one, and none needs to: by then the probe is cached and every request's first `tools/list` is
+   already narrowed.
+4. **A superset invariant test** — `tests/unit/handlers/tool-surface-superset.test.ts`. This is the
+   guard #589 lacked; it is why the regression was invisible to CI.
+
+`docs_page/architecture.md`'s tool-listing sequence diagram documented the 10s wait and was updated.
+
+### Why not the alternatives
+
+- *Lower the cap to ~2s* (the author's rejected option — agreed): still a race against unknown client
+  timeouts, and it silently loses the adjusted list on any slow system.
+- *Drop probe-dependence entirely and always list everything*: simplest, but throws away real
+  adaptation — hiding `source_code` search where text search 404s saves tokens and a failing call.
+- *Wait only for the 3 probe results the tool list consumes*: the probe already runs all 13 checks in
+  parallel, so latency is the slowest single request, not the count. No meaningful gain.
+
+---
+
+## Verification
+
+**Gates** (`origin/main` + this change): `typecheck` ✅ · `lint` ✅ · `npm test` ✅ **4762 passed /
+164 files** · `build` ✅ · `validate:policy` ✅ 125 entries / 14 schemas · `check:sizes` ✅ within
+budget.
+
+**Guard proves itself:** reverting `isGitToolVisible` to the pre-fix expression fails 6 of the 7
+superset tests with `discovery "all available" adds entries absent before it finished: expected
+[ 'SAPGit', …(18) ] to deeply equal []`. Reverting `server.ts` fails 3 of the 4 new server tests
+(`tools/list blocked`; `expected {} to deeply equal { listChanged: true }`).
+
+**Live, via raw stdio JSON-RPC** (`initialize` then immediate `tools/list`, as Cline does):
+
+| Scenario | first `tools/list` | tools | notification | late re-fetch |
+|---|---|---|---|---|
+| a4h · S/4HANA 2023 · 758 | **0.39s** | 12 (SAPGit ✅) | +1.57s | 12 |
+| **NPL · NetWeaver 7.50** (no git backend) | **0.44s** | 12 (SAPGit ✅) | +1.99s | **11 — SAPGit correctly dropped** |
+| unreachable SAP host | **0.41s** (was 10.44s) | 12 | — | — |
+
+The NPL row is the whole design in one line: superset first, discovery narrows, notification tells
+the client. On-prem HTTP re-checked separately — 200s, 12 tools per request, zero notification
+attempts (the stdio guard holds).
+
+---
+
+## Invariants (AGENTS.md · Security & Architectural Invariants)
+
+No ADT endpoint, scope, package gate, schema, or auth path is touched. Tool *listing* is not an
+authorization boundary: `filterToolsByAuthScope` still runs after the list is built, `SAPGit`'s write
+actions are still gated on `allowWrites && allowGitWrites`, and every action still passes
+`ACTION_POLICY` and `checkOperation` at dispatch. Showing an unsupported tool therefore cannot widen
+what a caller may do — it can only produce a typed error.
+
+stdout stays clean (`logger.debug` → stderr, no `console.log`). Type-only imports added to
+`tool-registry.ts`, so no runtime cycle.
+
+---
+
+## Credit
+
+Root cause, the MITM diagnostic method, and the notification-based approach are @DimiDR's
+(PR #589). The superset fix, the shared visibility rule, the invariant guard, and the rebase are the
+delta.

--- a/docs_page/architecture.md
+++ b/docs_page/architecture.md
@@ -169,14 +169,28 @@ sequenceDiagram
     participant Policy as Scope/deny pruning
 
     Client->>Server: tools/list
-    Server->>Probe: Wait up to 10s for feature probe
-    Probe-->>Server: Features + ADT discovery map
+    Server->>Probe: Read cached features (never waits)
+    Probe-->>Server: Features + ADT discovery map, or nothing yet
     Server->>Tools: Build standard or hyperfocused tool schema
     alt authInfo present
         Server->>Policy: Remove actions/types missing scope or denied by policy
     end
     Server-->>Client: Available tools and input schemas
+    opt stdio, once the startup probe finishes
+        Server-->>Client: notifications/tools/list_changed
+        Client->>Server: tools/list (now feature-adjusted)
+    end
 ```
+
+`tools/list` never blocks on SAP. MCP clients cancel it on their own schedule (Cline at roughly
+5 seconds) and a feature probe against a real system can take longer, which previously left those
+clients with no tools at all. Until the probe lands, the answer is built from configuration alone
+and is a **superset** of the probed surface — a tool may be listed that this system turns out not to
+support, but nothing is ever missing. The server declares `tools.listChanged` and, on stdio, emits
+`notifications/tools/list_changed` when discovery completes so clients can re-fetch the narrowed
+list. Clients that ignore that notification keep the superset, and unsupported calls fail with a
+typed error. On HTTP each request builds its own server, so its first `tools/list` already reflects
+the cached probe.
 
 Tool schemas also adapt to backend and configuration:
 

--- a/src/handlers/hyperfocused.ts
+++ b/src/handlers/hyperfocused.ts
@@ -12,6 +12,7 @@
 import type { ResolvedFeatures } from '../adt/types.js';
 import { getActionPolicy } from '../authz/policy.js';
 import type { ServerConfig } from '../server/types.js';
+import { isGitToolVisible } from './tool-registry.js';
 import type { ToolDefinition } from './tools.js';
 
 /** Map hyperfocused action to the real tool name */
@@ -88,10 +89,7 @@ export function getHyperfocusedToolDefinition(
   config: ServerConfig,
   resolvedFeatures?: ResolvedFeatures,
 ): ToolDefinition {
-  const gitAvailable =
-    resolvedFeatures !== undefined
-      ? !!(resolvedFeatures.gcts?.available || resolvedFeatures.abapGit?.available)
-      : config.featureAbapGit !== 'off' || config.featureGcts !== 'off';
+  const gitAvailable = isGitToolVisible(config, resolvedFeatures);
   // Mixed delegators stay visible when their read sub-actions are usable.
   // Mutating sub-actions are enforced downstream by the concrete tool policy.
   const readActions = [

--- a/src/handlers/tool-registry.ts
+++ b/src/handlers/tool-registry.ts
@@ -28,6 +28,8 @@
  */
 
 import { SDO_TYPES } from '../adt/server-driven.js';
+import type { ResolvedFeatures } from '../adt/types.js';
+import type { ServerConfig } from '../server/types.js';
 
 /**
  * Pull the on-prem (all rows) + BTP (btp:true rows) type arrays out of an `as const` type table.
@@ -165,6 +167,29 @@ const sapContextTypes = deriveTypeArrays(SAPCONTEXT_TYPE_TABLE);
 export const SAPCONTEXT_TYPES_ONPREM = sapContextTypes.onprem;
 /** SAPContext types on BTP. */
 export const SAPCONTEXT_TYPES_BTP = sapContextTypes.btp;
+
+// ─── Tool visibility ────────────────────────────────────────────────
+
+/**
+ * Should SAPGit appear in tools/list?
+ *
+ * Single source for standard AND hyperfocused mode — they had separate copies of this rule and
+ * only hyperfocused handled the unknown case, so standard mode dropped SAPGit entirely whenever
+ * tools/list answered before the startup probe finished.
+ *
+ * Probe not finished (`undefined`) must resolve to VISIBLE: config is the only signal we have, and
+ * a tool wrongly shown costs one failed call with a typed hint, while a tool wrongly hidden is
+ * unreachable for the whole session on clients that ignore tools/list_changed.
+ */
+export function isGitToolVisible(
+  config: Pick<ServerConfig, 'featureAbapGit' | 'featureGcts'>,
+  resolvedFeatures: Pick<ResolvedFeatures, 'gcts' | 'abapGit'> | undefined,
+): boolean {
+  if (resolvedFeatures === undefined) {
+    return config.featureAbapGit !== 'off' || config.featureGcts !== 'off';
+  }
+  return !!(resolvedFeatures.gcts?.available || resolvedFeatures.abapGit?.available);
+}
 
 // ─── Derived union types ────────────────────────────────────────────
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -25,6 +25,7 @@ import { getHyperfocusedToolDefinition } from './hyperfocused.js';
 import { CLASS_WRITE_INCLUDES } from './object-types.js';
 import { SAPWRITE_DESC_BTP, SAPWRITE_DESC_ONPREM, SAPWRITE_MINIMAL_PAYLOAD_GUIDE } from './tool-descriptions.js';
 import {
+  isGitToolVisible,
   SAPCONTEXT_TYPES_BTP,
   SAPCONTEXT_TYPES_ONPREM,
   SAPREAD_TYPES_BTP,
@@ -1619,8 +1620,9 @@ export function getToolDefinitions(
     });
   }
 
-  // SAPGit — registered only when gCTS or abapGit backend is available
-  if (resolvedFeatures?.gcts?.available || resolvedFeatures?.abapGit?.available) {
+  // SAPGit — registered when a gCTS/abapGit backend is available, or not yet probed (see
+  // isGitToolVisible: unknown must stay visible or the tool is lost for the whole session).
+  if (isGitToolVisible(config, resolvedFeatures)) {
     const sapGitActions =
       config.allowWrites && config.allowGitWrites
         ? [...SAPGIT_ACTIONS_READ, ...SAPGIT_ACTIONS_WRITE]

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -676,7 +676,7 @@ export function createServer(config: ServerConfig, options: CreateServerOptions 
   const server = new Server(
     { name: config.serverName, version: VERSION },
     {
-      capabilities: { tools: {} },
+      capabilities: { tools: { listChanged: true } },
       instructions: multiTarget ? buildMultiTargetServerInstructions(multiTarget) : SERVER_INSTRUCTIONS,
     },
   );
@@ -701,12 +701,11 @@ export function createServer(config: ServerConfig, options: CreateServerOptions 
 
   // Register tool listing — filtered by user's scopes when auth is active
   server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
-    // Wait for the startup probe (if provided), but with a timeout so a slow/unreachable
-    // SAP system doesn't stall the MCP connection setup. If the probe doesn't finish in
-    // time, fall back to the default tool set (textSearch unknown = show source_code).
-    if (startupProbePromise && !multiTarget) {
-      await Promise.race([startupProbePromise, new Promise((resolve) => setTimeout(resolve, 10_000))]);
-    }
+    // Never wait for the startup probe here. tools/list is protocol handshake, not SAP work:
+    // clients cancel it on their own schedule (Cline at ~5s) and a probe against a real system
+    // can outlast that, which used to leave the client with zero tools. Answer from whatever is
+    // cached now — unknown features yield a SUPERSET of the probed surface, never a subset, so
+    // nothing is ever missing — and let tools/list_changed deliver the narrowed list below.
     const featureKey = config.targetId ?? config.destinationName;
     // Multi-target schemas are immutable process contracts. User-backed feature probes may
     // improve runtime errors, but must never rewrite another user's tools/list response.
@@ -1013,6 +1012,22 @@ export function createServer(config: ServerConfig, options: CreateServerOptions 
 
     return dispatchWithClient(client, isPerUserClient);
   });
+
+  // Discovery finished after we already answered tools/list with the unprobed superset — tell the
+  // client so it can re-fetch and drop what this system does not actually have. stdio only: the
+  // HTTP transport builds a fresh Server per request (see serveMcpRequest), so no instance outlives
+  // a request to deliver this, and none needs to — by then the probe is cached and the first
+  // tools/list of every request is already the narrowed list.
+  if (startupProbePromise && !multiTarget && config.transport === 'stdio') {
+    startupProbePromise
+      .then(() => server.sendToolListChanged())
+      .catch((err) => {
+        // Best-effort: a client that never connected (or disconnected) must not crash startup.
+        logger.debug('Skipped tools/list_changed notification after startup probe', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  }
 
   return server;
 }

--- a/tests/unit/handlers/tool-surface-superset.test.ts
+++ b/tests/unit/handlers/tool-surface-superset.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Invariant: the UNPROBED tool surface is a superset of every probed one.
+ *
+ * tools/list answers immediately, before startup feature discovery finishes (clients cancel it on
+ * their own schedule — Cline at ~5s — and a probe against a real SAP system can outlast that). So
+ * the surface built with `resolvedFeatures === undefined` is what every stdio client sees FIRST,
+ * and on clients that ignore tools/list_changed it is all they ever see.
+ *
+ * Therefore discovery may only ever NARROW the surface. If it can also add, the unprobed answer is
+ * missing something and that capability is unreachable for the whole session — which is exactly how
+ * SAPGit went missing: the visibility rule existed twice and only the hyperfocused copy handled
+ * `undefined`. Both now share isGitToolVisible().
+ */
+import { describe, expect, it } from 'vitest';
+import { getToolDefinitions } from '../../../src/handlers/tools.js';
+import { btp, FULL, features, onprem } from './handler-test-config.js';
+
+/** Tool names plus every enum value, so a shrunken action list fails too — not just a dropped tool. */
+function surface(tools: ReturnType<typeof getToolDefinitions>): Set<string> {
+  const out = new Set<string>();
+  for (const tool of tools) {
+    out.add(tool.name);
+    const props = (tool.inputSchema as { properties?: Record<string, { enum?: string[] }> }).properties ?? {};
+    for (const [prop, schema] of Object.entries(props)) {
+      for (const value of schema.enum ?? []) out.add(`${tool.name}.${prop}=${value}`);
+    }
+  }
+  return out;
+}
+
+const CONFIGS = [
+  ['onprem', onprem(FULL)],
+  ['btp', btp(FULL)],
+  ['onprem-readonly', onprem()],
+  ['onprem-hyperfocused', onprem({ ...FULL, toolMode: 'hyperfocused' })],
+  ['btp-hyperfocused', btp({ ...FULL, toolMode: 'hyperfocused' })],
+] as const;
+
+// Every way discovery can come back, including the ones that used to ADD a tool.
+const PROBED = [
+  ['all available', true, features()],
+  ['text search off', false, features()],
+  ['git off', true, features({ gcts: false, abapGit: false })],
+  ['nothing available', false, features({}, false)],
+] as const;
+
+describe('unprobed tool surface is a superset', () => {
+  it.each(CONFIGS)('%s', (_label, config) => {
+    const unprobed = surface(getToolDefinitions(config, undefined, undefined));
+    for (const [probeLabel, textSearch, resolved] of PROBED) {
+      const missing = [...surface(getToolDefinitions(config, textSearch, resolved))].filter((e) => !unprobed.has(e));
+      expect(missing, `discovery "${probeLabel}" adds entries absent before it finished`).toEqual([]);
+    }
+  });
+
+  // Stronger than the superset check, and it ties the pre-discovery surface to an existing frozen
+  // snapshot: the unprobed answer IS the everything-available surface, already byte-pinned by
+  // tests/fixtures/tool-definitions/{onprem,btp}-full-textsearch-on.json. So no separate fixture is
+  // needed for what stdio clients see first — those two already are it.
+  it.each(CONFIGS)('%s unprobed surface equals the all-available surface', (_label, config) => {
+    expect(getToolDefinitions(config, undefined, undefined)).toEqual(getToolDefinitions(config, true, features()));
+  });
+
+  it('keeps SAPGit visible before discovery, and hides it only once probed unavailable', () => {
+    const config = onprem(FULL);
+    const names = (textSearch?: boolean, resolved?: ReturnType<typeof features>) =>
+      getToolDefinitions(config, textSearch, resolved).map((t) => t.name);
+
+    expect(names(undefined, undefined)).toContain('SAPGit');
+    expect(names(true, features())).toContain('SAPGit');
+    expect(names(true, features({ gcts: false, abapGit: false }))).not.toContain('SAPGit');
+  });
+
+  it('honours an explicit git opt-out even before discovery', () => {
+    const config = onprem({ ...FULL, featureAbapGit: 'off', featureGcts: 'off' });
+    expect(getToolDefinitions(config, undefined, undefined).map((t) => t.name)).not.toContain('SAPGit');
+  });
+});

--- a/tests/unit/server/server.test.ts
+++ b/tests/unit/server/server.test.ts
@@ -6,7 +6,11 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ToolListChangedNotificationSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { AdtApiError } from '../../../src/adt/errors.js';
@@ -71,6 +75,86 @@ describe('MCP Server', () => {
 
   it('has a valid version string', () => {
     expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  // tools/list must never wait on SAP. Clients cancel it on their own schedule (Cline at ~5s) and
+  // a probe against a real system can outlast that, which left the client with zero tools.
+  it('answers tools/list without waiting for the startup probe', async () => {
+    const neverResolves = new Promise<void>(() => {});
+    const server = createServer(DEFAULT_CONFIG, { startupProbePromise: neverResolves });
+    const handler = requestHandler(server, ListToolsRequestSchema.shape.method.value);
+
+    const result = await Promise.race([
+      handler({ method: 'tools/list', params: {} }, {}),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('tools/list blocked')), 250)),
+    ]);
+
+    // Unprobed answer is the superset — SAPGit included, not dropped while discovery is pending.
+    // tests/unit/handlers/tool-surface-superset.test.ts holds the general invariant.
+    expect((result.tools as { name: string }[]).map((t) => t.name)).toContain('SAPGit');
+  });
+
+  it('advertises listChanged and notifies the client once the startup probe resolves', async () => {
+    let resolveProbe: () => void = () => {};
+    const startupProbePromise = new Promise<void>((resolve) => {
+      resolveProbe = resolve;
+    });
+    const server = createServer(DEFAULT_CONFIG, { startupProbePromise });
+    const client = new Client({ name: 'arc1-listchanged-test', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    let notified = 0;
+
+    try {
+      client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+        notified += 1;
+      });
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      expect(client.getServerCapabilities()?.tools).toEqual({ listChanged: true });
+      expect(notified).toBe(0);
+
+      resolveProbe();
+      await vi.waitFor(() => expect(notified).toBe(1));
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('does not wire the notification on HTTP, where each request builds its own server', async () => {
+    let resolveProbe: () => void = () => {};
+    const startupProbePromise = new Promise<void>((resolve) => {
+      resolveProbe = resolve;
+    });
+    const server = createServer({ ...DEFAULT_CONFIG, transport: 'http-streamable' }, { startupProbePromise });
+    const sendSpy = vi.spyOn(server, 'sendToolListChanged');
+
+    resolveProbe();
+    await startupProbePromise;
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    sendSpy.mockRestore();
+  });
+
+  it('survives a probe that resolves before any client connected', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+
+    // Never connected: the SDK's sendToolListChanged() rejects, and that must stay non-fatal.
+    createServer(DEFAULT_CONFIG, { startupProbePromise: Promise.resolve() });
+
+    await vi.waitFor(() =>
+      expect(debugSpy).toHaveBeenCalledWith(
+        'Skipped tools/list_changed notification after startup probe',
+        expect.objectContaining({ error: expect.any(String) }),
+      ),
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 
   it('resolves schema nullable optionals off by default in auto mode', () => {


### PR DESCRIPTION
Supersedes #589. Root cause, the stdio MITM diagnostic method, and the notification approach are @DimiDR's — thank you. This adds the superset fix that PR was missing, unifies the duplicated rule behind it, guards the invariant, and rebases onto current `main`.

## The defect

`tools/list` awaited the startup feature probe behind a 10s cap. MCP clients cancel on their own schedule (Cline at ~5s), so against a slow SAP system the request was cancelled every time and the client showed "Tools (0)".

Reproduced on `main` against an unreachable host — `tools/list` answered at **10.44s**, exactly the cap.

## Why not just answer immediately

Because the unprobed answer was a **subset**, not a superset. `SAPGit` was registered only once the probe had reported a backend, so answering early dropped it — and all 17 of its action/backend enum values.

The reason is that the visibility rule existed **in two copies**: standard mode and hyperfocused. Only the hyperfocused copy handled "not probed yet". That is the actual bug, and it is why CI never noticed: every tool-definition fixture passes concrete features, so nothing exercised the `undefined` path.

Recovering via `tools/list_changed` alone is not enough — [Claude Code](https://github.com/anthropics/claude-code/issues/13646), [Codex](https://github.com/openai/codex/issues/10105) and [Gemini CLI](https://github.com/google-gemini/gemini-cli/issues/13850) don't implement it, so for those users the tool would never appear at all.

## What this does

The tool surface must be complete **without the network**; discovery may only ever *narrow* it. A tool wrongly shown costs one failed call with a typed hint — a tool wrongly hidden is unreachable for the whole session.

- `tools/list` never awaits the probe, so the race is gone for *every* client, not just Cline.
- Unknown features ⇒ superset by construction. The two copies of the git rule collapse into `isGitToolVisible()` in `tool-registry.ts`; unknown resolves to visible unless the admin set the feature `off`.
- `capabilities.tools.listChanged` + `notifications/tools/list_changed` on probe completion, so clients that support it converge to the narrowed list. **stdio only** — the HTTP transport builds a fresh `Server` per request, so no instance outlives a request to deliver one, and none needs to.
- `tests/unit/handlers/tool-surface-superset.test.ts` holds the invariant permanently.

Rejected alternatives (incl. lowering the cap to ~2s, and probing only the 3 results the tool list consumes) are recorded in the dossier.

## Verification

Gates: `typecheck` ✅ · `lint` ✅ · `npm test` ✅ **4762 passed / 164 files** · `build` ✅ · `validate:policy` ✅ · `check:sizes` ✅

The guards fail on the pre-fix code, as they should — reverting `isGitToolVisible` fails 6 of 7 superset tests; reverting `server.ts` fails 3 of 4 new server tests.

Live, over raw stdio JSON-RPC (`initialize` then immediate `tools/list`, as Cline does):

| Scenario | first `tools/list` | tools | notification | late re-fetch |
|---|---|---|---|---|
| a4h · S/4HANA 2023 · 758 | **0.39s** | 12 (SAPGit ✅) | +1.57s | 12 |
| **NPL · NetWeaver 7.50** (no git backend) | **0.44s** | 12 (SAPGit ✅) | +1.99s | **11 — SAPGit correctly dropped** |
| unreachable host | **0.41s** (was 10.44s) | 12 | — | — |

The NPL row is the design in one line: superset first, discovery narrows, notification tells the client. HTTP re-checked separately — 200s, 12 tools per request, zero notification attempts.

## Invariants

No ADT endpoint, scope, package gate, schema, or auth path touched. Tool listing is not an authorization boundary: `filterToolsByAuthScope` still runs after the list is built, SAPGit's write actions are still gated on `allowWrites && allowGitWrites`, and every action still passes `ACTION_POLICY` + `checkOperation` at dispatch — so listing an unsupported tool cannot widen what a caller may do.

`docs_page/architecture.md` documented the 10s wait and is updated. Full write-up: `docs/research/pull-requests/589-cline-tools-list-timeout.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)