### PR TITLE
fix: read FLP tiles through the Pages association instead of a $filter

### DIFF
--- a/docs/plans/completed/2026-08-03-flp-list-tiles-navigation-read.md
+++ b/docs/plans/completed/2026-08-03-flp-list-tiles-navigation-read.md
@@ -1,0 +1,87 @@
+# Plan: read FLP tiles through the `Pages` association (stop short-dumping the backend)
+
+## Evidence
+
+Use the verified findings in `docs/research/2026-08-03-flp-tile-listing-assertion-failed.md`.
+
+Load-bearing facts from that dossier, all live-verified:
+
+- `PageChipInstances` is a navigation-only child of `Pages`. `/UI2/CL_EDM_DA_V06_USAGE~get_entityset`
+  derives the page **only** from `previous_entity_keytab`, and passes any `$filter` select-options to
+  `_get_filter_from_gw_selopt`, whose `when others.` arm is `assert 1 = 2.` (source read live from `a4h`).
+- Therefore **no** `$filter` is safe on `PageChipInstances`: `pageId` dumps from the top-level entity
+  set, and `chipId` dumps even under the association. Both reproduced live.
+- `Pages('<encoded pageId>')/PageChipInstances` returns the complete set, row counts matching the
+  catalog's own `chipCount`, on NW 7.50, 758 and 816 — with zero ST22 entries.
+- `$select` and `$top` are genuinely honored (verified by response content, not status), so the
+  existing `$top=500` is a real cap that can truncate.
+- A missing catalog returns OData 404 `Resource Page not found` (no dump).
+- SAP's own `PageBuildingService.js` reads the same way, including `encodeURIComponent` on the key.
+
+## Implementation
+
+1. `src/adt/flp.ts` — rewrite `listTiles` to `GET`
+   `${FLP_SERVICE_PATH}/Pages('${encodeURIComponent(pageId)}')/PageChipInstances?$format=json&$top=500&$select=pageId,instanceId,chipId,title,configuration`,
+   where `pageId` is `X-SAP-UI2-CATALOGPAGE:` + `normalizeCatalogId(catalogId)`. No `$filter`.
+   Carry a short comment naming the assert so the filter is never reintroduced.
+2. `src/adt/flp.ts` — delete `isAssertionFailedError` and the `backendError` catch. Both existed only to
+   absorb a dump ARC-1 was itself causing; the message they produced ("known SAP issue with certain
+   catalogs… do NOT attempt alternative queries") is false on every clause and actively misleading.
+   Return `FlpTileInstance[]` and let real failures propagate as typed `AdtApiError`s.
+3. `src/adt/types.ts` — remove `FlpTileResult`; it only ever wrapped `tiles` + `backendError`.
+4. `src/handlers/manage.ts` — `flp_list_tiles` consumes the array directly; drop the `backendError` branch.
+5. `src/handlers/manage.ts` — do not report a truncated count as complete: when exactly `$top` rows come
+   back, say the listing may be truncated. One line; no new option, no pagination.
+6. `docs_page/roadmap.md` — the FLP bullet advertises "Graceful ASSERTION_FAILED handling for problematic
+   catalogs" as a feature. Replace with the access rule that actually holds.
+7. `tests/integration/adt.integration.test.ts` — the FLP tile test wraps the call in a `try/catch` that
+   treats a 500 as "a backend bug, not an ARC-1 bug" and skips. That diagnosis is what this change
+   disproves. Drop the escape hatch and assert the returned row count equals the catalog's own
+   `chipCount`, so a reintroduced `$filter` fails the suite instead of silently skipping it.
+8. **Added during Phase 6 live verification:** a missing catalog now reaches `dispatch.ts`'s generic 404
+   hint, which tells the LLM to `SAPSearch with query ""` — `SAPManage` has no name/type args to fill it.
+   Catch the 404 in `flp_list_tiles` and name the catalog, pointing at `flp_list_catalogs`. Kept local to
+   this action rather than touching dispatch's shared hinting.
+
+Deliberately out of scope: `createTile` / `addTileToGroup` / `deleteCatalog` (POST/DELETE by key, no
+`$filter`, no dump risk), `listCatalogs` / `listGroups` (different accessors; `listGroups`' `$filter` on
+`Pages` is live-verified working), and the richer `$expand` shape SAP uses for chip bags — `flp_list_tiles`
+reports instance metadata only.
+
+## Tests
+
+1. Replace the "handles ASSERTION_FAILED gracefully" unit test — it asserted the misleading message as
+   contract — with a test pinning the request shape: the URL contains
+   `/Pages('X-SAP-UI2-CATALOGPAGE%3AMY_CATALOG')/PageChipInstances?` and contains **no** `$filter`.
+2. Add a unit test for a slash-bearing catalog ID (`/UI2/FLP_ADMIN` → `%2FUI2%2FFLP_ADMIN`) — the
+   encoding of the key is the part most likely to regress.
+3. Update the existing normalization test, which asserted the raw `'X-SAP-UI2-CATALOGPAGE:MY_CATALOG'`
+   that only appeared in the old `$filter` literal, to the encoded association form.
+4. Update the two `listTiles` parsing tests to the array return.
+5. Focused run: `npx vitest run tests/unit/adt/flp.test.ts tests/unit/handlers`
+6. Broader gates: `npm run typecheck`, `npm run lint`, `npm test`.
+7. Live verification (no integration-test fixture exists for FLP; do it by hand and record it in the
+   dossier): on `a4h`, drive the built CLI — `arc1-cli call SAPManage --arg action=flp_list_tiles --arg
+   catalogId=…` for a normal catalog, a slash-bearing catalog, and a non-existent one; snapshot
+   `/sap/bc/adt/runtime/dumps` before and after and require **no** new ST22 entry. Repeat the read on
+   `npl` (7.50) and `a4h-2025` (816) since the area is release-sensitive.
+
+## Plan Review
+
+- **Root cause, not symptom.** The dump is caused by ARC-1's own request shape; the catch block is
+  removed rather than reworded, so there is no path left that can produce it.
+- **The rule in the code is the rule the evidence supports.** "No `$filter` on `PageChipInstances`" is
+  stronger than "filter under the association" — verified by the `chipId` reproduction, not assumed.
+- **Release coverage.** Behavior is identical on 7.50 / 758 / 816, so no discovery gate or release
+  branch is warranted; a gate here would add a probe for a difference that does not exist.
+- **No schema surface change.** `flp_list_tiles` keeps its action name and its single `catalogId`
+  parameter, so the three-file sync (`tools.ts` / `schemas.ts` / handler) and the tool-definition
+  fixtures are untouched. Only the tool's text output changes.
+- **Error behavior change is deliberate and an improvement.** A missing catalog previously produced a
+  fabricated "backend crashed" narrative with 0 tiles; it now surfaces the backend's own
+  `Resource Page not found` through the normal typed-error path. `AdtApiError` is what `dispatch.ts`
+  already formats for LLM clients.
+- **Removing `FlpTileResult` is safe.** Its only two consumers are `listTiles` and the one `manage.ts`
+  branch; the type is not exported from the package entry point or referenced by fixtures.
+- **The truncation line is the smallest honest fix.** `$top` is provably enforced, so a 500-row result
+  is ambiguous; nothing observed comes near 500, which is why this is one line and not pagination.

--- a/docs/research/2026-08-03-flp-tile-listing-assertion-failed.md
+++ b/docs/research/2026-08-03-flp-tile-listing-assertion-failed.md
@@ -140,7 +140,41 @@ and sufficient; slash-bearing domain IDs (`/UI2/FLP_ADMIN`) work as `%2F`.
 | **adt-ls** (`~/DEV/arc-1-lsp`) | No references to PAGE_BUILDER / PageChipInstance / CATALOGPAGE. |
 | **`mcp-abap-adt`, `mcp-abap-adt-fr0ster`** | No FLP coverage at all. ARC-1 is alone in this area; no third-party implementation to compare against. |
 | **OData `$metadata`** (fetched live) | `Page` declares `NavigationProperty Name="PageChipInstances"` via association `Page_PageChipInstance` (`Page` 1 → `PageChipInstance` *). `PageChipInstance`'s key is `(pageId, instanceId)`. Confirms the association is the modelled access path. |
-| **SAP Notes** | Searched — **no Note covers this.** `PAGE_BUILDER_CUST PageChipInstances ASSERTION_FAILED` → 0 hits. A broader `Fiori launchpad catalog tiles ASSERTION_FAILED` → 10 hits, all a different failure: catalog *copy/create* in the FLP designer, e.g. Note **2711280** (`CA-FLP-ABA`, "HTTP 500 in `/sap/opu/odata/UI2/PAGE_BUILDER_CONF/CloneCatalog`: ASSERTION_FAILED"), whose cause is chips referencing a stale backend catalog and whose fix is to replicate that catalog — a data condition on a different service and endpoint. Consistent with the diagnosis: our assert is not an SAP defect (identical on 7.50 / 758 / 816), so there is nothing for SAP to correct — the accessor is navigation-only by design. |
+| **SAP Notes** | **No Note covers this** — see the search log below. The `CA-FLP-ABA` Notes that *do* describe an `ASSERTION_FAILED` are corrected program errors in other operations, and Note **3472049** independently corroborates the design. |
+
+### SAP Notes search log
+
+Six queries, five angles (service name, class name, component + symptom, SAP's internal property names,
+generic OData-filter phrasing). Nothing matches; the last query degenerated into unrelated components
+(HANA SQL, Datasphere, Billing), which is the exhaustion signal.
+
+| Query | Result |
+|---|---|
+| `PAGE_BUILDER_CUST PageChipInstances ASSERTION_FAILED` | 0 hits |
+| `/UI2/CL_EDM_DA_V06_USAGE ASSERT condition violated` | 0 hits |
+| `PAGE_BUILDER_CUST short dump` | 4 hits, none related (Fiori setup task lists, an OData namespace-node dump) |
+| `CA-FLP-ABA ASSERTION_FAILED runtime error` | 15 hits — the three in-component ones are 2711280, 3075736 and two App-Manager dumps; none is a read of chip instances |
+| `Fiori launchpad catalog tiles ASSERTION_FAILED` | 10 hits; only the top 3 are `CA-FLP-ABA` (2711280, 3149589, 2625256), all catalog *copy/create*. The remaining 7 are unrelated components (Screen Personas, Focused Build, Gateway 404) |
+| `GADGET_ID BASE_CHIP_ID chip filter` | 2 hits, neither about filtering |
+
+The two `CA-FLP-ABA` asserts read in full are both **genuine program errors that SAP corrected**, in
+different operations:
+
+- **2711280** — `PAGE_BUILDER_CONF/CloneCatalog` returns HTTP 500 `ASSERTION_FAILED` when copying a
+  catalog whose chips reference a stale backend catalog. A data condition on a different service and
+  endpoint; the resolution is to replicate the referenced catalog.
+- **3075736** — `ASSERTION_FAILED` during backend-catalog replication when the backend catalog no
+  longer exists. Shipped as a correction/support package.
+
+That pattern is the point: SAP *does* correct real asserts in this component. There is no correction for
+filtering `PageChipInstances` because there is no defect to correct — and the behavior is byte-identical
+on 7.50, 758 and 816, i.e. unchanged across a decade of support packages.
+
+**Corroboration from SAP's own vocabulary:** Note **3472049** (`CA-FLP-ABA`, 2024) is titled
+"Significant Performance Improvements **EDM routed read requests** (allCatalogs, PageSets, ..)". It
+reworks the `/UI2/CL_EDM_*` read path behind the Launchpad Designer and App Finder — and every request
+it names is a read reached *through a parent entity*. SAP calls these reads "routed"; the routing is the
+navigation, which is exactly what `get_entityset` reading `previous_entity_keytab` implements.
 
 ## Affected ARC-1 code
 

--- a/docs/research/2026-08-03-flp-tile-listing-assertion-failed.md
+++ b/docs/research/2026-08-03-flp-tile-listing-assertion-failed.md
@@ -1,0 +1,200 @@
+# FLP tile listing short-dumps the backend — `PageChipInstances` is navigation-only
+
+**Date:** 2026-08-03
+**Systems:** `npl` (NW 7.50 SP02), `a4h` (S/4HANA 2023, SAP_BASIS **758**), `a4h-2025` (ABAP Platform 2025, SAP_BASIS **816**)
+**Trigger:** `SAPManage action=flp_list_tiles` produced an `ASSERTION_FAILED` ST22 short dump on every
+call, and ARC-1 reported it to the LLM as a catalog-specific SAP defect.
+
+## TL;DR
+
+`PageChipInstances` in `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` is a **navigation-only child collection
+of `Pages`**. Reading it as a top-level entity set with `$filter=pageId eq …` hits a data accessor that
+accepts exactly one filter property and `assert 1 = 2`s on anything else — a guaranteed backend short
+dump, on every release tested. The fix is to read through the association:
+
+```
+GET /sap/opu/odata/UI2/PAGE_BUILDER_CUST/Pages('X-SAP-UI2-CATALOGPAGE%3A<domain>')/PageChipInstances
+    ?$format=json&$top=500&$select=pageId,instanceId,chipId,title,configuration
+```
+
+This is also exactly how SAP's own launchpad client reads it. **Rule: never send `$filter` to
+`PageChipInstances` from any path — not even on `pageId`, not even on `chipId`.**
+
+## Root cause (ABAP source, read live from `a4h`)
+
+`/UI2/CL_EDM_DA_V06_USAGE` (read via `GET /sap/bc/adt/oo/classes/%2FUI2%2FCL_EDM_DA_V06_USAGE/source/main`,
+730 lines). Two methods matter.
+
+`_get_filter_from_gw_selopt`, lines 623–646 — verbatim:
+
+```abap
+loop at gw_selopt into ls_selopt_in.
+  case ls_selopt_in-property.
+    when 'GADGET_ID'.
+      ls_selopt_out-property = 'BASE_CHIP_ID'.
+      ls_selopt_out-select_options = ls_selopt_in-select_options.
+    when others.
+      assert 1 = 2.          "  <-- ASSERTION_FAILED short dump
+  endcase.
+  insert ls_selopt_out into table lt_selopt_out.
+endloop.
+```
+
+Its only caller, `get_entityset`, lines ~288–317:
+
+```abap
+data(lv_page_id) = /ui2/if_edm_data_accessor~previous_entity_keytab[ name = 'ID' ]-value.
+...
+if /ui2/if_edm_data_accessor~previous_entity = 'Page' ##no_text.
+  assert lv_page_id is not initial.
+  data(ls_page) = lr_cache->get_page( id = lv_page_id ).
+  if ls_page is initial.
+    /ui2/cx_runtime=>raise_resource_not_found( entity_type = 'Page' ).
+  endif.
+endif.
+
+lr_cache->get_chip_instances( exporting page_id   = ls_page-id
+                                        ir_filter = _get_filter_from_gw_selopt( it_filter_select_options )
+                              importing chip_instances = lt_chip_instance ).
+```
+
+Two conclusions follow, and they are the whole story:
+
+1. **The page is taken only from `previous_entity_keytab`** — i.e. from the navigation parent
+   `Pages('<id>')`. There is no code path that derives the page from a `$filter`. A top-level
+   `PageChipInstances` read is not a supported access shape; filtering it by `pageId` was never going to work.
+2. **`$filter` select-options are passed straight into the asserting method.** Only the internal
+   property `GADGET_ID` survives the `case`. The OData property names ARC-1 can send (`pageId`,
+   `chipId`, …) all fall into `when others` — see the live matrix below.
+
+The `raise_resource_not_found( 'Page' )` branch is why a bogus catalog on the navigation path returns a
+clean OData 404 instead of a dump.
+
+## Live evidence
+
+### The bug is release-invariant
+
+One deliberate reproduction per system; ST22 checked before and after each call on `a4h`.
+
+| Release | `PageChipInstances?$filter=pageId eq …` | `Pages('…')/PageChipInstances` |
+|---|---|---|
+| NW 7.50 SP02 (`npl`) | HTTP 500, "The ASSERT condition was violated." | HTTP 200 — 6 tiles for `SAP_EPM_TC_T` (`chipCount` 0006) |
+| S/4HANA 2023 / 758 (`a4h`) | HTTP 500, `<code>ASSERTION_FAILED</code>` + new ST22 entry | HTTP 200 — 2 tiles `ZARC1_DEMO`, 19 tiles `/UI2/FLP_ADMIN` (`chipCount` 0019), 141 tiles `SAP_BASIS_TCR_T` (`chipCount` 0141) |
+| ABAP Platform 2025 / 816 (`a4h-2025`) | HTTP 500, `<code>ASSERTION_FAILED</code>` | HTTP 200 — 6 tiles for `SAP_EPM_BC_PURCHASER_T` (`chipCount` 0006) |
+
+Returned row counts match the catalog's own `chipCount` exactly on every check, so the navigation path
+returns the *complete* set — not a silently filtered subset.
+
+ST22 on `a4h` across the whole session: the only new dumps were the deliberate `$filter` reproductions.
+Every navigation-path call — including the 404 case — produced **zero** dumps.
+
+### Query options are genuinely honored (not silently ignored)
+
+Against `Pages('X-SAP-UI2-CATALOGPAGE%3ASAP_BASIS_TCR_T')/PageChipInstances` on `a4h`:
+
+| Request | Observed |
+|---|---|
+| `$select=instanceId&$top=1` | 1 row, response keys = `['instanceId']` only |
+| `$top=3` | 3 rows |
+| no `$top` | 141 rows (full set; the service applies no default page size) |
+
+So `$top=500` is a real cap, not decoration — a catalog with more than 500 tiles would be truncated.
+Largest catalog observed anywhere: 162 (`FPM_TESTSUITE_GUIBB` on `a4h`).
+
+### No `$filter` is safe, on any path
+
+| Filter | Path | Result |
+|---|---|---|
+| `pageId eq '…'` | top-level entity set | **500 ASSERTION_FAILED** |
+| `chipId eq '…'` | **navigation path** | **500 ASSERTION_FAILED** |
+
+The second row is the important one: the fix is not "filter under the association instead". The DA's
+`case` matches the *internal* name `GADGET_ID`, which no OData-visible property maps onto here, so
+`$filter` is unusable against `PageChipInstances` regardless of parent. ARC-1 must never send one.
+
+### Missing catalog
+
+`Pages('X-SAP-UI2-CATALOGPAGE%3AZNOPE_XYZ')/PageChipInstances` →
+`{"error":{"code":"/IWBEP/CM_MGW_RT/020","message":{"value":"Resource Page not found"}}}`, no dump.
+A non-existent catalog is now a normal typed error rather than a silent empty list.
+
+### URL encoding
+
+ARC-1 emits the request through `AdtHttpClient.buildUrl()`, which re-serializes the query string
+(`$` → `%24`) but leaves the path untouched. The byte-exact URL ARC-1 produces was verified live:
+
+```
+…/PAGE_BUILDER_CUST/Pages('X-SAP-UI2-CATALOGPAGE%3A%2FUI2%2FFLP_ADMIN')/PageChipInstances
+  ?%24format=json&%24top=500&%24select=pageId%2CinstanceId%2CchipId%2Ctitle%2Cconfiguration&sap-client=001&sap-language=EN
+```
+
+→ HTTP 200, 19 tiles. `encodeURIComponent` on the whole `X-SAP-UI2-CATALOGPAGE:<domain>` key is required
+and sufficient; slash-bearing domain IDs (`/UI2/FLP_ADMIN`) work as `%2F`.
+
+## Cross-source check
+
+| Source | Finding |
+|---|---|
+| **SAP's own client** — `sap/ushell_abap/pbServices/ui2/PageBuildingService.js`, fetched from the system at `/sap/public/bc/ui5_ui5/resources/…` | `readPage` builds `"Pages('" + encodeURIComponent(pageId) + "')"` and adds `?$expand=Bags/Properties,PageChipInstances/Chip/ChipBags/ChipProperties,PageChipInstances/RemoteCatalog,PageChipInstances/ChipInstanceBags/ChipInstanceProperties`. Every chip-instance read in the library is reached through `Pages(…)` or `PageSets(…)` — **never** a top-level `PageChipInstances` collection with a `$filter`. Same `encodeURIComponent` treatment of the key as the fix. |
+| **Eclipse ADT** (`~/DEV/arc-1-eclipse-adt`) | `apis.md` lists "FLP OData: `/sap/opu/odata/UI2/PAGE_BUILDER_CUST`" explicitly as *not* an ADT parity target. No contract available — this is OData, not ADT. |
+| **adt-ls** (`~/DEV/arc-1-lsp`) | No references to PAGE_BUILDER / PageChipInstance / CATALOGPAGE. |
+| **`mcp-abap-adt`, `mcp-abap-adt-fr0ster`** | No FLP coverage at all. ARC-1 is alone in this area; no third-party implementation to compare against. |
+| **OData `$metadata`** (fetched live) | `Page` declares `NavigationProperty Name="PageChipInstances"` via association `Page_PageChipInstance` (`Page` 1 → `PageChipInstance` *). `PageChipInstance`'s key is `(pageId, instanceId)`. Confirms the association is the modelled access path. |
+| **SAP Notes** | Not checked — the `sap-notes` MCP search backend was unavailable (Playwright browser missing). Not blocking: the ABAP source is stronger evidence than a Note, and the behavior is identical on 7.50 / 758 / 816, i.e. SAP has not "corrected" it because it is not a defect — the accessor is navigation-only by design. |
+
+## Affected ARC-1 code
+
+| File | Change |
+|---|---|
+| `src/adt/flp.ts` | `listTiles` — build the association URL; drop `isAssertionFailedError` and the `backendError` fallback |
+| `src/adt/types.ts` | `FlpTileResult` existed only to carry `backendError` — remove; `listTiles` returns `FlpTileInstance[]` |
+| `src/handlers/manage.ts` | `flp_list_tiles` — drop the `backendError` branch |
+| `tests/unit/adt/flp.test.ts` | Replace the "handles ASSERTION_FAILED gracefully" test with shape assertions (no `$filter`; encoded association path incl. the slash case) |
+| `docs_page/roadmap.md` | The FLP bullet advertised "Graceful ASSERTION_FAILED handling" as a feature |
+
+Adjacent paths reviewed and deliberately **not** changed: `createTile` / `addTileToGroup` / `deleteCatalog`
+POST/DELETE `PageChipInstances` and `Catalogs('<key>')` by key — no `$filter` involved, no dump risk.
+`listCatalogs` and `listGroups` filter `Catalogs` / `Pages`, which are different accessors;
+`listGroups`' `$filter=catalogId eq '/UI2/FLPD_CATALOG'` is live-verified working and untouched.
+
+## Was ARC-1's error message right?
+
+No, on both counts. It told the LLM this was "a known SAP issue with certain catalogs" and instructed it
+not to try alternative queries. It is neither catalog-specific (every catalog dumps, on every release)
+nor an SAP defect (ARC-1 was calling an unsupported shape), and the "do not attempt alternative queries"
+line actively discouraged the one thing that works. Removed with the root cause.
+
+## As-shipped verification
+
+Driven end-to-end through the built ARC-1 CLI (`node dist/cli.js call SAPManage --arg
+action=flp_list_tiles --arg catalogId=…`), not curl, so the whole handler → client → HTTP chain is
+covered. ST22 entry count snapshotted before and after on `a4h`.
+
+| System | Catalog | Result |
+|---|---|---|
+| `a4h` 758 | `ZARC1_DEMO` | 2 tiles (`chipCount` 0002) |
+| `a4h` 758 | `/UI2/FLP_ADMIN` | 19 tiles (0019) — slash-bearing domain ID |
+| `a4h` 758 | `X-SAP-UI2-CATALOGPAGE:SAP_BASIS_TCR_T` | 141 tiles (0141) — full-prefix form |
+| `a4h` 758 | `ZNOPE_XYZ` | `FLP catalog "ZNOPE_XYZ" not found. Use SAPManage action="flp_list_catalogs" …` |
+| `npl` 7.50 | `SAP_EPM_TC_T` | 6 tiles (0006) |
+| `a4h-2025` 816 | `SAP_EPM_BC_PURCHASER_T` | 6 tiles (0006) |
+
+**ST22 on `a4h`: 68 entries before, 68 after.** Zero dumps across all four calls, including the 404.
+
+The FLP integration block also runs green live against `a4h`
+(`tests/integration/adt.integration.test.ts`, 3 FLP tests incl. the catalog CRUD lifecycle). The tile
+test now asserts `tiles.length === Number(catalog.chipCount)` with no dump-tolerant `try/catch`, so a
+reintroduced `$filter` fails the suite instead of skipping it.
+
+One wart surfaced only by this end-to-end run: the 404 initially reached `dispatch.ts`'s generic
+not-found hint, which told the LLM to `SAPSearch with query ""` — `SAPManage` has no name/type args to
+fill the template. `flp_list_tiles` now catches the 404 itself and names the catalog.
+
+## Residual gaps
+
+- `$top=500` truncates silently. No catalog observed anywhere on three systems comes close (max 162),
+  but a large productive S/4 catalog could. The handler now flags the boundary rather than reporting a
+  truncated count as complete.
+- The `$expand` shape SAP uses (`PageChipInstances/Chip/ChipBags/ChipProperties` …) would return chip
+  bag properties in one round trip. Not needed for `flp_list_tiles`, which only reports instance
+  metadata. Noted if richer tile detail is ever wanted.

--- a/docs/research/2026-08-03-flp-tile-listing-assertion-failed.md
+++ b/docs/research/2026-08-03-flp-tile-listing-assertion-failed.md
@@ -140,7 +140,7 @@ and sufficient; slash-bearing domain IDs (`/UI2/FLP_ADMIN`) work as `%2F`.
 | **adt-ls** (`~/DEV/arc-1-lsp`) | No references to PAGE_BUILDER / PageChipInstance / CATALOGPAGE. |
 | **`mcp-abap-adt`, `mcp-abap-adt-fr0ster`** | No FLP coverage at all. ARC-1 is alone in this area; no third-party implementation to compare against. |
 | **OData `$metadata`** (fetched live) | `Page` declares `NavigationProperty Name="PageChipInstances"` via association `Page_PageChipInstance` (`Page` 1 → `PageChipInstance` *). `PageChipInstance`'s key is `(pageId, instanceId)`. Confirms the association is the modelled access path. |
-| **SAP Notes** | Not checked — the `sap-notes` MCP search backend was unavailable (Playwright browser missing). Not blocking: the ABAP source is stronger evidence than a Note, and the behavior is identical on 7.50 / 758 / 816, i.e. SAP has not "corrected" it because it is not a defect — the accessor is navigation-only by design. |
+| **SAP Notes** | Searched — **no Note covers this.** `PAGE_BUILDER_CUST PageChipInstances ASSERTION_FAILED` → 0 hits. A broader `Fiori launchpad catalog tiles ASSERTION_FAILED` → 10 hits, all a different failure: catalog *copy/create* in the FLP designer, e.g. Note **2711280** (`CA-FLP-ABA`, "HTTP 500 in `/sap/opu/odata/UI2/PAGE_BUILDER_CONF/CloneCatalog`: ASSERTION_FAILED"), whose cause is chips referencing a stale backend catalog and whose fix is to replicate that catalog — a data condition on a different service and endpoint. Consistent with the diagnosis: our assert is not an SAP defect (identical on 7.50 / 758 / 816), so there is nothing for SAP to correct — the accessor is navigation-only by design. |
 
 ## Affected ARC-1 code
 

--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -1512,7 +1512,7 @@ For FUGR (function groups), the same pattern applies with `objecttype=FUGR/P` an
 - SAPManage actions: `flp_list_catalogs`, `flp_list_groups`, `flp_list_tiles`, `flp_create_catalog`, `flp_create_group`, `flp_create_tile`, `flp_add_tile_to_group`, `flp_delete_catalog`
 - Feature-gated via `featureFlp` config (auto-probed at startup)
 - Write ops use `OperationType.Workflow` — blocked unless `SAP_ALLOW_WRITES=true`
-- Graceful ASSERTION_FAILED handling for problematic catalogs
+- Tiles read via `Pages('<pageId>')/PageChipInstances` — a `$filter` on `pageId` short-dumps the backend
 
 ---
 

--- a/src/adt/flp.ts
+++ b/src/adt/flp.ts
@@ -4,11 +4,10 @@
  * Uses `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` for catalog/group/tile management.
  */
 
-import { logger } from '../server/logger.js';
 import { AdtApiError } from './errors.js';
 import type { AdtHttpClient } from './http.js';
 import { checkOperation, OperationType, type SafetyConfig } from './safety.js';
-import type { FlpCatalog, FlpGroup, FlpTileInstance, FlpTileResult } from './types.js';
+import type { FlpCatalog, FlpGroup, FlpTileInstance } from './types.js';
 
 export const FLP_SERVICE_PATH = '/sap/opu/odata/UI2/PAGE_BUILDER_CUST';
 
@@ -110,23 +109,14 @@ const CATALOG_PAGE_PREFIX = 'X-SAP-UI2-CATALOGPAGE:';
  * Normalize a catalog ID to domain-only form.
  *
  * listCatalogs returns both `id` (e.g. "X-SAP-UI2-CATALOGPAGE:FOO") and
- * `domainId` (e.g. "FOO"). Functions that build pageId filters expect the
- * domain ID, so we strip the prefix when callers pass the full form.
+ * `domainId` (e.g. "FOO"). Functions that build a pageId expect the domain
+ * ID, so we strip the prefix when callers pass the full form.
  */
 export function normalizeCatalogId(catalogId: string): string {
   if (catalogId.startsWith(CATALOG_PAGE_PREFIX)) {
     return catalogId.slice(CATALOG_PAGE_PREFIX.length);
   }
   return catalogId;
-}
-
-function isAssertionFailedError(err: unknown): boolean {
-  if (!(err instanceof AdtApiError) || err.statusCode !== 500) {
-    return false;
-  }
-  const body = (err.responseBody ?? '').toUpperCase();
-  const msg = err.message.toUpperCase();
-  return body.includes('ASSERTION_FAILED') || msg.includes('ASSERTION_FAILED');
 }
 
 function buildTileConfiguration(tile: FlpTileInput): string {
@@ -208,31 +198,31 @@ export async function listGroups(http: AdtHttpClient, safety: SafetyConfig): Pro
   return parseODataCollection<FlpGroupEntity>(resp.body).map(mapGroup);
 }
 
-export async function listTiles(http: AdtHttpClient, safety: SafetyConfig, catalogId: string): Promise<FlpTileResult> {
+/** Row cap for a single tile listing — `$top` is enforced by the service, so this can truncate. */
+export const FLP_TILE_PAGE_SIZE = 500;
+
+/**
+ * List the tiles of a catalog via the Page → PageChipInstances association.
+ *
+ * Never send a `$filter` to PageChipInstances — not on `pageId`, not on `chipId`.
+ * The data accessor (/UI2/CL_EDM_DA_V06_USAGE) takes the page from the navigation
+ * parent and `assert 1 = 2`s on any select-option but its internal GADGET_ID, so a
+ * filter short-dumps the backend (ST22) on 7.50, 758 and 816 alike.
+ */
+export async function listTiles(
+  http: AdtHttpClient,
+  safety: SafetyConfig,
+  catalogId: string,
+): Promise<FlpTileInstance[]> {
   checkOperation(safety, OperationType.Read, 'ListFlpTiles');
 
-  const domain = normalizeCatalogId(catalogId);
-  const pageId = `X-SAP-UI2-CATALOGPAGE:${encodeURIComponent(domain)}`;
+  const pageId = `X-SAP-UI2-CATALOGPAGE:${normalizeCatalogId(catalogId)}`;
   const path =
-    `${FLP_SERVICE_PATH}/PageChipInstances?` +
-    `$format=json&$top=500&$select=pageId,instanceId,chipId,title,configuration&$filter=pageId%20eq%20'${pageId}'`;
+    `${FLP_SERVICE_PATH}/Pages('${encodeURIComponent(pageId)}')/PageChipInstances?` +
+    `$format=json&$top=${FLP_TILE_PAGE_SIZE}&$select=pageId,instanceId,chipId,title,configuration`;
 
-  try {
-    const resp = await http.get(path, { Accept: 'application/json' });
-    return { tiles: parseODataCollection<FlpTileEntity>(resp.body).map(mapTile) };
-  } catch (err) {
-    if (isAssertionFailedError(err)) {
-      logger.warn('FLP tile listing hit backend ASSERTION_FAILED; returning empty result', { catalogId });
-      return {
-        tiles: [],
-        backendError:
-          'ASSERTION_FAILED — the SAP backend crashed while reading this catalog. ' +
-          'This is a known SAP issue with certain catalogs. The chipCount in the catalog metadata may show tiles exist, ' +
-          'but they cannot be read via the OData API. Do NOT attempt alternative queries — this is a backend limitation.',
-      };
-    }
-    throw err;
-  }
+  const resp = await http.get(path, { Accept: 'application/json' });
+  return parseODataCollection<FlpTileEntity>(resp.body).map(mapTile);
 }
 
 export async function createCatalog(

--- a/src/adt/types.ts
+++ b/src/adt/types.ts
@@ -1021,13 +1021,6 @@ export interface FlpTileInstance {
   configuration: Record<string, unknown> | null;
 }
 
-/** FLP tile listing result — includes backend error flag for ASSERTION_FAILED */
-export interface FlpTileResult {
-  tiles: FlpTileInstance[];
-  /** Set when backend returned ASSERTION_FAILED instead of data */
-  backendError?: string;
-}
-
 /** Transaction code metadata */
 export interface TransactionInfo {
   code: string;

--- a/src/handlers/manage.ts
+++ b/src/handlers/manage.ts
@@ -6,6 +6,7 @@
 import type { AdtClient } from '../adt/client.js';
 import { createObject, deleteObject, lockObject, unlockObject } from '../adt/crud.js';
 import { buildPackageXml, normalizeAdtResponsible, type PackageCreateParams } from '../adt/ddic-xml.js';
+import { AdtApiError } from '../adt/errors.js';
 import { probeFeatures } from '../adt/features.js';
 import {
   addTileToGroup,
@@ -13,6 +14,7 @@ import {
   createGroup,
   createTile,
   deleteCatalog,
+  FLP_TILE_PAGE_SIZE,
   listCatalogs,
   listGroups,
   listTiles,
@@ -381,13 +383,24 @@ export async function handleSAPManage(
     case 'flp_list_tiles': {
       const catalogId = String(args.catalogId ?? '');
       if (!catalogId) return errorResult('"catalogId" is required for flp_list_tiles action.');
-      const result = await listTiles(client.http, client.safety, catalogId);
-      if (result.backendError) {
-        return textResult(`⚠ Backend error for catalog "${catalogId}": ${result.backendError}\n\nReturned 0 tiles.`);
+      // SAP answers an unknown catalog with a 404 on the Page; dispatch's generic 404 hint would
+      // tell the LLM to SAPSearch for an empty name, so name the catalog here instead.
+      let tiles: Awaited<ReturnType<typeof listTiles>>;
+      try {
+        tiles = await listTiles(client.http, client.safety, catalogId);
+      } catch (err) {
+        if (err instanceof AdtApiError && err.statusCode === 404) {
+          return errorResult(
+            `FLP catalog "${catalogId}" not found. Use SAPManage action="flp_list_catalogs" to list available catalogs.`,
+          );
+        }
+        throw err;
       }
+      const truncated =
+        tiles.length === FLP_TILE_PAGE_SIZE ? ` (capped at ${FLP_TILE_PAGE_SIZE} — may be truncated)` : '';
       const lines = [
-        `${result.tiles.length} tiles in catalog "${catalogId}". Columns: instanceId | title | chipId | semanticObject | semanticAction`,
-        ...result.tiles.map((t) => {
+        `${tiles.length} tiles${truncated} in catalog "${catalogId}". Columns: instanceId | title | chipId | semanticObject | semanticAction`,
+        ...tiles.map((t) => {
           const so = (t.configuration as Record<string, unknown> | null)?.semantic_object ?? '';
           const sa = (t.configuration as Record<string, unknown> | null)?.semantic_action ?? '';
           return `${t.instanceId} | ${t.title || '(no title)'} | ${t.chipId} | ${so} | ${sa}`;

--- a/tests/integration/adt.integration.test.ts
+++ b/tests/integration/adt.integration.test.ts
@@ -206,25 +206,19 @@ describe('ADT Integration Tests', () => {
       }
     }, 60000);
 
-    it('lists tiles for a catalog (returns array, may be empty)', async (ctx) => {
+    it('lists every tile of a catalog without dumping the backend', async (ctx) => {
       requireOrSkip(ctx, serviceAvailable, SkipReason.BACKEND_UNSUPPORTED);
       const catalogs = await listCatalogs(client.http, unrestrictedSafetyConfig());
-      const catalogWithPrefix = catalogs.find((c) => c.id.startsWith('X-SAP-UI2-CATALOGPAGE:'));
-      requireOrSkip(ctx, catalogWithPrefix, SkipReason.NO_FIXTURE);
-      // Use full ID to verify normalization handles it correctly. On older
-      // releases the PageChipInstances OData service can ABAP-dump (500) for
-      // some catalogs — that's a backend bug, not an ARC-1 bug, skip cleanly.
-      try {
-        const result = await listTiles(client.http, unrestrictedSafetyConfig(), catalogWithPrefix.id);
-        expect(Array.isArray(result.tiles)).toBe(true);
-      } catch (err) {
-        expectSapFailureClass(err, [500], [/ASSERT condition/i, /RABAX/i, /Internal Server Error/i]);
-        requireOrSkip(
-          ctx,
-          undefined,
-          `${SkipReason.BACKEND_UNSUPPORTED}: PageChipInstances service unstable on this release`,
-        );
-      }
+      // Prefer a catalog that actually has tiles so the count assertion has teeth.
+      const populated = catalogs.find((c) => c.id.startsWith('X-SAP-UI2-CATALOGPAGE:') && Number(c.chipCount) > 0);
+      requireOrSkip(ctx, populated, SkipReason.NO_FIXTURE);
+
+      // Full ID on purpose — verifies prefix normalization AND key encoding.
+      // No dump-tolerant catch here: a 500 means ARC-1 sent a $filter to
+      // PageChipInstances again (/UI2/CL_EDM_DA_V06_USAGE asserts), and this
+      // test exists to fail loudly if it does.
+      const tiles = await listTiles(client.http, unrestrictedSafetyConfig(), populated.id);
+      expect(tiles.length).toBe(Number(populated.chipCount));
     }, 60000);
 
     it('CRUD lifecycle — create and delete catalog', async (ctx) => {

--- a/tests/unit/adt/flp.test.ts
+++ b/tests/unit/adt/flp.test.ts
@@ -112,13 +112,33 @@ describe('FLP OData client', () => {
         ]),
       );
 
-      const result = await listTiles(http, unrestrictedSafetyConfig(), 'MY_CATALOG');
+      const tiles = await listTiles(http, unrestrictedSafetyConfig(), 'MY_CATALOG');
 
-      expect(result.tiles).toHaveLength(1);
-      expect(result.tiles[0]?.configuration).toMatchObject({
+      expect(tiles).toHaveLength(1);
+      expect(tiles[0]?.configuration).toMatchObject({
         semantic_object: 'DataAgingObjectGroup',
         display_title_text: 'Manage Data Aging Groups',
       });
+    });
+
+    it('listTiles reads via the Page association and never filters on pageId', async () => {
+      const http = mockHttp(odataCollection([]));
+
+      await listTiles(http, unrestrictedSafetyConfig(), 'MY_CATALOG');
+
+      const url = vi.mocked(http.get).mock.calls[0]![0] as string;
+      // A $filter on pageId short-dumps the backend (/UI2/CL_EDM_DA_V06_USAGE asserts).
+      expect(url).not.toContain('$filter');
+      expect(url).toContain("/Pages('X-SAP-UI2-CATALOGPAGE%3AMY_CATALOG')/PageChipInstances?");
+    });
+
+    it('listTiles encodes slashes in the catalog key', async () => {
+      const http = mockHttp(odataCollection([]));
+
+      await listTiles(http, unrestrictedSafetyConfig(), '/UI2/FLP_ADMIN');
+
+      const url = vi.mocked(http.get).mock.calls[0]![0] as string;
+      expect(url).toContain("/Pages('X-SAP-UI2-CATALOGPAGE%3A%2FUI2%2FFLP_ADMIN')/PageChipInstances?");
     });
 
     it('listTiles handles malformed configuration gracefully', async () => {
@@ -134,19 +154,9 @@ describe('FLP OData client', () => {
         ]),
       );
 
-      const result = await listTiles(http, unrestrictedSafetyConfig(), 'MY_CATALOG');
+      const tiles = await listTiles(http, unrestrictedSafetyConfig(), 'MY_CATALOG');
 
-      expect(result.tiles[0]?.configuration).toBeNull();
-    });
-
-    it('listTiles handles ASSERTION_FAILED error gracefully', async () => {
-      const http = mockHttp();
-      vi.mocked(http.get).mockRejectedValue(new AdtApiError('ASSERTION_FAILED', 500, '/test', 'ASSERTION_FAILED'));
-
-      const result = await listTiles(http, unrestrictedSafetyConfig(), 'BROKEN_CATALOG');
-
-      expect(result.tiles).toEqual([]);
-      expect(result.backendError).toContain('ASSERTION_FAILED');
+      expect(tiles[0]?.configuration).toBeNull();
     });
   });
 
@@ -301,8 +311,8 @@ describe('FLP OData client', () => {
       await listTiles(http, unrestrictedSafetyConfig(), 'X-SAP-UI2-CATALOGPAGE:MY_CATALOG');
 
       const calledUrl = vi.mocked(http.get).mock.calls[0]![0] as string;
-      expect(calledUrl).toContain("'X-SAP-UI2-CATALOGPAGE:MY_CATALOG'");
-      expect(calledUrl).not.toContain('X-SAP-UI2-CATALOGPAGE:X-SAP-UI2-CATALOGPAGE');
+      expect(calledUrl).toContain("'X-SAP-UI2-CATALOGPAGE%3AMY_CATALOG'");
+      expect(calledUrl).not.toContain('CATALOGPAGE%3AX-SAP-UI2-CATALOGPAGE');
     });
 
     it('createTile accepts full catalog ID and strips prefix', async () => {

--- a/tests/unit/handlers/manage-context.test.ts
+++ b/tests/unit/handlers/manage-context.test.ts
@@ -5,6 +5,7 @@
  */
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FLP_TILE_PAGE_SIZE } from '../../../src/adt/flp.js';
 import { unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
 import { CachingLayer } from '../../../src/cache/caching-layer.js';
 import { MemoryCache } from '../../../src/cache/memory.js';
@@ -790,6 +791,93 @@ describe('SAPManage / SAPContext handlers', () => {
       });
       expect(result.isError).toBe(true);
       expect(result.content[0]?.text).toContain('"catalogId" is required');
+    });
+
+    it('flp_list_tiles reads the Page association without a $filter', async () => {
+      mockFetch.mockReset();
+      const urls: string[] = [];
+      mockFetch.mockImplementation((url: string | URL) => {
+        urls.push(String(url));
+        return Promise.resolve(
+          mockResponse(
+            200,
+            JSON.stringify({
+              d: {
+                results: [
+                  {
+                    pageId: 'X-SAP-UI2-CATALOGPAGE:ZCAT',
+                    instanceId: 'TILE1',
+                    chipId: 'X-SAP-UI2-CHIP:/UI2/STATIC_APPLAUNCHER',
+                    title: 'My Tile',
+                    configuration: '{"tileConfiguration":"{\\"semantic_object\\":\\"ZSO\\"}"}',
+                  },
+                ],
+              },
+            }),
+            { 'x-csrf-token': 'T' },
+          ),
+        );
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+        action: 'flp_list_tiles',
+        catalogId: 'ZCAT',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]!.text).toContain('1 tiles in catalog "ZCAT"');
+      expect(result.content[0]!.text).toContain('TILE1 | My Tile');
+      const tileUrl = urls.find((u) => u.includes('PageChipInstances'));
+      // A $filter here short-dumps the backend (/UI2/CL_EDM_DA_V06_USAGE asserts).
+      expect(tileUrl).not.toContain('filter');
+      expect(tileUrl).toContain("/Pages('X-SAP-UI2-CATALOGPAGE%3AZCAT')/PageChipInstances");
+    });
+
+    it('flp_list_tiles names the catalog when SAP reports it missing', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(404, JSON.stringify({ error: { message: { value: 'Resource Page not found' } } }), {
+          'x-csrf-token': 'T',
+        }),
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+        action: 'flp_list_tiles',
+        catalogId: 'ZNOPE',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain('FLP catalog "ZNOPE" not found');
+      expect(result.content[0]!.text).toContain('flp_list_catalogs');
+    });
+
+    it('flp_list_tiles flags a listing that hits the row cap', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(
+          200,
+          JSON.stringify({
+            d: {
+              results: Array.from({ length: FLP_TILE_PAGE_SIZE }, (_, i) => ({
+                pageId: 'X-SAP-UI2-CATALOGPAGE:ZBIG',
+                instanceId: `TILE${i}`,
+                chipId: 'X-SAP-UI2-CHIP:/UI2/STATIC_APPLAUNCHER',
+                title: `Tile ${i}`,
+                configuration: '',
+              })),
+            },
+          }),
+          { 'x-csrf-token': 'T' },
+        ),
+      );
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPManage', {
+        action: 'flp_list_tiles',
+        catalogId: 'ZBIG',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]!.text).toContain(`capped at ${FLP_TILE_PAGE_SIZE} — may be truncated`);
     });
 
     it('flp_create_catalog is blocked in read-only safety mode', async () => {


### PR DESCRIPTION
## The bug

`SAPManage action=flp_list_tiles` produced an `ASSERTION_FAILED` ABAP short dump in the SAP backend on **every** call, and ARC-1 then told the LLM the cause was an SAP defect specific to certain catalogs.

Both halves were wrong. `PageChipInstances` is a **navigation-only child of `Pages`**. Read live from `a4h`, `/UI2/CL_EDM_DA_V06_USAGE~get_entityset` takes the page exclusively from the navigation parent, and hands any `$filter` select-option to `_get_filter_from_gw_selopt`:

```abap
case ls_selopt_in-property.
  when 'GADGET_ID'.  " → BASE_CHIP_ID
  when others.
    assert 1 = 2.    "  <-- ASSERTION_FAILED
endcase.
```

ARC-1 was sending `$filter=pageId eq 'X-SAP-UI2-CATALOGPAGE:<id>'` — a guaranteed dump, on every catalog, on every release.

## The fix

Read through the association, the same shape SAP's own `sap.ushell_abap.pbServices.ui2.PageBuildingService` uses (`"Pages('" + encodeURIComponent(pageId) + "')"`):

```
GET …/PAGE_BUILDER_CUST/Pages('X-SAP-UI2-CATALOGPAGE%3A<domain>')/PageChipInstances
    ?$format=json&$top=500&$select=pageId,instanceId,chipId,title,configuration
```

**No `$filter` is safe on `PageChipInstances`** — `chipId` asserts too, even under the association (verified, not assumed). The code comment and unit test both pin the absolute rule.

The `isAssertionFailedError` catch, the `backendError` field and the `FlpTileResult` wrapper are gone: they existed only to absorb a dump ARC-1 was itself causing, and the message they produced ("known SAP issue with certain catalogs… do **NOT** attempt alternative queries") actively steered the LLM away from the one shape that works. A missing catalog now surfaces SAP's own 404, naming the catalog and pointing at `flp_list_catalogs`.

Two smaller things the research turned up:
- `$top` is genuinely enforced, so a 500-row result was ambiguous — the listing now says when it hits the cap instead of reporting a truncated count as complete.
- The integration test wrapped the call in a `try/catch` that dismissed a 500 as "a backend bug, not an ARC-1 bug" and skipped. That diagnosis is what this PR disproves; it now asserts `tiles.length === chipCount` with no escape hatch, so a reintroduced `$filter` fails the suite.

## Live verification

Driven end-to-end through the built CLI (handler → client → HTTP), with ST22 snapshotted before and after.

| System | Catalog | Result |
|---|---|---|
| `a4h` S/4HANA 2023, **758** | `ZARC1_DEMO` | 2 tiles (`chipCount` 0002) |
| `a4h` **758** | `/UI2/FLP_ADMIN` | 19 tiles (0019) — slash-bearing ID |
| `a4h` **758** | `X-SAP-UI2-CATALOGPAGE:SAP_BASIS_TCR_T` | 141 tiles (0141) — full-prefix form |
| `a4h` **758** | `ZNOPE_XYZ` | `FLP catalog "ZNOPE_XYZ" not found…` |
| `npl` NW **7.50** SP02 | `SAP_EPM_TC_T` | 6 tiles (0006) |
| `a4h-2025` ABAP Platform 2025, **816** | `SAP_EPM_BC_PURCHASER_T` | 6 tiles (0006) |

**ST22 on `a4h`: 68 entries before, 68 after** — zero dumps, including the 404 path. The old `$filter` shape was reproduced once per release to confirm the bug is release-invariant; each produced a dump.

FLP integration block green live against `a4h` (3 tests incl. catalog CRUD). `npm test` 4872 passing, `typecheck` and `lint` clean.

## Evidence

- Research dossier: [`docs/research/2026-08-03-flp-tile-listing-assertion-failed.md`](docs/research/2026-08-03-flp-tile-listing-assertion-failed.md) — ABAP root cause verbatim, per-release matrix, filter matrix, `$select`/`$top` honoring, cross-source check
- Plan: [`docs/plans/completed/2026-08-03-flp-list-tiles-navigation-read.md`](docs/plans/completed/2026-08-03-flp-list-tiles-navigation-read.md)

Cross-source note: Eclipse ADT lists PAGE_BUILDER_CUST explicitly as *not* an ADT parity target, and neither adt-ls nor either `mcp-abap-adt` repo touches FLP — SAP's own ushell client and the live systems were the only available witnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)