### PR TITLE
fix: walk the AUnit result structure so alerts, program name and skips survive

### DIFF
--- a/docs/research/pull-requests/647-aunit-class-and-program-level-alerts.md
+++ b/docs/research/pull-requests/647-aunit-class-and-program-level-alerts.md
@@ -1,0 +1,148 @@
+# AUnit alerts dropped when a run produces no `<testMethod>` — PR #647 review + the shipped fix
+
+**Reported by:** @francocapra in https://github.com/arc-mcp/arc-1/pull/647 (cross-repo fork)
+**Reviewed + extended:** 2026-07-31, live on **7.50 (npl)**, **7.58 (a4h)** and **8.16 (a4h-2025)**
+
+@francocapra's diagnosis is correct and both response shapes they describe are real — I reproduced
+each one live. Their patch is not what shipped: it reports a *skipped* test class as **failed**, a
+shape that occurs on any client whose AUnit risk ceiling sits below a test class's declared level.
+Chasing that down showed the parser had three more defects from the same root cause. This documents
+the review and the fix built on top of their commit.
+
+---
+
+## The root cause
+
+`parseUnitTestResults` did not walk the response. It searched the whole tree for `testMethod` nodes
+with `findDeepNodes` and reconstructed everything else — the class from the enclosing node, the
+program from *string-parsing the testClass URI*. Every defect below follows from that.
+
+The real structure, identical on all three releases:
+
+```
+aunit:runResult
+├── alerts?/alert*                       ← 7.50 exposes this slot too
+└── program  (adtcore:name = THE program name)
+    ├── alerts?/alert*                   ← generation failure: no testClasses at all
+    └── testClasses/testClass  (adtcore:name)
+        ├── alerts?/alert*               ← CLASS_SETUP dump, or risk-level refusal: no methods
+        └── testMethods/testMethod  (adtcore:name, executionTime)
+            └── alerts?/alert*
+
+alert  @kind @severity
+├── title
+├── details/detail[@text]  → nests further; the nested text is the payload
+└── stack/stackEntry
+```
+
+| # | Defect | Consequence |
+|---|--------|-------------|
+| 1 | only `testMethod` nodes are iterated | a class that aborted in `CLASS_SETUP` returns `[]` — silently |
+| 2 | same, one level up | a program that failed to generate returns `[]` — silently |
+| 3 | `program` parsed from the **testClass** URI | release-dependent garbage: `zcl_x#testclass=LTCL_Y` on 758/816 (7.50 differs again: `…/includes/testclasses#start=7,6`) |
+| 4 | `@severity` ignored | a class SAP *declined to run* is indistinguishable from one that failed |
+| 5 | only `<title>` read | the cause — `Expected [2] Actual [1]`, `Test failed in CLASS_SETUP or CLASS_CONSTRUCTOR` — is dropped |
+| 6 | entities not decoded | `Exception Error &lt;UNCAUGHT_EXCEPTION&gt;` reaches the caller |
+
+1 and 2 are what #647 found. 3–6 surfaced while verifying it.
+
+---
+
+## Live evidence
+
+Probe class with four outcomes in one run (passing method, failing assertion, `CLASS_SETUP` dump,
+`RISK LEVEL DANGEROUS`), created and deleted on each system.
+
+### The false failure that blocked #647
+
+```xml
+<testClass adtcore:name="LTCL_RISKY" durationCategory="long" riskLevel="dangerous">
+  <alerts>
+    <alert kind="warning" severity="tolerable">
+      <title>No execution, risk level of test class exceeds upper limit</title>
+```
+
+Same shape as a `CLASS_SETUP` abort — `testClass` + `alerts`, no `testMethod` — but `tolerable`.
+PR #647 reported it as `status:"failed"`. `UnitTestResult.status` already declared `'skipped'`;
+nothing ever produced it.
+
+### Program-level alert (no `testClass` at all)
+
+Forced by activating a class whose test include calls a helper, then deleting the helper:
+
+```xml
+<program adtcore:uri="…/zcl_arc1_genfail" adtcore:type="CLAS/OC" adtcore:name="ZCL_ARC1_GENFAIL">
+  <alerts><alert kind="warning" severity="critical">
+    <title>GENERATE for program [ZCL_ARC1_GENFAIL==============CP] failed</title>
+    <details><detail text="Type &quot;ZCL_ARC1_AUNIT_HELPER&quot; is unknown."/></details>
+```
+
+The node carries `adtcore:name` — so #647's stated reason for leaving `program` empty ("There is no
+URI at that level to parse it from") does not hold.
+
+### 7.50 divergences that would break a naive strict walk
+
+- empty containers are emitted as elements: `<alerts/>`, `<testMethods/>` → parse to `''`, not nodes
+- `<detail>` nests deeper and carries `<link rel=""/>` children
+- the testClass URI is `…/includes/testclasses#start=7,6`, not `…#testclass=LTCL_X`
+- a `runResult`-level `<alerts/>` slot exists above `<program>` — which retroactively justifies
+  @francocapra's `(run)` marker
+
+### Before / after (7.58, same class)
+
+| | `main` | PR #647 | shipped |
+|---|---|---|---|
+| `CLASS_SETUP` dump | *(absent)* | `failed` — `Exception Error &lt;UNCAUGHT_EXCEPTION&gt;` | `failed` — `Exception Error <UNCAUGHT_EXCEPTION> — …CX_SY_ITAB_LINE_NOT_FOUND… — Test failed in CLASS_SETUP or CLASS_CONSTRUCTOR` |
+| risk-level refusal | *(absent)* | **`failed`** | **`skipped`** — `No execution, risk level of test class exceeds upper limit` |
+| generation failure | `[]` | `failed`, `program:""` | `failed`, `program:"ZCL_ARC1_GENFAIL"`, cause included |
+| `program` (passing run) | `zcl_abapgit_hash#testclass=LTCL_TEST` | same | `ZCL_ABAPGIT_HASH` |
+| nothing testable | `[]` | `[]` | `[]` |
+
+Identical output verified on 7.50, 7.58 and 8.16.
+
+---
+
+## The fix
+
+Walk the structure instead of reconstructing it — every field then comes from the node that owns it,
+and defects 1–4 stop being expressible.
+
+- `src/adt/xml-parser.ts` — export the existing private `getNestedArray()`. Its falsy guard is what
+  makes 7.50's empty `<alerts/>` a non-event.
+- `src/adt/devtools.ts` — `parseUnitTestResults` walks `runResult → program → testClasses →
+  testClass → testMethods → testMethod`, reading each level's own `alerts` **directly** (never via
+  `findDeepNodes`, which descends and would attribute a method's alert to its program). Alerts
+  without a method become rows: `(run)`/`(alert)`, `(program)`/`(alert)`,
+  `<class>`/`(class-level alert)`. `alertStatus` maps `tolerable` → `skipped`. `alertMessage`
+  appends the recursively-flattened `<detail text>` values and runs the result through the existing
+  `decodeXmlEntities`.
+
+@francocapra's `alertTitle()` (the `#text`-vs-string handling) and their row markers are kept.
+
+### Deliberately not done
+
+- **Global `processEntities`** stays `false` — it is intentional for ST22 dumps. Decoding happens at
+  the boundary, as elsewhere in the codebase.
+- **No new `UnitTestResult` fields** for `kind`/`severity` — status + message carry the signal.
+- **No `tools.ts` guidance** about the synthetic rows. It would have cost ~68 tokens against 6 tokens
+  of headroom in the `standard-full-git` schema budget, and the ratchet is explicit that raising the
+  wall is a maintainer decision. The rows are self-describing now that messages carry the cause.
+- **No integration test** — these shapes need a deliberately broken class on a live system. The unit
+  tests run against captured real responses instead, which is where the fidelity gap actually was.
+
+### Test fixtures
+
+Hand-written AUnit XML hid two release traps (the `<alerts>`/`<testMethods>` wrappers and the
+testClass URI shape), so the `runUnitTests` tests now run against captured responses:
+
+| fixture | source | covers |
+|---|---|---|
+| `aunit-testrun-mixed-alerts.xml` | 8.16 | pass + failing assertion + tolerable skip + CLASS_SETUP dump |
+| `aunit-testrun-program-alert.xml` | 7.58 | program-level alert, no `testClasses` |
+| `aunit-testrun-nw750.xml` | 7.50 | empty `<alerts/>`/`<testMethods/>`, deeper detail nesting |
+| `aunit-testrun-with-coverage.xml` | *(already present)* | passing run + coverage measurement link |
+
+## Gates
+
+`typecheck`, `lint`, `npm test` (166 files / 4831 tests), `check:sizes`, `validate:policy`, `build` —
+all pass. Probe classes created on all three systems were deleted afterwards (verified).

