### PR TITLE
fix: propagate corrNr to the class-include init POST (#645)

### DIFF
--- a/docs/plans/completed/2026-07-31-fix-class-include-init-corrnr.md
+++ b/docs/plans/completed/2026-07-31-fix-class-include-init-corrnr.md
@@ -1,5 +1,19 @@
 # Fix: propagate `corrNr` to the class-include init POST (issue #645)
 
+> **Completed 2026-07-31.** Execution notes / deviations:
+> - `npm run build` failed as anticipated on the pre-existing `@arc-mcp/xsuaa-auth` type drift, and
+>   the worktree's `node_modules` additionally could not *load* `dist/server/destination-discovery.js`
+>   (missing `DestinationServiceRequestError` export). Worked around by compiling with bare `tsc`
+>   (which emits despite type errors) and running the CLI from a throwaway copy of the main
+>   checkout's working `dist/` with only `adt/crud.js` swapped in. Removed afterwards.
+> - The "read the include back with `SAPRead version=inactive`" step was covered by the stronger
+>   `SAPActivate` check: the class carries a `FOR TESTING` method in the include, so a successful
+>   activation proves the include content landed and compiled.
+> - Pre-existing red on this branch, unrelated to this change and unchanged by it: 2 unit failures
+>   (`tests/unit/lint/config-builder.test.ts`, `tests/unit/lint/lint-enhanced.test.ts` — both
+>   "Cloud version for BTP"), 18 `typecheck` errors in `src/server/*`, and 3 biome format errors in
+>   `tests/unit/handlers/`. All confirmed present on a clean tree with this change stashed.
+
 ## Overview
 
 `SAPWrite(action="update", type="CLAS", include="testclasses", …)` fails with HTTP 500
@@ -153,7 +167,7 @@ user <USER>` instead of reusing the covering `R3TR CLAS` lock. Live-verified on 
 `corrNr` returns 201 on all three. Mirror `deleteObject()` in the same file — it already builds
 exactly this URL shape.
 
-- [ ] In `src/adt/crud.ts`, add a trailing optional `transport?: string` parameter to
+- [x] In `src/adt/crud.ts`, add a trailing optional `transport?: string` parameter to
       `initClassInclude()` and append the request when set. Keep the existing
       `checkOperation(safety, OperationType.Create, 'InitClassInclude')` guard as the first
       statement. Target shape (mirrors `deleteObject`):
@@ -164,33 +178,33 @@ exactly this URL shape.
       }
       await http.post(url, '', undefined);
 
-- [ ] In `safeUpdateClassInclude()` in the same file, pass the already-computed
+- [x] In `safeUpdateClassInclude()` in the same file, pass the already-computed
       `effectiveTransport` (i.e. `transport ?? (lock.corrNr || undefined)`) as the new fifth
       argument to `initClassInclude`. Do not recompute it and do not reorder the
       probe → init → PUT sequence.
-- [ ] Update the doc comment above `initClassInclude`. It currently says the empty-POST mechanism is
+- [x] Update the doc comment above `initClassInclude`. It currently says the empty-POST mechanism is
       "Live-verified (a4h S/4HANA 2023)" without qualification — that verification was done in
       `$TMP`. State that a transportable package additionally requires `corrNr`, or SAP 500s with
       "already locked in request" (issue #645).
-- [ ] In `tests/unit/adt/crud.test.ts`, give `mockHttpWithSession()` an optional `corrNr` in its
+- [x] In `tests/unit/adt/crud.test.ts`, give `mockHttpWithSession()` an optional `corrNr` in its
       `opts` (default `''`) and build the lock body from it, so the helper can emulate a class
       recorded in a request. Keep `LOCK_BODY` and the existing default behavior intact so the four
       existing tests in this `describe` block are unaffected.
-- [ ] Add unit tests (~3) to `describe('safeUpdateClassInclude — auto-init missing class includes')`:
+- [x] Add unit tests (~3) to `describe('safeUpdateClassInclude — auto-init missing class includes')`:
       (a) include missing + explicit `transport` argument → the init POST URL contains
       `corrNr=<that transport>`; (b) include missing + no `transport` argument but lock returns
       `corrNr: 'NPLK900085'` → the init POST URL contains `corrNr=NPLK900085`; (c) **negative /
       regression guard** — include missing, no `transport`, lock `CORRNR` empty (`$TMP`) → the init
       POST URL is exactly `` `${INCLUDE_URL}?lockHandle=SESS_HANDLE` `` with **no** `corrNr`
       substring.
-- [ ] Update the existing `it('initClassInclude POSTs an empty body to the include URL with the
+- [x] Update the existing `it('initClassInclude POSTs an empty body to the include URL with the
       lock handle')` test: it asserts the full URL with `toBe()`, so keep that as the no-transport
       case and add a with-transport assertion
       (`` `${INCLUDE_URL}?lockHandle=LH99&corrNr=NPLK900085` ``).
-- [ ] Verify the `initClassInclude is gated by allowWrites` test still passes — the safety check
+- [x] Verify the `initClassInclude is gated by allowWrites` test still passes — the safety check
       must remain the first statement, before any URL building.
-- [ ] Run `npm test` — all tests must pass.
-- [ ] Run `npm run typecheck` and `npm run lint` — no errors. (`npm run build` may fail with the
+- [x] Run `npm test` — all tests must pass.
+- [x] Run `npm run typecheck` and `npm run lint` — no errors. (`npm run build` may fail with the
       pre-existing `multi-target-destination-runtime.ts` / `server.ts` errors described in
       Development Approach; that is not caused by this task.)
 
@@ -213,11 +227,11 @@ Credentials and hosts are in `INFRASTRUCTURE.md`. **Requires live SAP access —
 unreachable, follow the INFRASTRUCTURE.md runbook (Docker stop/start, Cloud Connector) before
 concluding failure.**
 
-- [ ] Build the CLI (`npm run build`). If it fails **only** with the pre-existing
+- [x] Build the CLI (`npm run build`). If it fails **only** with the pre-existing
       `src/server/multi-target-destination-runtime.ts` / `src/server/server.ts` type errors noted in
       Development Approach, use the main checkout's prebuilt `dist/` at
       `/Users/marianzeis/DEV/arc-1/dist/cli.js` instead and say so in the notes.
-- [ ] On **npl (7.50)**, client `001`, user `DEVELOPER`: pick a transportable Z package (e.g.
+- [x] On **npl (7.50)**, client `001`, user `DEVELOPER`: pick a transportable Z package (e.g.
       `ZDEMO_BOPF` — confirmed transportable) and create a workbench request for it (ADT:
       `POST /sap/bc/adt/cts/transports` with a `CreateCorrectionRequest` body naming that package,
       or `SAPTransport action=create` with `SAP_ALLOW_TRANSPORT_WRITES=true`). Then run the
@@ -231,33 +245,33 @@ concluding failure.**
 
       Step 2 must now succeed. Confirm in the `[http_request]` log line that the POST URL carries
       **both** `lockHandle` and `corrNr`.
-- [ ] Repeat step 2 with the `transport` field **omitted** — it must still succeed, because
+- [x] Repeat step 2 with the `transport` field **omitted** — it must still succeed, because
       `effectiveTransport` falls back to the lock's `CORRNR`. This is the reporter's step 3.
-- [ ] Read the include back (`SAPRead` with `version="inactive"`) and confirm the ABAP source landed.
-- [ ] **Activate** the class (`SAPActivate`) — activation is the definitive correctness check for a
+- [x] Read the include back (`SAPRead` with `version="inactive"`) and confirm the ABAP source landed.
+- [x] **Activate** the class (`SAPActivate`) — activation is the definitive correctness check for a
       write feature, and it proves the include was recorded in the request properly.
-- [ ] Regression check on the same system: repeat the whole flow with a **`$TMP`** class and no
+- [x] Regression check on the same system: repeat the whole flow with a **`$TMP`** class and no
       transport. It must still succeed, and the init POST URL must carry `lockHandle` only.
-- [ ] Repeat the transportable-package flow on **a4h-2025 (816)**, client `001`, user `MARIAN`.
+- [x] Repeat the transportable-package flow on **a4h-2025 (816)**, client `001`, user `MARIAN`.
       Note: `ZCUSTOM_DEVELOPMENT` and `ZCLASSIC_DEVELOPMENT` are **structure packages** there and
       reject object creation with 403 "Structure packages cannot contain development objects" — use
       `Z_BADI_CHECK` or another leaf package.
-- [ ] Delete every class created during this task (lock → DELETE with `lockHandle`+`corrNr`) so the
+- [x] Delete every class created during this task (lock → DELETE with `lockHandle`+`corrNr`) so the
       systems are left clean. Do not commit any throwaway scripts.
-- [ ] Record the observed results (system, release, HTTP status per step) in the plan notes or the
+- [x] Record the observed results (system, release, HTTP status per step) in the plan notes or the
       PR body.
 
 ### Task 3: Final verification
 
-- [ ] Run full test suite: `npm test` — all tests pass
-- [ ] Run typecheck: `npm run typecheck` — no errors
-- [ ] Run lint: `npm run lint` — no errors
-- [ ] `grep -rn "initClassInclude" src/ tests/` — every call site passes a transport argument or is
+- [x] Run full test suite: `npm test` — all tests pass
+- [x] Run typecheck: `npm run typecheck` — no errors
+- [x] Run lint: `npm run lint` — no errors
+- [x] `grep -rn "initClassInclude" src/ tests/` — every call site passes a transport argument or is
       a deliberate no-transport test case; no caller left on the old 4-argument signature
-- [ ] Confirm no tool-definition fixture changed:
+- [x] Confirm no tool-definition fixture changed:
       `git status tests/fixtures/tool-definitions/` is clean (this change must not touch the
       LLM-visible surface)
-- [ ] Update `docs/research/issues/645-class-include-create-missing-corrnr.md`: flip Status to
+- [x] Update `docs/research/issues/645-class-include-create-missing-corrnr.md`: flip Status to
       "Fixed" and add the PR link
-- [ ] Move this plan to `docs/plans/completed/`, then fix any relative links inside it (completed
+- [x] Move this plan to `docs/plans/completed/`, then fix any relative links inside it (completed
       plans sit one directory deeper — `../` paths gain a level)

--- a/docs/plans/fix-class-include-init-corrnr.md
+++ b/docs/plans/fix-class-include-init-corrnr.md
@@ -1,0 +1,263 @@
+# Fix: propagate `corrNr` to the class-include init POST (issue #645)
+
+## Overview
+
+`SAPWrite(action="update", type="CLAS", include="testclasses", …)` fails with HTTP 500
+`Object LIMU CINC <CLASS>==========CCAU is already locked in request <REQ> of user <USER>` whenever
+the class lives in a **transportable package** and is already recorded in a CTS request. Creating
+the test include creates a new `LIMU CINC …CCAU` TADIR sub-object, which CTS must record in a
+request; ARC-1's init POST sends only `lockHandle`, so CTS has no target request and reports the
+sub-object as already locked by the covering `R3TR CLAS` entry instead of reusing it.
+
+The fix is one line at one call site: `initClassInclude` must append `&corrNr=<transport>` the way
+`createObject` / `updateSource` / `updateObject` / `deleteObject` already do. The enclosing
+`safeUpdateClassInclude` **already** resolves `effectiveTransport = transport ?? lock.corrNr` and
+passes it to the follow-up source PUT — the init POST between them is the only place that drops it.
+
+This is deliberately a 3-task plan rather than the usual 5–12. The source change is a single
+parameter; padding it into more tasks would add ceremony, not safety. The risk here is not
+implementation complexity, it is *SAP truth*, and that has been retired up front by live
+verification on all three releases (see Verified Live Evidence).
+
+- Success: `include="testclasses"` succeeds on a class in a transportable package, on 7.50/758/816.
+- Success: `$TMP` behavior is byte-identical to today (lock returns empty `CORRNR` → no `corrNr`).
+- Non-goal: no tool-schema change, no new config, no error-hint rework (see Development Approach).
+
+## Context
+
+### Current State
+
+- `initClassInclude()` in `src/adt/crud.ts` builds
+  `` `${includeUrl}?lockHandle=${encodeURIComponent(lockHandle)}` `` and takes no transport
+  parameter at all.
+- `safeUpdateClassInclude()` in the same file computes
+  `const effectiveTransport = transport ?? (lock.corrNr || undefined);`, calls
+  `initClassInclude(session, safety, includeUrl, lock.lockHandle)` **without** it, then calls
+  `updateSource(…, effectiveTransport)` **with** it.
+- All three call sites already thread `transport` into `safeUpdateClassInclude`:
+  `src/handlers/write/update-delete.ts` (the `args.include !== undefined` branch),
+  `src/handlers/write/class-surgery.ts` (the `resolvedInclude` branch and the `include` ternary).
+- `initClassInclude` is the only lock-scoped write in the codebase that omits `corrNr`.
+- Existing unit coverage lives in `describe('safeUpdateClassInclude — auto-init missing class
+  includes')` in `tests/unit/adt/crud.test.ts`. Its `mockHttpWithSession()` helper returns a
+  `LOCK_BODY` const with an **empty** `<CORRNR></CORRNR>` — i.e. every existing test exercises only
+  the `$TMP`-shaped path, which is exactly why this shipped.
+
+### Target State
+
+- `initClassInclude(http, safety, includeUrl, lockHandle, transport?)` appends
+  `&corrNr=<encoded>` when `transport` is set, and is otherwise unchanged.
+- `safeUpdateClassInclude` passes `effectiveTransport` to it.
+- Unit tests cover: transport passed explicitly, transport derived from the lock's `CORRNR`, and no
+  transport (`$TMP`) → URL unchanged.
+- Live-verified on 7.50 and 816 (oldest + newest) with a real transportable package and request.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `src/adt/crud.ts` | `initClassInclude` (the defect) and `safeUpdateClassInclude` (the caller that already has the value) |
+| `tests/unit/adt/crud.test.ts` | `describe('safeUpdateClassInclude — auto-init missing class includes')` + the `mockHttpWithSession` / `LOCK_BODY` helpers |
+| `docs/research/issues/645-class-include-create-missing-corrnr.md` | The validated issue dossier this plan implements |
+
+### Verified Live Evidence
+
+Captured 2026-07-31 by raw ADT calls (stateful session, real response bodies) plus one end-to-end
+run through the shipped `arc1-cli`. Full detail and commands in the dossier
+`docs/research/issues/645-class-include-create-missing-corrnr.md`.
+
+| Scenario | 7.50 (npl) | 758 (a4h) | 816 (a4h-2025) |
+|---|---|---|---|
+| Transportable pkg, class in own request — `POST …/includes/testclasses?lockHandle=…` | **500** | **500** | **500** |
+| Same + `&corrNr=<REQ>` | **201** | **201** | **201** |
+| `$TMP` class — `?lockHandle=…` (lock `CORRNR` empty) | **201** | — | — |
+| `$TMP` class + a *bogus* `corrNr` (regression probe) | **201** (SAP ignores it) | — | — |
+| Skip the init POST: PUT source straight to a missing include, with `lockHandle`+`corrNr` | **500** `…CCAU does not have any inactive version` | — | — |
+| Fresh class, GET each include | — | — | `definitions`/`implementations`/`macros` **200**, `testclasses` **404** |
+
+The 500 body is identical across releases:
+`Object LIMU CINC <CLASS>=================CCAU is already locked in request <REQ> of user <USER>`
+(`<type id="ExceptionResourceCreationFailure"/>`).
+
+End-to-end through ARC-1 on npl 7.50, showing the wire URL carries `lockHandle` only:
+
+    POST /sap/bc/adt/oo/classes/ZCL_ARC1_645C/includes/testclasses?lockHandle=Nn1kQ… 500
+    AdtApiError: Object LIMU CINC ZCL_ARC1_645C=================CCAU is already locked in
+    request NPLK900085 of user DEVELOPER
+
+### Design Principles
+
+1. **Mirror the existing shape.** `deleteObject` in the same file already does exactly
+   `` let url = `${objectUrl}?lockHandle=…`; if (transport) url += `&corrNr=…`; `` — copy that, do
+   not invent a params-array refactor.
+2. **`transport` is optional and last.** Adding it as a trailing optional parameter keeps every
+   existing caller and test compiling.
+3. **Release-invariant.** The defect and the fix behave identically on 7.50, 758 and 816 (table
+   above), so no release gate, no `abapRelease` plumbing, no feature probe.
+4. **`$TMP` must not change.** With no transport the emitted URL must be byte-identical to today's.
+   A test must pin this.
+5. **No tool-surface change.** `transport` is already an accepted `SAPWrite` parameter and already
+   reaches `safeUpdateClassInclude` from all three call sites. No `tools.ts` / `schemas.ts` edits,
+   no tool-definition fixture regeneration.
+6. **The init POST stays.** Deleting it was tested and ruled out live — a plain PUT to a missing
+   include 500s with "does not have any inactive version" even with a valid `corrNr`.
+
+## Development Approach
+
+TDD, red→green: write the failing URL assertions first, then the one-line change.
+
+**Test strategy.** The bug's whole cause is that the existing tests only ever saw an empty
+`CORRNR`. So the new coverage must include a lock body that *has* one — extend
+`mockHttpWithSession()` with an optional `corrNr` and keep the default `''` so existing tests are
+untouched. Three cases matter, and the negative one is the important one:
+
+- explicit `transport` argument → `corrNr` present on the init POST
+- no `transport` argument, lock returns `CORRNR` → `corrNr` present, taken from the lock
+- no `transport`, lock `CORRNR` empty (`$TMP`) → **no** `corrNr` on the URL (the regression guard)
+
+Also update the existing `initClassInclude POSTs an empty body …` test — it pins the exact URL
+string with `toBe()`, so it must keep asserting the no-transport URL exactly and gain a
+with-transport sibling.
+
+**Fixture provenance.** No new XML fixtures — the ADT responses here are bare 201/500 with no body
+worth capturing. The 500 bodies are quoted in the dossier for the record.
+
+**Scope declarations.**
+- The misleading 500 hint in `src/handlers/dispatch.ts` ("often transient — wait 10-30 seconds and
+  retry") is **out of scope**; it is still wrong when a class is legitimately locked in another
+  user's request. Follow-up, not this PR.
+- The secondary observation in the dossier (double-init POST returning
+  `500 … could not be successfully created`) is unreachable through ARC-1's flow — do not chase it,
+  but do not reorder probe/create in a way that would make it reachable.
+- `npm run build` currently fails on this branch with **pre-existing** TS errors in
+  `src/server/multi-target-destination-runtime.ts` and `src/server/server.ts` (`@arc-mcp/xsuaa-auth`
+  type drift), unrelated to this change. `npm run typecheck` is the gate that matters here; if
+  `build` fails only with those errors, that is not a regression from this plan.
+
+## Validation Commands
+
+- `npm test`
+- `npm run typecheck`
+- `npm run lint`
+
+### Task 1: Propagate the transport to `initClassInclude` and pin it with tests
+
+**Files:**
+- Modify: `src/adt/crud.ts` (`initClassInclude`, `safeUpdateClassInclude`)
+- Modify: `tests/unit/adt/crud.test.ts` (`mockHttpWithSession`, `LOCK_BODY`, `describe('safeUpdateClassInclude — auto-init missing class includes')`)
+
+Creating a class's `testclasses` include creates a new `LIMU CINC …CCAU` TADIR sub-object that CTS
+must record in a transport request. `initClassInclude` sends only `lockHandle`, so on a
+transportable package SAP raises `500 Object LIMU CINC …CCAU is already locked in request <REQ> of
+user <USER>` instead of reusing the covering `R3TR CLAS` lock. Live-verified on 7.50/758/816; adding
+`corrNr` returns 201 on all three. Mirror `deleteObject()` in the same file — it already builds
+exactly this URL shape.
+
+- [ ] In `src/adt/crud.ts`, add a trailing optional `transport?: string` parameter to
+      `initClassInclude()` and append the request when set. Keep the existing
+      `checkOperation(safety, OperationType.Create, 'InitClassInclude')` guard as the first
+      statement. Target shape (mirrors `deleteObject`):
+
+      let url = `${includeUrl}?lockHandle=${encodeURIComponent(lockHandle)}`;
+      if (transport) {
+        url += `&corrNr=${encodeURIComponent(transport)}`;
+      }
+      await http.post(url, '', undefined);
+
+- [ ] In `safeUpdateClassInclude()` in the same file, pass the already-computed
+      `effectiveTransport` (i.e. `transport ?? (lock.corrNr || undefined)`) as the new fifth
+      argument to `initClassInclude`. Do not recompute it and do not reorder the
+      probe → init → PUT sequence.
+- [ ] Update the doc comment above `initClassInclude`. It currently says the empty-POST mechanism is
+      "Live-verified (a4h S/4HANA 2023)" without qualification — that verification was done in
+      `$TMP`. State that a transportable package additionally requires `corrNr`, or SAP 500s with
+      "already locked in request" (issue #645).
+- [ ] In `tests/unit/adt/crud.test.ts`, give `mockHttpWithSession()` an optional `corrNr` in its
+      `opts` (default `''`) and build the lock body from it, so the helper can emulate a class
+      recorded in a request. Keep `LOCK_BODY` and the existing default behavior intact so the four
+      existing tests in this `describe` block are unaffected.
+- [ ] Add unit tests (~3) to `describe('safeUpdateClassInclude — auto-init missing class includes')`:
+      (a) include missing + explicit `transport` argument → the init POST URL contains
+      `corrNr=<that transport>`; (b) include missing + no `transport` argument but lock returns
+      `corrNr: 'NPLK900085'` → the init POST URL contains `corrNr=NPLK900085`; (c) **negative /
+      regression guard** — include missing, no `transport`, lock `CORRNR` empty (`$TMP`) → the init
+      POST URL is exactly `` `${INCLUDE_URL}?lockHandle=SESS_HANDLE` `` with **no** `corrNr`
+      substring.
+- [ ] Update the existing `it('initClassInclude POSTs an empty body to the include URL with the
+      lock handle')` test: it asserts the full URL with `toBe()`, so keep that as the no-transport
+      case and add a with-transport assertion
+      (`` `${INCLUDE_URL}?lockHandle=LH99&corrNr=NPLK900085` ``).
+- [ ] Verify the `initClassInclude is gated by allowWrites` test still passes — the safety check
+      must remain the first statement, before any URL building.
+- [ ] Run `npm test` — all tests must pass.
+- [ ] Run `npm run typecheck` and `npm run lint` — no errors. (`npm run build` may fail with the
+      pre-existing `multi-target-destination-runtime.ts` / `server.ts` errors described in
+      Development Approach; that is not caused by this task.)
+
+### Task 2: Live verification on a transportable package (7.50 + 816)
+
+**Files:**
+- Verify: `src/adt/crud.ts` (no edits expected)
+
+The unit tests pin the URL string, not SAP's acceptance of it. This task proves end-to-end that
+SAP accepts the fixed request, on the oldest and newest systems, using the reporter's exact
+scenario. After Task 1 the init POST should go out as
+`POST …/oo/classes/<CLS>/includes/testclasses?lockHandle=<LH>&corrNr=<REQ>`.
+
+No automated integration test is added: reproducing this needs a **transportable** package plus a
+freshly created workbench request, which the `tests/integration` CRUD harness does not set up (it
+works in `$TMP`-shaped flows, exactly the blind spot that let this ship). Manual live verification
+here is the honest coverage; note that gap in the PR body.
+
+Credentials and hosts are in `INFRASTRUCTURE.md`. **Requires live SAP access — if a system is
+unreachable, follow the INFRASTRUCTURE.md runbook (Docker stop/start, Cloud Connector) before
+concluding failure.**
+
+- [ ] Build the CLI (`npm run build`). If it fails **only** with the pre-existing
+      `src/server/multi-target-destination-runtime.ts` / `src/server/server.ts` type errors noted in
+      Development Approach, use the main checkout's prebuilt `dist/` at
+      `/Users/marianzeis/DEV/arc-1/dist/cli.js` instead and say so in the notes.
+- [ ] On **npl (7.50)**, client `001`, user `DEVELOPER`: pick a transportable Z package (e.g.
+      `ZDEMO_BOPF` — confirmed transportable) and create a workbench request for it (ADT:
+      `POST /sap/bc/adt/cts/transports` with a `CreateCorrectionRequest` body naming that package,
+      or `SAPTransport action=create` with `SAP_ALLOW_TRANSPORT_WRITES=true`). Then run the
+      reporter's two steps. Environment for the CLI:
+
+      SAP_URL=https://npl.marianzeis.de SAP_CLIENT=001 SAP_USER=DEVELOPER SAP_PASSWORD=<see INFRASTRUCTURE.md>
+      SAP_INSECURE=true SAP_ALLOW_WRITES=true SAP_ALLOWED_PACKAGES=<PKG> SAP_LINT_BEFORE_WRITE=false
+
+      node dist/cli.js call SAPWrite --json '{"action":"create","type":"CLAS","name":"<CLS>","package":"<PKG>","description":"issue 645","transport":"<TR>","activate":false}'
+      node dist/cli.js call SAPWrite --json '{"action":"update","type":"CLAS","name":"<CLS>","include":"testclasses","transport":"<TR>","activate":false,"source":"CLASS ltc_t DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.\nENDCLASS.\nCLASS ltc_t IMPLEMENTATION.\nENDCLASS."}'
+
+      Step 2 must now succeed. Confirm in the `[http_request]` log line that the POST URL carries
+      **both** `lockHandle` and `corrNr`.
+- [ ] Repeat step 2 with the `transport` field **omitted** — it must still succeed, because
+      `effectiveTransport` falls back to the lock's `CORRNR`. This is the reporter's step 3.
+- [ ] Read the include back (`SAPRead` with `version="inactive"`) and confirm the ABAP source landed.
+- [ ] **Activate** the class (`SAPActivate`) — activation is the definitive correctness check for a
+      write feature, and it proves the include was recorded in the request properly.
+- [ ] Regression check on the same system: repeat the whole flow with a **`$TMP`** class and no
+      transport. It must still succeed, and the init POST URL must carry `lockHandle` only.
+- [ ] Repeat the transportable-package flow on **a4h-2025 (816)**, client `001`, user `MARIAN`.
+      Note: `ZCUSTOM_DEVELOPMENT` and `ZCLASSIC_DEVELOPMENT` are **structure packages** there and
+      reject object creation with 403 "Structure packages cannot contain development objects" — use
+      `Z_BADI_CHECK` or another leaf package.
+- [ ] Delete every class created during this task (lock → DELETE with `lockHandle`+`corrNr`) so the
+      systems are left clean. Do not commit any throwaway scripts.
+- [ ] Record the observed results (system, release, HTTP status per step) in the plan notes or the
+      PR body.
+
+### Task 3: Final verification
+
+- [ ] Run full test suite: `npm test` — all tests pass
+- [ ] Run typecheck: `npm run typecheck` — no errors
+- [ ] Run lint: `npm run lint` — no errors
+- [ ] `grep -rn "initClassInclude" src/ tests/` — every call site passes a transport argument or is
+      a deliberate no-transport test case; no caller left on the old 4-argument signature
+- [ ] Confirm no tool-definition fixture changed:
+      `git status tests/fixtures/tool-definitions/` is clean (this change must not touch the
+      LLM-visible surface)
+- [ ] Update `docs/research/issues/645-class-include-create-missing-corrnr.md`: flip Status to
+      "Fixed" and add the PR link
+- [ ] Move this plan to `docs/plans/completed/`, then fix any relative links inside it (completed
+      plans sit one directory deeper — `../` paths gain a level)

--- a/docs/research/issues/645-class-include-create-missing-corrnr.md
+++ b/docs/research/issues/645-class-include-create-missing-corrnr.md
@@ -1,0 +1,192 @@
+# Issue #645 — `initClassInclude` POST omits `corrNr` → 500 "already locked in request" (CONFIRMED)
+
+**Status:** Confirmed bug, root cause validated live 2026-07-31 on **all three** test systems —
+**NW 7.50**, **S/4HANA 2023 (758)**, **ABAP Platform 2025 (816)**. Reporter's diagnosis is correct;
+their *scope* is not.
+**Symptom:** `SAPWrite(action="update", type="CLAS", include="testclasses", …)` fails with
+`HTTP 500 … Object LIMU CINC <CLASS>==========CCAU is already locked in request <REQ> of user <USER>`
+whenever the class lives in a **transportable package** and is already recorded in a CTS request.
+
+## TL;DR
+
+- **Real and reproducible.** Confirmed end-to-end through ARC-1's own CLI, byte-identical to the
+  report.
+- **Root cause is exactly what the reporter says:** [`initClassInclude`](src/adt/crud.ts:264) builds
+  `POST …/includes/{include}?lockHandle=<LH>` and **never appends `corrNr`**, even though the
+  enclosing [`safeUpdateClassInclude`](src/adt/crud.ts:296) has already resolved
+  `effectiveTransport = transport ?? lock.corrNr` and correctly passes it to the follow-up
+  `updateSource` PUT. One-line omission at a single call site.
+- **The reporter's scope is wrong, and this matters.** It is **not** a 7.40/"older NetWeaver"
+  problem. It reproduces identically on **758 (S/4HANA 2023)** and **816 (ABAP Platform 2025)**. The
+  real trigger is **transportable package + covering CTS lock**. Every release is affected; nobody
+  noticed because the original live verification of this code path was done in `$TMP`, where the
+  lock returns an empty `CORRNR` and no CTS record is needed.
+- **Fix validated live:** adding `corrNr=<REQ>` to the same POST returns **201** on 7.50, 758 and
+  816; the include is created, and the subsequent source PUT + read-back succeed.
+- **The init POST is genuinely required — the lazier "just delete it" fix is ruled out.** Verified
+  live on 7.50: a plain PUT to a non-existent `testclasses` include, *with* `lockHandle` **and**
+  `corrNr`, still fails `500 … ZCL_ARC1_645P=…CCAU does not have any inactive version`. The
+  probe→init→PUT design stands; only the missing `corrNr` is wrong.
+- **Blast radius is exactly CCAU.** On a fresh class, `definitions`/`implementations`/`macros`
+  already exist (GET 200) — only `testclasses` is 404 — so `initClassInclude` only ever fires for
+  the test include. Verified on 816.
+- **No regression risk:** on `$TMP` the lock returns an empty `CORRNR`, so `effectiveTransport` is
+  `undefined` and the URL is byte-identical to today's. Even a *bogus* `corrNr` on a `$TMP` object
+  returns 201 (SAP ignores it) — verified.
+- Not an SAP defect; no SAP Note applies. SAP's CTS check is behaving correctly — ADT's
+  include-creation handler asks CTS to record `LIMU CINC …CCAU` and, given no target request, CTS
+  refuses rather than inferring the covering `R3TR CLAS` lock. Eclipse works because it sends
+  `corrNr`.
+
+## Live validation (2026-07-31)
+
+Raw ADT calls (curl, stateful session, real response bodies captured) plus one end-to-end run
+through the shipped `arc1-cli`.
+
+| Test | System | POST `…/includes/testclasses` | Result |
+|---|---|---|---|
+| Class in transportable pkg, recorded in own request — **no `corrNr`** (ARC-1 HEAD) | npl **7.50** | `?lockHandle=…` | **500** `ExceptionResourceCreationFailure` — *"Object LIMU CINC ZCL_ARC1_645A=…CCAU is already locked in request NPLK900085 of user DEVELOPER"* |
+| Same — **with `corrNr`** | npl **7.50** | `?lockHandle=…&corrNr=NPLK900085` | **201** → PUT source 200 → read-back OK |
+| Same — **no `corrNr`** | a4h **758** | `?lockHandle=…` | **500**, same message (`…is already locked in request A4HK906359 of user MARIAN`) |
+| Same — **with `corrNr`** | a4h **758** | `?lockHandle=…&corrNr=A4HK906359` | **201** → PUT source 200 → read-back OK |
+| Same — **no `corrNr`** | a4h-2025 **816** | `?lockHandle=…` | **500**, same message (`…is already locked in request A4HK904954 of user MARIAN`) |
+| Same — **with `corrNr`** | a4h-2025 **816** | `?lockHandle=…&corrNr=A4HK904954` | **201** |
+| Class in **`$TMP`** — no `corrNr` (lock returns empty `CORRNR`) | npl **7.50** | `?lockHandle=…` | **201** — unaffected today, unaffected by the fix |
+| **`$TMP`** object with a bogus `corrNr` (regression probe) | npl **7.50** | `?lockHandle=…&corrNr=NPLK900085` | **201** — SAP ignores it |
+| **Skip the init POST entirely** — PUT source straight to a missing include, with `lockHandle`+`corrNr` | npl **7.50** | *(PUT, no POST)* | **500** `…CCAU does not have any inactive version` — init POST is required |
+| Fresh class, probe all four includes | a4h-2025 **816** | *(GET)* | `definitions`/`implementations`/`macros` **200**, `testclasses` **404** — only CCAU is ever init'd |
+
+End-to-end through ARC-1 (`dist/cli.js`, npl 7.50, `SAP_ALLOWED_PACKAGES=ZDEMO_BOPF`):
+
+```
+1. SAPWrite create CLAS ZCL_ARC1_645C, package=ZDEMO_BOPF, transport=NPLK900085 → success
+2. SAPWrite update CLAS ZCL_ARC1_645C, include=testclasses, transport=NPLK900085 →
+   [http_request] POST /sap/bc/adt/oo/classes/ZCL_ARC1_645C/includes/testclasses?lockHandle=Nn1kQ… 500
+   AdtApiError: Object LIMU CINC ZCL_ARC1_645C=================CCAU is already locked in
+   request NPLK900085 of user DEVELOPER
+```
+
+Note the wire URL: **`lockHandle` only** — confirming the reporter's audit-log finding that
+`transport` never reaches the POST.
+
+All test objects (`ZCL_ARC1_645A/C/T/X` on npl, `ZCL_ARC1_645A` on a4h) were deleted after the run.
+Empty scratch requests `NPLK900085` / `A4HK906359` remain.
+
+## Root cause
+
+`safeUpdateClassInclude` resolves the transport correctly and uses it for the content PUT, but the
+init POST between them drops it:
+
+```ts
+// src/adt/crud.ts:296 — resolves it …
+const effectiveTransport = transport ?? (lock.corrNr || undefined);
+…
+if (!exists) {
+  await initClassInclude(session, safety, includeUrl, lock.lockHandle);   // ← effectiveTransport not passed
+}
+await updateSource(session, safety, includeUrl, source, lock.lockHandle, effectiveTransport);  // ← used here
+
+// src/adt/crud.ts:264 — the omission
+const url = `${includeUrl}?lockHandle=${encodeURIComponent(lockHandle)}`;
+```
+
+Creating the `testclasses` include creates a **new TADIR sub-object** (`LIMU CINC …CCAU`), which CTS
+must record in a request. With no `corrNr` the ADT handler cannot name a target request; CTS finds
+the sub-object already covered by the `R3TR CLAS` lock in the user's own request and raises
+"already locked" instead of reusing it. In `$TMP` there is no CTS record at all, so the POST
+succeeds — which is why the code path's original live verification (documented in the
+`initClassInclude` doc comment as "live-verified on a4h S/4HANA 2023") passed and this stayed hidden.
+
+`initClassInclude` is the **only** lock-scoped write in the codebase that omits `corrNr` —
+`createObject` (crud.ts:104), `updateSource` (crud.ts:152), `updateObject` (crud.ts:176) and
+`deleteObject` (crud.ts:206) all handle it. The FUGR structural-include create goes through
+`createObject`, so it is not affected.
+
+### Secondary observation (not a reachable bug)
+
+Immediately after a successful init POST, a `GET …/includes/testclasses` *inside the same stateful
+session* returns 404 (only the inactive version exists yet); outside the session it returns 200. A
+second init POST on an existing include returns
+`500 … CLASS_INCLUDE …/TESTCLASSES could not be successfully created` (subType
+`TestclassGeneration`). ARC-1's flow never hits this — it probes before creating, in a fresh session
+per tool call — but a fix must not reorder probe/create in a way that would.
+
+## Affected files (for the fix)
+
+| File | Change |
+|---|---|
+| `src/adt/crud.ts` | `initClassInclude`: add optional `transport` param, append `&corrNr=…` when set (mirror `deleteObject`); `safeUpdateClassInclude`: pass `effectiveTransport`. Update the doc comment — the "live-verified" note must say `$TMP`-only and record the transportable-package requirement |
+| `tests/unit/adt/crud.test.ts` | Extend the `safeUpdateClassInclude — auto-init missing class includes` block (line ~926): assert the init POST URL carries `corrNr` when a transport is supplied *and* when it comes from the lock's `CORRNR`, and carries none for `$TMP` |
+| `tests/unit/handlers/write-surgery-rap.test.ts` | Check whether the class-surgery callers' expectations need the same assertion |
+
+No tool-surface change → no `tools.ts`/`schemas.ts` edits, no tool-definition fixture regeneration.
+`transport` is already accepted and already threaded to `safeUpdateClassInclude` from all three call
+sites (`write/update-delete.ts:94`, `write/class-surgery.ts:154`, `write/class-surgery.ts:271`).
+
+## Out of scope
+
+- The 500 error hint (`dispatch.ts`) currently advises *"often transient — wait 10-30 seconds and
+  retry"* for this error, which is actively misleading here. Worth a targeted hint keyed on the
+  "is already locked in request" message, but as a separate change.
+- The secondary double-init 500 described above — unreachable today; note it, don't chase it.
+- `npm run build` on this branch fails with pre-existing TS errors in
+  `src/server/multi-target-destination-runtime.ts` and `src/server/server.ts` (`@arc-mcp/xsuaa-auth`
+  type drift), unrelated to this issue. Live validation used the main repo's prebuilt `dist/`.
+
+## Recommendation
+
+**Fix it.** Single-file surgical change with live-validated before/after and no schema impact —
+suitable for `/implement-feature` against this dossier.
+
+## Drafted comment for GitHub issue #645
+
+```markdown
+Confirmed — thanks for the unusually precise report. Your diagnosis is exactly right, and the
+audit-log observation ("the POST goes out without `corrNr` regardless of whether `transport` is
+passed") is what made this quick to pin down.
+
+**Reproduced live**, end-to-end through ARC-1's own CLI, byte-identical to your error:
+
+```
+POST /sap/bc/adt/oo/classes/ZCL_ARC1_645C/includes/testclasses?lockHandle=Nn1kQ… 500
+Object LIMU CINC ZCL_ARC1_645C=================CCAU is already locked in
+request NPLK900085 of user DEVELOPER
+```
+
+**Root cause** — `initClassInclude` (`src/adt/crud.ts:264`) builds the include-creation POST with
+only `lockHandle`. The enclosing `safeUpdateClassInclude` already resolves
+`effectiveTransport = transport ?? lock.corrNr` and correctly passes it to the follow-up source PUT
+— the init POST between them is the one place that drops it. It's the only lock-scoped write in the
+codebase that does; `createObject`, `updateSource`, `updateObject` and `deleteObject` all handle
+`corrNr`.
+
+Creating the `testclasses` include creates a new `LIMU CINC …CCAU` TADIR sub-object, which CTS has
+to record in a request. Without a `corrNr` the handler can't name a target, so CTS reports the
+sub-object as already locked by the covering `R3TR CLAS` entry instead of reusing it. Eclipse sends
+`corrNr`, which is why it works there.
+
+**One correction to the scope, and it's in your favour:** this isn't specific to 7.40 or to older
+NetWeaver. I reproduced it identically on **S/4HANA 2023 (SAP_BASIS 758)**. The actual trigger is
+*transportable package + the class already recorded in a request* — on any release. It stayed
+hidden because this code path was originally verified in `$TMP`, where the lock returns an empty
+`CORRNR` and no CTS record is needed, so the POST succeeds.
+
+**Your proposed fix is the right one and is validated:**
+
+| | 7.50 | 758 |
+|---|---|---|
+| POST `?lockHandle=…` (today) | 500 | 500 |
+| POST `?lockHandle=…&corrNr=<REQ>` | **201** | **201** |
+
+…followed by a successful source PUT and read-back on both. `$TMP` is unaffected either way — the
+lock's `CORRNR` is empty there, so the URL stays byte-identical to today's.
+
+One note on your workaround: until this ships, `include="testclasses"` should work on a class in
+`$TMP`, so a local-package scratch class is a lighter workaround than a separate global test class
+if that fits your flow.
+
+Also flagging that the `500` hint ARC-1 prints for this ("often transient — wait 10-30 seconds and
+retry") is misleading here; I'll make that message-specific separately.
+
+Fix incoming.
+```

--- a/docs/research/issues/645-class-include-create-missing-corrnr.md
+++ b/docs/research/issues/645-class-include-create-missing-corrnr.md
@@ -1,8 +1,9 @@
-# Issue #645 — `initClassInclude` POST omits `corrNr` → 500 "already locked in request" (CONFIRMED)
+# Issue #645 — `initClassInclude` POST omits `corrNr` → 500 "already locked in request" (FIXED)
 
-**Status:** Confirmed bug, root cause validated live 2026-07-31 on **all three** test systems —
-**NW 7.50**, **S/4HANA 2023 (758)**, **ABAP Platform 2025 (816)**. Reporter's diagnosis is correct;
-their *scope* is not.
+**Status:** **Fixed** — see the branch `claude/deep-issue-645-f616de`. Root cause validated live
+2026-07-31 on **all three** test systems (**NW 7.50**, **S/4HANA 2023 (758)**, **ABAP Platform 2025
+(816)**), fix re-verified end-to-end on 7.50 and 816 including activation. Reporter's diagnosis is
+correct; their *scope* is not.
 **Symptom:** `SAPWrite(action="update", type="CLAS", include="testclasses", …)` fails with
 `HTTP 500 … Object LIMU CINC <CLASS>==========CCAU is already locked in request <REQ> of user <USER>`
 whenever the class lives in a **transportable package** and is already recorded in a CTS request.
@@ -133,10 +134,25 @@ sites (`write/update-delete.ts:94`, `write/class-surgery.ts:154`, `write/class-s
   `src/server/multi-target-destination-runtime.ts` and `src/server/server.ts` (`@arc-mcp/xsuaa-auth`
   type drift), unrelated to this issue. Live validation used the main repo's prebuilt `dist/`.
 
-## Recommendation
+## Fix as shipped
 
-**Fix it.** Single-file surgical change with live-validated before/after and no schema impact —
-suitable for `/implement-feature` against this dossier.
+`initClassInclude` gained a trailing optional `transport?: string` and appends
+`&corrNr=<encoded>` when set (mirroring `deleteObject`); `safeUpdateClassInclude` passes the
+`effectiveTransport` it already computes. Three unit tests in
+`describe('safeUpdateClassInclude — auto-init missing class includes')` pin the explicit-transport,
+lock-derived-transport, and `$TMP`-unchanged-URL cases; the first two fail without the fix.
+
+Re-verified live 2026-07-31 through `arc1-cli` after the change:
+
+| Step | 7.50 (npl) | 816 (a4h-2025) |
+|---|---|---|
+| `create` CLAS in transportable pkg with `transport` | ✅ | ✅ |
+| `update … include="testclasses"` **with** `transport` (was 500) | ✅ | ✅ |
+| Same with `transport` **omitted** (lock `CORRNR` fallback — reporter step 3) | ✅ | — |
+| `SAPActivate` the class | ✅ | ✅ |
+| `$TMP` class, no transport anywhere (regression) | ✅ | — |
+
+All test objects deleted afterwards; both systems left clean.
 
 ## Drafted comment for GitHub issue #645
 

--- a/src/adt/crud.ts
+++ b/src/adt/crud.ts
@@ -243,11 +243,16 @@ export async function safeUpdateSource(
  * PUT fails with `HTTP 500 "…CCAU does not have any inactive version"`. SAP's
  * ADT contract is that the include must be created first.
  *
- * Live-verified mechanism (a4h S/4HANA 2023): inside a locked stateful session,
+ * Live-verified mechanism (7.50 / 758 / 816): inside a locked stateful session,
  * an empty `POST …/includes/{include}?lockHandle=<LH>` (no body, no content-type)
  * returns 201 and creates the include (SAP generates an empty skeleton). A bare
  * POST without the lock handle returns 423 ("Resource CLASS_INCLUDE … is not
  * locked"), so this MUST run with a valid lock on the parent class.
+ *
+ * `transport` is REQUIRED for a class in a transportable package: creating the include
+ * creates a new `LIMU CINC …CCAU` sub-object that CTS must record, and without a corrNr
+ * SAP 500s with "Object LIMU CINC … is already locked in request … of user …" instead of
+ * reusing the covering `R3TR CLAS` lock (#645). `$TMP` needs none.
  *
  * Caller contract: invoke inside `withStatefulSession`, holding the parent
  * class lock; pass that `lockHandle`.
@@ -257,11 +262,15 @@ export async function initClassInclude(
   safety: SafetyConfig,
   includeUrl: string,
   lockHandle: string,
+  transport?: string,
 ): Promise<void> {
   // Creating the include is a mutation — gated by allowWrites like every other
   // write (package gating already happened in the handler before this point).
   checkOperation(safety, OperationType.Create, 'InitClassInclude');
-  const url = `${includeUrl}?lockHandle=${encodeURIComponent(lockHandle)}`;
+  let url = `${includeUrl}?lockHandle=${encodeURIComponent(lockHandle)}`;
+  if (transport) {
+    url += `&corrNr=${encodeURIComponent(transport)}`;
+  }
   await http.post(url, '', undefined);
 }
 
@@ -308,7 +317,7 @@ export async function safeUpdateClassInclude(
         }
       }
       if (!exists) {
-        await initClassInclude(session, safety, includeUrl, lock.lockHandle);
+        await initClassInclude(session, safety, includeUrl, lock.lockHandle, effectiveTransport);
         initialized = true;
       }
       await updateSource(session, safety, includeUrl, source, lock.lockHandle, effectiveTransport);

--- a/tests/unit/adt/crud.test.ts
+++ b/tests/unit/adt/crud.test.ts
@@ -23,17 +23,20 @@ const LOCK_BODY =
  * get/post/put spies, so include auto-init tests can make the include GET-probe
  * return 200 (exists) or throw 404 (missing) and assert the call sequence.
  */
-function mockHttpWithSession(opts: { includeGetStatus: number }): {
+function mockHttpWithSession(opts: { includeGetStatus: number; corrNr?: string }): {
   http: AdtHttpClient;
   session: { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn>; put: ReturnType<typeof vi.fn> };
 } {
+  // A class in a transportable package locks with a non-empty CORRNR; $TMP locks with an
+  // empty one. Default '' = the $TMP shape (what every pre-#645 test exercised).
+  const lockBody = opts.corrNr ? LOCK_BODY.replace('<CORRNR></CORRNR>', `<CORRNR>${opts.corrNr}</CORRNR>`) : LOCK_BODY;
   const session = {
     get: vi.fn().mockImplementation(async (path: string) => {
       if (opts.includeGetStatus === 200) return { statusCode: 200, headers: {}, body: 'existing include source' };
       throw new AdtApiError(`probe ${opts.includeGetStatus}`, opts.includeGetStatus, path, '');
     }),
     post: vi.fn().mockImplementation(async (path: string) => {
-      if (path.includes('_action=LOCK')) return { statusCode: 200, headers: {}, body: LOCK_BODY };
+      if (path.includes('_action=LOCK')) return { statusCode: 200, headers: {}, body: lockBody };
       if (path.includes('_action=UNLOCK')) return { statusCode: 200, headers: {}, body: '' };
       return { statusCode: 201, headers: {}, body: '' }; // include-init POST
     }),
@@ -993,12 +996,47 @@ describe('CRUD Operations', () => {
       expect(body).toBe('');
     });
 
+    it('initClassInclude appends corrNr when a transport is supplied', async () => {
+      const post = vi.fn().mockResolvedValue({ statusCode: 201, headers: {}, body: '' });
+      const http = { post } as unknown as AdtHttpClient;
+      await initClassInclude(http, unrestrictedSafetyConfig(), INCLUDE_URL, 'LH99', 'NPLK900085');
+      expect(String(post.mock.calls[0]?.[0])).toBe(`${INCLUDE_URL}?lockHandle=LH99&corrNr=NPLK900085`);
+    });
+
     it('initClassInclude is gated by allowWrites (Create operation)', async () => {
       const post = vi.fn();
       const http = { post } as unknown as AdtHttpClient;
       const readOnly = { ...unrestrictedSafetyConfig(), allowWrites: false };
       await expect(initClassInclude(http, readOnly, INCLUDE_URL, 'LH99')).rejects.toThrow(AdtSafetyError);
       expect(post).not.toHaveBeenCalled();
+    });
+
+    // ─── #645: the init POST must carry corrNr, or SAP 500s on a transportable package ──
+    // "Object LIMU CINC <CLASS>=…CCAU is already locked in request <REQ> of user <USER>".
+    // Reproduced live on 7.50/758/816; with corrNr the same POST returns 201.
+    const initPostUrl = (session: { post: ReturnType<typeof vi.fn> }): string =>
+      String(
+        session.post.mock.calls.find(
+          (c) => !String(c[0]).includes('_action=LOCK') && !String(c[0]).includes('_action=UNLOCK'),
+        )?.[0] ?? '',
+      );
+
+    it('init POST carries corrNr from the explicit transport argument', async () => {
+      const { http, session } = mockHttpWithSession({ includeGetStatus: 404 });
+      await safeUpdateClassInclude(http, unrestrictedSafetyConfig(), CLASS_URL, INCLUDE_URL, 'x', 'NPLK900085');
+      expect(initPostUrl(session)).toContain('corrNr=NPLK900085');
+    });
+
+    it('init POST falls back to the corrNr returned by the LOCK when no transport is passed', async () => {
+      const { http, session } = mockHttpWithSession({ includeGetStatus: 404, corrNr: 'A4HK906359' });
+      await safeUpdateClassInclude(http, unrestrictedSafetyConfig(), CLASS_URL, INCLUDE_URL, 'x');
+      expect(initPostUrl(session)).toContain('corrNr=A4HK906359');
+    });
+
+    it('$TMP (no transport, empty lock CORRNR): init POST URL is unchanged, no corrNr', async () => {
+      const { http, session } = mockHttpWithSession({ includeGetStatus: 404 });
+      await safeUpdateClassInclude(http, unrestrictedSafetyConfig(), CLASS_URL, INCLUDE_URL, 'x');
+      expect(initPostUrl(session)).toBe(`${INCLUDE_URL}?lockHandle=SESS_HANDLE`);
     });
   });
 });


### PR DESCRIPTION
Fixes #645.

## The bug

`SAPWrite(action="update", type="CLAS", include="testclasses", …)` failed with HTTP 500 whenever the
class lived in a **transportable package** and was already recorded in a CTS request:

```
POST /sap/bc/adt/oo/classes/<CLS>/includes/testclasses?lockHandle=… 500
Object LIMU CINC <CLS>=================CCAU is already locked in request <REQ> of user <USER>
```

Creating the `testclasses` include creates a new `LIMU CINC …CCAU` TADIR sub-object that CTS must
record in a request. `initClassInclude` sent only `lockHandle`, so SAP had no target request and
reported the sub-object as already locked by the covering `R3TR CLAS` entry instead of reusing it.
Eclipse sends `corrNr`, which is why it works there.

`safeUpdateClassInclude` **already** resolved `effectiveTransport = transport ?? lock.corrNr` and
passed it to the follow-up source PUT — the init POST between them was the only lock-scoped write in
the codebase that dropped it (`createObject`, `updateSource`, `updateObject` and `deleteObject` all
handle it).

## Not a 7.40 problem

The report framed this as specific to older NetWeaver. It is not — it reproduces identically on
**7.50**, **758** and **816**. The trigger is *transportable package + covering CTS lock*, on any
release. It stayed hidden because this code path was originally verified in `$TMP`, where the lock
returns an empty `CORRNR` and no CTS record is needed.

## The fix

`initClassInclude` gains a trailing optional `transport?: string` and appends `&corrNr=<encoded>`
when set (mirroring `deleteObject`); `safeUpdateClassInclude` passes the value it already computes.
No tool-schema change — `transport` was already accepted and already reached the helper from all
three call sites, so `tests/fixtures/tool-definitions/` is untouched.

## Verification

Raw ADT (real response bodies) on all three releases, before and after:

| | 7.50 | 758 | 816 |
|---|---|---|---|
| `POST …/includes/testclasses?lockHandle=…` | 500 | 500 | 500 |
| `POST …?lockHandle=…&corrNr=<REQ>` | **201** | **201** | **201** |

End-to-end through `arc1-cli` after the change, on 7.50 and 816 — the reporter's failing call now
succeeds and the class **activates**; `$TMP` with no transport anywhere still works and emits a
byte-identical URL to before. All test objects deleted; systems left clean.

Two alternatives were tested and ruled out live:
- **Drop the init POST entirely** — a plain PUT to a missing include still fails
  `500 …CCAU does not have any inactive version` even with a valid `corrNr`, so the probe→init→PUT
  design stands.
- **Blast radius beyond CCAU** — on a fresh class `definitions`/`implementations`/`macros` already
  exist (GET 200), so `initClassInclude` only ever fires for `testclasses`.

Unit tests pin all three URL shapes (explicit transport, lock-derived transport, `$TMP` unchanged);
the first two fail without the fix.

## Notes for the reviewer

- No automated integration test: reproducing this needs a transportable package plus a fresh
  workbench request, which the `tests/integration` CRUD harness doesn't set up — it works in
  `$TMP`-shaped flows, exactly the blind spot that let this ship. Live verification is recorded in
  the dossier instead.
- Follow-up, deliberately **not** in this PR: the 500 hint in `dispatch.ts` says *"often transient —
  wait 10-30 seconds and retry"*, which is wrong for this error and stays wrong when a class is
  legitimately locked in another user's request.
- An earlier draft of this description claimed pre-existing test/typecheck failures on this branch.
  That was a stale local `node_modules` (`@abaplint/core` 2.119.37 vs 2.120.5 locked,
  `@arc-mcp/xsuaa-auth` 0.1.3 vs 1.0.1 locked), not a repo problem — CI runs `npm ci` and is green.

Full analysis: `docs/research/issues/645-class-include-create-missing-corrnr.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
