### PR TITLE
ci: keep the release-notes gate out of the npm publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,17 @@ jobs:
       # GITHUB_TOKEN, so test.yml never runs on it (GITHUB_TOKEN events don't trigger
       # workflows) — nothing else tests the released commit. Do not remove.
       # Coverage is dropped here: it's non-gating and no one reads it at publish time.
+      #
+      # release-notes.test.ts is excluded for the same reason link-release-notes is
+      # continue-on-error: documentation polish must never fail an artifact release. It
+      # asserts CHANGELOG ⊆ docs_page/release-notes.md, and the CHANGELOG only gains the
+      # new version when the release PR merges — so an unannotated release fails HERE,
+      # after the tag, GitHub Release, Docker image and .mcpb have all shipped, and
+      # strands npm alone (v1.0.1). The gate still runs on every normal PR via test.yml,
+      # where a missing entry blocks a merge instead of half a release. The exclusion is
+      # pinned by a test in that same file, so renaming it cannot silently restore this.
       - name: Run tests
-        run: npm test
+        run: npm test -- --exclude 'tests/unit/server/release-notes.test.ts'
 
       - name: Build
         run: npm run build

--- a/docs_page/release-notes.md
+++ b/docs_page/release-notes.md
@@ -26,6 +26,20 @@ until they are promoted.
     line — nobody runs them today, and the one part that still matters when jumping from an ancient version
     is the **v0.7.0 authorization break**, which is spelled out in full at the bottom of this page.
 
