### PR TITLE
feat: IDE integration — clickable IDE links, roots awareness, stateful-session release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -75,13 +75,13 @@
     "sap_allow_data_preview": {
       "type": "boolean",
       "title": "Allow Table Data Preview",
-      "description": "Allow SAPRead(type=TABLE_CONTENTS) and SAPQuery table preview. Can expose application data — review your data-governance rules.",
+      "description": "Allow SAPRead(type=TABLE_CONTENTS) and SAPQuery table preview. Can expose application data \u2014 review your data-governance rules.",
       "default": false
     },
     "sap_allow_free_sql": {
       "type": "boolean",
       "title": "Allow Freestyle SQL",
-      "description": "Allow read-only ad-hoc ABAP SQL via SAPQuery. Can expose application data — review your data-governance rules.",
+      "description": "Allow read-only ad-hoc ABAP SQL via SAPQuery. Can expose application data \u2014 review your data-governance rules.",
       "default": false
     },
     "sap_allow_transport_writes": {
@@ -113,6 +113,13 @@
       "title": "UI Loopback Address",
       "description": "Loopback bind address for the local read-only UI.",
       "default": "127.0.0.1:8711"
+    },
+    "arc1_ide_links": {
+      "type": "string",
+      "title": "IDE Links",
+      "description": "Append a clickable IDE link to results about one object. auto | off | vscode | eclipse | a template using {type} {name} {package} {uri} {sid} {client}. Claude Desktop has no IDE of its own, so set 'vscode' or an adt:// template to choose where links should open.",
+      "default": "auto",
+      "required": false
     }
   },
   "mcpServers": {
@@ -137,7 +144,8 @@
         "SAP_ALLOW_GIT_WRITES": "${user_config.sap_allow_git_writes}",
         "ARC1_UI": "${user_config.arc1_ui}",
         "ARC1_UI_OPEN": "${user_config.arc1_ui_open}",
-        "ARC1_UI_ADDR": "${user_config.arc1_ui_addr}"
+        "ARC1_UI_ADDR": "${user_config.arc1_ui_addr}",
+        "ARC1_IDE_LINKS": "${user_config.arc1_ide_links}"
       }
     }
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -75,13 +75,13 @@
     "sap_allow_data_preview": {
       "type": "boolean",
       "title": "Allow Table Data Preview",
-      "description": "Allow SAPRead(type=TABLE_CONTENTS) and SAPQuery table preview. Can expose application data \u2014 review your data-governance rules.",
+      "description": "Allow SAPRead(type=TABLE_CONTENTS) and SAPQuery table preview. Can expose application data — review your data-governance rules.",
       "default": false
     },
     "sap_allow_free_sql": {
       "type": "boolean",
       "title": "Allow Freestyle SQL",
-      "description": "Allow read-only ad-hoc ABAP SQL via SAPQuery. Can expose application data \u2014 review your data-governance rules.",
+      "description": "Allow read-only ad-hoc ABAP SQL via SAPQuery. Can expose application data — review your data-governance rules.",
       "default": false
     },
     "sap_allow_transport_writes": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -117,7 +117,7 @@
     "arc1_ide_links": {
       "type": "string",
       "title": "IDE Links",
-      "description": "Append a clickable IDE link to results about one object. auto | off | vscode | eclipse | a template using {type} {name} {package} {uri} {sid} {client}. Claude Desktop has no IDE of its own, so set 'vscode' or an adt:// template to choose where links should open.",
+      "description": "Append a clickable IDE link to results about one object. auto | off | vscode | eclipse | a template using {type} {name} {package} {uri} {sid} {client}. NOTE: Claude Desktop renders vscode:// and adt:// links but will not open them (it only hands http/https to the OS), so a link set here is copy-paste only. 'auto' correctly emits nothing in Claude Desktop.",
       "default": "auto",
       "required": false
     }

--- a/.env.example
+++ b/.env.example
@@ -263,3 +263,14 @@ SAP_TRANSPORT=stdio              # or: http-streamable
 #
 # See docs_page/updating.md#v07-authorization-refactor-breaking-change for
 # the full migration guide.
