### PR TITLE
fix: restore the release gate that ran publish jobs on every push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,8 @@ on:
   # gate, since excluded). Re-running the original run cannot fix it — a re-run replays
   # the triggering commit, and the release tag points at that same pre-fix state. main,
   # however, still carries the stuck version in package.json plus whatever fixed the
-  # failure, so publishing main IS publishing that version.
-  #
-  # It drives the whole npm chain — publish-npm, then publish-npm-sbom and
-  # publish-mcp-registry, which are downstream of it and were skipped along with it.
-  # build-mcpb and publish-docker* stay push-only: they don't depend on npm and had
-  # already shipped. Every step in the chain no-ops on an already-published artifact,
-  # so the hatch is safe to fire more than once.
+  # failure, so publishing main IS publishing that version. Only publish-npm honours
+  # this trigger; the tag, GitHub Release, Docker images and .mcpb already shipped.
   workflow_dispatch:
 
 jobs:
@@ -24,12 +19,8 @@ jobs:
       pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
-      # On the republish hatch release-please creates nothing, so these fall back to the
-      # version main already carries — which IS the stuck release's version.
-      tag_name: ${{ steps.release.outputs.tag_name || steps.republish.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version || steps.republish.outputs.version }}
-      # Single gate for the npm chain: a real release, or a manual republish.
-      publish: ${{ steps.release.outputs.release_created || github.event_name == 'workflow_dispatch' }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5
         id: release
@@ -37,27 +28,16 @@ jobs:
         # From 1.0 the pre-major bump flags are gone, so semver applies normally:
         # feat→minor, fix→patch, breaking→major.
 
-      - uses: actions/checkout@v7
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        with:
-          persist-credentials: false
-
-      - name: Resolve the republish target
-        id: republish
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          set -euo pipefail
-          version="$(node -p "require('./package.json').version")"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag_name=v$version" >> "$GITHUB_OUTPUT"
-
   # npm publishes independently of the Docker CVE gate — a HIGH/CRITICAL finding
   # blocks the Docker image but not the npm package. (The scheduled security-scan.yml
   # gate-preview is what keeps base-image CVEs from reaching a release in the first
   # place, so the two artifacts rarely diverge.)
   publish-npm:
     needs: release-please
-    if: ${{ needs.release-please.outputs.publish }}
+    # The manual arm is the republish hatch documented on workflow_dispatch above. It
+    # publishes main as-is; npm rejects a duplicate version, so a stray dispatch is a
+    # no-op rather than a way to overwrite a published release.
+    if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -103,18 +83,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        # Skip-if-present rather than let npm's duplicate-version 403 fail the run: the
-        # republish hatch exists to un-stick a partial release, and the jobs downstream
-        # of this one gate on its success. A stray dispatch is still a no-op — this only
-        # ever skips a version that is already on the registry, never overwrites one.
-        run: |
-          set -euo pipefail
-          VERSION="$(node -p "require('./package.json').version")"
-          if npm view "arc-1@${VERSION}" version >/dev/null 2>&1; then
-            echo "arc-1@${VERSION} is already published — nothing to do"
-            exit 0
-          fi
-          npm publish --provenance --access public
+        run: npm publish --provenance --access public
 
   # Point the GitHub Release at the annotated release notes (docs_page/release-notes.md), which
   # add the context release-please cannot: what each change means and whether it needs an action.
@@ -153,7 +122,7 @@ jobs:
   # SBOM generation or upload failures must never fail the artifact release.
   publish-npm-sbom:
     needs: [release-please, publish-npm]
-    if: ${{ needs.release-please.outputs.publish }}
+    if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
@@ -347,15 +316,6 @@ jobs:
   # and other MCP clients that consume the registry API.
   publish-mcp-registry:
     needs: [release-please, publish-npm, publish-docker-merge]
-    # always() so a SKIPPED publish-docker-merge doesn't skip this too — that is the
-    # republish-hatch shape, where the images already shipped in the original run. A
-    # FAILED merge still blocks: the step below probes GHCR anyway and omits the OCI
-    # package when it isn't pullable, but a failed merge means something is wrong that
-    # the probe's 30s of retries shouldn't paper over.
-    if: >-
-      ${{ always() && needs.release-please.outputs.publish
-      && needs.publish-npm.result == 'success'
-      && needs.publish-docker-merge.result != 'failure' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs_page/release-notes.md
+++ b/docs_page/release-notes.md
@@ -26,6 +26,19 @@ until they are promoted.
     line — nobody runs them today, and the one part that still matters when jumping from an ancient version
     is the **v0.7.0 authorization break**, which is spelled out in full at the bottom of this page.
 
+## 1.0.2 — completes the 1.0.1 release (2026-08-03)
+
+**No product change: the package contents are identical to 1.0.1.** 1.0.1's own release pipeline stopped
+part-way — npm eventually published, but the CycloneDX SBOM never got attached to the GitHub Release and
+the MCP Registry still advertised 1.0.0. 1.0.2 exists to ship those, and to fix the release-workflow
+regression that caused the second half of that mess. If you are already on 1.0.1 there is nothing to gain
+by upgrading beyond consistency; if you are on 1.0.0, [read 1.0.1](#101--three-total-outage-fixes-2026-08-03)
+— all of it is here.
+
+| Change | What it means | Action |
+|---|---|---|
+| Restore the release gate that ran publish jobs on every push ([#669](https://github.com/arc-mcp/arc-1/pull/669)) | CI only. A gate added while un-sticking 1.0.1 routed the version through a job *output*, and job outputs are strings — so the falsey value became the string `"false"`, which GitHub's `if:` treats as **true**. Every ordinary push to main then ran the npm/SBOM/registry chain with an empty version. Reverted to the per-job conditions, where the expression is evaluated as a real boolean. | `none` |
+
 ## 1.0.1 — three total-outage fixes (2026-08-03)
 
 A pure bugfix release, and every entry in it was failing *100% of the time* for the users it touched, not

--- a/tests/unit/server/release-sbom-workflow.test.ts
+++ b/tests/unit/server/release-sbom-workflow.test.ts
@@ -32,16 +32,9 @@ describe('release npm SBOM workflow', () => {
     const releaseJob = workflow.jobs['release-please'];
     const sbomJob = workflow.jobs['publish-npm-sbom'];
 
-    // release-please's own output first; the republish-hatch fallback only fills in when a
-    // manual dispatch re-publishes a release that release-please already cut.
-    expect(releaseJob.outputs?.version).toBe(
-      githubExpression('steps.release.outputs.version || steps.republish.outputs.version'),
-    );
+    expect(releaseJob.outputs?.version).toBe(githubExpression('steps.release.outputs.version'));
     expect(sbomJob.needs).toEqual(['release-please', 'publish-npm']);
-    // The SBOM describes what npm published, so it must ride exactly the same gate — pinned
-    // as one shared expression so the two can never drift into publishing without an SBOM.
-    expect(sbomJob.if).toBe(githubExpression('needs.release-please.outputs.publish'));
-    expect(workflow.jobs['publish-npm'].if).toBe(sbomJob.if);
+    expect(sbomJob.if).toBe(githubExpression('needs.release-please.outputs.release_created'));
     expect(sbomJob['continue-on-error']).toBe(true);
     expect(sbomJob.permissions).toEqual({ contents: 'write' });
 


### PR DESCRIPTION
Reverts #668, and cuts **1.0.2** as the way to ship v1.0.1's missing artifacts. Chasing them through the
republish hatch has now cost more than a clean release would have.

## The regression

#668 routed the release gate through a job **output**. Job outputs are strings — so
`publish: ${{ '' || false }}` became the string `"false"`, and GitHub's `if:` treats any non-empty string
as **true**. Every ordinary push to main therefore ran the whole npm chain with an empty version
([run 30837419041](https://github.com/arc-mcp/arc-1/actions/runs/30837419041), triggered by #668's own merge):

```
publish-npm-sbom     ::error::Release version mismatch: output= package=1.0.1 lock=1.0.1
publish-mcp-registry 422 validation failed: body.version — "expected length >= 1"
```

npm itself was saved only by the skip-if-already-published guard in the same PR.

The old gate worked because `release_created`'s falsey value is the **empty string**. #667's per-job
conditions are also safe — inside `if:` the expression evaluates as a real boolean instead of being
stringified through an output. So this reverts to exactly that.

## Why 1.0.2 rather than one more hatch fix

v1.0.1 shipped its tag, GitHub Release, Docker images, `.mcpb` and npm, but never got its SBOM asset or
its MCP Registry entry. Every attempt to backfill them has run into a different edge of the "republish a
past release" problem. A normal release doesn't have that problem: it publishes all five artifacts in one
pass, from a commit where everything is already correct.

This lands as `fix:`, so release-please cuts 1.0.2 on merge. **The package contents are identical to
1.0.1** — 1.0.2 exists to run the pipeline end to end. 1.0.2's notes are pre-annotated here, per the
documented flow, so the CHANGELOG ⊆ notes gate stays green through the release merge.

What survives from the last three PRs: #666's exclusion (a docs gate can't strand npm) and #667's manual
`workflow_dispatch` arm on `publish-npm`.

## Verification

Workflow re-parsed as YAML — `publish-npm` back to the #667 condition, `publish-npm-sbom` back to
`release_created`, `publish-mcp-registry` back to needs-only gating (so a plain push skips it via a skipped
`publish-npm`). `release-sbom-workflow.test.ts` restored to its original assertions. Full gate green: 4884
tests, typecheck, lint, `validate:policy`, `check:sizes`, build.

## After merge

release-please opens the 1.0.2 release PR; merging that publishes npm, SBOM, MCP Registry, Docker and
`.mcpb` together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)