### PR TITLE
fix: route server-driven types in batch SAPActivate instead of the program path

### DIFF
--- a/scripts/ci/check-file-sizes.mjs
+++ b/scripts/ci/check-file-sizes.mjs
@@ -48,6 +48,10 @@ const BUDGETS = {
   // the default. Keep tight headroom.
   // + getFunctionModuleProperties and the getFunctionGroup pre-7.52 objectstructure fallback.
   'src/adt/client.ts': 1730,
+  // +regression coverage for batch SAPActivate routing server-driven types via the registry href
+  // (the objectBasePath default arm silently built a program URL). Small, deliberate bump over the
+  // 3000 test default; split the SAPWrite create/batch suites if it needs raising again.
+  'tests/unit/handlers/write-create-batch.test.ts': 3050,
 };
 
 const DEFAULT_SRC = 1500;

--- a/src/handlers/activate.ts
+++ b/src/handlers/activate.ts
@@ -225,6 +225,20 @@ export async function handleSAPActivate(
 
   if (args.objects && Array.isArray(args.objects)) {
     const rawObjects = args.objects as Array<Record<string, unknown>>;
+    // Server-driven types need the registry href — objectBasePath(<sdo>) has no case and its
+    // default arm maps unknown non-slash types to the PROGRAM path, so an ungated batch entry
+    // silently activated /sap/bc/adt/programs/programs/<name>. Gate once per DISTINCT type
+    // (the resolver below runs per object, and the gate may fetch discovery).
+    const batchSdoTypes = [
+      ...new Set(
+        rawObjects.map((o) => normalizeObjectType(String(o.type ?? type))).filter((t) => isServerDrivenObjectType(t)),
+      ),
+    ];
+    for (const sdoType of batchSdoTypes) {
+      if (!(await ensureServerDrivenSupport(client.http, client.safety, sdoType))) {
+        return errorResult(serverDrivenUnavailableMessage('SAPActivate', sdoType));
+      }
+    }
     // Resolve URLs sequentially. For TABL we await the URL resolver so DDIC
     // structures (which live at /sap/bc/adt/ddic/structures/) are addressed
     // correctly; the resolver short-circuits on its in-memory cache.
@@ -262,6 +276,9 @@ export async function handleSAPActivate(
           const group = String(o.group ?? args.group).trim();
           const groupLc = encodeURIComponent(group.toLowerCase());
           url = `/sap/bc/adt/functions/groups/${groupLc}/includes/${encodeURIComponent(objName.toLowerCase())}`;
+        } else if (isServerDrivenObjectType(objType)) {
+          // Availability already gated per distinct type above.
+          url = serverDrivenObjectUrl(objType, objName);
         } else {
           url = objectUrlForType(objType, objName);
         }
@@ -350,9 +367,10 @@ export async function handleSAPActivate(
     const groupLc = encodeURIComponent(String(args.group).trim().toLowerCase());
     objectUrl = `/sap/bc/adt/functions/groups/${groupLc}/includes/${encodeURIComponent(name.toLowerCase())}`;
   } else if (isServerDrivenObjectType(type)) {
-    // Server-driven objects (8.16+): objectBasePath(<sdo>) throws, so route via the registry href.
-    // Single-object activation only — SDO is not added to the batch resolver above (batch is
-    // RAP-stack-oriented). The generic activate() endpoint handles SDO (verified: activate(DESD) → ok).
+    // Server-driven objects: objectBasePath(<sdo>) has no case and its default arm would route to
+    // the program path, so use the registry href. The batch resolver above does the same (EVTB/EVTO
+    // are RAP objects, so they legitimately appear in a RAP-stack batch).
+    // The generic activate() endpoint handles SDO (verified: activate(DESD) → ok).
     // Gated like the SAPRead/SAPWrite branches so unsupported releases get the release message.
     if (!(await ensureServerDrivenSupport(client.http, client.safety, type))) {
       return errorResult(serverDrivenUnavailableMessage('SAPActivate', type));

--- a/tests/unit/handlers/write-create-batch.test.ts
+++ b/tests/unit/handlers/write-create-batch.test.ts
@@ -228,6 +228,42 @@ describe('SAPWrite handler — create / batch_create', () => {
       expect(result.content[0]?.text).toContain('does not advertise ADT support');
       expect(callMatching('POST', '/sap/bc/adt/activation')).toBeUndefined();
     });
+
+    it('batch SAPActivate routes a server-driven type through the registry URL, never the program path', async () => {
+      await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPActivate', {
+        action: 'activate',
+        objects: [{ type: 'DESD', name: 'ZARC1_SDO' }],
+      });
+      const activation = callMatching('POST', '/sap/bc/adt/activation');
+      expect(activation).toBeDefined();
+      // The bug: objectBasePath's default arm maps unknown non-slash types to the program path,
+      // so a batch entry silently activated /sap/bc/adt/programs/programs/ZARC1_SDO.
+      expect(activation?.[1].body).not.toContain('/sap/bc/adt/programs/programs/');
+      expect(activation?.[1].body).toContain('/sap/bc/adt/ddic/desd/ZARC1_SDO');
+    });
+
+    it('batch SAPActivate gates a server-driven type on discovery like the single-object path', async () => {
+      const client = createClient();
+      (client.http as unknown as { hasDiscoveryData(): boolean }).hasDiscoveryData = () => true;
+      (client.http as unknown as { discoveryAcceptFor(p: string): string | undefined }).discoveryAcceptFor = () =>
+        undefined;
+      const result = await handleToolCall(client, DEFAULT_CONFIG, 'SAPActivate', {
+        action: 'activate',
+        objects: [{ type: 'DESD', name: 'ZARC1_SDO' }],
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('does not advertise ADT support');
+      expect(callMatching('POST', '/sap/bc/adt/activation')).toBeUndefined();
+    });
+
+    it('batch SAPActivate still routes non-SDO types normally', async () => {
+      await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPActivate', {
+        action: 'activate',
+        objects: [{ type: 'PROG', name: 'ZARC1_PROG' }],
+      });
+      const activation = callMatching('POST', '/sap/bc/adt/activation');
+      expect(activation?.[1].body).toContain('/sap/bc/adt/programs/programs/ZARC1_PROG');
+    });
   });
 
   describe('SAPWrite package enforcement', () => {


### PR DESCRIPTION
> **Stacked on #642** — base is `feat/ladi-uiad-read-sdo-gate-v2` because this uses `ensureServerDrivenSupport`, which that PR introduces. Rebase onto `main` once #642 merges.

## The bug

Single-object `SAPActivate` routes server-driven objects (SDO) via the registry href. The batch `objects` resolver had no such branch, so SDO types fell through to `objectUrlForType` → `objectBasePath`.

SDO codes aren't in `KNOWN_BASE_TYPES` and carry no slash, so **neither guard fired** — not the exhaustiveness guard, not the slash-form guard. The call landed on the default arm, which maps unknown non-slash types to the **program path**.

Confirmed live on a4h-2025 (816), by reverting the fix and re-running:

| | `SAPActivate objects=[{type: EVTB, name: S_BUSINESSPARTNER_CHANGE}]` |
|---|---|
| **Before** | `404 at /sap/bc/adt/programs/programs/S_BUSINESSPARTNER_CHANGE` |
| **After** | `Successfully activated 1 objects: S_BUSINESSPARTNER_CHANGE.` |

Affects all registered SDO types: `DESD`, `DTSC`, `CSNM`, `EVTB`, `EVTO`, `COTA`, `DSFD`, `DTDC`, `UIAD`.

## The fix — route, don't reject

The stale comment claimed SDO was *deliberately* left out because batch is "RAP-stack-oriented". But `EVTB` and `EVTO` are RAP **event** objects — they belong in exactly those batches. So routing is the fix that matches the path's own rationale, and it keeps batch consistent with the single-object branch. Comment updated.

Availability is gated **once per distinct type**, before the per-object resolver runs — `ensureServerDrivenSupport` may fetch discovery, and gating inside the resolver would repeat that fetch for every object in the batch.

## Verification

Three unit tests were written **first and observed failing** (the routing test asserted the program URL was present in the activation body):

- batch routes an SDO type through the registry href, never the program path
- batch gates an SDO type on discovery like the single-object path
- batch still routes non-SDO types normally (control — guards against over-broad matching)

Live:

| Case | Result |
|---|---|
| 816 — batch `[EVTB]` | activates ✅ |
| 816 — mixed batch `[EVTB, DESD]` | both activate ✅ |
| 758 — batch `[DESD]` / `[UIAD]` | release message, no program URL ✅ |
| 758 — batch `[EVTB]` (ships on 758) | still activates ✅ |

Gates: 4774 unit tests, typecheck, lint, `validate:policy`, build, size budgets — all green.

## Note

`tests/unit/handlers/write-create-batch.test.ts` went 17 lines over the 3000-line test default, so its budget is raised to 3050 with an in-place comment. Splitting a 3000-line suite felt disproportionate to a three-test regression addition — happy to split instead if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)