+
+# Append an IDE deep link to tool results that name exactly one object.
+#   off      no links
+#   auto     derive from the calling MCP client (default; VS Code gets a bridge link,
+#            clients with no IDE get nothing)
+#   vscode   link into the ARC-1 ABAP Bridge extension
+#   eclipse  adt:// link (needs a system id — see below)
+#   <template>  custom, using {type} {name} {package} {uri} {sid} {client}
+# On a plain on-prem connection there is no system id, so put it in a template:
+#   ARC1_IDE_LINKS='adt://A4H{uri}?sap-client=001'
+ARC1_IDE_LINKS=auto

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Full per-option details (defaults, clamps, layer interactions): [docs_page/confi
 | `ARC1_MULTI_TARGET_ALLOW_BASIC_AUTH` | Default false. Permits shared BasicAuthentication targets in multi mode; never PP fallback, credentials stay request-local, and v1 requires exactly one CF instance. |
 | `SAP_PP_ENABLED` / `SAP_PP_STRICT` / `SAP_PP_ALLOW_SHARED_COOKIES` | Principal propagation + strict mode + cookie-coexistence escape hatch |
 | `SAP_DISABLE_SAML` | Disable SAML redirect — never on BTP ABAP / S/4 Public Cloud |
+| `ARC1_IDE_LINKS` | Append an IDE deep link to single-object tool results: `off`/`auto`/`vscode`/`eclipse`/template (`{type} {name} {package} {uri} {sid} {client}`). `auto` derives from the calling client and emits nothing for clients with no IDE. Link rides in its OWN content block — never concatenated onto a JSON payload |
 | `ARC1_MINIMAL_ERRORS` | Hide SAP diagnostic details from client-facing tool errors; keep request correlation for operators |
 | `ARC1_LOG_HTTP_DEBUG` | HTTP debug fields in audit; bodies are centrally redacted before sink writes |
 

--- a/docs/plans/ide-integration-v1.md
+++ b/docs/plans/ide-integration-v1.md
@@ -209,42 +209,48 @@ reliable path exists. The template escape hatch remains for anyone who wants to 
 full knowledge of the trade-offs — ARC-1 just does not own that brittleness. A prototype redirect page
 lives at `arc1-abap-bridge/redirect/index.html` for reference.
 
-## Session hygiene on writes — hypothesis disproven, real fix shipped
+## The IDE logouts — SOLVED: the ABAP debugger, not ARC-1
 
-Observed four times on 2026-08-03: the ADT session in VS Code dies and every `abap:` operation fails,
-surfacing misleadingly as `NoPermissions (FileSystemError): Method "createDirectory" not yet implemented`.
+Repeated "Disconnected from destination A4H2023", surfacing misleadingly as
+`NoPermissions (FileSystemError): Method "createDirectory" not yet implemented`.
 
-**The original hypothesis was wrong.** It assumed SAP issues a fresh `SAP_SESSIONID` for a stateful
-request, so that discarding the clone's cookie jar orphaned one session per write. Probed directly
-against a4h (read-only, three GETs on `/sap/bc/adt/discovery`):
+**Cause, from the ADT Communication Log** (`adt.enableCommunicationLog: true` → Output → *ADT
+Communication Log*):
 
-| Request | New session cookie |
-|---|---|
-| plain GET | yes — the initial session |
-| GET with `X-sap-adt-sessiontype: stateful` | **none — cookie reused** |
-| GET with `X-sap-adt-sessiontype: stateless` | none — cookie reused |
+```
+16:22:23  POST 504  60220ms  ../debugger/listeners?debuggingMode=user&requestUser=MARIAN…
+16:22:24  GET  200    151ms  ../debugger/listeners…
+16:23:24  POST 504  60075ms  ../debugger/listeners…
+16:23:26  GET  200    119ms  /sap/public/bc/icf/logoff     ← the LS logs ITSELF out
+```
 
-So there is no per-write session orphaning, and that mechanism cannot explain the logouts.
+The ADT debugger long-polls `POST ../debugger/listeners`. The poll is killed at **60 s** (durations
+60220 ms and 60075 ms — a textbook 60-second `proxy_read_timeout` in the nginx fronting a4h for TLS),
+and after the second consecutive 504 the language server calls `/sap/public/bc/icf/logoff` and
+terminates the session. `adt.debugger.enableDebugger` defaults to **true**, so this runs unprompted.
 
-**What was genuinely wrong, and is now fixed** (`withStatefulSession`):
+**Control experiment.** A plain SAP session with no IDE and no debugger, polled every 5 minutes with
+cookie-only auth (`arc1-abap-bridge/session-monitor.mjs`): **alive at 175 minutes**. The IDE session
+died in ~2 minutes. That rules out an idle/absolute timeout, the per-user mode cap, and ARC-1.
 
-1. **The stateful context was never released.** A stateful ADT session persists until explicitly ended —
-   omitting the header on later requests does *not* end it. ARC-1 sent `stateful` and never followed with
-   `stateless`, so its session stayed stateful and held an ABAP mode until timeout. Eclipse ADT and
-   `abap-adt-api` both send the release. Now sent as a best-effort `HEAD /sap/bc/adt/core/discovery`
-   in a `finally`, so it also runs when the write throws and can never mask the caller's error.
-2. **A rotated session cookie was lost.** The clone's jar was discarded, so if SAP ever rotates the
-   session id mid-block the parent keeps using a dead one and the next request silently starts a new
-   session. Not observed on 7.58, but the window is real; the jar and CSRF token are now merged back.
+**Fixes**, in preference order:
 
-Verified live: create → update → delete of a `$TMP` program, all three stateful cycles clean.
+1. **Raise the reverse-proxy read timeout** for the ADT paths — `proxy_read_timeout 600s;` — so the
+   debugger's long poll survives. Keeps the debugger working. This is the real fix.
+2. **`"adt.debugger.enableDebugger": false`** (requires an IDE restart) — instant relief, at the cost of
+   ABAP debugging in VS Code.
 
-**The logouts remain unexplained.** Remaining candidates, cheapest first: an idle/absolute timeout on the
-ADT language server's reentrance-ticket session (most likely, and nothing to do with ARC-1); the per-user
-mode cap (`rdisp/max_alt_modes`, commonly 6) with ARC-1 + the LS + SAP GUI all logged on as the same user;
-or the bridge's parallel `readDirectory` load on the LS. To identify it, record the interval between
-logon and logout — a consistent ~30/60 minutes points to a timeout, correlation with write bursts points
-to load.
+Two earlier hypotheses were wrong and are recorded so nobody re-derives them: (a) that stateful writes
+orphaned a SAP session per write — disproven, SAP reuses the session cookie for a stateful request;
+(b) that an idle timeout was expiring the session — disproven by the 175-minute control.
+
+### Still worth having: the stateful-session release
+
+Independent of the logouts, `withStatefulSession` had two genuine defects, now fixed. A stateful ADT
+session persists until explicitly ended — dropping the header does *not* end it — so ARC-1's session
+stayed stateful and held an ABAP mode until timeout; it now sends the release in a `finally`, so it runs
+on the throw path too and can never mask a caller's error. And a session cookie rotated mid-block was
+discarded with the clone, leaving the parent on a dead id; the jar and CSRF token are now merged back.
 
 ## Out of scope for v1
 

--- a/docs/plans/ide-integration-v1.md
+++ b/docs/plans/ide-integration-v1.md
@@ -172,6 +172,27 @@ an object is not in the workspace and therefore not openable.
 deployments simply keep the warning that roots would have suppressed — nothing breaks, and those
 deployments (Copilot Studio, browser clients) usually have no IDE anyway.
 
+### Measured: Claude Desktop renders `vscode://` links but will not open them
+
+Live test, 2026-08-03. With `ARC1_IDE_LINKS=vscode`, Claude Desktop renders the link as a normal blue
+"Open in IDE" hyperlink — and **clicking does nothing**. The scheme itself is fine: `open
+"vscode://marianfoo.arc1-abap-bridge/open?name=ZCL_ARC1_TASK_SERVICE"` from a shell returns 0 and fronts
+VS Code, and the identical link works from VS Code's own chat. Claude Desktop only hands `http`/`https`
+to the OS.
+
+Consequences:
+
+- **`auto` emitting nothing for `claude-ai` is now evidence-based, not caution.** A link there would
+  render and silently fail — worse than no link.
+- **Setting `vscode` explicitly in Claude Desktop is a trap**, and the `user_config` description said to
+  do exactly that. Corrected: the link is copy-paste only there.
+- Expect the same for `adt://` from Claude Desktop, for the same reason. Untested but it is the same
+  class of scheme.
+
+If the Desktop→IDE jump is wanted later, the vehicle has to be `http`: a loopback listener in the bridge
+(`http://127.0.0.1:<port>/open?name=…`) that performs the navigation in-process. Claude Desktop will open
+an http link, and the bridge is already the component that knows how to resolve and open an object.
+
 ## Known issue: ARC-1 writes appear to log the IDE out
 
 Observed four times on 2026-08-03, and more frequently as ARC-1 write volume rose: the ADT session in

--- a/docs/plans/ide-integration-v1.md
+++ b/docs/plans/ide-integration-v1.md
@@ -290,12 +290,24 @@ is too much to build speculatively.
 - Security line: `clientAgent` is client-controlled. Fine for choosing a link format, never for anything
   security-relevant.
 
-**T2. Roots-derived destination awareness.**
+**T2. Roots-derived destination awareness.** ✅ **DONE**
 - Files: `src/server/server.ts` (call `server.listRoots()` once per session, cache, refresh on
   `notifications/roots/list_changed`), consumed where links are emitted.
 - Measured: VS Code returns `[{name:"UI5con_2026",uri:"file:///…"},{name:"A4H2023",uri:"abap:/repotree-v1/A4H2023"}]`.
 - Strictly additive: roots changes what ARC-1 *knows*, never what it *does*. Impossible on HTTP
   (`src/server/http.ts:193` builds a per-request `Server`), so every feature must work without it.
+
+Shipped as `src/server/ide-roots.ts` (cached per session, capability-gated, 2s timeout, never throws)
+plus `abapDestinationsFromRoots` in `ide-links.ts`. Two behaviours it buys:
+
+1. **Links are gated on a real ABAP folder, not the client's name.** `auto` previously keyed on "is this
+   VS Code", so a VS Code user *without* the bridge or without a package in the workspace got a link that
+   could not resolve. An `abap:` root proves the extension is live and a package is open. When roots are
+   unavailable (HTTP, or a client without the capability) it falls back to the client name, so nothing
+   regresses.
+2. **`{sid}` comes from the IDE.** `abap:/repotree-v1/A4H2023` → `A4H2023`, which is the only place a
+   system id exists at all on a plain on-prem connection — `destinationName`/`targetId` are BTP/multi-target
+   only. That makes `eclipse` links work without a hand-written template.
 
 **T3. `package` on results.** Free on writes (`resolveObjectPackage` already runs when `allowedPackages`
 is restricted); opt-in on reads (`includePackage: true`) because it costs an extra ADT GET.

--- a/docs/plans/ide-integration-v1.md
+++ b/docs/plans/ide-integration-v1.md
@@ -189,9 +189,25 @@ Consequences:
 - Expect the same for `adt://` from Claude Desktop, for the same reason. Untested but it is the same
   class of scheme.
 
-If the Desktop→IDE jump is wanted later, the vehicle has to be `http`: a loopback listener in the bridge
-(`http://127.0.0.1:<port>/open?name=…`) that performs the navigation in-process. Claude Desktop will open
-an http link, and the bridge is already the component that knows how to resolve and open an object.
+Two workarounds were prototyped and **both rejected**:
+
+1. **Loopback listener in the bridge.** For ARC-1 to emit a correct URL it must know the port at emit
+   time, so the port has to be fixed and guessable — and a fixed, unauthenticated local endpoint that
+   performs actions is reachable by any web page you visit (CORS blocks reading the response, not the
+   side effect). A random port plus a token published in `~/.arc1/bridge.json` closes that hole, but it
+   is a listener in the editor plus a secrets file to save a copy-paste.
+2. **Hosted `http` page that bounces to `vscode://`.** Verified working: a browser *will* hand a custom
+   scheme to the OS from page JS, with no confirmation prompt. Putting the object in the URL **fragment**
+   keeps it off the server entirely. But the chain is Desktop link policy → default browser → host
+   reachable → not proxy-blocked → browser hands off → fragment survives every hop → VS Code running →
+   bridge installed. Eight links, seven outside our control, and it fails *after* the click rather than
+   by simply not being clickable. The fragment was already lost once during testing (macOS `open` strips
+   it from a `file://` URL), producing a silent empty-name link.
+
+**Decision: neither ships.** `auto` emitting nothing in Claude Desktop is the correct behaviour because no
+reliable path exists. The template escape hatch remains for anyone who wants to wire up a redirect with
+full knowledge of the trade-offs — ARC-1 just does not own that brittleness. A prototype redirect page
+lives at `arc1-abap-bridge/redirect/index.html` for reference.
 
 ## Known issue: ARC-1 writes appear to log the IDE out
 

--- a/docs/plans/ide-integration-v1.md
+++ b/docs/plans/ide-integration-v1.md
@@ -172,6 +172,32 @@ an object is not in the workspace and therefore not openable.
 deployments simply keep the warning that roots would have suppressed — nothing breaks, and those
 deployments (Copilot Studio, browser clients) usually have no IDE anyway.
 
+## Known issue: ARC-1 writes appear to log the IDE out
+
+Observed four times on 2026-08-03, and more frequently as ARC-1 write volume rose: the ADT session in
+VS Code dies and every `abap:` operation fails. It surfaces misleadingly as
+`NoPermissions (FileSystemError): Method "createDirectory" not yet implemented`.
+
+Two code-level facts (certain):
+
+1. **Stateful-session cookies are discarded.** `withStatefulSession` (`src/adt/http.ts:296`) does
+   `sessionClient.cookieJar = new Map(this.cookieJar)` and never merges the jar back, so any cookie SAP
+   sets during lock→modify→unlock is lost when the clone goes out of scope.
+2. **The stateful context is never released.** No `X-sap-adt-sessiontype: stateless` request exists
+   anywhere in the codebase. Eclipse ADT and `abap-adt-api` both send one after unlocking.
+
+Hypothesis (fits the symptom, not yet proven): if SAP issues a fresh `SAP_SESSIONID` for the stateful
+interaction, ARC-1 orphans one session per write. SAP caps concurrent sessions per user
+(`rdisp/max_alt_modes`, commonly 6) and evicts the oldest when the cap is reached — the long-lived IDE
+session.
+
+**To verify** (one write, non-destructive on a `$TMP` object): run with `ARC1_LOG_HTTP_DEBUG=true` and
+check whether a `Set-Cookie` carrying a *different* `SAP_SESSIONID` appears inside the stateful block.
+
+**Proposed fix:** merge the clone's cookie jar back into the parent after `fn` resolves, and send a
+trailing `X-sap-adt-sessiontype: stateless` request to release the context. Both belong in
+`withStatefulSession` so every write path inherits them.
+
 ## Out of scope for v1
 
 - **Write journal** (`ARC1_WRITE_JOURNAL_DIR`) — deferred by decision. It is also the change with a real

--- a/docs/plans/ide-integration-v1.md
+++ b/docs/plans/ide-integration-v1.md
@@ -209,7 +209,7 @@ reliable path exists. The template escape hatch remains for anyone who wants to 
 full knowledge of the trade-offs — ARC-1 just does not own that brittleness. A prototype redirect page
 lives at `arc1-abap-bridge/redirect/index.html` for reference.
 
-## The IDE logouts — SOLVED: the ABAP debugger, not ARC-1
+## The IDE logouts — probable cause: the ABAP debugger, not ARC-1
 
 Repeated "Disconnected from destination A4H2023", surfacing misleadingly as
 `NoPermissions (FileSystemError): Method "createDirectory" not yet implemented`.
@@ -225,9 +225,14 @@ Communication Log*):
 ```
 
 The ADT debugger long-polls `POST ../debugger/listeners`. The poll is killed at **60 s** (durations
-60220 ms and 60075 ms — a textbook 60-second `proxy_read_timeout` in the nginx fronting a4h for TLS),
-and after the second consecutive 504 the language server calls `/sap/public/bc/icf/logoff` and
-terminates the session. `adt.debugger.enableDebugger` defaults to **true**, so this runs unprompted.
+60220 ms and 60075 ms — a textbook 60-second `proxy_read_timeout` in the nginx fronting a4h for TLS).
+`adt.debugger.enableDebugger` defaults to **true**, so this runs whether or not you ever debug.
+
+**What is proven vs inferred.** The 504s are certain and wrong on their own terms — a long poll designed
+to hang open should not die every 60 s. That the *logoff* is caused by them is **not** proven: it is one
+sample, and `/sap/public/bc/icf/logoff` is also exactly what a clean IDE shutdown emits, so the 1.7 s gap
+is equally consistent with the window being closed at 16:23:26. Confirmed only if the disconnects stop
+now that the timeout is raised.
 
 **Control experiment.** A plain SAP session with no IDE and no debugger, polled every 5 minutes with
 cookie-only auth (`arc1-abap-bridge/session-monitor.mjs`): **alive at 175 minutes**. The IDE session
@@ -235,8 +240,11 @@ died in ~2 minutes. That rules out an idle/absolute timeout, the per-user mode c
 
 **Fixes**, in preference order:
 
-1. **Raise the reverse-proxy read timeout** for the ADT paths — `proxy_read_timeout 600s;` — so the
-   debugger's long poll survives. Keeps the debugger working. This is the real fix.
+1. **Raise the reverse-proxy read timeout** so the debugger's long poll survives. Keeps the debugger
+   working. Applied 2026-08-05 on the host serving all three test systems, as a single http-level
+   `/etc/nginx/conf.d/sap-proxy-timeout.conf` (`proxy_read_timeout`/`proxy_send_timeout 3600s`) — the
+   three SAP vhosts are the only things that proxy, and revert is `rm` plus a reload. Nothing had set a
+   timeout before, so every vhost sat on nginx's 60 s default.
 2. **`"adt.debugger.enableDebugger": false`** (requires an IDE restart) — instant relief, at the cost of
    ABAP debugging in VS Code.
 

--- a/docs/plans/ide-integration-v1.md
+++ b/docs/plans/ide-integration-v1.md
@@ -209,31 +209,42 @@ reliable path exists. The template escape hatch remains for anyone who wants to 
 full knowledge of the trade-offs — ARC-1 just does not own that brittleness. A prototype redirect page
 lives at `arc1-abap-bridge/redirect/index.html` for reference.
 
-## Known issue: ARC-1 writes appear to log the IDE out
+## Session hygiene on writes — hypothesis disproven, real fix shipped
 
-Observed four times on 2026-08-03, and more frequently as ARC-1 write volume rose: the ADT session in
-VS Code dies and every `abap:` operation fails. It surfaces misleadingly as
-`NoPermissions (FileSystemError): Method "createDirectory" not yet implemented`.
+Observed four times on 2026-08-03: the ADT session in VS Code dies and every `abap:` operation fails,
+surfacing misleadingly as `NoPermissions (FileSystemError): Method "createDirectory" not yet implemented`.
 
-Two code-level facts (certain):
+**The original hypothesis was wrong.** It assumed SAP issues a fresh `SAP_SESSIONID` for a stateful
+request, so that discarding the clone's cookie jar orphaned one session per write. Probed directly
+against a4h (read-only, three GETs on `/sap/bc/adt/discovery`):
 
-1. **Stateful-session cookies are discarded.** `withStatefulSession` (`src/adt/http.ts:296`) does
-   `sessionClient.cookieJar = new Map(this.cookieJar)` and never merges the jar back, so any cookie SAP
-   sets during lock→modify→unlock is lost when the clone goes out of scope.
-2. **The stateful context is never released.** No `X-sap-adt-sessiontype: stateless` request exists
-   anywhere in the codebase. Eclipse ADT and `abap-adt-api` both send one after unlocking.
+| Request | New session cookie |
+|---|---|
+| plain GET | yes — the initial session |
+| GET with `X-sap-adt-sessiontype: stateful` | **none — cookie reused** |
+| GET with `X-sap-adt-sessiontype: stateless` | none — cookie reused |
 
-Hypothesis (fits the symptom, not yet proven): if SAP issues a fresh `SAP_SESSIONID` for the stateful
-interaction, ARC-1 orphans one session per write. SAP caps concurrent sessions per user
-(`rdisp/max_alt_modes`, commonly 6) and evicts the oldest when the cap is reached — the long-lived IDE
-session.
+So there is no per-write session orphaning, and that mechanism cannot explain the logouts.
 
-**To verify** (one write, non-destructive on a `$TMP` object): run with `ARC1_LOG_HTTP_DEBUG=true` and
-check whether a `Set-Cookie` carrying a *different* `SAP_SESSIONID` appears inside the stateful block.
+**What was genuinely wrong, and is now fixed** (`withStatefulSession`):
 
-**Proposed fix:** merge the clone's cookie jar back into the parent after `fn` resolves, and send a
-trailing `X-sap-adt-sessiontype: stateless` request to release the context. Both belong in
-`withStatefulSession` so every write path inherits them.
+1. **The stateful context was never released.** A stateful ADT session persists until explicitly ended —
+   omitting the header on later requests does *not* end it. ARC-1 sent `stateful` and never followed with
+   `stateless`, so its session stayed stateful and held an ABAP mode until timeout. Eclipse ADT and
+   `abap-adt-api` both send the release. Now sent as a best-effort `HEAD /sap/bc/adt/core/discovery`
+   in a `finally`, so it also runs when the write throws and can never mask the caller's error.
+2. **A rotated session cookie was lost.** The clone's jar was discarded, so if SAP ever rotates the
+   session id mid-block the parent keeps using a dead one and the next request silently starts a new
+   session. Not observed on 7.58, but the window is real; the jar and CSRF token are now merged back.
+
+Verified live: create → update → delete of a `$TMP` program, all three stateful cycles clean.
+
+**The logouts remain unexplained.** Remaining candidates, cheapest first: an idle/absolute timeout on the
+ADT language server's reentrance-ticket session (most likely, and nothing to do with ARC-1); the per-user
+mode cap (`rdisp/max_alt_modes`, commonly 6) with ARC-1 + the LS + SAP GUI all logged on as the same user;
+or the bridge's parallel `readDirectory` load on the LS. To identify it, record the interval between
+logon and logout — a consistent ~30/60 minutes points to a timeout, correlation with write bursts points
+to load.
 
 ## Out of scope for v1
 

--- a/docs/plans/ide-integration-v1.md
+++ b/docs/plans/ide-integration-v1.md
@@ -1,0 +1,376 @@
+# Plan: IDE integration v1 — ARC-1 proposes, the IDE writes
+
+Status: **spec, not yet implemented**. Dated 2026-08-03.
+Research behind it: `docs/research/2026-07-31-vscode-arc1-diff-bridge.md` (VS Code surfaces) and
+`docs/research/2026-08-01-native-abap-editing-integration.md` (what "native" costs).
+Reference implementation of the IDE half: `~/DEV/arc1-abap-bridge` (v0.4.0, working against a4h).
+
+## Goal
+
+Bring ARC-1 and the IDE close enough that an ABAP change feels like a normal Copilot code change:
+the object opens in the real editor, the model's answer links to it, and the diff is a diff editor.
+Secondary and equally important: make ARC-1 useful in the **many deployments that will never enable
+writes** — by letting it *propose* changes the IDE applies.
+
+## Measured basis (do not re-derive)
+
+| Fact | Evidence |
+|---|---|
+| Copilot's Keep/Undo UI renders only for **its own** edit tools on a workspace URI | stable VS Code API has no edit-carrying chat part; every candidate is proposed API (Copilot enables 63) |
+| `abap:` is a **writable** FileSystemProvider, so an ABAP object *is* a workspace URI | `registerFileSystemProvider(oe, this, {isCaseSensitive:true})` in `sapse.adt-vscode` 1.1.1 |
+| No scheme gate on Copilot's edit path | `scheme!=="file"` appears 3× in the 20 MB bundle: cache-key normaliser, raw `node:fs` reader, `.copilotignore` discovery — none on the edit path |
+| VS Code sends workspace folders as **MCP roots, including non-`file:` schemes** | workbench filters roots by `authority`, not scheme; only `file:` gets path normalisation |
+| VS Code advertises the `roots` capability | probe: `Visual Studio Code` 1.131.0, proto 2025-11-25, caps `roots,sampling,elicitation,tasks,extensions` |
+| Claude Desktop advertises **no** roots | probe: `claude-ai` 0.1.0, caps `extensions` |
+| Claude Code names its client per-server | probe: `local-agent-mode-client-probe` → under ARC-1 it is `local-agent-mode-arc-1`; match by **prefix** |
+| `listRoots()` is impossible on ARC-1's HTTP transport | `src/server/http.ts:193` builds a per-request `Server` that never sees `initialize` |
+| `server.listRoots()` exists in the SDK ARC-1 already ships | `@modelcontextprotocol/sdk ^1.28.0` |
+
+## A. `SAPWrite action="propose"` — read-scoped dry run
+
+**The headline change.** Runs every transform, gate and check, returns what *would* happen, writes nothing.
+
+### Shape
+
+```
+SAPWrite(action="propose", proposeAction="edit_method", type="CLAS", name="ZCL_X", method="…", source="…")
+```
+
+One new action enum value plus one `proposeAction` property covers **all** write actions. The alternative —
+`propose_update`, `propose_edit_method`, ×20 — would blow the tool-definition snapshots and the schema
+budget for no benefit.
+
+### Policy
+
+```ts
+'SAPWrite.propose': { scope: 'read', opType: OperationType.Intelligence }
+```
+
+`Intelligence` is the correct opType (SAP-side compute, no mutation — same class as where-used and
+completion) and `OPTYPE_SCOPE` already maps it to `read`. This satisfies the invariant that a tool may not
+claim `read` while declaring a write op — which is exactly why `dryRun` **cannot** be a boolean flag on the
+existing write actions. `filterToolsByAuthScope` already prunes per-action enums, so a read-only user sees
+`SAPWrite` with `action` reduced to `["propose"]` — no new tool, no extra listing logic.
+
+### Gating
+
+- **Requires `read` scope only.** Works with `SAP_ALLOW_WRITES=false`. That is the point.
+- Must never lock, PUT, DELETE, or take any CSRF-mutating path.
+- `allowedPackages` is **evaluated and reported, never enforced**: nothing is written, so blocking a
+  proposal buys nothing, and in a read-only deployment ARC-1's ceiling was never the enforcement point —
+  `S_DEVELOP` and the IDE are. Response carries e.g. *"ZARC1_DEMO is outside allowedPackages; ARC-1 could
+  not apply this itself."*
+- Emits a distinct audit event (`tool_call_*` with the propose action) so admins can see proposals being
+  generated in a writes-disabled system.
+
+### Payload rules (context-safety)
+
+Large classes and reports must not overflow the caller's context. Three rules, no size knob needed:
+
+1. **Never echo back caller-supplied source.** For `update`/`edit_method` the model already sent the new
+   source — return only the unified diff plus verdicts (lint, package, syntax).
+2. **Return generated source only where ARC-1 generated it** — RAP scaffolding, create-from-template,
+   `batch_create`, `generate_behavior_implementation`.
+3. **Return the smallest replaceable unit** — a method for `edit_method`, a section for class surgery —
+   never the whole object.
+
+Plus a hard cap on the diff with an explicit truncation notice; the full text stays reachable via
+`SAPRead action="diff"`.
+
+### Engineering cost — the real work
+
+Each write action must split into a pure **plan** (`{source?, diff, warnings, package, verdicts}`, no
+mutation) and an **apply** (lock → PUT → unlock). Affects `src/handlers/write/` (`create.ts` 1304 lines,
+`class-surgery.ts` 616, `update-delete.ts` 321, `rap.ts` 291, `unit-surgery.ts` 82) and `write.ts` (329).
+Independently a quality win: plans become unit-testable without a SAP system.
+
+Follow the playbook — freeze `tests/fixtures/tool-definitions/*.json` first, move code verbatim, one action
+at a time, full gate between commits.
+
+## B. Diff on ordinary writes
+
+Successful writes currently return `Successfully updated CLAS ZCL_X.` Add `+N/-M` and optionally the hunks.
+Needs the same pre-write GET of current source that `propose` needs (ETag-cached) — **build the pre-read
+once, serve both A and B**. `unifiedDiff` already exists in `src/adt/source-diff.ts`.
+
+## C. `package` on results
+
+- **Writes: free** — `enforceAllowedPackageForObjectUrl` already calls `client.resolveObjectPackage()`
+  whenever `allowedPackages` is restricted. Include it in the result.
+- **Reads: one extra ADT GET** — `/source/main` carries no package. Therefore **opt-in only**
+  (`includePackage: true`), never on by default. Do not spend a round trip per read.
+
+## D. `ARC1_IDE_LINKS` — clickable output
+
+```
+ARC1_IDE_LINKS = auto | off | vscode | eclipse | <template>
+```
+
+`<template>` takes `{type} {name} {package} {uri}` so it stays vendor-neutral (principle 5).
+
+`auto` resolves from the existing `clientAgent` (`clientInfo` on stdio, `User-Agent` on HTTP —
+`src/server/context.ts:27`, `src/server/http.ts:201`), today marked audit-only; promote it to a
+**presentation** input:
+
+| clientInfo | auto emits |
+|---|---|
+| `Visual Studio Code` (prefix match, covers forks) | `vscode://marianfoo.arc1-abap-bridge/open?name=…&package=…` |
+| `local-agent-mode-*` (Claude Code) | nothing — no IDE to target |
+| `claude-ai`, anything unrecognised | **nothing** |
+
+Claude Desktop advertises no roots and has no IDE, so `auto` can never infer there — which is exactly why
+the explicit setting matters. `.mcpb` `user_config` supports only `string`/`boolean`, so it is a string
+field defaulting to `auto`, mapped to `ARC1_IDE_LINKS` in `server.mcp_config.env`. A Claude Desktop user
+picks `vscode` or an Eclipse template in the extension's settings UI.
+
+**Security line:** `clientAgent` is client-controlled. Fine for choosing a link format (worst case: a
+useless link). Never for anything security-relevant.
+
+**Mismatch behaviour (decided):** emit the link anyway, with a warning when the IDE destination cannot be
+confirmed. Suppress the warning when roots confirms the same system.
+
+### Eclipse `adt://` links — format derived, scheme is OS-registered
+
+ADT registers the scheme with the operating system, so an `adt://` link clicked from Claude Desktop, a
+browser or anywhere else routes into Eclipse:
+
+```xml
+<extension point="org.eclipse.urischeme.uriSchemeHandlers">
+  <uriSchemeHandler class="com.sap.adt.tools.core.ui.internal.openurl.AdtLinkHandler" uriScheme="adt"/>
+```
+
+Present in every ADT from 3.32 to 3.60. `AdtLinkHandler` implements `IUriSchemeHandler` and delegates
+straight to `AdtNavigationServiceFactory` → `IAdtNavigationService`.
+
+The format comes from `com.sap.adt.tools.abapsource.urimapping.ExternalUriUtil`, whose constants are
+`adt://`, `getSystemId`, `adtObjectBaseUri`, `client` / `sap-client`, `addSystemClientToUriIfNecessary`
+and `useSystemAgnosticURI`:
+
+```
+adt://<systemId>/<adt object uri>[?sap-client=NNN]
+e.g. adt://A4H/sap/bc/adt/oo/classes/zcl_arc1_task_service?sap-client=001
+```
+
+**ARC-1 already has every part** — the ADT object URI is what it builds for every read/write, and the SID
+and client come from the connection. A *system-agnostic* variant (no `<systemId>`) exists for sharing a
+link with someone on a different system; worth exposing as a template option.
+
+Remaining empirical detail: whether the authority is the **SID** (`A4H`) or the ADT **project name**
+(`A4H2023` in the current VS Code destination). `getSystemId` implies SID. Confirm with one
+**ABAP: Share Link… → Copy ADT Link** before shipping the `eclipse` variant.
+
+## E. IDE context via MCP roots — strictly additive
+
+On stdio, call `server.listRoots()` once per session (cached, refreshed on
+`notifications/roots/list_changed`) and keep any `abap:` roots. Gives ARC-1, with **zero extension
+involvement**: which destination the IDE has open, and which packages are in the workspace.
+
+Uses: confirm the IDE is on the same system before emitting a link without a warning; tell the model when
+an object is not in the workspace and therefore not openable.
+
+**Rule: roots changes what ARC-1 knows, never what it does.** Every feature must work without it. HTTP
+deployments simply keep the warning that roots would have suppressed — nothing breaks, and those
+deployments (Copilot Studio, browser clients) usually have no IDE anyway.
+
+## Out of scope for v1
+
+- **Write journal** (`ARC1_WRITE_JOURNAL_DIR`) — deferred by decision. It is also the change with a real
+  security story: plaintext source to disk, outside the audit sinks' redaction.
+- Pushing an edit into Copilot's Keep/Undo UI — requires proposed APIs, not publishable.
+- MCP `resource_link` to an ABAP file — VS Code rewrites every one to `mcp-resource://`.
+- Name→URI resolution, editors, diff editors — bridge/plugin territory, deliberately not in ARC-1.
+
+## IDE side (context, not ARC-1 work)
+
+**VS Code** — `arc1-abap-bridge` already resolves name→`abap:` URI (package via ARC-1's
+`SAPSearch(tadir_lookup)` through `lm.invokeTool`, no model turn), opens objects, serves `vscode://` deep
+links, and renders the activated↔inactive diff. Remaining: `line`/`method` in deep links, and consuming
+`propose` output once it exists.
+
+**Eclipse** — plugin hosting an in-process MCP server (Copilot for Eclipse has zero extension points but
+full MCP support). Core logic is *simpler* than VS Code — `com.sap.adt.tools.core.ui.navigation` is
+exported public API, and `CompareUI` handles diffs — but packaging is OSGi/Tycho. Build only if Eclipse
+becomes a primary target.
+
+## Sequencing — revised after live measurement
+
+**`propose` is demoted.** The measured flow needs no ARC-1 write at all: Copilot edits the `abap:` file,
+SAP's own provider performs the write under SAP auth, and ARC-1's ceiling never enters it. A read-only
+ARC-1 deployment already works today with zero changes. `propose` now covers only two cases — objects not
+reachable in the workspace, and ARC-1's generative transforms (RAP scaffolding, `batch_create`,
+class-section surgery). Both real, neither urgent, and a plan/apply split across ~3000 lines of `write/`
+is too much to build speculatively.
+
+### Tier 1 — small, fully evidence-backed, testable in both clients
+
+**T1. `ARC1_IDE_LINKS`** — `off | auto | vscode | eclipse | <template>`, default `auto`.
+- Files: `src/server/types.ts` (default), `src/server/config.ts` (parse/validate),
+  `src/handlers/shared.ts` (append to `textResult`), `mcpb-manifest.json` (`user_config` string field +
+  `server.mcp_config.env`).
+- Detection from the existing `clientAgent` (`src/server/context.ts:27`), promoted from audit-only to a
+  presentation input. Measured client names: `Visual Studio Code` (prefix match, covers forks),
+  `claude-ai`, `local-agent-mode-*` (Claude Code — the name is derived from the *server* name, so match
+  by prefix). Unrecognised ⇒ emit nothing.
+- Templates: `vscode://marianfoo.arc1-abap-bridge/open?name={name}&package={package}` and
+  `adt://{sid}/{uri}?sap-client={client}`.
+- Security line: `clientAgent` is client-controlled. Fine for choosing a link format, never for anything
+  security-relevant.
+
+**T2. Roots-derived destination awareness.**
+- Files: `src/server/server.ts` (call `server.listRoots()` once per session, cache, refresh on
+  `notifications/roots/list_changed`), consumed where links are emitted.
+- Measured: VS Code returns `[{name:"UI5con_2026",uri:"file:///…"},{name:"A4H2023",uri:"abap:/repotree-v1/A4H2023"}]`.
+- Strictly additive: roots changes what ARC-1 *knows*, never what it *does*. Impossible on HTTP
+  (`src/server/http.ts:193` builds a per-request `Server`), so every feature must work without it.
+
+**T3. `package` on results.** Free on writes (`resolveObjectPackage` already runs when `allowedPackages`
+is restricted); opt-in on reads (`includePackage: true`) because it costs an extra ADT GET.
+
+### Tier 2 — after Tier 1 has been used in anger
+
+**T4. Diff on ordinary writes** — needs a pre-write GET; build it once and it also serves `propose`.
+
+**T5. `propose`** — build when a concrete case demands it (first RAP scaffold, or the first object outside
+the workspace). Design as specified in section A: one action + `proposeAction`, `{scope:'read',
+opType:Intelligence}`, plan/apply split. `SAPDiagnose action="syntax"` with `source` is the working
+precedent — SAP-side, mutation-free, read-scoped, already shipping.
+
+## How to test each change in both clients
+
+**VS Code (with the bridge).** ARC-1 is already wired as a stdio MCP server in
+`~/Library/Application Support/Code/User/mcp.json`. Point it at the local build instead of `npx arc-1@latest`:
+
+```json
+"arc-1": { "type": "stdio", "command": "node", "args": ["/Users/marianzeis/DEV/arc-1/dist/index.js"], "env": { … } }
+```
+
+Then `npm run build` in `~/DEV/arc-1`, restart VS Code, and exercise it through Copilot chat. The bridge's
+*ARC-1 ABAP Bridge* output channel shows every tool the bridge itself invokes.
+
+**Claude Code.** Add the same local build via `claude mcp add`, or a `.mcp.json` in the project. Claude
+Code advertises `roots` (measured) but has no `abap:` filesystem and no bridge — so it is the honest test
+of whether a feature degrades gracefully:
+- **T1** should emit *nothing* under `local-agent-mode-*`, since there is no IDE to target. If it emits a
+  `vscode://` link there, the detection is wrong.
+- **T2** should return the *file* cwd roots, not an `abap:` root. Confirms ARC-1 handles both shapes.
+
+**Fast loop without any client** — `node dist/cli.js call <Tool> --json …` against the real system, which
+is how the `SAPDiagnose action="syntax"` behaviour in this document was measured.
+
+## The inversion is supported by design — resolved
+
+`copilot_applyPatch` takes a **patch string**, not a URI, so the question is how a path inside the patch
+resolves. Copilot's `IPromptPathRepresentationService`:
+
+```js
+getFilePath(uri) {                       // how a document is named TO the model
+  if (uri.scheme === file || uri.scheme === vscodeRemote) { … return uri.fsPath }
+  return uri.toString();                 // non-file schemes → the full URI string
+}
+resolveFilePath(path, defaultScheme = file) {
+  … return defaultScheme === file ? Uri.file(p) : Uri.from({ scheme: defaultScheme, path: p.path });
+}
+```
+
+and the resolver used on the model's response:
+
+```js
+_createUriFromResponsePath(p) {
+  for (const f of this._editCodeStep.workingSet)
+    if (pathService.getFilePath(f.document.uri) === p) return f.document.uri;   // working set first
+  const u = pathService.resolveFilePath(p, this._editCodeStep.getPredominantScheme());
+  …
+}
+```
+
+`getPredominantScheme()` means Copilot tracks the edit session's dominant URI scheme and resolves patch
+paths against it. Together with `getFilePath` returning `uri.toString()` for non-`file` schemes and the
+explicit non-file branch in `resolveFilePath`, this is purpose-built machinery for editing virtual
+filesystems — not an accident. Combined with the absence of any scheme gate on the edit path, the
+inversion is safe to build on.
+
+### Measured live (bridge v0.5.0 self-test, VS Code 1.131.0, a4h)
+
+| Step | Result |
+|---|---|
+| `workspace.fs.isWritableFileSystem('abap')` | **true** |
+| Edit tools invokable by a third party | `copilot_applyPatch`, `copilot_insertEdit`, `copilot_createFile`, `copilot_editFiles` |
+| Resolve + `readFile` on `abap:` | ok, 2579 bytes |
+| How the doc would be named to the model | `abap:/repotree-v1/A4H2023/System%20Library/…` (URI string, as predicted) |
+| **Third-party `WorkspaceEdit` on an `abap:` doc** | **applied: true, becameDirty: true, reverted: true** |
+| `copilot_applyPatch` invoked *outside* a chat session | **failed** — resolved the path to `file:///abap%3A/repotree-v1/…System%2520Library/…`, "outside of your workspace", "No changes detected" |
+
+**The working set is the mechanism, not an optimisation.** With no chat session there is no
+`getPredominantScheme()` and no working set to match against, so `resolveFilePath` fell into its `file`
+branch and mangled the URI. Copilot can only target an `abap:` document when that document is in the edit
+session's working set.
+
+### Consequence: two write paths, one guaranteed
+
+1. **Bridge-applied (primary, guaranteed).** The bridge takes ARC-1's proposed source and applies it with
+   `workspace.applyEdit` — measured working. The editor shows the change and goes dirty; the user reviews
+   and saves; SAP's own provider performs the write. No Keep/Undo chrome, but it depends on nothing inside
+   Copilot and cannot break when Copilot changes.
+2. **Copilot-applied (opportunistic, nicer).** Native hunks and Keep/Undo, but only inside a real chat edit
+   session with the object attached. **Requirement for the bridge: `abapOpen` must add the object to the
+   chat working set, not merely open an editor.** VS Code registers
+   `workbench.action.chat.attachFile` (alongside `attachContext`, `attachFolder`, `attachSelection`,
+   `attachPinnedEditors`), so the bridge can do this itself — best-effort, wrapped in try/catch, since
+   these are workbench commands and not stable API.
+
+Build 1, and let 2 happen when the conditions are right.
+
+### Confirmed live: Copilot edits `abap:` natively — and SAP rejects the save
+
+With the object **attached to the chat**, Copilot resolved it correctly and applied a real edit:
+`Edited zcl_arc1_task_service.clas.abap +1 -0`, green hunk decoration, **Keep / Undo**. Attachment was the
+missing ingredient — the same tool without it produced `file:///abap%3A/…` and "No changes detected".
+
+The save then failed:
+
+```
+Failed to save 'zcl_arc1_task_service.clas.abap':
+The class contains unknown comments which can't be stored.
+```
+
+**This is the finding that matters.** Copilot wrote syntactically plausible ABAP that the backend refuses —
+a comment in a position the class serializer will not store. Nothing in the IDE knew that until SAP said
+no, after the edit was already applied and the buffer dirty.
+
+⇒ **The division of labour is not "Copilot writes, ARC-1 reads". It is "Copilot writes, ARC-1 validates
+before the write lands."** That is a role only ARC-1 can play: it already has `SAPLint` (abaplint with the
+right release profile), pre-write hints, and the SAP-side syntax check. Add to the plan:
+
+#### Validated live — and it needs **no ARC-1 change at all**
+
+`SAPDiagnose action="syntax"` already accepts `source`: *"SAP compiles the given content as if it lived at
+the object's URI (pre-write dry-run, nothing is written)"*. Run against the exact buffer SAP refused:
+
+```json
+{ "hasErrors": false,
+  "messages": [ { "severity": "warning",
+                  "text": "The class contains unknown comments which can't be stored.",
+                  "line": 23, "column": 0,
+                  "uri": "/sap/bc/adt/oo/classes/zcl_arc1_task_service/source/main#start=23,0" } ] }
+```
+
+Identical message, correct line, **795 ms**, nothing written. Two corrections this produced:
+
+1. **Offline abaplint cannot substitute.** `arc1 lint` crashes on this class — `ZARC1_T_TASK not found,
+   lookupView` — identically for the good and the bad source, because DDIC types are not resolvable
+   offline. Pre-save validation **must** use the SAP-side check, not local lint.
+2. **`hasErrors` is `false` — it is a *warning*.** A naive `if (hasErrors)` gate would let exactly this
+   failure through. Surface warnings too.
+
+So the work is entirely on the IDE side:
+
+- **Bridge:** on `onWillSaveTextDocument` for an `abap:` document, call `SAPDiagnose action="syntax"` with
+  the buffer through `lm.invokeTool`, and warn (never block) on any message regardless of `hasErrors`.
+- **Instructions:** after editing an ABAP file and before saving, validate the buffer with ARC-1.
+
+This is also a working precedent for the `propose` design in section A: SAP-side dry-run, mutation-free,
+read-scoped, already shipping.
+
+Also observed while the destination was disconnected: `NoPermissions (FileSystemError): Method
+"createDirectory" not yet implemented`. Treat as a symptom of the logged-off session rather than a
+separate defect unless it recurs while connected.

--- a/docs/research/2026-07-31-vscode-arc1-diff-bridge.md
+++ b/docs/research/2026-07-31-vscode-arc1-diff-bridge.md
@@ -1,0 +1,156 @@
+# Research: showing ARC-1 changes as diffs / clickable files in VS Code + Copilot
+
+Dated 2026-07-31. Verified against **VS Code 1.129.1**, **built-in `copilot-chat` 0.57.0**, and
+**`sapse.adt-vscode` 1.1.0** (installed locally, `~/.vscode/extensions/sapse.adt-vscode-1.1.0-darwin-arm64`).
+Evidence = teardown of the shipped bundles, not docs.
+
+## Problem
+
+ARC-1 writes ABAP source over ADT REST straight into SAP. Nothing in the VS Code workspace changes, so
+Copilot has no edit to render: no diff, no Keep/Undo, no clickable file. The user wants both, using
+`sapse.adt-vscode` (virtual ABAP filesystem) as the editor.
+
+## Ground truth
+
+### 1. Copilot's diff UI is bound to *its own* edit pipeline
+
+Built-in edit tools are `copilot_applyPatch`, `copilot_insertEdit`, `copilot_editFiles`,
+`copilot_createFile` (38 tools in `extensions/copilot/package.json`). The Keep/Undo diff decoration
+only appears for edits those tools make on a workspace URI. **No API lets a third-party MCP server or
+extension push an edit into that UI.**
+
+There *is* an internal `kind:"externalEdit"` chat part carrying `beforeContentUri`/`afterContentUri`/
+`diff:{added,removed}` — but it is fed from **AHP / `chatSessions` agent-host** `content[].type==="fileEdit"`
+items (external agent CLIs surfaced as chat sessions), not from MCP tool results or `lm.registerTool`.
+Different integration surface; not reachable from ARC-1.
+
+### 2. MCP `resource_link` cannot point at a workspace file
+
+VS Code rewrites **every** `resource_link` URI a server returns:
+
+```js
+// workbench.desktop.main.js — pT.fromServer
+r.with({ scheme: "mcp-resource", authority: enc(server.id),
+         path: ["", r.scheme, r.authority || "dylo78gyp"].join("/") + r.path })
+```
+
+So `file:///…` becomes `mcp-resource://<server>/file/…` and is read back through the server's own
+`resources/read`. Clicking it opens ARC-1-served content in a read-only editor — never SAP's ABAP editor,
+never a real file. Useful as a zero-extension fallback, useless for "open the ABAP object".
+
+### 3. `vscode://` links in chat survive; `file:` is special-cased local
+
+Chat's markdown link rewriter (`qRn`) leaves a link alone iff its scheme is in the allowlist:
+
+```
+http https mailto ws wss ftp ftps data blob javascript command vscode vscode-insiders … copilot-skill
+```
+
+Everything else (including `abap:`) is wrapped into the remote-agent scheme via `Np()`. `Np()` passes
+`file:` through untouched when the session is local. **⇒ a `vscode://<publisher>.<ext>/…` deep link is the
+one reliable clickable hook a tool result can put in front of the user.** (`command:` is allow-listed
+against rewriting but still needs `isTrusted`, which model output doesn't get.)
+
+### 4. What `sapse.adt-vscode` 1.1.0 actually exposes
+
+| Fact | Value |
+|---|---|
+| FS scheme | `abap`, activation `onFileSystem:abap` (lazy — any extension touching an `abap:` URI activates it) |
+| Real URI shape | `abap:/repotree-v1/<DEST>/<Tree Root>/<pkg path>/Source%20Code%20Library/Classes/<OBJ>/<obj>.clas.abap` |
+| Writable? | Yes — `adtLs/fileSystem/{readFile,writeFile,lockFile,unlockFile,toggleVersion,forceRefresh}` |
+| Public extension API | **None** (`activate()` exports nothing) |
+| URI handler / deep links | **None** — `registerUriHandler` count = 0 |
+| `openAbapObject` command args | **None** — always opens the QuickPick |
+| Proposed APIs | **None** ⇒ no `FileSearchProvider` ⇒ **`workspace.findFiles` does not work on `abap:`** |
+| Chat integration | ships `contributes.chatAgents` → `agents/abap-developer.agent.md`, and `mcpServerDefinitionProviders` for the ADT MCP server |
+
+The URI embeds the **package hierarchy plus localized tree labels** (`Local Objects ($TMP)`,
+`System Library`, `Source Code Library`, `Classes`, and for `$TMP` the *owning user*). Real examples from
+this machine's `state.vscdb`:
+
+```
+abap:/repotree-v1/A4H/Local%20Objects%20%28%24TMP%29/DEVELOPER/Source%20Code%20Library/Classes/ZCL_ARC1LSP_ATC/zcl_arc1lsp_atc.clas.abap
+abap:/repotree-v1/A4H/System%20Library/Z_RAP_VB_1/Core%20Data%20Services/Data%20Definitions/ZC_FBCLUBTP/zc_fbclubtp.ddls.acds
+```
+
+⇒ **you cannot synthesize the URI from an object name.** Resolution options, in order of laziness:
+open tabs/`workspace.textDocuments` → walk workspace folders with `workspace.fs.readDirectory`. Never
+`findFiles`. SAP's own agent file says the same thing: *"You MUST adjust the file search because the ABAP
+extension uses the virtual workspace file system. Always search via the directory first!"*
+
+### 5. SAP already solved this — by not writing out-of-band
+
+`agents/abap-developer.agent.md` (21 lines, shipped in the extension):
+
+> Use the adt-mcp-server for creating new ABAP development objects … **Always add and edit source code via
+> the VS Code editor.** If needed open the editor first via the provided file paths.
+
+SAP's MCP server deliberately has **no edit-source tool**. Creation/activation/tests go through MCP; source
+edits go through Copilot's normal edit tools on the `abap:` virtual file — which is why SAP gets native
+diffs for free. First-party evidence that `copilot_applyPatch` & co. work on the `abap:` scheme.
+
+## Options
+
+### Option 0 — no code at all (start here)
+
+Add the SAP package as a workspace folder, and tell Copilot (via `.github/copilot-instructions.md` or a
+custom `*.agent.md`) to **edit through the editor** and use ARC-1 only for what the SAP extension can't do
+(search, where-used, context compression, lint, transports, ATC on old releases, CDS/RAP intelligence).
+Native diff + Keep/Undo + clickable files, zero maintenance. Cost: only works for objects in the workspace,
+and requires an SAP-extension logon in addition to ARC-1's.
+
+### Option 0b — local mirror (also no extension)
+
+`ARC1_MIRROR_DIR`: ARC-1 writes every source it PUTs to a local git-tracked mirror
+(the `setup-abap-mirror` skill's layout). VS Code's built-in Git shows every ARC-1 change as a normal diff,
+`file:` links in chat are clickable (§3), and it works in Cursor/Claude Code/any editor. Cost: a second copy
+of the truth; no ADT navigation on those files.
+
+### Option 1 — the bridge extension (what was asked for)
+
+One file, ~200 LOC, no dependency on SAP's extension internals beyond the `abap:` scheme:
+
+```ts
+// 1. read-only buffers for before/after
+workspace.registerTextDocumentContentProvider('arc1', { provideTextDocumentContent: uri => buffers.get(uri.path) });
+
+// 2. journal watcher → diff editor pops automatically, no model involvement
+watcher.onDidCreate(async f => {
+  const c = JSON.parse(await readFile(f));            // { dest, type, name, before, after }
+  buffers.set(`/before/${c.name}`, c.before); buffers.set(`/after/${c.name}`, c.after);
+  commands.executeCommand('vscode.diff',
+    Uri.parse(`arc1:/before/${c.name}`), Uri.parse(`arc1:/after/${c.name}`),
+    `${c.name} — ARC-1 change`);
+});
+
+// 3. clickable link in Copilot chat
+window.registerUriHandler({ handleUri: u => openObject(new URLSearchParams(u.query)) });
+// → vscode://arc-mcp.arc1-bridge/open?dest=A4H&name=ZCL_FOO
+
+// 4. open the real ABAP editor: match an open tab, else walk abap: workspace folders
+//    with workspace.fs.readDirectory; fall back to the arc1: buffer.
+```
+
+Optional 5th piece: `contributes.languageModelTools` + `lm.registerTool('arc1_showDiff')` so the model can
+also trigger the diff on demand — but the watcher already covers the common case without spending tokens or
+depending on tool-call reliability.
+
+**ARC-1 side (small):** emit the journal entry on every successful `SAPWrite`. The pieces exist —
+`src/adt/source-diff.ts` (`unifiedDiff`) and the shipped `SAPRead action="diff"` (active-vs-inactive,
+`src/adt/version-diff.ts`). Needs one pre-write GET of the current source (already ETag-cached) plus a
+`ARC1_WRITE_JOURNAL_DIR` config option, and the tool result should carry the `vscode://…` link with a tool
+description instructing the model to print it.
+
+## Recommendation
+
+Option 0 first — it costs nothing and is what SAP designed for. Build Option 1 only for the ARC-1-only
+workflows (writes outside the workspace, batch creates, RAP scaffolding, remote/BTP targets), and start with
+the journal watcher + `UriHandler`; skip the LM tool until the watcher proves insufficient.
+
+## Open items to spike (≤20 LOC each)
+
+1. Does a `vscode://ext.id/…` markdown link actually render clickable in a Copilot chat *answer* (not just
+   survive rewriting)? §3 says the scheme is allow-listed; rendering path unverified.
+2. Do `copilot_applyPatch` / `copilot_editFiles` accept `abap:` URIs? SAP's agent file assumes yes.
+3. `adt-vscode.forceRefreshRelatedFiles` — argument shape, so the bridge can refresh an open ABAP editor
+   after an ARC-1 write.

--- a/docs/research/2026-08-01-native-abap-editing-integration.md
+++ b/docs/research/2026-08-01-native-abap-editing-integration.md
@@ -1,0 +1,164 @@
+# Research: how close can ARC-1 + IDE get to native Copilot editing for ABAP?
+
+Dated 2026-08-01. Verified against **VS Code 1.129.1**, built-in **copilot-chat 0.57.0**,
+**`sapse.adt-vscode` 1.1.1**, **Copilot for Eclipse 0.20.0**, ADT for Eclipse 3.5x.
+Companion to `2026-07-31-vscode-arc1-diff-bridge.md`, which covers the plumbing already built
+(`~/DEV/arc1-abap-bridge`, v0.4.0, working against a4h).
+
+## The question
+
+Get ABAP as close as possible to what Copilot does natively for a TypeScript file: the model edits,
+you see inline hunks with Keep/Undo, changed files are listed in chat and clickable, links open at the
+right line. Which parts are reachable, with what, and what is simply closed off.
+
+## The one gate that decides everything
+
+Copilot's edit UI — inline hunks, Keep/Undo, the edited-files list, the undo stop — is rendered only for
+edits produced by **its own edit tools** (`copilot_applyPatch`, `copilot_editFiles`, `copilot_insertEdit`,
+`copilot_createFile`) acting on a **workspace URI**. Verified two ways:
+
+1. **The stable VS Code API has no edit-carrying chat part.** The complete stable set is
+   `ChatResponseMarkdownPart`, `AnchorPart`, `ProgressPart`, `ReferencePart`, `FileTreePart`,
+   `CommandButtonPart`. Nothing that carries a text edit.
+2. **Everything that could carry one is proposed API.** Copilot itself enables **63 proposals**, among them
+   `chatParticipantAdditions` (where the edit parts live), `chatSessionsProvider`, `mappedEditsProvider`,
+   `contribLanguageModelToolSets`. Proposed APIs cannot be published to the Marketplace — they need
+   `--enable-proposed-api` or an allowlist entry.
+
+There *is* an internal `kind:"externalEdit"` chat part carrying `beforeContentUri`/`afterContentUri`/
+`diff:{added,removed}`/`undoStopId` — it is how external agent CLIs surface their edits natively. It is fed
+from the **AHP `chatSessions`** protocol (`content[].type === "fileEdit"`), which is `chatSessionsProvider`,
+i.e. proposed. **Not reachable for a distributable extension.**
+
+> **Consequence — the whole strategy follows from this.** Do not try to *push* an edit into Copilot's UI.
+> Instead make Copilot's own edit tools do the write, and have ARC-1 feed them. In VS Code that is
+> possible today because `sapse.adt-vscode` registers `abap:` as a **writable** `FileSystemProvider`
+> (`registerFileSystemProvider(oe, this, {isCaseSensitive:true})`) — an ABAP object in a workspace folder
+> *is* a workspace URI. SAP designed for exactly this: their shipped `abap-developer.agent.md` says
+> *"Always add and edit source code via the VS Code editor."*
+
+## Verified capability matrix
+
+| Capability | VS Code | Eclipse |
+|---|---|---|
+| ABAP object is a workspace file Copilot's edit tools can target | **Yes** — `abap:` writable FS provider | **No** — ADT editors are not `IFile`s; Copilot works on the open *document* |
+| Native inline diff + Keep/Undo for model edits | **Yes**, via Copilot's edit tools | Yes for its own edits (`ChangedFiles`, `DiffModel`, `DiffPopup`, `EditableFileCompareInput`, `UndoableTextViewer` in `copilot.eclipse.ui`) |
+| Third party can register a tool the assistant calls | **Yes** — `lm.registerTool` (stable) | **No** — Copilot for Eclipse declares *zero* extension points |
+| Third party can reach the assistant at all | tools, MCP | **MCP only** (54 MCP classes incl. `McpServerToolsCollection`, `McpResource`, `IMcpConfigService`) |
+| Open an object by name from code | hard — no public resolver; solved by the bridge | **easy** — `com.sap.adt.tools.core.ui.navigation` is exported with **no `x-friends`** restriction |
+| Show a diff from code | `vscode.diff` | `org.eclipse.compare.CompareUI` + ADT's own version compare |
+| Clickable link in chat that opens the object | **Yes** — `vscode://<ext>/…`, verified live | ADT link (`shareLink` / `openWithAdtForEclipse`) — format is LS-side, capture it from the command |
+| Extension can call another tool without a model turn | **Yes** — `lm.invokeTool` works for MCP tools too (already used to fetch the package) | via MCP client only |
+
+## Strategy: invert the write path
+
+Today ARC-1 writes source over ADT REST and the IDE learns nothing. The closest-to-native arrangement is
+the opposite:
+
+```
+ARC-1  = read, search, where-used, SQL, lint, ATC, transports, activation,
+         CDS/RAP intelligence  +  PROPOSE source for its smart transforms
+Copilot = performs the actual text write, through its own edit tools
+Bridge  = makes sure the right file is open/targeted, and shows diffs for
+          the cases where ARC-1 did write after all
+```
+
+ARC-1 keeps its unique value (method-level surgery, class-section splice, RAP scaffolding, batch create,
+AFF validation) — it just returns the resulting source instead of PUTting it, and lets Copilot apply it.
+That single change turns every ARC-1 transform into a natively-rendered edit.
+
+## Ladder of changes, cheapest first
+
+### Rung 1 — system instructions only (no code)
+
+Already partly done (`copilot-instructions.md`, shipped by the bridge). Extend to state the split above,
+and specifically: *when an object is reachable in the workspace, never write it through ARC-1 — read it,
+decide the change, and apply it with your normal edit tools.* Cost: minutes. Gets: full native diff for
+ordinary edits.
+
+Weakness: instruction-following is probabilistic. Observed live — asked to "show what changed", Copilot
+picked ARC-1's `SAPRead action="diff"` (text) over the bridge's `abapChanges` (diff editor) until the tool
+descriptions were rewritten to split them by *audience*. Tool descriptions beat instructions.
+
+### Rung 2 — ARC-1 `dryRun` / propose mode  ← highest leverage
+
+`SAPWrite(..., dryRun: true)` performs every gate and transform but **returns the resulting full source
+plus a unified diff instead of writing**. `src/adt/source-diff.ts` (`unifiedDiff`) already exists, and
+`SAPRead action="diff"` proves the shape.
+
+Why it matters: `edit_method`, `edit_section`, RAP scaffolding and `batch_create` are real intelligence
+that Copilot cannot replicate. Dry-run lets that intelligence flow through Copilot's edit pipeline, so the
+user gets native hunks and Keep/Undo on an ARC-1-quality change. Without it, every ARC-1 transform is
+invisible.
+
+Also worth returning `package` on `SAPRead`/`SAPWrite` results (search already returns `packageName`), so
+links can be built without a second lookup.
+
+### Rung 3 — bridge: target the file for Copilot
+
+The bridge already resolves name → `abap:` URI and opens it (v0.4.0). Additions, all small:
+
+- **`line`/`method` in the deep link and the open tool** — reveal a range, so links land on the right line
+  rather than the top of the file.
+- **Attach-to-chat** — opening is not the same as being in Copilot's working set. Worth testing whether an
+  open editor is enough for `copilot_applyPatch` to target it, or whether the file must be attached.
+- **Post-write refresh** — after any ARC-1 write, call `adt-vscode.forceRefreshRelatedFiles` so the open
+  editor is not stale. Takes no arguments and acts on the active editor, so the object must be shown first.
+
+### Rung 4 — ARC-1 write journal + auto-diff
+
+For writes that must stay server-side (BTP targets, objects outside the workspace, batch creates,
+activation-time changes): `ARC1_WRITE_JOURNAL_DIR` drops `{dest, type, name, before, after}` per write; the
+bridge already watches it (`arc1AbapBridge.journalDir`) and pops a diff with zero tokens and no model
+involvement. Only unbuilt half is the ARC-1 emitter.
+
+### Rung 5 — IDE links in ARC-1 output
+
+Config `ARC1_IDE_LINKS = off | vscode | eclipse`. ARC-1 knows the ADT object URI, so it can append a
+clickable link to read/write results:
+
+- **VS Code** — `vscode://marianfoo.arc1-abap-bridge/open?name=…&package=…` (scheme is allow-listed in
+  chat's markdown rewriter; verified clickable live).
+- **Eclipse** — the canonical ADT link. Its exact shape is built inside the ADT language server and is not
+  a literal in any shipped jar; capture it once by running **ABAP: Share Link…** → *Copy ADT Link*.
+
+This is the most direct answer to "show a link in chat you can click", and it works for any MCP client,
+not just the two IDEs.
+
+### Rung 6 — Eclipse plugin (only if Eclipse matters)
+
+Copilot for Eclipse has no extension points but full MCP support, so the shape inverts: an Eclipse plugin
+that **hosts a small MCP server in-process**, which Copilot connects to. Tool calls then run inside the
+workbench with full access. Precedent: SAP's own ADT MCP server runs in-process in Eclipse (port 2234).
+
+The core logic is far *simpler* than the VS Code bridge — `com.sap.adt.tools.core.ui.navigation` is public
+API, so name→object navigation is one call, and `CompareUI` handles diffs. The cost is packaging: OSGi
+bundle, Java, Tycho/PDE, update site, versus 400 lines of plain JS with no build. And the payoff is
+smaller, because ADT *is* native there and already has version compare.
+
+## What is out of reach, so nobody spends time on it
+
+| Wish | Why not |
+|---|---|
+| Push an ARC-1 write into Copilot's Keep/Undo UI | needs `chatParticipantAdditions` / `chatSessionsProvider` — proposed, not publishable |
+| MCP `resource_link` pointing at the ABAP file | VS Code rewrites every one to `mcp-resource://` and reads it back through the server |
+| `command:` links in a model answer | needs trusted markdown; model output is untrusted |
+| Reuse SAP's own name→URI resolver | `adtLs/repository/quickSearch` is language-server-side, no public API, no `registerUriHandler` |
+| Copilot for Eclipse calling a local plugin directly | zero extension points; MCP is the only door |
+
+## Recommended sequence
+
+1. **Rung 2 in ARC-1** (`dryRun`) — biggest jump toward native, and useful to every MCP client.
+2. **Rung 1 + rung 3** — instructions and bridge polish to make the model actually take that path.
+3. **Rung 5** (`ARC1_IDE_LINKS`) — cheap, and serves Eclipse and non-IDE clients too.
+4. **Rung 4** (journal) — closes the gap for writes that cannot go through the editor.
+5. **Rung 6** only if Eclipse becomes a primary target.
+
+## Open items to verify
+
+1. Do `copilot_applyPatch` / `copilot_editFiles` actually accept `abap:` URIs? SAP's shipped agent file
+   assumes yes; never confirmed live. **This is the load-bearing assumption of the whole strategy** — test
+   it before building rungs 2–3.
+2. Does an object have to be attached to the chat context, or is an open editor enough for the edit tools
+   to target it?
+3. Does Copilot for Eclipse's inline edit work inside an ADT editor, given ADT documents are not `IFile`s?

--- a/mcpb-manifest.json
+++ b/mcpb-manifest.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "SAPGit",
-      "description": "Version control for ABAP via gCTS or abapGit (status, clone, pull, commit, push) \u2014 available when a Git backend is present"
+      "description": "Version control for ABAP via gCTS or abapGit (status, clone, pull, commit, push) — available when a Git backend is present"
     },
     {
       "name": "SAPContext",
@@ -174,14 +174,14 @@
     "sap_allow_data_preview": {
       "type": "boolean",
       "title": "Allow Table Data Preview",
-      "description": "Allow SAPRead(type=TABLE_CONTENTS) and SAPQuery table preview. Can expose application data \u2014 review your data-governance rules.",
+      "description": "Allow SAPRead(type=TABLE_CONTENTS) and SAPQuery table preview. Can expose application data — review your data-governance rules.",
       "default": false,
       "required": false
     },
     "sap_allow_free_sql": {
       "type": "boolean",
       "title": "Allow Freestyle SQL",
-      "description": "Allow read-only ad-hoc ABAP SQL via SAPQuery. Can expose application data \u2014 review your data-governance rules.",
+      "description": "Allow read-only ad-hoc ABAP SQL via SAPQuery. Can expose application data — review your data-governance rules.",
       "default": false,
       "required": false
     },

--- a/mcpb-manifest.json
+++ b/mcpb-manifest.json
@@ -41,7 +41,8 @@
         "SAP_ALLOW_GIT_WRITES": "${user_config.sap_allow_git_writes}",
         "ARC1_UI": "${user_config.arc1_ui}",
         "ARC1_UI_OPEN": "${user_config.arc1_ui_open}",
-        "ARC1_UI_ADDR": "${user_config.arc1_ui_addr}"
+        "ARC1_UI_ADDR": "${user_config.arc1_ui_addr}",
+        "ARC1_IDE_LINKS": "${user_config.arc1_ide_links}"
       }
     }
   },
@@ -76,7 +77,7 @@
     },
     {
       "name": "SAPGit",
-      "description": "Version control for ABAP via gCTS or abapGit (status, clone, pull, commit, push) — available when a Git backend is present"
+      "description": "Version control for ABAP via gCTS or abapGit (status, clone, pull, commit, push) \u2014 available when a Git backend is present"
     },
     {
       "name": "SAPContext",
@@ -173,14 +174,14 @@
     "sap_allow_data_preview": {
       "type": "boolean",
       "title": "Allow Table Data Preview",
-      "description": "Allow SAPRead(type=TABLE_CONTENTS) and SAPQuery table preview. Can expose application data — review your data-governance rules.",
+      "description": "Allow SAPRead(type=TABLE_CONTENTS) and SAPQuery table preview. Can expose application data \u2014 review your data-governance rules.",
       "default": false,
       "required": false
     },
     "sap_allow_free_sql": {
       "type": "boolean",
       "title": "Allow Freestyle SQL",
-      "description": "Allow read-only ad-hoc ABAP SQL via SAPQuery. Can expose application data — review your data-governance rules.",
+      "description": "Allow read-only ad-hoc ABAP SQL via SAPQuery. Can expose application data \u2014 review your data-governance rules.",
       "default": false,
       "required": false
     },
@@ -217,6 +218,13 @@
       "title": "UI Loopback Address",
       "description": "Loopback bind address for the local read-only UI.",
       "default": "127.0.0.1:8711",
+      "required": false
+    },
+    "arc1_ide_links": {
+      "type": "string",
+      "title": "IDE Links",
+      "description": "Append a clickable IDE link to results about one object. auto | off | vscode | eclipse | a template using {type} {name} {package} {uri} {sid} {client}. Claude Desktop has no IDE of its own, so set 'vscode' or an adt:// template to choose where links should open.",
+      "default": "auto",
       "required": false
     }
   }

--- a/mcpb-manifest.json
+++ b/mcpb-manifest.json
@@ -223,7 +223,7 @@
     "arc1_ide_links": {
       "type": "string",
       "title": "IDE Links",
-      "description": "Append a clickable IDE link to results about one object. auto | off | vscode | eclipse | a template using {type} {name} {package} {uri} {sid} {client}. Claude Desktop has no IDE of its own, so set 'vscode' or an adt:// template to choose where links should open.",
+      "description": "Append a clickable IDE link to results about one object. auto | off | vscode | eclipse | a template using {type} {name} {package} {uri} {sid} {client}. NOTE: Claude Desktop renders vscode:// and adt:// links but will not open them (it only hands http/https to the OS), so a link set here is copy-paste only. 'auto' correctly emits nothing in Claude Desktop.",
       "default": "auto",
       "required": false
     }

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -296,7 +296,52 @@ export class AdtHttpClient {
     sessionClient.cookieJar = new Map(this.cookieJar);
     sessionClient.discoveryMap = this.discoveryMap;
     sessionClient.negotiatedHeaders = new Map(this.negotiatedHeaders);
-    return fn(sessionClient);
+    try {
+      return await fn(sessionClient);
+    } finally {
+      // Tell SAP the ABAP session context can go. A stateful ADT session persists until it is
+      // explicitly released — omitting the header on later requests does NOT end it — so without
+      // this the session stays stateful and holds a mode until it times out. Eclipse ADT and
+      // abap-adt-api both send this. Best-effort: never let cleanup fail a completed write.
+      await sessionClient.releaseStatefulSession();
+      // Adopt any cookie SAP rotated during the block. Previously the clone's jar was discarded,
+      // so a rotated session id was lost and the next parent request would start a fresh session,
+      // orphaning the old one. (Not observed on 7.58 — SAP reuses the cookie — but the window is
+      // real and the merge is free.)
+      for (const [name, value] of sessionClient.cookieJar) {
+        this.cookieJar.set(name, value);
+      }
+      this.csrfToken = sessionClient.csrfToken;
+    }
+  }
+
+  /**
+   * Drop the stateful ABAP session context. Transport hygiene, not an ADT operation — same class
+   * as `fetchCsrfToken`, and deliberately silent: a failure here must never surface to a caller
+   * whose write already succeeded.
+   */
+  private async releaseStatefulSession(): Promise<void> {
+    if (this.config.sessionType !== 'stateful') return;
+    try {
+      const headers: Record<string, string> = {
+        'X-sap-adt-sessiontype': 'stateless',
+        Accept: '*/*',
+      };
+      if (this.config.disableSaml) headers['X-SAP-SAML2'] = 'disabled';
+      this.applyAuthHeader(headers);
+      if (this.config.bearerTokenProvider) {
+        headers.Authorization = `Bearer ${await this.config.bearerTokenProvider()}`;
+      }
+      if (this.config.sapConnectivityAuth && !this.config.ppProxyAuth) {
+        headers['SAP-Connectivity-Authentication'] = this.config.sapConnectivityAuth;
+      }
+      const cookieHeader = this.composeCookieHeader();
+      if (cookieHeader) headers.Cookie = cookieHeader;
+      const response = await this.doFetch(this.buildUrl('/sap/bc/adt/core/discovery'), 'HEAD', headers);
+      this.storeCookies(response);
+    } catch {
+      // Deliberately swallowed — see the doc comment.
+    }
   }
 
   /** Core request method — wraps requestInner with optional concurrency limiter */

