### PR TITLE
ci: add a manual republish hatch for a failed npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: Release
 on:
   push:
     branches: [main]
+  # Escape hatch for a release whose publish-npm job failed (v1.0.1: the release-notes
+  # gate, since excluded). Re-running the original run cannot fix it — a re-run replays
+  # the triggering commit, and the release tag points at that same pre-fix state. main,
+  # however, still carries the stuck version in package.json plus whatever fixed the
+  # failure, so publishing main IS publishing that version. Only publish-npm honours
+  # this trigger; the tag, GitHub Release, Docker images and .mcpb already shipped.
+  workflow_dispatch:
 
 jobs:
   release-please:
@@ -27,7 +34,10 @@ jobs:
   # place, so the two artifacts rarely diverge.)
   publish-npm:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    # The manual arm is the republish hatch documented on workflow_dispatch above. It
+    # publishes main as-is; npm rejects a duplicate version, so a stray dispatch is a
+    # no-op rather than a way to overwrite a published release.
+    if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Follow-up to #666. The notes are on main, but **v1.0.1 still isn't on npm** — and re-running the failed
job can't fix it.

## Why the re-run keeps failing

`actions/checkout` on a re-run replays the **triggering commit** (`c53437f6`, the release-please merge),
not current main. The `v1.0.1` tag points at that same commit. So the release-notes gate that failed then
fails identically on every retry, forever — #666 fixed the *next* release, not this one.

## The way out

main's `package.json` is already `1.0.1`. main **is** v1.0.1 plus the annotated notes and the exclusion —
it just has no way to be published, because `release.yml` only triggers on push and `publish-npm` is gated
on `release_created`.

So: let `workflow_dispatch` reach `publish-npm`, and nothing else.

- Only `publish-npm` honours the manual trigger. `build-mcpb`, `publish-docker`, `link-release-notes` and
  `publish-npm-sbom` keep their `release_created` gate — those artifacts already shipped for 1.0.1.
- A stray dispatch is a **no-op**: npm rejects a duplicate version. It can't overwrite a published release.
- OIDC trusted publishing is unaffected — same repo, same workflow file.

Considered and rejected: cutting a `Release-As: 1.0.2` to ride the paved road. It works, but leaves 1.0.1
permanently missing from npm while the GitHub Release and the Docker image both claim it shipped — and it
does nothing for the next failed publish. A publish-retry hatch is the thing that was actually missing.

## After merge

```bash
gh workflow run release.yml --repo arc-mcp/arc-1 --ref main
```

Verified: YAML re-parsed to confirm the trigger and that the four other jobs still gate on `release_created`.
Full gate green (4884 tests, typecheck, lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)