+## 1.0.1 — three total-outage fixes (2026-08-03)
+
+A pure bugfix release, and every entry in it was failing *100% of the time* for the users it touched, not
+intermittently: `SAPWrite` rejected every call from schema-filling LLM clients, `ARC1_PLUGINS` crashed ARC-1
+on startup on Windows, and FLP tile listing produced an ABAP short dump on every catalog. Upgrade if you use
+any of the three; the transport change is a contract correction with no action attached.
+
+| Change | What it means | Action |
+|---|---|---|
+| Drop inapplicable FUNC processing metadata instead of rejecting the write ([#665](https://github.com/arc-mcp/arc-1/pull/665)) | **Regression in 1.0.0.** `1.0.0` added `processingType`/`updateTaskKind` as enum-only optionals with no `null` form, plus a validator that rejects them for any non-`FUNC` type. Clients that must emit a value for *every* advertised schema property (OpenAI/GPT strict mode, and the MCP clients emulating it) therefore fabricate `normal`/`startImmediate` — and **every** `SAPWrite` call died at input validation, whatever the object type, including genuine `FUNC` creates. ARC-1 now drops metadata the write cannot use instead of failing the write, the same way it already handles a stray `include`. | `none` — on `1.0.0`, `ARC1_SCHEMA_NULLABLE_OPTIONALS=on` is the workaround |
+| Load extension plugins on Windows ([#662](https://github.com/arc-mcp/arc-1/pull/662)) | `ARC1_PLUGINS` aborted startup before the MCP handshake on Windows. The world-writable (`S_IWOTH`) permission check ran unconditionally, but Windows reports a synthetic `0666` mode, so every valid plugin looked world-writable. Both POSIX ownership checks are now gated behind `process.getuid`; Windows requires an absolute, stat-able path and relies on Windows ACLs. | `none` |
+| Read FLP tiles through the Pages association instead of a `$filter` ([#663](https://github.com/arc-mcp/arc-1/pull/663)) | `SAPManage action=flp_list_tiles` caused an `ASSERTION_FAILED` short dump in SAP on every call, on every catalog and release — and ARC-1 then told the LLM it was an SAP defect. `PageChipInstances` is navigation-only under `Pages`, and *any* `$filter` on it asserts. It is now read through the association, the same shape SAP's own page-builder service uses. The misleading `backendError` wrapper is gone. | `none` |
+| Correct CTS transport checks ([#659](https://github.com/arc-mcp/arc-1/pull/659)) | `SAPTransport check` now parses the real ADT response — live candidate requests and object locks (with parent owner and task IDs) — surfaces SAP result flags, and fails closed on fatal diagnostics returned with HTTP 200. Adds `operation=create|modify` (default `create`) and distinguishes `transportRequired` from `transportAssignmentRequired`. Corrects the documented contract: `CreateCorrectionRequest` always creates a Workbench (K) request; package and layer affect route and target, not the request kind. | `none` |
+
 ## 1.0.0 — semver commitment, experimental multi-target, bounded tool results (2026-07-31)
 
 The version number is the headline: from `1.0` ARC-1 follows semantic versioning, so breaking changes to the

--- a/tests/unit/server/release-notes.test.ts
+++ b/tests/unit/server/release-notes.test.ts
@@ -1,4 +1,6 @@
 import { readFile } from 'node:fs/promises';
+import { relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
 
@@ -13,6 +15,10 @@ import { parse } from 'yaml';
 
 const CHANGELOG_PATH = 'CHANGELOG.md';
 const NOTES_PATH = 'docs_page/release-notes.md';
+
+/** This file's own repo-relative path — derived, not hard-coded, so a rename breaks the
+ *  workflow-exclusion assertion below instead of silently disarming it. */
+const SELF_PATH = relative(process.cwd(), fileURLToPath(import.meta.url)).replaceAll(sep, '/');
 
 /** Same helper as release-sbom-workflow.test.ts — a GitHub expression is not a JS template. */
 const githubExpression = (expression: string): string => `\${{ ${expression} }}`;
@@ -53,6 +59,21 @@ describe('annotated release notes', () => {
     // release-please inserts new entries below any prose that precedes the first version heading,
     // so this pointer survives every release (googleapis/release-please src/updaters/changelog.ts).
     expect(changelog.slice(0, changelog.indexOf('## ['))).toContain('release-notes');
+  });
+
+  // Same principle as link-release-notes being continue-on-error: documentation polish must never
+  // fail an artifact release. The annotation gate above can only fail AFTER the release PR merges
+  // (that merge is what adds the version to CHANGELOG.md), i.e. once the tag, GitHub Release, Docker
+  // image and .mcpb have already shipped — leaving npm stranded alone (v1.0.1). It therefore runs on
+  // the PR gate, not in publish-npm. This pins the exclusion so renaming this file cannot silently
+  // put the trap back.
+  it('stay out of the npm publish gate', async () => {
+    const workflow = parse(await readFile('.github/workflows/release.yml', 'utf8')) as {
+      jobs: Record<string, { steps?: { name?: string; run?: string }[] }>;
+    };
+
+    const testStep = workflow.jobs['publish-npm']?.steps?.find((step) => step.name === 'Run tests');
+    expect(testStep?.run).toContain(`--exclude '${SELF_PATH}'`);
   });
 
   it('link the published notes from the GitHub Release, best-effort', async () => {


### PR DESCRIPTION
**v1.0.1 is tagged, released, and on GHCR — but not on npm.** [`publish-npm` failed](https://github.com/arc-mcp/arc-1/actions/runs/30830868181/job/91744227715) on:

```
FAIL tests/unit/server/release-notes.test.ts
AssertionError: Unannotated releases in docs_page/release-notes.md: 1.0.1.
```

## Why this can only fail there

The gate asserts `CHANGELOG.md ⊆ docs_page/release-notes.md`. The CHANGELOG only gains the new version
**when the release PR merges** — and that merge is the same push that runs the Release workflow. On top of
that, release-please opens its PR with the default `GITHUB_TOKEN`, so `test.yml` never runs on it
(GITHUB_TOKEN events don't trigger workflows — the existing comment in `release.yml` already says so).

Net effect: an unannotated release fires this gate for the first time **inside `publish-npm`**, after the
tag, the GitHub Release, the Docker images and the `.mcpb` have all shipped — and strands npm alone. Which
is exactly what happened. Pre-annotating (as AGENTS.md prescribes) avoids it; nothing *enforces* it at a
point where failing is cheap.

## The fix

`release.yml` already encodes the right principle one job over — `link-release-notes` is
`continue-on-error: true`, with the comment *"Documentation polish must never fail an artifact release."*
Apply it to the annotation gate too: exclude that one spec from `publish-npm`'s test run.

- The rest of the suite still gates the publish (deliberate — nothing else tests the released commit).
- The gate still runs on **every normal PR** via `test.yml`, where a missing entry blocks a merge instead
  of half a release. It keeps its forcing-function role; it just can't hold artifacts hostage.
- **Rot-proofed:** a new test pins the exclusion, deriving this file's own path from `import.meta.url`
  rather than hard-coding it — rename the spec and CI fails instead of silently restoring the trap.
  Verified by breaking the glob and watching it fail.

Considered and rejected: gating `release-please` itself on the notes check. It removes the half-shipped
state, but blocks *every* artifact — including a security patch — on prose.

## Also in this PR

The missing **1.0.1 annotated release notes** (#665 FUNC metadata, #662 Windows plugins, #663 FLP tiles,
#659 CTS transport checks), which is what unblocks the publish right now.

## Verification

`npm test -- --exclude '…release-notes.test.ts'` → 168 files / 4880 tests (`--exclude` appends to the
config's excludes; `node_modules` is not re-scanned). Full gate green: 4884 tests, typecheck, lint,
`validate:policy`, `check:sizes`, build. `release.yml` re-parsed as YAML to confirm the step.

After merge, `publish-npm` needs a re-run — it does a bare `actions/checkout`, so it will pick up main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)