### PR TITLE
fix(deps): resolve npm audit advisories in transitive dependencies

### DIFF
--- a/btp/approuter/package-lock.json
+++ b/btp/approuter/package-lock.json
@@ -811,9 +811,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -224,9 +224,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -244,9 +241,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -264,9 +258,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -284,9 +275,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2724,9 +2712,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -3069,9 +3057,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3156,9 +3144,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4028,9 +4016,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4046,8 +4034,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -224,6 +224,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -241,6 +244,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -258,6 +264,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -275,6 +284,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
`npm audit --audit-level=high --omit=optional` fails CI on **every** branch right now — four advisories landed against existing transitive dependencies. Nothing in this repo changed; the advisories did.

| Package | Severity | Advisory | Reached via | Bump |
|---|---|---|---|---|
| `fast-uri` | high | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | `ajv` | 3.1.4 → 3.1.5 |
| `ip-address` | high | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) +2 | `express-rate-limit` | 10.2.0 → 10.4.0 |
| `hono` | moderate | [GHSA-8j4g-w8fx-2239](https://github.com/advisories/GHSA-8j4g-w8fx-2239) | `@modelcontextprotocol/sdk` | 4.12.31 → 4.12.34 |
| `postcss` | moderate | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) | `vitest` → `vite` | 8.5.18 → 8.5.25 |

Lockfile-only (`npm audit fix --package-lock-only --omit=optional`) — no `package.json` change, no direct dependency touched. `npm audit` reports 0 vulnerabilities afterwards.

Split out of #671 deliberately: that PR's lockfile is byte-identical to main, so this is not its regression, and every other open branch needs the same fix.

## Closes the three open Dependabot alerts

The three alerts still open on `main` are all covered here, so #674 (`ip-address` 10.4.0) is redundant with this branch and Dependabot should close it on merge.

| Alert | Advisory | Fixed in | This branch ships |
|---|---|---|---|
| [#31](https://github.com/arc-mcp/arc-1/security/dependabot/31) `ip-address` | [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) | 10.2.1 | 10.4.0 ✅ |
| [#32](https://github.com/arc-mcp/arc-1/security/dependabot/32) `ip-address` | [GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh) | 10.2.2 | 10.4.0 ✅ |
| [#30](https://github.com/arc-mcp/arc-1/security/dependabot/30) `postcss` | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) | 8.5.23 | 8.5.25 ✅ |

## Exposure analysis — ARC-1 is not exploitable by any of the three

Worth recording, because it sets the urgency: this is hygiene and a green CI gate, not an incident.

**Both `ip-address` advisories are SSRF/trust-boundary bypasses in the address *classification* API** — `isLoopback()`, `isPrivate()`, `isLinkLocal()`, `isInSubnet()`, `getType()`, `getScope()`. ARC-1 never imports `ip-address`; it arrives only under `express-rate-limit@8`, whose entire use of it is `ipKeyGenerator`:

```js
if (isIPv6(ip)) {
  const address = new Address6(ip);
  if (address.is4()) return address.to4().correctForm();
  if (ipv6Subnet) return new Address6(`${ip}/${ipv6Subnet}`).networkForm();
}
```

That touches `is4()` / `to4()` / `networkForm()` and **no classification method**, so neither advisory has a reachable sink. Two further reasons the CIDR-suffix variant (GHSA-4xrf-jv44-h6hh) cannot land: the input is Express's `req.ip` behind `trust proxy 1` ([`auth-rate-limit.ts:78`](https://github.com/arc-mcp/arc-1/blob/fix/npm-audit-advisories/src/server/auth-rate-limit.ts#L78)), not an attacker-supplied bare string, and Node's `isIPv6()` gate rejects anything carrying a `/suffix` before `Address6` is constructed. Worst case under a hypothetical bypass is rate-limit *key* skew, not a request to an internal host.

**ARC-1's own SSRF guard is path-based, not IP-classification-based** — `odata_perf` requires a host-relative path on the configured SAP system ([`diagnostics.ts:1097`](https://github.com/arc-mcp/arc-1/blob/fix/npm-audit-advisories/src/adt/diagnostics.ts#L1097)). It never resolves or classifies an IP, so it is structurally unaffected by this class of bug.

**`postcss` is dev-only** (`vitest` → `vite`, `"dev": true`) and the advisory needs PostCSS to process attacker-influenced CSS with the `from` option unset and `result.map` exposed to a user. ARC-1 ships no CSS pipeline and no PostCSS config; Vite passes `from` when it does process CSS. Not reachable.

`ip-address@10.4.0` adds a `prepare` script (`git config core.hooksPath hooks || true`), which Dependabot flags on #674. npm does not run `prepare` for registry tarballs — only for git/link dependencies — so it never executes for this install, and the script is a no-op hook path anyway.

## Follow-up commit: restored `libc` metadata

Review catch, fixed in `cc393be8`. The `npm audit fix` run that produced this branch was done on npm 10, which does not write the `libc` field, so it silently stripped it from the four `@biomejs/cli-linux-*` optional binaries — metadata this repo has carried since #460.

Without it npm 11+ cannot filter those binaries by C library, so `npm ci` on the Alpine (musl) Docker builder stops skipping the glibc variants. Restored by hand rather than by regenerating, so the lockfile now differs from `main` by **exactly the four intended bumps and nothing else** — verified by a key-by-key comparison of every `packages` entry.

## Verification

- `npm ci` → clean install, resolves `ip-address@10.4.0` / `postcss@8.5.25`
- `npm audit --omit=optional` → **0 vulnerabilities** (at *moderate* too, not just the `high` CI gate)
- `npm audit --prefix btp/approuter --omit=optional` → 0 vulnerabilities
- `npm test` → 4884 passed / 169 files · `npm run typecheck` · `npm run lint` · `npm run build` · `npm run check:sizes` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
