### PR TITLE
fix: surface class- and program-level AUnit alerts instead of returning []

### DIFF
--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -1083,10 +1083,39 @@ function parseSyntaxCheckResult(xml: string): SyntaxCheckResult {
   };
 }
 
+/** Extract the human-readable title from an AUnit alert node (string or #text object). */
+function alertTitle(alert: Record<string, unknown>): string | undefined {
+  const titleVal = alert.title;
+  if (titleVal == null) return undefined;
+  if (typeof titleVal === 'string') return titleVal;
+  if (typeof titleVal === 'object' && !Array.isArray(titleVal)) {
+    return String((titleVal as Record<string, unknown>)['#text'] ?? '');
+  }
+  return String(titleVal);
+}
+
 function parseUnitTestResults(xml: string): UnitTestResult[] {
   const results: UnitTestResult[] = [];
   const parsed = parseXml(xml);
   const testClasses = findDeepNodes(parsed, 'testClass');
+
+  // Program- or run-level alerts with no testClass at all (e.g. "cannot be tested", abort
+  // before discovery): without this, the run silently returns [] and the reason is lost.
+  if (testClasses.length === 0) {
+    const orphanAlerts = findDeepNodes(parsed, 'alert');
+    for (const alert of orphanAlerts) {
+      results.push({
+        program: '',
+        testClass: '(run)',
+        testMethod: '(alert)',
+        status: 'failed',
+        ...(alertTitle(alert as Record<string, unknown>)
+          ? { message: alertTitle(alert as Record<string, unknown>) }
+          : {}),
+      });
+    }
+    return results;
+  }
 
   for (const tc of testClasses) {
     const className = String(tc['@_name'] ?? '');
@@ -1108,24 +1137,29 @@ function parseUnitTestResults(xml: string): UnitTestResult[] {
     }
 
     const methods = findDeepNodes(tc, 'testMethod');
+
+    // Class-level abort (e.g. class_setup failure): the testClass node carries alerts but no
+    // testMethod children. Surface the alert instead of dropping the class from the result.
+    if (methods.length === 0) {
+      const classAlerts = findDeepNodes(tc, 'alert');
+      results.push({
+        program,
+        testClass: className,
+        testMethod: '(class-level alert)',
+        status: 'failed',
+        ...(classAlerts.length > 0 && alertTitle(classAlerts[0] as Record<string, unknown>)
+          ? { message: alertTitle(classAlerts[0] as Record<string, unknown>) }
+          : { message: 'test class returned no methods and no alert — aborted before discovery' }),
+      });
+      continue;
+    }
+
     for (const method of methods) {
       const methodName = String(method['@_name'] ?? '');
       const alerts = findDeepNodes(method, 'alert');
       const hasAlert = alerts.length > 0;
       // Extract message from first alert's title element
-      let message: string | undefined;
-      if (hasAlert) {
-        const titleVal = (alerts[0] as Record<string, unknown>).title;
-        if (titleVal != null) {
-          if (typeof titleVal === 'string') {
-            message = titleVal;
-          } else if (typeof titleVal === 'object' && !Array.isArray(titleVal)) {
-            message = String((titleVal as Record<string, unknown>)['#text'] ?? '');
-          } else {
-            message = String(titleVal);
-          }
-        }
-      }
+      const message = hasAlert ? alertTitle(alerts[0] as Record<string, unknown>) : undefined;
       // Extract duration from executionTime attribute (in seconds)
       const execTime = method['@_executionTime'];
       const duration = execTime ? Number(execTime) : undefined;

--- a/tests/unit/adt/devtools.test.ts
+++ b/tests/unit/adt/devtools.test.ts
@@ -1341,6 +1341,58 @@ describe('DevTools', () => {
       );
       expect(results[0]?.duration).toBe(0.015);
     });
+
+    it('surfaces run-level alerts when the response has no testClass at all', async () => {
+      const xml = `<testResult>
+        <alert kind="error" severity="critical"><title>Object cannot be tested</title></alert>
+      </testResult>`;
+      const http = mockHttp(xml);
+      const { tests: results } = await runUnitTests(
+        http,
+        unrestrictedSafetyConfig(),
+        '/sap/bc/adt/oo/classes/ZCL_TEST',
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.status).toBe('failed');
+      expect(results[0]?.testClass).toBe('(run)');
+      expect(results[0]?.testMethod).toBe('(alert)');
+      expect(results[0]?.message).toBe('Object cannot be tested');
+    });
+
+    it('surfaces a class-level alert when the testClass has no testMethod children', async () => {
+      const xml = `<testResult>
+        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses">
+          <alert kind="error"><title>CX_SY_ITAB_LINE_NOT_FOUND in class_setup</title></alert>
+        </testClass>
+      </testResult>`;
+      const http = mockHttp(xml);
+      const { tests: results } = await runUnitTests(
+        http,
+        unrestrictedSafetyConfig(),
+        '/sap/bc/adt/oo/classes/ZCL_TEST',
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.status).toBe('failed');
+      expect(results[0]?.testClass).toBe('LTCL_TEST');
+      expect(results[0]?.program).toBe('ZCL_TEST');
+      expect(results[0]?.testMethod).toBe('(class-level alert)');
+      expect(results[0]?.message).toBe('CX_SY_ITAB_LINE_NOT_FOUND in class_setup');
+    });
+
+    it('reports an explicit reason when a testClass has neither methods nor alerts', async () => {
+      const xml = `<testResult>
+        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses"/>
+      </testResult>`;
+      const http = mockHttp(xml);
+      const { tests: results } = await runUnitTests(
+        http,
+        unrestrictedSafetyConfig(),
+        '/sap/bc/adt/oo/classes/ZCL_TEST',
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.status).toBe('failed');
+      expect(results[0]?.message).toContain('aborted before discovery');
+    });
   });
 
   describe('AUnit coverage (FEAT-41)', () => {


### PR DESCRIPTION
## Problem

`parseUnitTestResults` only reads alerts that hang off a `<testMethod>` node. Any alert
that lives above that level is dropped, and the function returns an empty array with no
error — so the caller reports "no tests" and the reason the run failed is lost entirely.

Two response shapes hit this:

1. **No `<testClass>` at all.** The run aborted before test discovery (for example an
   object that cannot be tested). The alert explaining why sits at run level.
2. **A `<testClass>` with alerts but no `<testMethod>` children.** Typically a
   `class_setup` failure, which aborts the class before any method executes.

I ran into this against a 7.58 system while chasing a different problem: a batch
activation left a stale negative discovery cache, AUnit returned shape 1, and the tool
reported an empty run. The alert that would have pointed straight at the cause was parsed
and thrown away.

## Change

Both shapes now emit synthetic `failed` rows carrying the alert title:

- run-level alerts become `testClass: '(run)'` / `testMethod: '(alert)'`
- a class with no methods becomes `testMethod: '(class-level alert)'`, with an explicit
  message when there is no alert to report either

A response with neither test classes nor alerts still returns `[]`, so the existing
"no tests ran" path is unchanged.

The title extraction (which handles both a plain string and a `#text` object, depending on
how `fast-xml-parser` renders the node) is factored into an `alertTitle()` helper and the
existing per-method path now reuses it instead of duplicating the branch.

## Two deliberate choices worth flagging

- **Orphan alerts are only collected when there are zero test classes.** If a response
  carried both test classes and unattached alerts, the latter are still ignored. That
  avoids reporting the same alert twice when it is already surfaced under its method; a
  broader sweep would need dedup rules I could not derive from observed responses.
- **`program` is empty on run-level rows.** There is no URI at that level to parse it
  from, and inventing one from the requested object felt worse than leaving it blank.

Happy to change either if you would rather they behaved differently.

## Tests

Three cases added to `tests/unit/adt/devtools.test.ts`, covering run-level alerts, a
class-level alert, and a class with neither methods nor alerts. Full file passes (157
tests), along with `typecheck`, Biome, and the file-size/schema ratchets.