--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -29,6 +29,7 @@ import {
   decodeXmlEntities,
   escapeXmlAttr,
   findDeepNodes,
+  getNestedArray,
   type NamedItem,
   parseAtcSystemCheckVariant,
   parseNamedItems,
@@ -1084,9 +1085,9 @@ function parseSyntaxCheckResult(xml: string): SyntaxCheckResult {
 }
 
 /** Extract the human-readable title from an AUnit alert node (string or #text object). */
-function alertTitle(alert: Record<string, unknown>): string | undefined {
+function alertTitle(alert: Record<string, unknown>): string {
   const titleVal = alert.title;
-  if (titleVal == null) return undefined;
+  if (titleVal == null) return '';
   if (typeof titleVal === 'string') return titleVal;
   if (typeof titleVal === 'object' && !Array.isArray(titleVal)) {
     return String((titleVal as Record<string, unknown>)['#text'] ?? '');
@@ -1094,88 +1095,115 @@ function alertTitle(alert: Record<string, unknown>): string | undefined {
   return String(titleVal);
 }
 
+/** Flatten `<details><detail text="…">`, which nests further on some releases. The nested texts
+ *  carry the payload ("Expected [2] Actual [1]"); the title alone is often generic. */
+function alertDetails(node: Record<string, unknown>): string[] {
+  const texts: string[] = [];
+  for (const detail of getNestedArray(node, 'details', 'detail')) {
+    const text = String(detail['@_text'] ?? '').trim();
+    if (text) texts.push(text);
+    texts.push(...alertDetails(detail));
+  }
+  return texts;
+}
+
+/** Title + details, entity-decoded (the shared parser runs with `processEntities: false`). */
+function alertMessage(alert: Record<string, unknown>): string | undefined {
+  const parts = [alertTitle(alert), ...alertDetails(alert)].filter(Boolean);
+  return parts.length > 0 ? decodeXmlEntities(parts.join(' — ')) : undefined;
+}
+
+/** `severity="tolerable"` means SAP declined to run the test ("risk level of test class exceeds
+ *  upper limit"), NOT that it failed — reporting those as failures sends the caller after a
+ *  phantom bug. Anything else (critical/fatal) is a real failure. */
+function alertStatus(alerts: Array<Record<string, unknown>>): 'failed' | 'skipped' {
+  return alerts.some((a) => a['@_severity'] !== 'tolerable') ? 'failed' : 'skipped';
+}
+
+/** One row for one alert that has no test method to hang off (run, program or class level). */
+function alertRow(
+  program: string,
+  testClass: string,
+  testMethod: string,
+  alert: Record<string, unknown>,
+): UnitTestResult {
+  const message = alertMessage(alert);
+  return { program, testClass, testMethod, status: alertStatus([alert]), ...(message ? { message } : {}) };
+}
+
+/**
+ * Parse an `abapunit/testruns` result.
+ *
+ * Walks the response structure — `runResult → program → testClasses → testClass → testMethods →
+ * testMethod`, each level carrying its own optional `alerts` — rather than searching the tree for
+ * `testMethod` nodes. Two reasons, both live-verified on 7.50 / 7.58 / 8.16:
+ *   - an alert at run, program or class level is the ONLY record of why a run produced no methods
+ *     (CLASS_SETUP dump, generation failure, risk level above the client ceiling);
+ *   - the program name must come from `<program adtcore:name>`, because the testClass URI it used
+ *     to be parsed from is release-dependent (7.50 `…/includes/testclasses#start=7,6`
+ *     vs 758/816 `…#testclass=LTCL_X`).
+ */
 function parseUnitTestResults(xml: string): UnitTestResult[] {
   const results: UnitTestResult[] = [];
-  const parsed = parseXml(xml);
-  const testClasses = findDeepNodes(parsed, 'testClass');
+  const runResult = (parseXml(xml).runResult ?? {}) as Record<string, unknown>;
 
-  // Program- or run-level alerts with no testClass at all (e.g. "cannot be tested", abort
-  // before discovery): without this, the run silently returns [] and the reason is lost.
-  if (testClasses.length === 0) {
-    const orphanAlerts = findDeepNodes(parsed, 'alert');
-    for (const alert of orphanAlerts) {
-      results.push({
-        program: '',
-        testClass: '(run)',
-        testMethod: '(alert)',
-        status: 'failed',
-        ...(alertTitle(alert as Record<string, unknown>)
-          ? { message: alertTitle(alert as Record<string, unknown>) }
-          : {}),
-      });
-    }
-    return results;
+  for (const alert of getNestedArray(runResult, 'alerts', 'alert')) {
+    results.push(alertRow('', '(run)', '(alert)', alert));
   }
 
-  for (const tc of testClasses) {
-    const className = String(tc['@_name'] ?? '');
-    const uri = String(tc['@_uri'] ?? '');
-    // Extract program name from URI:
-    //   classes: /sap/bc/adt/oo/classes/ZCL_TEST/...
-    //   programs: /sap/bc/adt/programs/programs/ZTEST/...  (note: "programs" appears twice)
-    const uriParts = uri.split('/');
-    let program = '';
-    for (let i = 0; i < uriParts.length - 1; i++) {
-      if (uriParts[i] === 'classes') {
-        program = uriParts[i + 1] ?? '';
-        break;
-      }
-      if (uriParts[i] === 'programs' && uriParts[i + 1] === 'programs' && i + 2 < uriParts.length) {
-        program = uriParts[i + 2] ?? '';
-        break;
-      }
+  for (const program of asNodeArray(runResult.program)) {
+    const programName = String(program['@_name'] ?? '');
+
+    for (const alert of getNestedArray(program, 'alerts', 'alert')) {
+      results.push(alertRow(programName, '(program)', '(alert)', alert));
     }
 
-    const methods = findDeepNodes(tc, 'testMethod');
+    for (const tc of getNestedArray(program, 'testClasses', 'testClass')) {
+      const className = String(tc['@_name'] ?? '');
+      const classAlerts = getNestedArray(tc, 'alerts', 'alert');
+      const methods = getNestedArray(tc, 'testMethods', 'testMethod');
 
-    // Class-level abort (e.g. class_setup failure): the testClass node carries alerts but no
-    // testMethod children. Surface the alert instead of dropping the class from the result.
-    if (methods.length === 0) {
-      const classAlerts = findDeepNodes(tc, 'alert');
-      results.push({
-        program,
-        testClass: className,
-        testMethod: '(class-level alert)',
-        status: 'failed',
-        ...(classAlerts.length > 0 && alertTitle(classAlerts[0] as Record<string, unknown>)
-          ? { message: alertTitle(classAlerts[0] as Record<string, unknown>) }
-          : { message: 'test class returned no methods and no alert — aborted before discovery' }),
-      });
-      continue;
-    }
+      // A class that aborted in CLASS_SETUP, or that SAP declined to run, reports alerts here and
+      // no methods at all — the shape that used to vanish from the result.
+      for (const alert of classAlerts) {
+        results.push(alertRow(programName, className, '(class-level alert)', alert));
+      }
 
-    for (const method of methods) {
-      const methodName = String(method['@_name'] ?? '');
-      const alerts = findDeepNodes(method, 'alert');
-      const hasAlert = alerts.length > 0;
-      // Extract message from first alert's title element
-      const message = hasAlert ? alertTitle(alerts[0] as Record<string, unknown>) : undefined;
-      // Extract duration from executionTime attribute (in seconds)
-      const execTime = method['@_executionTime'];
-      const duration = execTime ? Number(execTime) : undefined;
+      for (const method of methods) {
+        const alerts = getNestedArray(method, 'alerts', 'alert');
+        const message = alerts.length > 0 ? alertMessage(alerts[0] as Record<string, unknown>) : undefined;
+        const execTime = method['@_executionTime'];
+        const duration = execTime ? Number(execTime) : undefined;
 
-      results.push({
-        program,
-        testClass: className,
-        testMethod: methodName,
-        status: hasAlert ? 'failed' : 'passed',
-        ...(message ? { message } : {}),
-        ...(duration !== undefined && !Number.isNaN(duration) ? { duration } : {}),
-      });
+        results.push({
+          program: programName,
+          testClass: className,
+          testMethod: String(method['@_name'] ?? ''),
+          status: alerts.length > 0 ? alertStatus(alerts) : 'passed',
+          ...(message ? { message } : {}),
+          ...(duration !== undefined && !Number.isNaN(duration) ? { duration } : {}),
+        });
+      }
+
+      if (classAlerts.length === 0 && methods.length === 0) {
+        results.push({
+          program: programName,
+          testClass: className,
+          testMethod: '(class-level alert)',
+          status: 'skipped',
+          message: 'test class reported no test methods and no alert',
+        });
+      }
     }
   }
 
   return results;
+}
+
+/** One-or-many node → array (`program` is not an ARRAY_TAG, so a single one parses as an object). */
+function asNodeArray(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) return value as Array<Record<string, unknown>>;
+  return value && typeof value === 'object' ? [value as Record<string, unknown>] : [];
 }
 
 function toNodeRecord(value: unknown): Record<string, unknown> | undefined {

--- a/src/adt/devtools.ts
+++ b/src/adt/devtools.ts
@@ -1083,10 +1083,39 @@ function parseSyntaxCheckResult(xml: string): SyntaxCheckResult {
   };
 }
 
+/** Extract the human-readable title from an AUnit alert node (string or #text object). */
+function alertTitle(alert: Record<string, unknown>): string | undefined {
+  const titleVal = alert.title;
+  if (titleVal == null) return undefined;
+  if (typeof titleVal === 'string') return titleVal;
+  if (typeof titleVal === 'object' && !Array.isArray(titleVal)) {
+    return String((titleVal as Record<string, unknown>)['#text'] ?? '');
+  }
+  return String(titleVal);
+}
+
 function parseUnitTestResults(xml: string): UnitTestResult[] {
   const results: UnitTestResult[] = [];
   const parsed = parseXml(xml);
   const testClasses = findDeepNodes(parsed, 'testClass');
+
+  // Program- or run-level alerts with no testClass at all (e.g. "cannot be tested", abort
+  // before discovery): without this, the run silently returns [] and the reason is lost.
+  if (testClasses.length === 0) {
+    const orphanAlerts = findDeepNodes(parsed, 'alert');
+    for (const alert of orphanAlerts) {
+      results.push({
+        program: '',
+        testClass: '(run)',
+        testMethod: '(alert)',
+        status: 'failed',
+        ...(alertTitle(alert as Record<string, unknown>)
+          ? { message: alertTitle(alert as Record<string, unknown>) }
+          : {}),
+      });
+    }
+    return results;
+  }
 
   for (const tc of testClasses) {
     const className = String(tc['@_name'] ?? '');
@@ -1108,24 +1137,29 @@ function parseUnitTestResults(xml: string): UnitTestResult[] {
     }
 
     const methods = findDeepNodes(tc, 'testMethod');
+
+    // Class-level abort (e.g. class_setup failure): the testClass node carries alerts but no
+    // testMethod children. Surface the alert instead of dropping the class from the result.
+    if (methods.length === 0) {
+      const classAlerts = findDeepNodes(tc, 'alert');
+      results.push({
+        program,
+        testClass: className,
+        testMethod: '(class-level alert)',
+        status: 'failed',
+        ...(classAlerts.length > 0 && alertTitle(classAlerts[0] as Record<string, unknown>)
+          ? { message: alertTitle(classAlerts[0] as Record<string, unknown>) }
+          : { message: 'test class returned no methods and no alert — aborted before discovery' }),
+      });
+      continue;
+    }
+
     for (const method of methods) {
       const methodName = String(method['@_name'] ?? '');
       const alerts = findDeepNodes(method, 'alert');
       const hasAlert = alerts.length > 0;
       // Extract message from first alert's title element
-      let message: string | undefined;
-      if (hasAlert) {
-        const titleVal = (alerts[0] as Record<string, unknown>).title;
-        if (titleVal != null) {
-          if (typeof titleVal === 'string') {
-            message = titleVal;
-          } else if (typeof titleVal === 'object' && !Array.isArray(titleVal)) {
-            message = String((titleVal as Record<string, unknown>)['#text'] ?? '');
-          } else {
-            message = String(titleVal);
-          }
-        }
-      }
+      const message = hasAlert ? alertTitle(alerts[0] as Record<string, unknown>) : undefined;
       // Extract duration from executionTime attribute (in seconds)
       const execTime = method['@_executionTime'];
       const duration = execTime ? Number(execTime) : undefined;

--- a/src/adt/xml-parser.ts
+++ b/src/adt/xml-parser.ts
@@ -1216,8 +1216,13 @@ export function decodeXmlEntities(s: string): string {
     .replace(/&amp;/g, '&');
 }
 
-/** Safely get a nested array from parsed XML */
-function getNestedArray(obj: Record<string, unknown>, parent: string, child: string): Array<Record<string, unknown>> {
+/** Safely get a nested array from parsed XML.
+ *  Absent, empty (`<alerts/>` → `''` on 7.50) and single-node containers all collapse to an array. */
+export function getNestedArray(
+  obj: Record<string, unknown>,
+  parent: string,
+  child: string,
+): Array<Record<string, unknown>> {
   const parentObj = obj[parent] as Record<string, unknown> | undefined;
   if (!parentObj) return [];
   const arr = parentObj[child];

--- a/tests/fixtures/xml/aunit-testrun-mixed-alerts.xml
+++ b/tests/fixtures/xml/aunit-testrun-mixed-alerts.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<aunit:runResult xmlns:aunit="http://www.sap.com/adt/aunit">
+<program adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe" adtcore:type="CLAS/OC" adtcore:name="ZCL_ARC1_AUNIT_PROBE" uriType="semantic" xmlns:adtcore="http://www.sap.com/adt/core">
+<testClasses>
+<testClass adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe#testclass=LTCL_OK" adtcore:type="CLAS/OP" adtcore:name="LTCL_OK" uriType="semantic" durationCategory="short" riskLevel="harmless">
+<testMethods>
+<testMethod adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe#testclass=LTCL_OK;testmethod=FAILS" adtcore:type="CLAS/OLI" adtcore:name="FAILS" executionTime="0.63" uriType="semantic" unit="s">
+<alerts>
+<alert kind="failedAssertion" severity="critical">
+<title>Critical Assertion Error: 'one is not two'</title>
+<details>
+<detail text="Different values">
+<details>
+<detail text="Expected [2] Actual [1]"/>
+</details>
+</detail>
+<detail text="Test 'LTCL_OK-&gt;FAILS' in Main Program 'ZCL_ARC1_AUNIT_PROBE================CP'"/>
+</details>
+<stack>
+<stackEntry adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe/includes/testclasses#start=12,0;end=12,0" adtcore:type="CLAS/OCN/testclasses" adtcore:name="ZCL_ARC1_AUNIT_PROBE" adtcore:description="Include: &lt;ZCL_ARC1_AUNIT_PROBE================CCAU&gt; Line: &lt;12&gt; (FAILS)"/>
+</stack>
+</alert>
+</alerts>
+</testMethod>
+<testMethod adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe#testclass=LTCL_OK;testmethod=PASSES" adtcore:type="CLAS/OLI" adtcore:name="PASSES" executionTime="0" uriType="semantic" unit="s"/>
+</testMethods>
+</testClass>
+<testClass adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe#testclass=LTCL_RISKY" adtcore:type="CLAS/OP" adtcore:name="LTCL_RISKY" uriType="semantic" durationCategory="long" riskLevel="dangerous">
+<alerts>
+<alert kind="warning" severity="tolerable">
+<title>No execution, risk level of test class exceeds upper limit</title>
+<details>
+<detail text="You can find further information in document &lt;HY&gt; &lt;CHAPSAUNIT_TEST_PROPS&gt;"/>
+</details>
+</alert>
+</alerts>
+</testClass>
+<testClass adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe#testclass=LTCL_SETUP_FAIL" adtcore:type="CLAS/OP" adtcore:name="LTCL_SETUP_FAIL" uriType="semantic" durationCategory="short" riskLevel="harmless">
+<alerts>
+<alert kind="exception" severity="critical">
+<title>Exception Error &lt;UNCAUGHT_EXCEPTION&gt;</title>
+<details>
+<detail text="An exception with the type CX_SY_ITAB_LINE_NOT_FOUND was raised, but was not handled locally or declared in a RAISING clause."/>
+<detail text="A row with the index 1 is not in the table."/>
+<detail text="Test 'LTCL_SETUP_FAIL' in Main Program 'ZCL_ARC1_AUNIT_PROBE================CP'"/>
+<detail text="Test failed in CLASS_SETUP or CLASS_CONSTRUCTOR"/>
+</details>
+<stack>
+<stackEntry adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe/includes/testclasses#start=26,0;end=26,0" adtcore:type="CLAS/OCN/testclasses" adtcore:name="ZCL_ARC1_AUNIT_PROBE" adtcore:description="Include: &lt;ZCL_ARC1_AUNIT_PROBE================CCAU&gt; Line: &lt;26&gt;"/>
+</stack>
+</alert>
+</alerts>
+</testClass>
+</testClasses>
+</program>
+</aunit:runResult>

--- a/tests/fixtures/xml/aunit-testrun-nw750.xml
+++ b/tests/fixtures/xml/aunit-testrun-nw750.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<aunit:runResult xmlns:aunit="http://www.sap.com/adt/aunit">
+<alerts/>
+<program adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe" adtcore:type="CLAS/OC" adtcore:name="ZCL_ARC1_AUNIT_PROBE" adtcore:packageName="$TMP" xmlns:adtcore="http://www.sap.com/adt/core">
+<alerts/>
+<testClasses>
+<testClass adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe/includes/testclasses#start=7,6" adtcore:type="CLAS/OCN/testclasses" adtcore:name="LTCL_OK" adtcore:packageName="$TMP">
+<alerts/>
+<testMethods>
+<testMethod adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe/includes/testclasses#start=11,9" adtcore:type="CLAS/OCN/testclasses" adtcore:name="FAILS" adtcore:packageName="$TMP" executionTime="0.05" unit="s">
+<alerts>
+<alert kind="failedAssertion" severity="critical">
+<title>Critical Assertion Error: 'one is not two'</title>
+<details>
+<detail text="Different Values:">
+<link rel=""/>
+<details>
+<detail text="Expected [2] Actual [1]">
+<link rel=""/>
+</detail>
+</details>
+</detail>
+<detail text="Test 'LTCL_OK-&gt;FAILS' in Main Program 'ZCL_ARC1_AUNIT_PROBE================CP'.">
+<link rel=""/>
+</detail>
+</details>
+<stack>
+<stackEntry adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe/includes/testclasses#start=12,0" adtcore:type="CLAS/OCN/testclasses" adtcore:name="ZCL_ARC1_AUNIT_PROBE" adtcore:packageName="$TMP" adtcore:description="Include: &lt;ZCL_ARC1_AUNIT_PROBE================CCAU&gt; Line: &lt;12&gt; (FAILS)"/>
+</stack>
+</alert>
+</alerts>
+</testMethod>
+<testMethod adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe/includes/testclasses#start=8,9" adtcore:type="CLAS/OCN/testclasses" adtcore:name="PASSES" adtcore:packageName="$TMP" executionTime="0" unit="s">
+<alerts/>
+</testMethod>
+</testMethods>
+</testClass>
+<testClass adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe/includes/testclasses#start=37,6" adtcore:type="CLAS/OCN/testclasses" adtcore:name="LTCL_RISKY" adtcore:packageName="$TMP">
+<alerts>
+<alert kind="warning" severity="tolerable">
+<title>No execution, risk level of test class exceeds upper limit</title>
+<details>
+<detail text="You can find further informations in document &lt;CHAP&gt; &lt;SAUNIT_TEST_PROPS&gt;">
+<link rel=""/>
+</detail>
+</details>
+<stack/>
+</alert>
+</alerts>
+<testMethods/>
+</testClass>
+<testClass adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe/includes/testclasses#start=22,6" adtcore:type="CLAS/OCN/testclasses" adtcore:name="LTCL_SETUP_FAIL" adtcore:packageName="$TMP">
+<alerts>
+<alert kind="exception" severity="critical">
+<title>Exception Error &lt;UNCAUGHT_EXCEPTION&gt;</title>
+<details>
+<detail text="'An exception with the type CX_SY_ITAB_LINE_NOT_FOUND was raised, but was not handled locally or declared in a RAISING clause.'">
+<link rel=""/>
+</detail>
+<detail text="'A row with the index 1 is not in the table.'">
+<link rel=""/>
+</detail>
+<detail text="Test 'LTCL_SETUP_FAIL-&gt;CLASS_SETUP' in Main Program 'ZCL_ARC1_AUNIT_PROBE================CP'.">
+<link rel=""/>
+</detail>
+</details>
+<stack>
+<stackEntry adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe/includes/testclasses#start=26,0" adtcore:type="CLAS/OCN/testclasses" adtcore:name="ZCL_ARC1_AUNIT_PROBE" adtcore:packageName="$TMP" adtcore:description="Include: &lt;ZCL_ARC1_AUNIT_PROBE================CCAU&gt; Line: &lt;26&gt;"/>
+</stack>
+</alert>
+</alerts>
+<testMethods/>
+</testClass>
+</testClasses>
+</program>
+</aunit:runResult>

--- a/tests/fixtures/xml/aunit-testrun-program-alert.xml
+++ b/tests/fixtures/xml/aunit-testrun-program-alert.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<aunit:runResult xmlns:aunit="http://www.sap.com/adt/aunit">
+<program adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe" adtcore:type="CLAS/OC" adtcore:name="ZCL_ARC1_AUNIT_PROBE" uriType="semantic" xmlns:adtcore="http://www.sap.com/adt/core">
+<alerts>
+<alert kind="warning" severity="critical">
+<title>GENERATE for program [ZCL_ARC1_AUNIT_PROBE==============CP] failed</title>
+<details>
+<detail text="Type &quot;ZCL_ARC1_AUNIT_HELPER&quot; is unknown."/>
+</details>
+<stack>
+<stackEntry adtcore:uri="/sap/bc/adt/oo/classes/zcl_arc1_aunit_probe/source/main#start=1,0" adtcore:type="CLAS/OC" adtcore:name="ZCL_ARC1_AUNIT_PROBE" adtcore:description="Include: &lt;ZCL_ARC1_AUNIT_PROBE==============CP&gt; Line: &lt;1&gt;"/>
+</stack>
+</alert>
+</alerts>
+</program>
+</aunit:runResult>
+HTTP=200

--- a/tests/unit/adt/devtools.test.ts
+++ b/tests/unit/adt/devtools.test.ts
@@ -1341,6 +1341,58 @@ describe('DevTools', () => {
       );
       expect(results[0]?.duration).toBe(0.015);
     });
+
+    it('surfaces run-level alerts when the response has no testClass at all', async () => {
+      const xml = `<testResult>
+        <alert kind="error" severity="critical"><title>Object cannot be tested</title></alert>
+      </testResult>`;
+      const http = mockHttp(xml);
+      const { tests: results } = await runUnitTests(
+        http,
+        unrestrictedSafetyConfig(),
+        '/sap/bc/adt/oo/classes/ZCL_TEST',
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.status).toBe('failed');
+      expect(results[0]?.testClass).toBe('(run)');
+      expect(results[0]?.testMethod).toBe('(alert)');
+      expect(results[0]?.message).toBe('Object cannot be tested');
+    });
+
+    it('surfaces a class-level alert when the testClass has no testMethod children', async () => {
+      const xml = `<testResult>
+        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses">
+          <alert kind="error"><title>CX_SY_ITAB_LINE_NOT_FOUND in class_setup</title></alert>
+        </testClass>
+      </testResult>`;
+      const http = mockHttp(xml);
+      const { tests: results } = await runUnitTests(
+        http,
+        unrestrictedSafetyConfig(),
+        '/sap/bc/adt/oo/classes/ZCL_TEST',
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.status).toBe('failed');
+      expect(results[0]?.testClass).toBe('LTCL_TEST');
+      expect(results[0]?.program).toBe('ZCL_TEST');
+      expect(results[0]?.testMethod).toBe('(class-level alert)');
+      expect(results[0]?.message).toBe('CX_SY_ITAB_LINE_NOT_FOUND in class_setup');
+    });
+
+    it('reports an explicit reason when a testClass has neither methods nor alerts', async () => {
+      const xml = `<testResult>
+        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses"/>
+      </testResult>`;
+      const http = mockHttp(xml);
+      const { tests: results } = await runUnitTests(
+        http,
+        unrestrictedSafetyConfig(),
+        '/sap/bc/adt/oo/classes/ZCL_TEST',
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.status).toBe('failed');
+      expect(results[0]?.message).toContain('aborted before discovery');
+    });
   });
 
   describe('AUnit coverage (FEAT-41)', () => {

--- a/tests/unit/adt/devtools.test.ts
+++ b/tests/unit/adt/devtools.test.ts
@@ -1207,191 +1207,158 @@ describe('DevTools', () => {
   // ─── runUnitTests ──────────────────────────────────────────────────
 
   describe('runUnitTests', () => {
-    it('parses passing tests with class info', async () => {
-      const xml = `<testResult>
-        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses">
-          <testMethod name="test_success"></testMethod>
-        </testClass>
-      </testResult>`;
-      const http = mockHttp(xml);
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_TEST',
-      );
-      expect(results).toHaveLength(1);
-      expect(results[0]?.testMethod).toBe('test_success');
-      expect(results[0]?.status).toBe('passed');
-      expect(results[0]?.testClass).toBe('LTCL_TEST');
-      expect(results[0]?.program).toBe('ZCL_TEST');
+    // Captured `abapunit/testruns` responses (see tests/fixtures/xml). Hand-written AUnit XML used
+    // to hide two release-dependent traps — the `<alerts>`/`<testMethods>` wrappers and the
+    // testClass URI shape — so every parse assertion below runs against a real response.
+    const aunitFixtures = join(import.meta.dirname, '../../fixtures/xml');
+    const mixed816 = readFileSync(join(aunitFixtures, 'aunit-testrun-mixed-alerts.xml'), 'utf-8');
+    const programAlert758 = readFileSync(join(aunitFixtures, 'aunit-testrun-program-alert.xml'), 'utf-8');
+    const nw750 = readFileSync(join(aunitFixtures, 'aunit-testrun-nw750.xml'), 'utf-8');
+
+    const runFixture = async (xml: string) =>
+      (await runUnitTests(mockHttp(xml), unrestrictedSafetyConfig(), '/sap/bc/adt/oo/classes/ZCL_ARC1_AUNIT_PROBE'))
+        .tests;
+
+    it('parses passing and failing methods, worst detail included (real 8.16 response)', async () => {
+      const results = await runFixture(mixed816);
+      const passed = results.find((r) => r.testMethod === 'PASSES');
+      const failed = results.find((r) => r.testMethod === 'FAILS');
+      expect(passed).toMatchObject({ testClass: 'LTCL_OK', status: 'passed', duration: 0 });
+      expect(passed?.message).toBeUndefined();
+      expect(failed?.status).toBe('failed');
+      expect(failed?.duration).toBe(0.63);
+      // The title alone omits the values; the payload is in the nested <detail text="…">.
+      expect(failed?.message).toContain("Critical Assertion Error: 'one is not two'");
+      expect(failed?.message).toContain('Expected [2] Actual [1]');
     });
 
-    it('detects failing tests (with alerts)', async () => {
-      const xml = `<testResult>
-        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses">
-          <testMethod name="test_fail"><alert kind="failedAssertion"><title>Expected X got Y</title></alert></testMethod>
-        </testClass>
-      </testResult>`;
-      const http = mockHttp(xml);
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_TEST',
-      );
-      expect(results).toHaveLength(1);
-      expect(results[0]?.status).toBe('failed');
+    it('takes the program name from <program adtcore:name>, not the testClass URI', async () => {
+      // The testClass URI is `…/classes/zcl_arc1_aunit_probe#testclass=LTCL_OK` on 758/816 and
+      // `…/includes/testclasses#start=7,6` on 7.50 — neither yields a usable program name.
+      for (const xml of [mixed816, nw750]) {
+        const results = await runFixture(xml);
+        expect(results.length).toBeGreaterThan(0);
+        for (const row of results) expect(row.program).toBe('ZCL_ARC1_AUNIT_PROBE');
+      }
     });
 
-    it('handles empty results (no test methods)', async () => {
-      const http = mockHttp('<testResult/>');
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_TEST',
-      );
+    it('reports a CLASS_SETUP abort as failed with the cause (class has alerts, no methods)', async () => {
+      const results = await runFixture(mixed816);
+      const row = results.find((r) => r.testClass === 'LTCL_SETUP_FAIL');
+      expect(row).toMatchObject({ testMethod: '(class-level alert)', status: 'failed' });
+      expect(row?.message).toContain('CX_SY_ITAB_LINE_NOT_FOUND');
+      expect(row?.message).toContain('Test failed in CLASS_SETUP or CLASS_CONSTRUCTOR');
+      // Entities are decoded — the shared parser runs with processEntities: false.
+      expect(row?.message).toContain('<UNCAUGHT_EXCEPTION>');
+      expect(row?.message).not.toContain('&lt;');
+    });
+
+    it('reports a risk-level refusal as skipped, not failed (severity="tolerable")', async () => {
+      // SAP declined to run the class; calling that a failure sends the caller after a phantom bug.
+      for (const xml of [mixed816, nw750]) {
+        const row = (await runFixture(xml)).find((r) => r.testClass === 'LTCL_RISKY');
+        expect(row).toMatchObject({ testMethod: '(class-level alert)', status: 'skipped' });
+        expect(row?.message).toContain('risk level of test class exceeds upper limit');
+      }
+    });
+
+    it('surfaces a program-level alert when the run produced no test class at all', async () => {
+      // Generation failure: <program> carries <alerts> and no <testClasses>.
+      const results = await runFixture(programAlert758);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        program: 'ZCL_ARC1_AUNIT_PROBE',
+        testClass: '(program)',
+        testMethod: '(alert)',
+        status: 'failed',
+      });
+      expect(results[0]?.message).toContain('GENERATE for program');
+      expect(results[0]?.message).toContain('"ZCL_ARC1_AUNIT_HELPER" is unknown');
+    });
+
+    it('tolerates NW 7.50 empty <alerts/> and <testMethods/> elements', async () => {
+      // 7.50 emits the containers even when empty; they parse to '' rather than to a node.
+      const results = await runFixture(nw750);
+      expect(results.map((r) => `${r.testClass}.${r.testMethod}=${r.status}`)).toEqual([
+        'LTCL_OK.FAILS=failed',
+        'LTCL_OK.PASSES=passed',
+        'LTCL_RISKY.(class-level alert)=skipped',
+        'LTCL_SETUP_FAIL.(class-level alert)=failed',
+      ]);
+    });
+
+    it('returns [] for an empty run result (nothing testable — no tests, no alerts)', async () => {
+      // Live on 7.58: a table, a domain, a class without a test include and a nonexistent class all
+      // return exactly this. "No tests ran" must stay distinguishable from "the run failed".
+      const results = await runFixture('<?xml version="1.0" encoding="utf-8"?><aunit:runResult xmlns:aunit="x"/>');
       expect(results).toEqual([]);
     });
 
-    it('handles multiple test methods', async () => {
-      const xml = `<testResult>
-        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses">
-          <testMethod name="test_a"></testMethod>
-          <testMethod name="test_b"><alert kind="failedAssertion"><title>Assertion failed</title></alert></testMethod>
-          <testMethod name="test_c"></testMethod>
-        </testClass>
-      </testResult>`;
-      const http = mockHttp(xml);
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_TEST',
+    it('surfaces a run-level alert (7.50 carries an alerts slot above <program>)', async () => {
+      const results = await runFixture(
+        `<?xml version="1.0"?><aunit:runResult xmlns:aunit="x">
+           <alerts><alert kind="error" severity="critical"><title>Object cannot be tested</title></alert></alerts>
+         </aunit:runResult>`,
       );
-      expect(results).toHaveLength(3);
-      expect(results[0]?.status).toBe('passed');
-      expect(results[1]?.status).toBe('failed');
-      expect(results[2]?.status).toBe('passed');
+      expect(results).toEqual([
+        {
+          program: '',
+          testClass: '(run)',
+          testMethod: '(alert)',
+          status: 'failed',
+          message: 'Object cannot be tested',
+        },
+      ]);
     });
 
-    it('extracts alert message from title element', async () => {
-      const xml = `<testResult>
-        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses">
-          <testMethod name="test_fail">
-            <alert kind="failedAssertion"><title>Expected 42 got 0</title></alert>
-          </testMethod>
-        </testClass>
-      </testResult>`;
-      const http = mockHttp(xml);
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_TEST',
+    it('reports a test class that returned neither methods nor alerts', async () => {
+      const results = await runFixture(
+        `<?xml version="1.0"?><aunit:runResult xmlns:aunit="x">
+           <program adtcore:name="ZCL_X" xmlns:adtcore="y">
+             <testClasses><testClass adtcore:name="LTCL_EMPTY"/></testClasses>
+           </program>
+         </aunit:runResult>`,
       );
-      expect(results).toHaveLength(1);
-      expect(results[0]?.message).toBe('Expected 42 got 0');
+      expect(results).toEqual([
+        {
+          program: 'ZCL_X',
+          testClass: 'LTCL_EMPTY',
+          testMethod: '(class-level alert)',
+          status: 'skipped',
+          message: 'test class reported no test methods and no alert',
+        },
+      ]);
     });
 
-    it('parses multiple test classes in one response', async () => {
-      const xml = `<testResult>
-        <testClass name="LTCL_FIRST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses">
-          <testMethod name="test_one"></testMethod>
-        </testClass>
-        <testClass name="LTCL_SECOND" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses">
-          <testMethod name="test_two"></testMethod>
-        </testClass>
-      </testResult>`;
-      const http = mockHttp(xml);
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_TEST',
+    it('parses multiple test classes and reads the alert title from a #text node', async () => {
+      const results = await runFixture(
+        `<?xml version="1.0"?><aunit:runResult xmlns:aunit="x">
+           <program adtcore:name="ZCL_X" xmlns:adtcore="y">
+             <testClasses>
+               <testClass adtcore:name="LTCL_FIRST">
+                 <testMethods><testMethod adtcore:name="test_one"/></testMethods>
+               </testClass>
+               <testClass adtcore:name="LTCL_SECOND">
+                 <testMethods>
+                   <testMethod adtcore:name="test_two">
+                     <alerts><alert kind="failedAssertion" severity="critical">
+                       <title lang="EN">Expected 42 got 0</title>
+                     </alert></alerts>
+                   </testMethod>
+                 </testMethods>
+               </testClass>
+             </testClasses>
+           </program>
+         </aunit:runResult>`,
       );
       expect(results).toHaveLength(2);
-      expect(results[0]?.testClass).toBe('LTCL_FIRST');
-      expect(results[0]?.testMethod).toBe('test_one');
-      expect(results[1]?.testClass).toBe('LTCL_SECOND');
-      expect(results[1]?.testMethod).toBe('test_two');
-    });
-
-    it('extracts program name from URI', async () => {
-      const xml = `<testResult>
-        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_MY_CLASS/includes/testclasses">
-          <testMethod name="test_it"></testMethod>
-        </testClass>
-      </testResult>`;
-      const http = mockHttp(xml);
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_MY_CLASS',
-      );
-      expect(results[0]?.program).toBe('ZCL_MY_CLASS');
-    });
-
-    it('extracts duration from executionTime attribute', async () => {
-      const xml = `<testResult>
-        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses">
-          <testMethod name="test_fast" executionTime="0.015"></testMethod>
-        </testClass>
-      </testResult>`;
-      const http = mockHttp(xml);
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_TEST',
-      );
-      expect(results[0]?.duration).toBe(0.015);
-    });
-
-    it('surfaces run-level alerts when the response has no testClass at all', async () => {
-      const xml = `<testResult>
-        <alert kind="error" severity="critical"><title>Object cannot be tested</title></alert>
-      </testResult>`;
-      const http = mockHttp(xml);
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_TEST',
-      );
-      expect(results).toHaveLength(1);
-      expect(results[0]?.status).toBe('failed');
-      expect(results[0]?.testClass).toBe('(run)');
-      expect(results[0]?.testMethod).toBe('(alert)');
-      expect(results[0]?.message).toBe('Object cannot be tested');
-    });
-
-    it('surfaces a class-level alert when the testClass has no testMethod children', async () => {
-      const xml = `<testResult>
-        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses">
-          <alert kind="error"><title>CX_SY_ITAB_LINE_NOT_FOUND in class_setup</title></alert>
-        </testClass>
-      </testResult>`;
-      const http = mockHttp(xml);
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_TEST',
-      );
-      expect(results).toHaveLength(1);
-      expect(results[0]?.status).toBe('failed');
-      expect(results[0]?.testClass).toBe('LTCL_TEST');
-      expect(results[0]?.program).toBe('ZCL_TEST');
-      expect(results[0]?.testMethod).toBe('(class-level alert)');
-      expect(results[0]?.message).toBe('CX_SY_ITAB_LINE_NOT_FOUND in class_setup');
-    });
-
-    it('reports an explicit reason when a testClass has neither methods nor alerts', async () => {
-      const xml = `<testResult>
-        <testClass name="LTCL_TEST" uri="/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses"/>
-      </testResult>`;
-      const http = mockHttp(xml);
-      const { tests: results } = await runUnitTests(
-        http,
-        unrestrictedSafetyConfig(),
-        '/sap/bc/adt/oo/classes/ZCL_TEST',
-      );
-      expect(results).toHaveLength(1);
-      expect(results[0]?.status).toBe('failed');
-      expect(results[0]?.message).toContain('aborted before discovery');
+      expect(results[0]).toMatchObject({ testClass: 'LTCL_FIRST', testMethod: 'test_one', status: 'passed' });
+      expect(results[1]).toMatchObject({
+        testClass: 'LTCL_SECOND',
+        testMethod: 'test_two',
+        status: 'failed',
+        message: 'Expected 42 got 0',
+      });
     });
   });
 


### PR DESCRIPTION
Supersedes #647 by @francocapra, whose commit is the first of the two here. Their diagnosis was right and it is what made this findable: a run that produces no `<testMethod>` returns `[]` with no error, and the alert explaining why is parsed and thrown away. I reproduced both shapes they describe live on 7.58.

## Why not merge #647 as-is

It reports every class-level alert as `failed`, but SAP reuses that shape for a benign skip. A test class whose risk level exceeds the client ceiling comes back as:

```xml
<testClass adtcore:name="LTCL_RISKY" riskLevel="dangerous">
  <alerts><alert kind="warning" severity="tolerable">
    <title>No execution, risk level of test class exceeds upper limit</title>
```

Same shape as a `CLASS_SETUP` abort — `testClass` + `alerts`, no `testMethod` — but `tolerable`. Every such class would be reported as a failing test, sending an LLM after a test that never ran. Live-verified on 7.50, 7.58 and 8.16.

## Root cause

Chasing that down showed the whole thing shares one cause: `parseUnitTestResults` never walked the response. It searched the tree for `testMethod` nodes with `findDeepNodes` and reconstructed everything else — including taking the program name from string-parsing the **testClass** URI, whose shape is release-dependent:

| release | `testClass/@adtcore:uri` | resulting `program` |
|---|---|---|
| 7.50 | `…/classes/zcl_x/includes/testclasses#start=7,6` | `zcl_x` (by luck) |
| 7.58 / 8.16 | `…/classes/zcl_x#testclass=LTCL_Y` | `zcl_x#testclass=LTCL_Y` |

So `program` has been wrong on current releases for every row, on the passing path too. Meanwhile `<program adtcore:name="ZCL_X">` sits right there in the response.

| # | Defect | Consequence |
|---|---|---|
| 1 | only `testMethod` nodes iterated | `CLASS_SETUP` abort → `[]`, silently (#647) |
| 2 | same, one level up | generation failure → `[]`, silently (#647) |
| 3 | `program` from the testClass URI | `zcl_x#testclass=LTCL_Y` on 758/816 |
| 4 | `@severity` ignored | SAP declining to run ≡ failing |
| 5 | only `<title>` read | the cause is in `<details><detail text>` |
| 6 | entities not decoded | `Exception Error &lt;UNCAUGHT_EXCEPTION&gt;` |

## The fix

Walk the structure instead of reconstructing it — `runResult → program → testClasses → testClass → testMethods → testMethod`, each level's own `alerts` read **directly** (not via `findDeepNodes`, which descends and would attribute a method's alert to its program). Defects 1–4 then stop being expressible.

Kept from #647: @francocapra's `alertTitle()` `#text` handling and their row markers. Alerts with no method become rows — `(run)`/`(alert)`, `(program)`/`(alert)`, `<class>`/`(class-level alert)`. `tolerable` → `skipped` (`UnitTestResult` already declared it; nothing ever produced it). Messages append the recursively-flattened `<detail text>` values through the existing `decodeXmlEntities`.

## Before / after (7.58)

| | `main` | #647 | here |
|---|---|---|---|
| `CLASS_SETUP` dump | *(absent)* | `failed` — `Exception Error &lt;UNCAUGHT_EXCEPTION&gt;` | `failed` — `Exception Error <UNCAUGHT_EXCEPTION> — …CX_SY_ITAB_LINE_NOT_FOUND… — Test failed in CLASS_SETUP or CLASS_CONSTRUCTOR` |
| risk-level refusal | *(absent)* | **`failed`** | **`skipped`** |
| generation failure | `[]` | `failed`, `program:""` | `failed`, `program:"ZCL_ARC1_GENFAIL"`, cause included |
| `program` (passing run) | `zcl_abapgit_hash#testclass=LTCL_TEST` | same | `ZCL_ABAPGIT_HASH` |
| nothing testable | `[]` | `[]` | `[]` |

Identical output verified on **7.50, 7.58 and 8.16** with a probe class covering all four outcomes in one run (created and deleted on each system).

## Tests

Hand-written AUnit XML hid two release traps — the `<alerts>`/`<testMethods>` wrappers, and the testClass URI shape — so the `runUnitTests` tests now run against captured responses: `aunit-testrun-mixed-alerts.xml` (8.16: pass + failing assertion + tolerable skip + `CLASS_SETUP` dump), `aunit-testrun-program-alert.xml` (7.58: program-level alert, no `testClasses`), `aunit-testrun-nw750.xml` (7.50: empty `<alerts/>`/`<testMethods/>`, deeper detail nesting), alongside the `aunit-testrun-with-coverage.xml` already in the repo.

`typecheck`, `lint`, `npm test` (166 files / 4831 tests), `check:sizes`, `validate:policy`, `build` all pass.

## Deliberately not done

- **Global `processEntities`** stays `false` — intentional for ST22 dumps. Decoding happens at the boundary, as elsewhere in the codebase.
- **No new `UnitTestResult` fields** for `kind`/`severity` — status + message carry the signal.
- **No `tools.ts` guidance** about the synthetic rows: ~68 tokens against 6 tokens of headroom in the `standard-full-git` schema budget, and the ratchet is explicit that raising the wall is a maintainer decision. The rows are self-describing now that messages carry the cause.
- **No integration test** — these shapes need a deliberately broken class on a live system; the fidelity gap was in the fixtures, and that is where it got fixed.

Full review and evidence: `docs/research/pull-requests/647-aunit-class-and-program-level-alerts.md`.

@francocapra — thank you, this was a real silent-failure bug and a good catch. Could you close #647 in favour of this one? Your commit and authorship are preserved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)