### PR TITLE
chore: drop the release-as 1.0.0 pin now that 1.0.0 has shipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5
         id: release
-        # No release-type here — the action reads release-please-config.json,
-        # which sets bump-minor-pre-major: true so breaking changes only bump
-        # the minor version while the package is pre-1.0.0.
+        # No release-type here — the action reads release-please-config.json.
+        # From 1.0 the pre-major bump flags are gone, so semver applies normally:
+        # feat→minor, fix→patch, breaking→major.
 
   # npm publishes independently of the Docker CVE gate — a HIGH/CRITICAL finding
   # blocks the Docker image but not the npm package. (The scheduled security-scan.yml

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "release-as": "1.0.0",
       "include-component-in-tag": false,
       "extra-files": [
         {


### PR DESCRIPTION
## The problem

`release-please-config.json` still carries `"release-as": "1.0.0"`. That value is authoritative — it overrides commit footers and the computed bump — so **every release PR from here on would be pinned to 1.0.0 and no new version could be cut.**

[7b6fc90b](https://github.com/arc-mcp/arc-1/commit/7b6fc90b27412cf73613dc6eb1aece0cdbcce26d) added it deliberately, to force the pending release past two competing `Release-As` footers in the unreleased range (`1.0.0` on #604, `0.10.0` on #579), and said so in the commit body:

> MUST remove release-as from this config immediately after 1.0.0 is released, otherwise every subsequent release PR is pinned to 1.0.0.

## Verified before removing

- `v1.0.0` is tagged (`cdb86bc0`, 2026-07-31) and `npm view arc-1 version` returns `1.0.0` — the release it was pinning is done
- `.release-please-manifest.json` is `1.0.0`, so the next bump computes from the right base
- The unreleased range `v1.0.0..main` (7 commits: 1 `docs:`, 6 `chore(deps):`) contains **no `Release-As:` and no `BREAKING CHANGE:` footer** — removing the pin cannot resurrect the old `Release-As: 0.10.0` regression. Those 7 commit types are all `hidden` in `changelog-sections`, so the correct outcome after this merges is simply *no release* until a `feat:`/`fix:` lands.

## Other stale pre-1.0 settings

None in the config — `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` were already removed in that same commit, and `SECURITY.md` already lists `1.x` as supported.

The comment on the release-please action step still described those flags as active (`"which sets bump-minor-pre-major: true … while the package is pre-1.0.0"`), which is now false and misleading in the file that governs releasing. Corrected to state what actually applies from 1.0: `feat`→minor, `fix`→patch, breaking→major.

This PR is `chore:` and touches no runtime code, so it does not itself trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)