--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -316,29 +316,15 @@ export class AdtHttpClient {
   }
 
   /**
-   * Drop the stateful ABAP session context. Transport hygiene, not an ADT operation — same class
-   * as `fetchCsrfToken`, and deliberately silent: a failure here must never surface to a caller
-   * whose write already succeeded.
+   * Drop the stateful ABAP session context. Transport hygiene, not an ADT operation — deliberately
+   * silent: a failure here must never surface to a caller whose write already succeeded.
    */
   private async releaseStatefulSession(): Promise<void> {
     if (this.config.sessionType !== 'stateful') return;
     try {
-      const headers: Record<string, string> = {
-        'X-sap-adt-sessiontype': 'stateless',
-        Accept: '*/*',
-      };
-      if (this.config.disableSaml) headers['X-SAP-SAML2'] = 'disabled';
-      this.applyAuthHeader(headers);
-      if (this.config.bearerTokenProvider) {
-        headers.Authorization = `Bearer ${await this.config.bearerTokenProvider()}`;
-      }
-      if (this.config.sapConnectivityAuth && !this.config.ppProxyAuth) {
-        headers['SAP-Connectivity-Authentication'] = this.config.sapConnectivityAuth;
-      }
-      const cookieHeader = this.composeCookieHeader();
-      if (cookieHeader) headers.Cookie = cookieHeader;
-      const response = await this.doFetch(this.buildUrl('/sap/bc/adt/core/discovery'), 'HEAD', headers);
-      this.storeCookies(response);
+      // Flip the clone to stateless so the normal request path emits the release header for us.
+      this.config.sessionType = 'stateless';
+      await this.head('/sap/bc/adt/core/discovery');
     } catch {
       // Deliberately swallowed — see the doc comment.
     }
@@ -436,8 +422,9 @@ export class AdtHttpClient {
       headers['X-SAP-SAML2'] = 'disabled';
     }
 
-    if (this.config.sessionType === 'stateful') {
-      headers['X-sap-adt-sessiontype'] = 'stateful';
+    // Both directions matter: `stateful` opens the ABAP session context, `stateless` releases it.
+    if (this.config.sessionType) {
+      headers['X-sap-adt-sessiontype'] = this.config.sessionType;
     }
 
     if (contentType) {

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -27,6 +27,7 @@ import type { CachingLayer } from '../cache/caching-layer.js';
 import { type RegistryEntry, type ToolDispatchContext, ToolRegistry } from '../registry/tool-registry.js';
 import { sanitizeArgs } from '../server/audit.js';
 import { generateRequestId, getCurrentContext, requestContext } from '../server/context.js';
+import { buildIdeLink, formatIdeLink, objectIdentity, resolveTemplate } from '../server/ide-links.js';
 import { logger } from '../server/logger.js';
 import { type McpRateLimiter, resolveRateLimitUserKey } from '../server/mcp-rate-limit.js';
 import { formatClientInfo } from '../server/trace-context.js';
@@ -41,7 +42,12 @@ import { expandHyperfocusedArgs } from './hyperfocused.js';
 import { handleSAPLint } from './lint.js';
 import { handleSAPManage } from './manage.js';
 import { handleSAPNavigate } from './navigate.js';
-import { canonicalTablType, normalizeObjectType, normalizeTypeArgsForValidation } from './object-types.js';
+import {
+  canonicalTablType,
+  normalizeObjectType,
+  normalizeTypeArgsForValidation,
+  objectBasePath,
+} from './object-types.js';
 import { handleSAPQuery } from './query.js';
 import { handleSAPRead } from './read.js';
 import { getToolSchema } from './schemas.js';
@@ -632,6 +638,60 @@ export function classifyMultiTargetSapError(
  *   all tools are allowed (backward compatibility).
  * @param server - MCP Server instance for elicitation support.
  */
+
+/**
+ * Append an IDE deep link to a successful, single-object tool result (`ARC1_IDE_LINKS`).
+ *
+ * Deliberately narrow: successes only (an error should stay an error, not gain a link), and only
+ * when the args identify exactly one object. Never throws — a link is a nicety and must not be able
+ * to fail a tool call.
+ */
+function appendIdeLink(
+  result: ToolResult,
+  toolName: string,
+  args: Record<string, unknown>,
+  config: ServerConfig,
+  clientAgent: string | undefined,
+): ToolResult {
+  try {
+    if (result.isError) return result;
+    const template = resolveTemplate(config.ideLinks, clientAgent);
+    if (!template) return result;
+    const identity = objectIdentity(args);
+    if (!identity) return result;
+
+    // objectBasePath throws for types with no single addressable path (FUNC needs its group).
+    // That must only cost the {uri} placeholder, not the whole link.
+    let uri: string | undefined;
+    try {
+      uri = `${objectBasePath(identity.type)}${identity.name.toLowerCase()}`;
+    } catch {
+      uri = undefined;
+    }
+
+    const link = buildIdeLink(template, {
+      type: identity.type,
+      name: identity.name,
+      package: typeof args.package === 'string' ? args.package : undefined,
+      uri,
+      // No dedicated SID on ServerConfig — the ADT destination name is the closest equivalent.
+      sid: config.targetId ?? config.destinationName,
+      client: config.client,
+    });
+    if (!link) return result;
+
+    // A SEPARATE content block, never concatenated onto the payload: most tool results are JSON,
+    // and appending prose to them makes them unparseable for any client that reads them as JSON.
+    return {
+      ...result,
+      content: [...result.content, { type: 'text' as const, text: formatIdeLink(link, identity.name) }],
+    };
+  } catch (err) {
+    logger.debug('ide link suppressed', { tool: toolName, error: err instanceof Error ? err.message : String(err) });
+    return result;
+  }
+}
+
 export async function handleToolCall(
   client: AdtClient,
   config: ServerConfig,
@@ -870,6 +930,8 @@ export async function handleToolCall(
 
         const guardedResult = postDispatchResult?.();
         if (guardedResult) result = guardedResult;
+
+        result = appendIdeLink(result, toolName, args, config, clientAgent);
 
         const durationMs = Date.now() - start;
         const fullText = result.content.map((c) => c.text).join('');

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -27,7 +27,14 @@ import type { CachingLayer } from '../cache/caching-layer.js';
 import { type RegistryEntry, type ToolDispatchContext, ToolRegistry } from '../registry/tool-registry.js';
 import { sanitizeArgs } from '../server/audit.js';
 import { generateRequestId, getCurrentContext, requestContext } from '../server/context.js';
-import { buildIdeLink, formatIdeLink, objectIdentity, resolveTemplate } from '../server/ide-links.js';
+import {
+  abapDestinationsFromRoots,
+  buildIdeLink,
+  formatIdeLink,
+  objectIdentity,
+  resolveTemplate,
+} from '../server/ide-links.js';
+import { getIdeRoots } from '../server/ide-roots.js';
 import { logger } from '../server/logger.js';
 import { type McpRateLimiter, resolveRateLimitUserKey } from '../server/mcp-rate-limit.js';
 import { formatClientInfo } from '../server/trace-context.js';
@@ -652,10 +659,15 @@ function appendIdeLink(
   args: Record<string, unknown>,
   config: ServerConfig,
   clientAgent: string | undefined,
+  ide: { roots: Array<{ uri?: string }>; known: boolean },
 ): ToolResult {
   try {
     if (result.isError) return result;
-    const template = resolveTemplate(config.ideLinks, clientAgent);
+    const destinations = abapDestinationsFromRoots(ide.roots);
+    const template = resolveTemplate(config.ideLinks, clientAgent, {
+      known: ide.known,
+      hasAbapFolder: destinations.length > 0,
+    });
     if (!template) return result;
     const identity = objectIdentity(args);
     if (!identity) return result;
@@ -674,8 +686,9 @@ function appendIdeLink(
       name: identity.name,
       package: typeof args.package === 'string' ? args.package : undefined,
       uri,
-      // No dedicated SID on ServerConfig — the ADT destination name is the closest equivalent.
-      sid: config.targetId ?? config.destinationName,
+      // Prefer the destination the IDE actually has open — on a plain on-prem connection it is
+      // the only place a system id exists at all. Falls back to the configured destination.
+      sid: destinations[0] ?? config.targetId ?? config.destinationName,
       client: config.client,
     });
     if (!link) return result;
@@ -931,7 +944,7 @@ export async function handleToolCall(
         const guardedResult = postDispatchResult?.();
         if (guardedResult) result = guardedResult;
 
-        result = appendIdeLink(result, toolName, args, config, clientAgent);
+        result = appendIdeLink(result, toolName, args, config, clientAgent, await getIdeRoots(_server));
 
         const durationMs = Date.now() - start;
         const fullText = result.content.map((c) => c.text).join('');

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -753,6 +753,8 @@ export function resolveConfig(args: string[]): { config: ServerConfig; sources: 
     'minimalErrors',
   );
 
+  config.ideLinks = resolveStr('ide-links', 'ARC1_IDE_LINKS', 'auto', 'ideLinks').trim() || 'auto';
+
   // ── Misc ───────────────────────────────────────────────────────────
   config.verbose = resolveBool('verbose', 'SAP_VERBOSE', false, 'verbose');
   if (config.verbose) config.logLevel = 'debug';

--- a/src/server/ide-links.ts
+++ b/src/server/ide-links.ts
@@ -44,15 +44,25 @@ export interface IdeLinkFields {
  * `auto` deliberately emits nothing for an unrecognised client: a chat client with no IDE has
  * nothing to open, and a wrong guess is worse than no link.
  */
-export function resolveTemplate(mode: string | undefined, clientAgent: string | undefined): string | undefined {
+export function resolveTemplate(
+  mode: string | undefined,
+  clientAgent: string | undefined,
+  ide?: { hasAbapFolder: boolean; known: boolean },
+): string | undefined {
   const configured = (mode ?? 'auto').trim();
   if (!configured || configured === 'off') return undefined;
   if (configured === 'vscode') return VSCODE_TEMPLATE;
   if (configured === 'eclipse') return ECLIPSE_TEMPLATE;
   if (configured !== 'auto') return configured; // explicit template wins, always
 
+  // When the client told us its roots, believe them over its name. An `abap:` root proves SAP's
+  // ABAP extension is live and a package is open — i.e. something can actually open the link.
+  // Its absence means a link would be dead, even in VS Code.
+  if (ide?.known) return ide.hasAbapFolder ? VSCODE_TEMPLATE : undefined;
+
   const agent = (clientAgent ?? '').toLowerCase();
   if (!agent) return undefined;
+  // No roots to go on (HTTP transport, or a client without the capability): fall back to the name.
   // Forks (Cursor, Windsurf, …) usually keep the upstream name, hence a substring match.
   if (agent.includes('visual studio code') || agent.includes('vscode')) return VSCODE_TEMPLATE;
   return undefined;
@@ -92,6 +102,33 @@ export function buildIdeLink(template: string, fields: IdeLinkFields): string | 
   if (missing) return undefined;
   // Drop an empty trailing `&package=` so the link stays tidy.
   return link.replace(/&package=(?=&|$)/, '');
+}
+
+/**
+ * ADT destinations the IDE has open, derived from the MCP roots the client reported.
+ *
+ * VS Code hands its workspace folders to MCP servers as roots, and — measured — it does NOT filter
+ * by scheme, so an ABAP package folder arrives verbatim:
+ *   `abap:/repotree-v1/A4H2023` → destination `A4H2023`
+ * The second path segment is the destination, matching how `sapse.adt-vscode` itself reads it
+ * (`path.split('/')[2]`).
+ *
+ * An `abap:` root proves three things at once: SAP's ABAP extension is active, a package is open,
+ * and which system it is. That is a far better signal than the client's self-reported name.
+ * @param roots
+ */
+export function abapDestinationsFromRoots(roots: ReadonlyArray<{ uri?: string }> | undefined): string[] {
+  if (!roots) return [];
+  const found: string[] = [];
+  for (const root of roots) {
+    const uri = root?.uri;
+    if (typeof uri !== 'string' || !uri.toLowerCase().startsWith('abap:')) continue;
+    // abap:/repotree-v1/<DEST>/... — tolerate abap:// too.
+    const segments = uri.slice('abap:'.length).replace(/^\/+/, '').split('/');
+    const destination = segments[1];
+    if (destination) found.push(decodeURIComponent(destination));
+  }
+  return [...new Set(found)];
 }
 
 /**

--- a/src/server/ide-links.ts
+++ b/src/server/ide-links.ts
@@ -1,0 +1,117 @@
+/**
+ * IDE deep links appended to tool results (`ARC1_IDE_LINKS`).
+ *
+ * A tool result that names an ABAP object is far more useful when the user can click through to it.
+ * Which link is right depends on where ARC-1 is running, so `auto` derives it from the calling
+ * client — VS Code gets a link into the ARC-1 ABAP Bridge extension, Eclipse gets an `adt://` link
+ * (a scheme ADT registers with the operating system).
+ *
+ * SECURITY: the client identity comes from `clientInfo`/`User-Agent`, which the client controls.
+ * That is acceptable here because the only consequence of a wrong guess is a link that does not
+ * resolve. It must never be used for anything security-relevant.
+ *
+ * Measured client identities (2026-08-03, MCP protocol 2025-11-25):
+ *   VS Code 1.131      → `Visual Studio Code`
+ *   Claude Desktop     → `claude-ai`
+ *   Claude Code        → `local-agent-mode-<server-name>`  (derived from the SERVER name — match by prefix)
+ */
+
+/** Link into the ARC-1 ABAP Bridge VS Code extension. */
+export const VSCODE_TEMPLATE = 'vscode://marianfoo.arc1-abap-bridge/open?name={name}&package={package}';
+
+/**
+ * ADT link. `adt` is registered with the OS by `org.eclipse.urischeme.uriSchemeHandlers`
+ * (handler `com.sap.adt.tools.core.ui.internal.openurl.AdtLinkHandler`), so this opens in Eclipse
+ * from anywhere — including a chat client that has no IDE of its own. Shape derived from
+ * `com.sap.adt.tools.abapsource.urimapping.ExternalUriUtil`.
+ */
+export const ECLIPSE_TEMPLATE = 'adt://{sid}{uri}?sap-client={client}';
+
+export interface IdeLinkFields {
+  type?: string;
+  name?: string;
+  package?: string;
+  /** ADT object URI, e.g. `/sap/bc/adt/oo/classes/zcl_x`. */
+  uri?: string;
+  /** System id / ADT destination name. */
+  sid?: string;
+  client?: string;
+}
+
+/**
+ * Pick the link template for this call, or undefined to emit nothing.
+ *
+ * `auto` deliberately emits nothing for an unrecognised client: a chat client with no IDE has
+ * nothing to open, and a wrong guess is worse than no link.
+ */
+export function resolveTemplate(mode: string | undefined, clientAgent: string | undefined): string | undefined {
+  const configured = (mode ?? 'auto').trim();
+  if (!configured || configured === 'off') return undefined;
+  if (configured === 'vscode') return VSCODE_TEMPLATE;
+  if (configured === 'eclipse') return ECLIPSE_TEMPLATE;
+  if (configured !== 'auto') return configured; // explicit template wins, always
+
+  const agent = (clientAgent ?? '').toLowerCase();
+  if (!agent) return undefined;
+  // Forks (Cursor, Windsurf, …) usually keep the upstream name, hence a substring match.
+  if (agent.includes('visual studio code') || agent.includes('vscode')) return VSCODE_TEMPLATE;
+  return undefined;
+}
+
+/**
+ * Placeholders that land in a URI *path* — their slashes must survive. `encodeURIComponent`
+ * would turn `/sap/bc/adt/oo/classes/zcl_x` into `%2Fsap%2Fbc%2F…` and the link would not resolve.
+ */
+const PATH_PLACEHOLDERS = new Set(['uri']);
+
+/**
+ * Fill a template. Returns undefined when a placeholder the template needs has no value —
+ * a half-built link is worse than none.
+ */
+export function buildIdeLink(template: string, fields: IdeLinkFields): string | undefined {
+  const values: Record<string, string | undefined> = {
+    type: fields.type,
+    name: fields.name,
+    package: fields.package,
+    uri: fields.uri,
+    sid: fields.sid,
+    client: fields.client,
+  };
+  let missing = false;
+  const link = template.replace(/\{(\w+)\}/g, (_match, key: string) => {
+    const value = values[key];
+    if (value === undefined || value === '') {
+      // `package` is genuinely optional — the bridge resolves it itself when absent.
+      if (key === 'package') return '';
+      missing = true;
+      return '';
+    }
+    // Encode per position: path segments keep their separators, query values do not.
+    return PATH_PLACEHOLDERS.has(key) ? value.split('/').map(encodeURIComponent).join('/') : encodeURIComponent(value);
+  });
+  if (missing) return undefined;
+  // Drop an empty trailing `&package=` so the link stays tidy.
+  return link.replace(/&package=(?=&|$)/, '');
+}
+
+/**
+ * The object a tool call is about, or undefined when it is not about one object.
+ * Deliberately conservative: only `type` + `name` together count as an identity.
+ */
+export function objectIdentity(args: Record<string, unknown>): { type: string; name: string } | undefined {
+  const type = typeof args.type === 'string' ? args.type.trim() : '';
+  const name = typeof args.name === 'string' ? args.name.trim() : '';
+  if (!type || !name) return undefined;
+  // Wildcards and comma lists are searches, not a single object.
+  if (/[*,\s]/.test(name)) return undefined;
+  return { type: type.toUpperCase(), name: name.toUpperCase() };
+}
+
+/**
+ * The link line. Emitted as its OWN MCP content block, never concatenated onto the payload:
+ * most tool results are JSON, and appending prose to them makes the JSON unparseable.
+ * Kept to one short line — it rides along on every single-object call.
+ */
+export function formatIdeLink(link: string, name: string): string {
+  return `Open ${name} in your IDE: ${link}`;
+}

--- a/src/server/ide-links.ts
+++ b/src/server/ide-links.ts
@@ -110,8 +110,12 @@ export function objectIdentity(args: Record<string, unknown>): { type: string; n
 /**
  * The link line. Emitted as its OWN MCP content block, never concatenated onto the payload:
  * most tool results are JSON, and appending prose to them makes the JSON unparseable.
+ *
+ * The leading newline is for clients that render content blocks by joining them with no
+ * separator (ARC-1's own CLI and Claude Desktop both do) — without it the result reads
+ * `endmethod.Open ZCL_X in your IDE: …`. Block-aware clients are unaffected.
  * Kept to one short line — it rides along on every single-object call.
  */
 export function formatIdeLink(link: string, name: string): string {
-  return `Open ${name} in your IDE: ${link}`;
+  return `\nOpen ${name} in your IDE: ${link}`;
 }

--- a/src/server/ide-roots.ts
+++ b/src/server/ide-roots.ts
@@ -1,0 +1,69 @@
+/**
+ * IDE workspace roots, read from the MCP client (`roots/list`).
+ *
+ * Gives ARC-1 a little awareness of what the developer has open — specifically which ADT
+ * destination and packages, when the client is an IDE. Used only for presentation (see
+ * `ide-links.ts`).
+ *
+ * STRICTLY ADDITIVE. Roots change what ARC-1 *knows*, never what it *does*. They are impossible
+ * on the HTTP transport — `src/server/http.ts` builds a per-request `Server` that never sees
+ * `initialize`, so there is no session to ask — and every feature must work without them.
+ *
+ * Three guards, because a presentation nicety must never delay or fail a tool call:
+ *   1. capability gate — skipped entirely unless the client advertised `roots`
+ *   2. timeout — a client that accepts the request but never answers cannot hang us
+ *   3. cached, including failure — asked once per server, not once per call
+ */
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { logger } from './logger.js';
+
+/** How long to wait for the client to answer before giving up for good. */
+const ROOTS_TIMEOUT_MS = 2000;
+
+export interface IdeRoots {
+  /** Raw roots as reported. Empty when the client has none. */
+  roots: Array<{ uri?: string; name?: string }>;
+  /** False when roots could not be obtained at all — the caller must not infer "no ABAP folder". */
+  known: boolean;
+}
+
+const UNKNOWN: IdeRoots = { roots: [], known: false };
+
+/** Per-server cache. A `Server` instance is one client session. */
+const cache = new WeakMap<object, Promise<IdeRoots>>();
+
+/**
+ * Ask the client for its workspace roots, once. Never throws.
+ * @param server the MCP server for this session, if there is one (absent on the CLI)
+ */
+export function getIdeRoots(server: Server | undefined): Promise<IdeRoots> {
+  if (!server) return Promise.resolve(UNKNOWN);
+  const cached = cache.get(server);
+  if (cached) return cached;
+
+  const pending = fetchRoots(server);
+  cache.set(server, pending);
+  return pending;
+}
+
+/** Drop the cache so the next call re-asks — for `notifications/roots/list_changed`. */
+export function invalidateIdeRoots(server: Server | undefined): void {
+  if (server) cache.delete(server);
+}
+
+async function fetchRoots(server: Server): Promise<IdeRoots> {
+  try {
+    // Guard 1: never send a request the client did not say it supports. Without this, a client
+    // that ignores `roots/list` would cost every session a full timeout.
+    if (!server.getClientCapabilities()?.roots) return UNKNOWN;
+
+    // Guard 2: bound the wait. `timeout` is honoured by the SDK's request options.
+    const result = await server.listRoots(undefined, { timeout: ROOTS_TIMEOUT_MS });
+    const roots = Array.isArray(result?.roots) ? result.roots : [];
+    logger.debug('ide roots', { count: roots.length });
+    return { roots, known: true };
+  } catch (err) {
+    logger.debug('ide roots unavailable', { error: err instanceof Error ? err.message : String(err) });
+    return UNKNOWN;
+  }
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -151,6 +151,15 @@ export interface ServerConfig {
   logFormat: 'text' | 'json';
   /** Hide SAP response details from client-facing tool errors while retaining server-side correlation data. */
   minimalErrors: boolean;
+  /** Append an IDE deep link to tool results that name one object:
+   *  `off` | `auto` (derive from the calling client) | `vscode` | `eclipse` | a custom template
+   *  using `{type} {name} {package} {uri} {sid} {client}`.
+   *
+   *  `eclipse` needs a system id, which only exists on BTP/multi-target setups today
+   *  (`destinationName`/`targetId`). On a plain on-prem connection, supply it in a template
+   *  instead: `ARC1_IDE_LINKS='adt://A4H{uri}?sap-client=001'`. Once ARC-1 reads MCP roots it can
+   *  take the ADT project name from the IDE (`abap:/repotree-v1/A4H2023`) and fill `{sid}` itself. */
+  ideLinks: string;
 
   // --- Tool Mode ---
   /** Tool mode: 'standard' (12 intent tools, SAPGit feature-gated) or 'hyperfocused' (1 universal SAP tool, ~200 tokens) */
@@ -302,5 +311,6 @@ export const DEFAULT_CONFIG: ServerConfig = {
   logLevel: 'info',
   logFormat: 'text',
   minimalErrors: false,
+  ideLinks: 'auto',
   verbose: false,
 };

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -840,9 +840,56 @@ describe('AdtHttpClient', () => {
         await session.post('/lock', '<xml/>');
       });
 
-      // The POST from session client should have stateful header
-      const lastCallHeaders = fetchHeaders(mockFetch.mock.calls.length - 1);
-      expect(lastCallHeaders['X-sap-adt-sessiontype']).toBe('stateful');
+      // Assert on the POST itself, not "the last call" — the last call is now the session
+      // release, which is deliberately stateless.
+      const lockCall = mockFetch.mock.calls.findIndex((c) => String(c[0]).includes('/lock'));
+      expect(lockCall).toBeGreaterThanOrEqual(0);
+      expect(fetchHeaders(lockCall)['X-sap-adt-sessiontype']).toBe('stateful');
+    });
+
+    it('releases the stateful session when the block finishes', async () => {
+      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      (client as any).csrfToken = 'T';
+      await client.withStatefulSession(async (session) => {
+        await session.post('/lock', '<xml/>');
+      });
+
+      // A stateful ADT session persists until explicitly released — dropping the header on later
+      // requests does NOT end it, so without this the session holds a mode until it times out.
+      const last = mockFetch.mock.calls.length - 1;
+      expect(fetchHeaders(last)['X-sap-adt-sessiontype']).toBe('stateless');
+      expect(fetchOptions(last).method).toBe('HEAD');
+    });
+
+    it('releases the session even when the block throws, and never masks the error', async () => {
+      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+
+      const client = new AdtHttpClient(getDefaultConfig());
+      (client as any).csrfToken = 'T';
+      await expect(
+        client.withStatefulSession(async () => {
+          throw new Error('write blew up');
+        }),
+      ).rejects.toThrow('write blew up');
+
+      const last = mockFetch.mock.calls.length - 1;
+      expect(fetchHeaders(last)['X-sap-adt-sessiontype']).toBe('stateless');
+    });
+
+    it('adopts a session cookie rotated during the stateful block', async () => {
+      const client = new AdtHttpClient(getDefaultConfig());
+      (client as any).csrfToken = 'T';
+      (client as any).cookieJar = new Map([['SAP_SESSIONID_A4H_001', 'OLD']]);
+
+      await client.withStatefulSession(async (session) => {
+        // Simulate SAP rotating the session id mid-block.
+        (session as any).cookieJar.set('SAP_SESSIONID_A4H_001', 'ROTATED');
+      });
+
+      // Previously the clone's jar was discarded, so the parent kept using a dead session id.
+      expect((client as any).cookieJar.get('SAP_SESSIONID_A4H_001')).toBe('ROTATED');
     });
 
     it('session client shares CSRF token with parent', async () => {

--- a/tests/unit/handlers/dispatch-ide-links.test.ts
+++ b/tests/unit/handlers/dispatch-ide-links.test.ts
@@ -33,7 +33,7 @@ describe('IDE links (ARC1_IDE_LINKS)', () => {
     // The payload block must not be touched — this is what keeps JSON results parseable.
     expect(result.content[0]?.text).toBe(SOURCE);
     expect(result.content[1]?.text).toBe(
-      'Open ZHELLO in your IDE: vscode://marianfoo.arc1-abap-bridge/open?name=ZHELLO',
+      '\nOpen ZHELLO in your IDE: vscode://marianfoo.arc1-abap-bridge/open?name=ZHELLO',
     );
   });
 

--- a/tests/unit/handlers/dispatch-ide-links.test.ts
+++ b/tests/unit/handlers/dispatch-ide-links.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `ARC1_IDE_LINKS` at the dispatch layer.
+ *
+ * The contract that matters is structural: the link is its OWN content block. An earlier revision
+ * concatenated it onto the payload, which turned every JSON tool result into unparseable text.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_CONFIG } from '../../../src/server/types.js';
+import { mockResponse } from '../../helpers/mock-fetch.js';
+import { createClient, mockFetch } from './setup-undici-mock.js';
+
+const { handleToolCall } = await import('../../../src/handlers/dispatch.js');
+
+const SOURCE = "REPORT zhello.\nWRITE: / 'Hello'.";
+
+describe('IDE links (ARC1_IDE_LINKS)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockFetch.mockResolvedValue(mockResponse(200, SOURCE, { 'x-csrf-token': 'mock-csrf-token' }));
+  });
+
+  it('adds no link by default (auto, and the CLI/stdio path has no client identity)', async () => {
+    const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', { type: 'PROG', name: 'ZHELLO' });
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]?.text).toBe(SOURCE);
+  });
+
+  it('appends the link as a separate block, leaving the payload byte-identical', async () => {
+    const config = { ...DEFAULT_CONFIG, ideLinks: 'vscode' };
+    const result = await handleToolCall(createClient(), config, 'SAPRead', { type: 'PROG', name: 'ZHELLO' });
+
+    expect(result.content).toHaveLength(2);
+    // The payload block must not be touched — this is what keeps JSON results parseable.
+    expect(result.content[0]?.text).toBe(SOURCE);
+    expect(result.content[1]?.text).toBe(
+      'Open ZHELLO in your IDE: vscode://marianfoo.arc1-abap-bridge/open?name=ZHELLO',
+    );
+  });
+
+  it('adds nothing when the call is not about exactly one object', async () => {
+    const config = { ...DEFAULT_CONFIG, ideLinks: 'vscode' };
+    const result = await handleToolCall(createClient(), config, 'SAPSearch', { query: 'ZCL_*' });
+    expect(result.content.some((block) => block.text.includes('in your IDE'))).toBe(false);
+  });
+
+  it('adds nothing to an error result', async () => {
+    const config = { ...DEFAULT_CONFIG, ideLinks: 'vscode' };
+    const result = await handleToolCall(createClient(), config, 'SAPRead', { type: 'INVALID_TYPE', name: 'X' });
+    expect(result.isError).toBe(true);
+    expect(result.content.some((block) => block.text.includes('in your IDE'))).toBe(false);
+  });
+
+  it('is disabled by off', async () => {
+    const config = { ...DEFAULT_CONFIG, ideLinks: 'off' };
+    const result = await handleToolCall(createClient(), config, 'SAPRead', { type: 'PROG', name: 'ZHELLO' });
+    expect(result.content).toHaveLength(1);
+  });
+});

--- a/tests/unit/plugin/plugin-manifest.test.ts
+++ b/tests/unit/plugin/plugin-manifest.test.ts
@@ -124,6 +124,7 @@ describe('config surface parity (plugin ↔ mcpb)', () => {
     'ARC1_UI',
     'ARC1_UI_OPEN',
     'ARC1_UI_ADDR',
+    'ARC1_IDE_LINKS',
   ];
 
   const surfaces: Record<string, { env: Record<string, string>; cfg: Record<string, Record<string, unknown>> }> = {

--- a/tests/unit/server/ide-links.test.ts
+++ b/tests/unit/server/ide-links.test.ts
@@ -93,9 +93,10 @@ describe('objectIdentity', () => {
 });
 
 describe('formatIdeLink', () => {
-  it('is a single short line with no leading whitespace — it is its own content block', () => {
+  it('leads with a newline so clients that concatenate blocks stay readable', () => {
+    // Measured: ARC-1's CLI and Claude Desktop both join content blocks with no separator,
+    // producing `endmethod.Open ZCL_X …` without this.
     const line = formatIdeLink('vscode://x', 'ZCL_X');
-    expect(line).toBe('Open ZCL_X in your IDE: vscode://x');
-    expect(line.split('\n')).toHaveLength(1);
+    expect(line).toBe('\nOpen ZCL_X in your IDE: vscode://x');
   });
 });

--- a/tests/unit/server/ide-links.test.ts
+++ b/tests/unit/server/ide-links.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  abapDestinationsFromRoots,
   buildIdeLink,
   ECLIPSE_TEMPLATE,
   formatIdeLink,
@@ -98,5 +99,58 @@ describe('formatIdeLink', () => {
     // producing `endmethod.Open ZCL_X …` without this.
     const line = formatIdeLink('vscode://x', 'ZCL_X');
     expect(line).toBe('\nOpen ZCL_X in your IDE: vscode://x');
+  });
+});
+
+describe('abapDestinationsFromRoots', () => {
+  // Exactly what VS Code 1.131 returned from roots/list, measured 2026-08-03.
+  const VSCODE_ROOTS = [
+    { name: 'UI5con_2026', uri: 'file:///Users/marianzeis/DEV/UI5con_2026' },
+    { name: 'A4H2023', uri: 'abap:/repotree-v1/A4H2023' },
+  ];
+
+  it('extracts the ADT destination from an abap: root', () => {
+    expect(abapDestinationsFromRoots(VSCODE_ROOTS)).toEqual(['A4H2023']);
+  });
+
+  it('ignores file: roots and returns nothing when no ABAP folder is open', () => {
+    expect(abapDestinationsFromRoots([{ uri: 'file:///tmp/x' }])).toEqual([]);
+    expect(abapDestinationsFromRoots([])).toEqual([]);
+    expect(abapDestinationsFromRoots(undefined)).toEqual([]);
+  });
+
+  it('handles a deeper package root, the abap:// form, and deduplicates', () => {
+    expect(
+      abapDestinationsFromRoots([
+        { uri: 'abap:/repotree-v1/A4H2023/System%20Library/ZARC1_DEMO' },
+        { uri: 'abap://repotree-v1/A4H2023' },
+      ]),
+    ).toEqual(['A4H2023']);
+  });
+});
+
+describe('resolveTemplate with IDE roots', () => {
+  const KNOWN_WITH_ABAP = { known: true, hasAbapFolder: true };
+  const KNOWN_NO_ABAP = { known: true, hasAbapFolder: false };
+  const UNKNOWN = { known: false, hasAbapFolder: false };
+
+  it('emits a link when the IDE actually has an ABAP folder open', () => {
+    expect(resolveTemplate('auto', VS_CODE, KNOWN_WITH_ABAP)).toBe(VSCODE_TEMPLATE);
+  });
+
+  it('emits NOTHING in VS Code when no ABAP folder is open — the link would be dead', () => {
+    // The flaw roots fixes: the client name says "VS Code", but without the ABAP extension and a
+    // package in the workspace there is nothing that can open a vscode://…/open?name= link.
+    expect(resolveTemplate('auto', VS_CODE, KNOWN_NO_ABAP)).toBeUndefined();
+  });
+
+  it('falls back to the client name when roots are unavailable (HTTP transport)', () => {
+    expect(resolveTemplate('auto', VS_CODE, UNKNOWN)).toBe(VSCODE_TEMPLATE);
+    expect(resolveTemplate('auto', CLAUDE_DESKTOP, UNKNOWN)).toBeUndefined();
+  });
+
+  it('an explicit mode still overrides everything, roots included', () => {
+    expect(resolveTemplate('vscode', CLAUDE_DESKTOP, KNOWN_NO_ABAP)).toBe(VSCODE_TEMPLATE);
+    expect(resolveTemplate('off', VS_CODE, KNOWN_WITH_ABAP)).toBeUndefined();
   });
 });

--- a/tests/unit/server/ide-links.test.ts
+++ b/tests/unit/server/ide-links.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildIdeLink,
+  ECLIPSE_TEMPLATE,
+  formatIdeLink,
+  objectIdentity,
+  resolveTemplate,
+  VSCODE_TEMPLATE,
+} from '../../../src/server/ide-links.js';
+
+// Client identities measured 2026-08-03 against MCP protocol 2025-11-25.
+const VS_CODE = 'Visual Studio Code/1.131.0';
+const CLAUDE_DESKTOP = 'claude-ai/0.1.0';
+const CLAUDE_CODE = 'local-agent-mode-arc-1/1.0.0';
+
+describe('resolveTemplate', () => {
+  it('emits nothing when off or empty', () => {
+    expect(resolveTemplate('off', VS_CODE)).toBeUndefined();
+    expect(resolveTemplate('', VS_CODE)).toBeUndefined();
+  });
+
+  it('auto picks the VS Code bridge link for VS Code and its forks', () => {
+    expect(resolveTemplate('auto', VS_CODE)).toBe(VSCODE_TEMPLATE);
+    expect(resolveTemplate('auto', 'Cursor (Visual Studio Code)/1.0')).toBe(VSCODE_TEMPLATE);
+  });
+
+  it('auto emits nothing for a client with no IDE to open', () => {
+    // Claude Desktop and Claude Code have no ABAP editor — a link there would go nowhere.
+    expect(resolveTemplate('auto', CLAUDE_DESKTOP)).toBeUndefined();
+    expect(resolveTemplate('auto', CLAUDE_CODE)).toBeUndefined();
+    expect(resolveTemplate('auto', undefined)).toBeUndefined();
+    expect(resolveTemplate('auto', 'some-unknown-client/9')).toBeUndefined();
+  });
+
+  it('an explicit mode overrides detection — this is how a Claude Desktop user opts in', () => {
+    expect(resolveTemplate('vscode', CLAUDE_DESKTOP)).toBe(VSCODE_TEMPLATE);
+    expect(resolveTemplate('eclipse', CLAUDE_DESKTOP)).toBe(ECLIPSE_TEMPLATE);
+    expect(resolveTemplate('https://wiki/{name}', CLAUDE_CODE)).toBe('https://wiki/{name}');
+  });
+});
+
+describe('buildIdeLink', () => {
+  it('fills the VS Code template and url-encodes values', () => {
+    expect(buildIdeLink(VSCODE_TEMPLATE, { name: 'ZCL_X', package: '$TMP' })).toBe(
+      'vscode://marianfoo.arc1-abap-bridge/open?name=ZCL_X&package=%24TMP',
+    );
+  });
+
+  it('treats package as optional and leaves no dangling parameter', () => {
+    expect(buildIdeLink(VSCODE_TEMPLATE, { name: 'ZCL_X' })).toBe(
+      'vscode://marianfoo.arc1-abap-bridge/open?name=ZCL_X',
+    );
+  });
+
+  it('builds an adt:// link from the object uri, sid and client', () => {
+    const link = buildIdeLink(ECLIPSE_TEMPLATE, {
+      uri: '/sap/bc/adt/oo/classes/zcl_x',
+      sid: 'A4H',
+      client: '001',
+    });
+    // The object uri is a PATH — its slashes must survive, or the link does not resolve.
+    expect(link).toBe('adt://A4H/sap/bc/adt/oo/classes/zcl_x?sap-client=001');
+  });
+
+  it('percent-encodes path segments without destroying the separators', () => {
+    const link = buildIdeLink(ECLIPSE_TEMPLATE, {
+      uri: '/sap/bc/adt/functions/groups/my group/fmodules/z fm',
+      sid: 'A4H',
+      client: '001',
+    });
+    expect(link).toBe('adt://A4H/sap/bc/adt/functions/groups/my%20group/fmodules/z%20fm?sap-client=001');
+  });
+
+  it('returns undefined rather than a half-built link when a required value is missing', () => {
+    // No destination name configured — an adt:// link without a system is useless.
+    expect(buildIdeLink(ECLIPSE_TEMPLATE, { uri: '/sap/bc/adt/oo/classes/zcl_x', client: '001' })).toBeUndefined();
+    expect(buildIdeLink(VSCODE_TEMPLATE, { package: 'ZFOO' })).toBeUndefined();
+  });
+});
+
+describe('objectIdentity', () => {
+  it('recognises a single object', () => {
+    expect(objectIdentity({ type: 'clas', name: 'zcl_x' })).toEqual({ type: 'CLAS', name: 'ZCL_X' });
+  });
+
+  it('ignores calls that are not about exactly one object', () => {
+    expect(objectIdentity({ type: 'CLAS' })).toBeUndefined();
+    expect(objectIdentity({ name: 'ZCL_X' })).toBeUndefined();
+    expect(objectIdentity({ type: 'CLAS', name: 'ZCL_*' })).toBeUndefined(); // a search
+    expect(objectIdentity({ type: 'CLAS', name: 'ZCL_A,ZCL_B' })).toBeUndefined(); // a list
+    expect(objectIdentity({ type: 'CLAS', name: '   ' })).toBeUndefined();
+  });
+});
+
+describe('formatIdeLink', () => {
+  it('is a single short line with no leading whitespace — it is its own content block', () => {
+    const line = formatIdeLink('vscode://x', 'ZCL_X');
+    expect(line).toBe('Open ZCL_X in your IDE: vscode://x');
+    expect(line.split('\n')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

Two features that bring ARC-1 and the IDE closer together, plus a session-hygiene fix found along the way.

**`ARC1_IDE_LINKS`** — appends a clickable IDE deep link to results that name exactly one object.
`off | auto | vscode | eclipse | <template>`, default `auto`.

**IDE roots awareness** — ARC-1 asks the client once per session what workspace folders it has open, and
uses an `abap:` root to decide whether a link can actually be opened.

**Stateful-session release** (`src/adt/http.ts`) — ARC-1 opened stateful ADT sessions and never released
them, so its session held an ABAP mode until timeout. Eclipse ADT and `abap-adt-api` both send the
release; now ARC-1 does too.

## Why it works this way

Everything here was measured against VS Code 1.131, Claude Desktop, Claude Code and a4h rather than
inferred. The interesting findings:

- **VS Code hands `abap:` workspace folders to MCP servers as roots** — it filters roots by authority,
  not scheme. So an `abap:` root proves SAP's ABAP extension is live *and* a package is open, which is a
  far better gate than the client's self-reported name. Without it, a VS Code user with no ABAP folder
  would get a link that cannot resolve.
- **The root also supplies `{sid}`** (`abap:/repotree-v1/A4H2023` → `A4H2023`) — the only place a system
  id exists on a plain on-prem connection, since `destinationName`/`targetId` are BTP/multi-target only.
- **Claude Desktop renders `vscode://` links but will not open them** (it only hands http/https to the
  OS), so `auto` emitting nothing there is correct, not a gap. Two workarounds were prototyped and
  rejected — see the plan doc.
- **The link is its own MCP content block.** Concatenating it onto the payload made every JSON tool
  result unparseable; a dispatch test now pins the payload block as byte-identical.

## Safety

- `clientAgent` is client-controlled, so it selects a *link format* and nothing else.
- Roots are strictly additive: capability-gated, 2s timeout, per-session cache that also caches failure,
  and impossible on the HTTP transport — every path works without them.
- The link never fails a tool call: errors are swallowed, and `objectBasePath` throwing (FUNC has no
  single addressable path) costs only the `{uri}` placeholder.
- No schema change — the tool-definition fixtures are untouched.

## Docs

`docs/plans/ide-integration-v1.md` plus two research dossiers record what was measured, what was
rejected and why, and the open question about the IDE logouts (hypothesis disproven, candidates listed).

## Test

4996 tests / 172 files, typecheck, lint, action-policy and schema budget all green. Verified live against
a4h: link emission per client, and create/update/delete cycles exercising the session release.
