### PR TITLE
docs: refocus BTP ABAP Environment page on ARC-1 setup

### DIFF
--- a/docs_page/auth-test-process.md
+++ b/docs_page/auth-test-process.md
@@ -284,6 +284,58 @@ cf ssh arc1 -c "curl -s http://localhost:8080/health"
 
 ---
 
+## BTP ABAP Environment (service key)
+
+ARC-1 has two tiers of BTP ABAP integration tests. Both are **local-only**: the service-key provider
+authenticates with the browser Authorization Code flow, and free-tier instances are stopped
+automatically. Tests skip when no credentials are configured. Setup: [BTP ABAP Environment](btp-abap-environment.md).
+
+### Smoke tests
+
+Core connectivity and API contracts, no repository mutations: connect + CSRF token, system-info
+shape, read a released class (`CL_ABAP_RANDOM`), search released objects, and confirm classic
+programs (`RSHOWTIM`) are not reachable.
+
+```bash
+TEST_BTP_SERVICE_KEY_FILE=~/.config/arc-1/btp-abap-service-key.json npm run test:integration:btp:smoke
+# or: TEST_BTP_SERVICE_KEY='{"uaa":{…},…}' npm run test:integration:btp:smoke
+```
+
+### Extended tests
+
+Interactive scenarios — browser OAuth login, writes (create/update/delete), code intelligence,
+transports, and restriction behavior. Never run in CI.
+
+```bash
+TEST_BTP_SERVICE_KEY_FILE=~/.config/arc-1/btp-abap-service-key.json npm run test:integration:btp
+```
+
+### Failure taxonomy
+
+| Category | Symptoms | Cause |
+|---|---|---|
+| **Auth** | 401, token exchange failure | Token expired, service key invalid or revoked |
+| **Connectivity** | `ECONNREFUSED`, `ETIMEDOUT`, DNS failure | Instance stopped (free tier), network unreachable |
+| **Backend unavailable** | 503, maintenance page | Platform maintenance or provisioning |
+| **Assertion** | `expect` mismatch | API contract changed — a real regression to investigate |
+
+Only assertion failures indicate an ARC-1 problem; auth and connectivity failures are expected with
+free-tier instances.
+
+### Tenant assumptions
+
+- Standard released objects exist (`CL_ABAP_RANDOM`, `IF_ABAP_RANDOM`).
+- Free tier: one system per global account, stopped automatically, 90-day limit.
+
+### Checklist
+
+- [ ] Smoke suite passes against a running instance
+- [ ] Browser login completes and the token is reused for later calls
+- [ ] `SAPManage probe` reports `systemType: "btp"`
+- [ ] Write tests target a real development package (not `ZLOCAL`/`$TMP`)
+
+---
+
 ## Full Regression Suite
 
 Run all tests:

--- a/docs_page/btp-abap-environment.md
+++ b/docs_page/btp-abap-environment.md
@@ -222,7 +222,7 @@ is the default) and the first `tools/list` may still advertise on-premise types.
 | `SAPContext` | CLAS, INTF, DDLS, TABL — `action="impact"` for CDS blast radius. |
 | `SAPSearch` / `SAPNavigate` | Work; scope is released SAP objects plus custom Z/Y objects. Classic programs and includes are not searchable. |
 | `SAPQuery` | Freestyle SQL needs `SAP_ALLOW_FREE_SQL=true` (table/CDS previews need `SAP_ALLOW_DATA_PREVIEW=true`). Custom tables and released CDS entities (`I_LANGUAGE`, `I_COUNTRY`, …) work; SAP standard tables (`MARA`, `TADIR`, `DD02L`, …) are blocked — the error suggests CDS views. |
-| `SAPTransport` | Works, but `release` triggers a gCTS Git push, not a TMS export. |
+| `SAPTransport` | Works, but `release` triggers a gCTS Git push, not a TMS export — the software-component model, see the tutorial [Transport a Software Component Between two Systems](https://developers.sap.com/tutorials/abap-environment-gcts..html). |
 | `SAPActivate` / `SAPLint` | Unchanged (`SAPLint` runs client-side). |
 | `SAPDiagnose` | ATC works and uses the system's default check variant (`ABAP_CLOUD_DEVELOPMENT_DEFAULT`) unless you pass `variant`. |
 | `SAPManage` | `probe` reports `systemType: "btp"`. |
@@ -245,9 +245,11 @@ the on-premise `adtcore:masterSystem` / `adtcore:responsible` and adds
 Two prerequisites:
 
 1. **Enable writes** — `SAP_ALLOW_WRITES=true`.
-2. **Target a real development package.** `$TMP` does not exist on BTP, and the booster-provided
-   `ZLOCAL` is a *structure* package that cannot contain development objects. Create a development
-   sub-package under `ZLOCAL` (ARC-1 `SAPManage create_package`, or ADT), then allow it:
+2. **Target a real development package.** `$TMP` does not exist on BTP — the software component
+   `ZLOCAL` plays that role, and its `ZLOCAL` *structure* package cannot contain development objects.
+   Create a development sub-package under it with ARC-1 (`SAPManage create_package`) or in ADT
+   ([tutorial](https://developers.sap.com/tutorials/abap-environment-console-application..html), step
+   "Create ABAP package"), then allow it:
 
    ```bash
    SAP_ALLOW_WRITES=true
@@ -322,7 +324,7 @@ same subaccount → `OAuth2UserTokenExchange`, different subaccounts → `SAMLAs
    `OAuth2SAMLBearerAssertion`) and register the source subaccount's Destination service as a trusted
    IdP in the ABAP environment's subaccount — see
    [OAuth SAML Bearer Assertion Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-saml-bearer-assertion-authentication)
-   and [Setting up Trust Between Systems](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/setting-up-trust-between-systems-for-saml-bearer-assertion-flows).
+   and [User Propagation via SAML 2.0 Bearer Assertion Flow](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/user-propagation-via-saml-2-0-bearer-assertion-flow).
    ARC-1 needs no change — it consumes both the assertion and the bearer token the Destination
    service returns (this is the same code path S/4HANA Public Cloud uses, verified there rather than
    on the ABAP Environment).

--- a/docs_page/btp-abap-environment.md
+++ b/docs_page/btp-abap-environment.md
@@ -71,14 +71,10 @@ service instance (`cf create-service destination lite arc1-destination -c dest.j
 }}}
 ```
 
-| Property | Value |
-|---|---|
-| **Type** | `HTTP` |
-| **URL** | service key `url` — the **`.abap.`** API host, never the `.abap-web.` Fiori host |
-| **Proxy Type** | `Internet` (no Cloud Connector) |
-| **Authentication** | `OAuth2UserTokenExchange` |
-| **Token Service URL** | `<uaa.url>/oauth/token` |
-| **Client ID / Secret** | service key `uaa.clientid` / `uaa.clientsecret` |
+`URL` is the service key's `url` — the **`.abap.`** API host, never the `.abap-web.` Fiori host.
+`ProxyType: Internet` is what keeps ARC-1 off the Cloud Connector proxy. In the cockpit the same
+fields appear as *Token Service URL*, *Client ID* and *Client Secret*
+([property reference](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-user-token-exchange-authentication)).
 
 !!! warning "`OAuth2UserTokenExchange` requires the same subaccount"
     It is an XSUAA→XSUAA exchange *inside one identity zone*: ARC-1 and the ABAP Environment must sit
@@ -147,56 +143,36 @@ or the CLI flags `--btp-service-key-file` / `--btp-service-key`.
 
 ### MCP client configuration
 
-=== "Claude Desktop / Claude Code"
+Two env vars in the client's stdio server entry — the rest of the file follows your client's normal
+format ([Install in Claude](install-in-claude.md), [Local Development](local-development.md#mcp-client-configuration)):
 
-    ```json
-    {
-      "mcpServers": {
-        "arc-1-btp": {
-          "command": "npx",
-          "args": ["-y", "arc-1"],
-          "env": {
-            "SAP_BTP_SERVICE_KEY_FILE": "/path/to/service-key.json",
-            "SAP_SYSTEM_TYPE": "btp"
-          }
-        }
+```json
+{
+  "mcpServers": {
+    "arc-1-btp": {
+      "command": "npx",
+      "args": ["-y", "arc-1"],
+      "env": {
+        "SAP_BTP_SERVICE_KEY_FILE": "/path/to/service-key.json",
+        "SAP_SYSTEM_TYPE": "btp"
       }
     }
-    ```
-
-=== "VS Code (Copilot Chat)"
-
-    ```json
-    {
-      "servers": {
-        "arc-1-btp": {
-          "command": "arc1",
-          "env": {
-            "SAP_BTP_SERVICE_KEY_FILE": "${userHome}/.config/arc-1/btp-service-key.json",
-            "SAP_SYSTEM_TYPE": "btp"
-          }
-        }
-      }
-    }
-    ```
+  }
+}
+```
 
 Docker works the same way (`-e SAP_BTP_SERVICE_KEY_FILE=…` with the key mounted), but only for a local
 interactive run where your browser can reach the container's callback port.
 
 ### First login
 
-1. Make any tool call in your MCP client (e.g. "search for ABAP classes").
-2. A browser window opens on the BTP login page — authenticate (IAS, SAP ID service, Entra ID, …).
-3. The browser shows "Authentication Successful"; the tool call completes.
-4. Later calls reuse the cached token. When the ~12 h access token expires, ARC-1 refreshes it
-   silently; only an expired refresh token triggers another browser login.
-
-Under the hood: ARC-1 reads `url` + `uaa` from the service key, starts a callback listener bound to
-`localhost` (port from `SAP_BTP_OAUTH_CALLBACK_PORT`, auto by default), runs the Authorization Code
-flow with PKCE and a `state` check, then sends `Authorization: Bearer <token>` on every ADT call.
-CSRF and cookie handling are identical to on-premise. If no browser can be opened (macOS `open`,
-Linux `xdg-open`, Windows `start`), the authorization URL is logged to stderr — usable only if that
-browser can still reach the loopback callback.
+Make any tool call; a browser opens on the BTP login page (IAS, SAP ID service, Entra ID, …), and the
+call completes once you authenticate. ARC-1 runs the Authorization Code flow with PKCE and a `state`
+check against a callback listener bound to `localhost` (`SAP_BTP_OAUTH_CALLBACK_PORT`, auto by
+default), then sends `Authorization: Bearer <token>` on every ADT call — CSRF and cookies behave as
+on-premise. The ~12 h access token is refreshed silently; only an expired refresh token means another
+browser login. When no browser can be launched, the authorization URL goes to stderr — usable only if
+that browser can still reach the loopback callback, which rules out most remote hosts.
 
 ### Smoke test
 
@@ -245,11 +221,10 @@ the on-premise `adtcore:masterSystem` / `adtcore:responsible` and adds
 Two prerequisites:
 
 1. **Enable writes** — `SAP_ALLOW_WRITES=true`.
-2. **Target a real development package.** `$TMP` does not exist on BTP — the software component
-   `ZLOCAL` plays that role, and its `ZLOCAL` *structure* package cannot contain development objects.
-   Create a development sub-package under it with ARC-1 (`SAPManage create_package`) or in ADT
-   ([tutorial](https://developers.sap.com/tutorials/abap-environment-console-application..html), step
-   "Create ABAP package"), then allow it:
+2. **Target a real development package** — not `$TMP` (does not exist here) and not the structure
+   package `ZLOCAL`. Create a development sub-package under `ZLOCAL`
+   ([prerequisites, step 6](btp-abap-prerequisites.md#6-a-development-package-writes-only)), then
+   allow it:
 
    ```bash
    SAP_ALLOW_WRITES=true
@@ -267,15 +242,16 @@ Two prerequisites:
 
 ## Constraints vs On-Premise
 
-| Area | Constraint |
-|---|---|
-| ABAP language | Restricted "ABAP for Cloud Development" |
-| APIs | Only C1-released objects are accessible |
-| Tooling | ADT only — no SAP GUI |
-| Packages | Customer namespaces (`Z*`/`Y*`) only |
-| Transports | gCTS / software components instead of classic TMS |
-| Table preview | Off by default; `SAP_ALLOW_DATA_PREVIEW=true` and the backend may still restrict standard tables |
-| Free SQL | `SAP_ALLOW_FREE_SQL=true` required; custom tables and released CDS views are the practical targets |
+The system is **ABAP Cloud**: restricted "ABAP for Cloud Development", only C1-released APIs, ADT only
+(no SAP GUI), `Z`/`Y` namespaces, and gCTS software components instead of classic TMS — SAP's
+[ABAP Cloud Development Model](https://help.sap.com/docs/abap-cloud/abap-cloud/abap-cloud-in-nutshell)
+is the reference. What that changes for ARC-1:
+
+- Types the platform has no concept of are removed from the tool schemas — see
+  [What to expect](#what-to-expect-on-btp-abap).
+- Data access stays behind the usual opt-ins (`SAP_ALLOW_DATA_PREVIEW`, `SAP_ALLOW_FREE_SQL`), and the
+  backend blocks SAP standard tables even when you enable them.
+- `SAPTransport release` is a Git push, so transport-shaped workflows behave differently.
 
 ## Configuration Reference
 
@@ -365,6 +341,6 @@ Free-tier instances are stopped automatically; restart from the Landscape Portal
 - [SAP-Side Prerequisites](btp-abap-prerequisites.md) — provisioning, booster, developer role, service key
 - [BTP Cloud Foundry Deployment](btp-cloud-foundry-deployment.md) · [BTP Destination Setup](btp-destination-setup.md) · [Principal Propagation](principal-propagation-setup.md)
 - [S/4HANA Public Cloud](s4hana-public-cloud.md) — the sibling ABAP Cloud setup (`SAMLAssertion`)
-- SAP: [OAuth User Token Exchange Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-user-token-exchange-authentication) · [Destination Authentication Methods](https://help.sap.com/docs/btp/btp-admin-guide/destination-authentication-methods) · [Routing via Destination](https://help.sap.com/docs/ABAP_ENVIRONMENT/250515df61b74848810389e964f8c367/97d7a02cd6fd4f579fd96f41ee0d0c1d.html)
+- SAP: [OAuth User Token Exchange Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-user-token-exchange-authentication) · [Routing via Destination](https://help.sap.com/docs/ABAP_ENVIRONMENT/250515df61b74848810389e964f8c367/97d7a02cd6fd4f579fd96f41ee0d0c1d.html)
 - Testing ARC-1 against a BTP ABAP system (contributors): [Authentication Test Process](auth-test-process.md#btp-abap-environment-service-key)
 - Design background: [BTP ABAP Environment connectivity report](https://github.com/arc-mcp/arc-1/blob/main/docs/plans/completed/2026-04-01-btp-abap-environment-connectivity.md)

--- a/docs_page/btp-abap-environment.md
+++ b/docs_page/btp-abap-environment.md
@@ -1,265 +1,48 @@
 # BTP ABAP Environment Setup
 
-ARC-1 connects to a SAP BTP ABAP Environment (Steampunk) in two ways:
+How to point ARC-1 at a **SAP BTP ABAP Environment** (Steampunk). The SAP-side groundwork —
+provisioning, the ABAP development booster, the developer role, the service key — is a prerequisite,
+not part of this page: see [SAP-Side Prerequisites](btp-abap-prerequisites.md).
 
-- **Recommended — deploy ARC-1 on BTP Cloud Foundry and connect through a per-user destination** (`OAuth2UserTokenExchange`). This is how ARC-1 is meant to be consumed: a centrally managed, BTP-native service that acts in SAP as each MCP user's own identity (see [deployment-best-practices.md](deployment-best-practices.md)). It runs fully headless and needs no Cloud Connector. See [Recommended: BTP deployment with a per-user destination](#recommended-btp-deployment-with-a-per-user-destination).
-- **Local development — a BTP service key with browser login** (the same OAuth 2.0 Authorization Code flow Eclipse ADT uses; a browser opens and tokens are cached). Fine on a laptop with `stdio` transport, but it **cannot run headless** — the OAuth callback binds to `localhost`, so it is not suitable for a deployed or shared server. This mode is covered first, below.
+There are two ways to connect, and they are not interchangeable:
 
-> **Do not set `SAP_DISABLE_SAML=true` with BTP ABAP.** The SAML/SAML2 disable opt-in (SEC-09) is intended for on-prem SAP systems and breaks BTP ABAP / S/4HANA Public Cloud authentication. See [enterprise-auth.md](enterprise-auth.md) for details.
+| | **Deployed on BTP Cloud Foundry** (recommended) | **Local service key** (development) |
+|---|---|---|
+| SAP identity | Each MCP user's own SAP user (`OAuth2UserTokenExchange`) | Whoever logs in via the browser — one identity |
+| Login | Headless; the Destination service exchanges the user's JWT | Browser opens on first call (OAuth Authorization Code + PKCE) |
+| Transport | `http-streamable`, multi-user | `stdio` on a laptop |
+| Headless / shared server | ✅ | ❌ the OAuth callback binds to loopback |
+| Cloud Connector | Not needed — the ABAP Environment is Internet-facing | Not needed |
+| Setup | [Recommended: BTP deployment with a per-user destination](#recommended-btp-deployment-with-a-per-user-destination) | [Local development: service key + browser login](#local-development-service-key-browser-login) |
 
-## Prerequisites
+The deployed path is how ARC-1 is meant to be consumed — a centrally managed BTP-native service that
+acts in SAP as each user (see [Deployment Best Practices](deployment-best-practices.md)). Use the
+service key only on a laptop.
 
-- A SAP BTP ABAP Environment service instance (see [Provisioning a BTP ABAP Free Tier Instance](#provisioning-a-btp-abap-free-tier-instance) if you don't have one)
-- For local service-key OAuth: a service key for the instance (created in BTP Cockpit)
-- For deployed CF usage: XSUAA and Destination service instances, plus a BTP Destination configured with `OAuth2UserTokenExchange`
-- ARC-1 installed (`npm install -g arc-1` or via Docker)
+!!! danger "Do not set `SAP_DISABLE_SAML=true` with BTP ABAP"
+    The SAML/SAML2 disable opt-in (SEC-09) exists for on-premise systems and breaks BTP ABAP /
+    S/4HANA Public Cloud authentication. See [enterprise-auth.md](enterprise-auth.md).
 
-## Provisioning a BTP ABAP Free Tier Instance
+## Before you start
 
-If you don't have a BTP ABAP Environment instance yet, you can create one on the free tier:
-
-### Prerequisites for Free Tier
-
-- A SAP BTP global account with free-tier eligible entitlements (trial or pay-as-you-go)
-- Cloud Foundry enabled in your subaccount (with an org and space)
-- The `abap` / `free` entitlement assigned to your subaccount
-
-### Assign the Entitlement
-
-1. Go to **Global Account** > **Entitlements** > **Entity Assignments**
-2. Select your subaccount
-3. Click **Configure Entitlements** > **Add Service Plans**
-4. Search for **ABAP Environment**, select the **free** plan
-5. Click **Save**
-
-### Create the Instance
-
-**Via BTP Cockpit:**
-1. Go to your **Subaccount** > **Service Marketplace**
-2. Find **ABAP Environment** and click **Create**
-3. Select plan **free**
-4. In the JSON parameters, provide:
-   ```json
-   {
-     "admin_email": "your.email@example.com",
-     "is_development_allowed": true,
-     "sap_system_name": "H01"
-   }
-   ```
-5. Click **Create**
-
-**Via CF CLI:**
-```bash
-# Login to Cloud Foundry
-cf login -a https://api.cf.<region>.hana.ondemand.com
-
-# Create the instance (use a params file to avoid shell quoting issues)
-cat > params.json << 'EOF'
-{
-  "admin_email": "your.email@example.com",
-  "is_development_allowed": true,
-  "sap_system_name": "H01"
-}
-EOF
-
-cf create-service abap free my-abap-instance -c params.json
-```
-
-**Important notes:**
-- `admin_email` must be a valid email address (the one you use to log into BTP)
-- `sap_system_name` is a 3-character SID (e.g., `H01`, `DEV`, `Z01`)
-- Free tier availability depends on your region and commercial model; check SAP Discovery Center and your subaccount entitlements for current region support
-- Only **one** free instance per global account
-- Provisioning takes **30-60 minutes** — check status with `cf service my-abap-instance`
-- Free tier instances may be **stopped periodically** — restart via Landscape Portal or BTP Cockpit
-- Check current free-tier limits (system sizing, expiry) in SAP Help before planning capacity
-
-### Common Error: admin_email Validation
-
-If you see:
-```
-Service broker error: Failed to validate service parameters,
-reason: /admin_email must NOT have fewer than 6 characters, /admin_email must match pattern...
-```
-
-This means `admin_email` was missing or invalid in your parameters JSON. Make sure you provide a valid email address in the JSON body (not as a separate field).
-
-### Required: Run the Booster and Assign Developer Role
-
-After provisioning, you **cannot log in** to the ABAP system directly — the classic login form (Benutzer/Kennwort) appears but you have no password. You must first set up trust with SAP Cloud Identity Services:
-
-1. **Run the Booster**: BTP Cockpit → **Global Account** → **Boosters** → search for **"Prepare an Account for ABAP Development"** → run it
-   - This configures trust between your subaccount and SAP Cloud Identity Services (IAS)
-   - Creates the initial admin user with SSO-based login
-   - After the booster, login redirects to IAS instead of showing the classic form
-
-2. **Subscribe to "Web Access for ABAP"** (if not already done): BTP Cockpit → subaccount → **Service Marketplace** → "Web access for ABAP" → **Create**
-
-3. **Assign the Developer Role**:
-   - Access the admin launchpad: BTP Cockpit → your space → Service Instances → your instance → **View Dashboard**
-   - Open **"Maintain Business Users"**
-   - Find your user
-   - Go to **"Assigned Business Roles"** → **Add** → search for **`SAP_BR_DEVELOPER`**
-   - Save
-
-   > **Note:** The booster only assigns the administrator role. Without `SAP_BR_DEVELOPER`, Eclipse ADT and ARC-1 connections will fail with: "You have not been successfully logged on. Make sure the developer role is assigned to the user."
-
-4. **Verify**: Connect with Eclipse ADT to confirm login works before testing with ARC-1.
-
-## Step 1: Create a Service Key
-
-1. Open your SAP BTP Cockpit
-2. Navigate to your Subaccount > Service Instances
-3. Find your **ABAP Environment** service instance
-4. Go to **Service Keys** and create a new one (or use an existing one)
-5. Download the service key JSON file
-
-The service key looks like this:
-
-```json
-{
-  "uaa": {
-    "url": "https://your-subdomain.authentication.eu10.hana.ondemand.com",
-    "clientid": "sb-abap-12345...",
-    "clientsecret": "your-client-secret"
-  },
-  "url": "https://your-system.abap.eu10.hana.ondemand.com",
-  "abap": {
-    "url": "https://your-system.abap.eu10.hana.ondemand.com",
-    "sapClient": "100"
-  },
-  "catalogs": {
-    "abap": { "path": "/sap/bc/adt", "type": "sap_abap" }
-  }
-}
-```
-
-## Step 2: Configure ARC-1
-
-### Option A: Service Key File (recommended for local development)
-
-Save the service key to a file and point ARC-1 to it:
-
-```bash
-# Save the service key
-cp ~/Downloads/service-key.json ~/.config/arc-1/btp-service-key.json
-
-# Start ARC-1 with the service key
-SAP_BTP_SERVICE_KEY_FILE=~/.config/arc-1/btp-service-key.json arc1
-```
-
-!!! danger "A service key is a full-access SAP credential — keep it outside the repo"
-    The `uaa.clientid` + `uaa.clientsecret` + `url` in a service key grant OAuth access to the entire ABAP system. Store it outside the repository (e.g. `~/.config/arc-1/`, as above) and never commit it. ARC-1's `.gitignore` / `.dockerignore` / `.cfignore` match `*service-key*.json` so an in-tree key won't be committed or baked into an image by accident — but keep keys outside the tree as defense-in-depth, and treat an inline `SAP_BTP_SERVICE_KEY` env value the same way.
-
-### Option B: Inline Service Key (short-lived local env only)
-
-Pass the entire service key JSON as an environment variable:
-
-```bash
-SAP_BTP_SERVICE_KEY='{"uaa":{"url":"...","clientid":"...","clientsecret":"..."},"url":"..."}' arc1
-```
-
-Do not use this as the normal CF production path. The direct service-key mode opens a browser and binds the callback to local loopback, so it is not suitable for a shared or headless server. For deployed BTP CF, create the destination shown in [Recommended: BTP deployment with a per-user destination](#recommended-btp-deployment-with-a-per-user-destination).
-
-### Option C: CLI Flags
-
-```bash
-arc1 --btp-service-key-file /path/to/service-key.json
-# or
-arc1 --btp-service-key '{"uaa":{...}}'
-```
-
-## Step 3: Configure Your MCP Client
-
-### Claude Desktop / Claude Code
-
-Add to your MCP client config (`claude_desktop_config.json` or `.mcp.json`):
-
-```json
-{
-  "mcpServers": {
-    "arc-1-btp": {
-      "command": "arc1",
-      "env": {
-        "SAP_BTP_SERVICE_KEY_FILE": "/path/to/service-key.json",
-        "SAP_SYSTEM_TYPE": "btp"
-      }
-    }
-  }
-}
-```
-
-Or via npx (no global install):
-
-```json
-{
-  "mcpServers": {
-    "arc-1-btp": {
-      "command": "npx",
-      "args": ["-y", "arc-1"],
-      "env": {
-        "SAP_BTP_SERVICE_KEY_FILE": "/path/to/service-key.json",
-        "SAP_SYSTEM_TYPE": "btp"
-      }
-    }
-  }
-}
-```
-
-### VS Code (Copilot Chat)
-
-In your `.vscode/mcp.json`:
-
-```json
-{
-  "servers": {
-    "arc-1-btp": {
-      "command": "arc1",
-      "env": {
-        "SAP_BTP_SERVICE_KEY_FILE": "${userHome}/.config/arc-1/btp-service-key.json",
-        "SAP_SYSTEM_TYPE": "btp"
-      }
-    }
-  }
-}
-```
-
-### Docker
-
-The direct service-key Docker example is only useful for a local interactive run where the OAuth callback can be reached from the browser. For a deployed/shared Docker container, use the per-user destination pattern instead.
-
-```bash
-docker run -p 8080:8080 \
-  -e SAP_BTP_SERVICE_KEY='{"uaa":{"url":"...","clientid":"...","clientsecret":"..."},"url":"..."}' \
-  -e SAP_SYSTEM_TYPE=btp \
-  ghcr.io/arc-mcp/arc-1:latest
-```
-
-## Step 4: First Login
-
-1. Start your MCP client (Claude Desktop, VS Code, etc.)
-2. Make any tool call (e.g., ask Claude to "search for ABAP classes")
-3. **A browser window opens automatically** to the SAP BTP login page
-4. Authenticate in the browser (SAP ID service, SAP Cloud Identity Services / IAS, Microsoft Entra ID, etc.)
-5. After successful login, the browser shows "Authentication Successful"
-6. Return to your MCP client — the tool call completes
-7. Subsequent calls reuse the cached token (no browser needed)
-
-When the access token expires (~12 hours), ARC-1 automatically refreshes it using the refresh token. A browser login is only needed again if the refresh token also expires.
-
-### Browser Doesn't Open?
-
-If the browser fails to open automatically, ARC-1 logs the authorization URL. Manual copy/paste only works when the browser can reach the callback listener on the same local machine or container mapping. On remote/headless servers this usually fails because the callback is bound to loopback; use the per-user BTP Destination pattern instead.
+- The ABAP system is prepared and Eclipse ADT can log on — [SAP-Side Prerequisites](btp-abap-prerequisites.md).
+- A **service key** of the ABAP instance (both paths need it: directly, or as the destination's OAuth client).
+- ARC-1 installed: `npm install -g arc-1`, `npx arc-1`, or the Docker image `ghcr.io/arc-mcp/arc-1`.
+- For the deployed path: ARC-1 on Cloud Foundry **in the same subaccount as the ABAP Environment** —
+  see [BTP Cloud Foundry Deployment](btp-cloud-foundry-deployment.md) and the
+  [cross-subaccount caveat](#cross-subaccount-principal-propagation-fails).
 
 ## Recommended: BTP deployment with a per-user destination
 
-ARC-1 is designed to run as a **centrally managed service on SAP BTP Cloud Foundry** — not on individual laptops — and to act in SAP as **each MCP user's own identity**. For a BTP ABAP Environment, the recommended setup follows directly from that: deploy ARC-1 on Cloud Foundry and connect through a **per-user destination** using `OAuth2UserTokenExchange`. It runs fully headless (no browser), propagates the logged-in user to the ABAP system so SAP's own authorizations apply per user, and needs **no Cloud Connector** — the ABAP Environment is Internet-facing, so this is a direct cloud-to-cloud call.
+ARC-1 on Cloud Foundry validates the MCP user's XSUAA token, the Destination service exchanges it for
+an ABAP-context token (`OAuth2UserTokenExchange`), and every ADT call runs as that user — so SAP's own
+authorizations apply per user and no technical SAP user exists. It is a direct cloud-to-cloud call:
+no Cloud Connector, no Connectivity service.
 
-SAP documents `OAuth2UserTokenExchange` for applications that need to call another application while passing the logged-in user's context through the Destination service ([SAP Help](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-user-token-exchange-authentication)). That matches ARC-1 on Cloud Foundry calling the ABAP Environment: ARC-1 validates the MCP user's XSUAA token, the Destination service exchanges it for an ABAP-context token, and no technical SAP user is needed for ADT calls.
+SAP documents this exchange for applications that must call another application in the user's context
+([OAuth User Token Exchange Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-user-token-exchange-authentication)).
 
 ### 1. Bind the BTP services
-
-ARC-1 needs an XSUAA instance (for MCP-client login) and a Destination service instance. No Connectivity service is needed, because there is no Cloud Connector.
 
 ```bash
 cf create-service xsuaa application arc1-xsuaa -c xs-security.json
@@ -268,7 +51,9 @@ cf create-service destination lite arc1-destination
 
 ### 2. Create the per-user destination
 
-Take the OAuth client credentials from the ABAP instance's **service key** (`uaa` section; append `/oauth/token` to `uaa.url` for the token endpoint). Create the destination in the BTP cockpit (**Connectivity → Destinations**) or declaratively when provisioning the destination service instance (`cf create-service destination lite arc1-destination -c dest.json`):
+The destination's OAuth client is the ABAP instance's **own** service key (`uaa` section). Create it
+in the cockpit (**Connectivity → Destinations**) or declaratively when creating the destination
+service instance (`cf create-service destination lite arc1-destination -c dest.json`):
 
 ```json
 { "init_data": { "instance": {
@@ -289,342 +74,295 @@ Take the OAuth client credentials from the ABAP instance's **service key** (`uaa
 | Property | Value |
 |---|---|
 | **Type** | `HTTP` |
-| **URL** | service key `url` (the ABAP system) |
+| **URL** | service key `url` — the **`.abap.`** API host, never the `.abap-web.` Fiori host |
 | **Proxy Type** | `Internet` (no Cloud Connector) |
 | **Authentication** | `OAuth2UserTokenExchange` |
 | **Token Service URL** | `<uaa.url>/oauth/token` |
-| **Client ID / Secret** | service key `uaa.clientid` / `uaa.clientsecret` (the ABAP instance's own OAuth client) |
+| **Client ID / Secret** | service key `uaa.clientid` / `uaa.clientsecret` |
 
-> **⚠️ `OAuth2UserTokenExchange` requires the same subaccount.** This auth type is an XSUAA→XSUAA
-> token exchange *within one subaccount/identity zone*, so ARC-1 and the ABAP Environment must be in
-> the **same BTP subaccount**. If they are in **different subaccounts**, the Destination Service fails
-> with `Token header claim [kid] references unknown signing key` (or `Unable to map issuer`) and every
-> tool call returns `Principal propagation failed`. Per SAP's
-> [Routing via Destination](https://help.sap.com/docs/ABAP_ENVIRONMENT/250515df61b74848810389e964f8c367/97d7a02cd6fd4f579fd96f41ee0d0c1d.html):
-> **same subaccount → `OAuth2UserTokenExchange`; different subaccounts → `OAuth2SAMLBearerAssertion`**
-> (the source subaccount's Destination Service becomes a trusted IdP in the ABAP env's subaccount; see
-> [User Propagation via SAML 2.0 Bearer Assertion Flow](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/user-propagation-via-saml-2-0-bearer-assertion-flow)).
-> ARC-1 handles the bearer token from an `OAuth2SAMLBearerAssertion` destination with no extra
-> configuration on its side. See [Troubleshooting](#cross-subaccount-principal-propagation-fails).
+!!! warning "`OAuth2UserTokenExchange` requires the same subaccount"
+    It is an XSUAA→XSUAA exchange *inside one identity zone*: ARC-1 and the ABAP Environment must sit
+    in the **same BTP subaccount**. Across subaccounts the Destination service fails with
+    `Token header claim [kid] references unknown signing key` and every tool call returns
+    `Principal propagation failed` — see [Troubleshooting](#cross-subaccount-principal-propagation-fails)
+    for the two supported fixes.
 
 ### 3. Configure ARC-1
 
 ```yaml
 env:
-  SAP_SYSTEM_TYPE: btp
+  SAP_SYSTEM_TYPE: btp          # ABAP Cloud tool surface from startup
   SAP_TRANSPORT: http-streamable
-  SAP_XSUAA_AUTH: "true"      # MCP clients authenticate via XSUAA OAuth
-  SAP_PP_ENABLED: "true"      # per-user principal propagation
-  SAP_PP_STRICT: "true"       # recommended: reject API-key/non-JWT tool calls
+  SAP_XSUAA_AUTH: "true"        # MCP clients authenticate via XSUAA OAuth
+  SAP_PP_ENABLED: "true"        # per-user principal propagation
+  SAP_PP_STRICT: "true"         # recommended: reject API-key / non-JWT tool calls
   SAP_BTP_DESTINATION: ABAP_PP
 services:
   - arc1-xsuaa
   - arc1-destination
 ```
 
-Per request, ARC-1 validates the MCP user's XSUAA JWT, has the Destination service exchange it for an ABAP-context Bearer token, and sends `Authorization: Bearer <token>` on every ADT call. SAP therefore sees the actual end user, and SAP-side authorizations (`S_DEVELOP`, package checks) apply per user.
+The repository ships this as a ready manifest: [`manifest-btp-abap.yml`](https://github.com/arc-mcp/arc-1/blob/main/manifest-btp-abap.yml)
+(`cf push -f manifest-btp-abap.yml`). Start read-only and widen the safety ceiling only after
+acceptance — see [BTP Cloud Foundry Deployment](btp-cloud-foundry-deployment.md).
 
 ### 4. Grant users access
 
-Assign each MCP user a role collection that grants the ARC-1 scopes they need (e.g. `ARC-1 Developer`) in the subaccount under **Security → Role Collections / Users** — XSUAA only issues a token for scopes the user actually holds. The user must also have developer authorization in the ABAP Environment itself (the `SAP_BR_DEVELOPER` business role; see [Required: Run the Booster and Assign Developer Role](#required-run-the-booster-and-assign-developer-role)).
+1. **BTP** — assign each MCP user a role collection with the ARC-1 scopes they need (e.g. `ARC-1
+   Developer`) under **Security → Role Collections / Users**; XSUAA only issues tokens for scopes the
+   user holds. See [Authorization & Roles](authorization.md).
+2. **ABAP** — the same user needs the `SAP_BR_DEVELOPER` business role in the ABAP Environment
+   ([prerequisites, step 3](btp-abap-prerequisites.md#3-assign-the-developer-role)).
 
-### References (SAP documentation)
+### 5. Verify
 
-- [OAuth2 User Token Exchange Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-user-token-exchange-authentication) — how Destination service exchanges the logged-in user's token for a target-application token.
-- [Destination Authentication Methods](https://help.sap.com/docs/btp/btp-admin-guide/destination-authentication-methods) — `OAuth2UserTokenExchange` alongside the other destination auth types.
-- [SAP Cloud SDK — Destinations](https://sap.github.io/cloud-sdk/docs/js/features/connectivity/destinations) — how the destination and token exchange are resolved at runtime (ARC-1 uses this SDK).
-- [ARC-1 BTP Destination Setup](btp-destination-setup.md) and [Principal Propagation Setup](principal-propagation-setup.md) — ARC-1's destination / principal-propagation configuration in depth (including the on-premise Cloud Connector variant).
+With `ARC1_LOG_LEVEL=debug`, make one tool call and check `cf logs arc1-btp-abap --recent`:
+
+```
+BTP destination resolved  destination:ABAP_PP  ppEnabled:true
+PP: using destination-exchanged Bearer token (OAuth2UserTokenExchange)
+[auth_pp_created] success:true  user:<the MCP user>
+```
+
+`auth_pp_created success:false` means the exchange failed — the message carries the Destination
+service's own error verbatim.
+
+## Local development: service key + browser login
+
+The same OAuth 2.0 Authorization Code flow Eclipse ADT uses: ARC-1 opens a browser, you log in, and
+the tokens are cached in memory. Fine on a laptop with `stdio`; **not** for a deployed or shared
+server, because the callback listener binds to loopback.
+
+### Configure ARC-1
+
+```bash
+# Keep the key outside the repo
+cp ~/Downloads/service-key.json ~/.config/arc-1/btp-service-key.json
+
+SAP_BTP_SERVICE_KEY_FILE=~/.config/arc-1/btp-service-key.json SAP_SYSTEM_TYPE=btp arc1
+```
+
+Alternatives: `SAP_BTP_SERVICE_KEY='{"uaa":{…},"url":"…"}'` (inline JSON, short-lived local env only)
+or the CLI flags `--btp-service-key-file` / `--btp-service-key`.
+
+### MCP client configuration
+
+=== "Claude Desktop / Claude Code"
+
+    ```json
+    {
+      "mcpServers": {
+        "arc-1-btp": {
+          "command": "npx",
+          "args": ["-y", "arc-1"],
+          "env": {
+            "SAP_BTP_SERVICE_KEY_FILE": "/path/to/service-key.json",
+            "SAP_SYSTEM_TYPE": "btp"
+          }
+        }
+      }
+    }
+    ```
+
+=== "VS Code (Copilot Chat)"
+
+    ```json
+    {
+      "servers": {
+        "arc-1-btp": {
+          "command": "arc1",
+          "env": {
+            "SAP_BTP_SERVICE_KEY_FILE": "${userHome}/.config/arc-1/btp-service-key.json",
+            "SAP_SYSTEM_TYPE": "btp"
+          }
+        }
+      }
+    }
+    ```
+
+Docker works the same way (`-e SAP_BTP_SERVICE_KEY_FILE=…` with the key mounted), but only for a local
+interactive run where your browser can reach the container's callback port.
+
+### First login
+
+1. Make any tool call in your MCP client (e.g. "search for ABAP classes").
+2. A browser window opens on the BTP login page — authenticate (IAS, SAP ID service, Entra ID, …).
+3. The browser shows "Authentication Successful"; the tool call completes.
+4. Later calls reuse the cached token. When the ~12 h access token expires, ARC-1 refreshes it
+   silently; only an expired refresh token triggers another browser login.
+
+Under the hood: ARC-1 reads `url` + `uaa` from the service key, starts a callback listener bound to
+`localhost` (port from `SAP_BTP_OAUTH_CALLBACK_PORT`, auto by default), runs the Authorization Code
+flow with PKCE and a `state` check, then sends `Authorization: Bearer <token>` on every ADT call.
+CSRF and cookie handling are identical to on-premise. If no browser can be opened (macOS `open`,
+Linux `xdg-open`, Windows `start`), the authorization URL is logged to stderr — usable only if that
+browser can still reach the loopback callback.
+
+### Smoke test
+
+```bash
+SAP_BTP_SERVICE_KEY_FILE=/path/to/service-key.json SAP_SYSTEM_TYPE=btp arc1 --verbose search "ZCL_*"
+```
+
+Browser login, then results as JSON. A `client_credentials` token cannot be used instead: ADT requires
+a user context and returns 401.
+
+## System type: `SAP_SYSTEM_TYPE=btp`
+
+Set it. It adapts the tool definitions **at startup** instead of after the first `SAPManage probe`,
+so the LLM never sees types the ABAP Environment does not have. Without it, ARC-1 auto-detects (`auto`
+is the default) and the first `tools/list` may still advertise on-premise types.
+
+## What to expect on BTP ABAP
+
+| Tool | On the ABAP Environment |
+|---|---|
+| `SAPRead` | CLAS, INTF, FUNC, FUGR, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD/KTD, TABL, DOMA, DTEL, MSAG, DEVC, TABLE_CONTENTS, TABLE_QUERY, SYSTEM, COMPONENTS, BSP/BSP_DEPLOY, API_STATE, INACTIVE_OBJECTS, plus the discovery-gated server-driven types (DESD, DTSC, CSNM, EVTB, EVTO, COTA, DSFD, DTDC, UIAD). Removed: PROG, INCL, VIEW, TRAN, TTYP, SOBJ, TEXT_ELEMENTS, VARIANTS, AUTH, FEATURE_TOGGLE/FTG2, ENHO, VERSIONS, VERSION_SOURCE. |
+| `SAPWrite` | CLAS, INTF, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD/KTD, TABL (+ `TABL/DT`, `TABL/DS`), DOMA, DTEL, MSAG, and the server-driven types. The `edit_unit` and `edit_text_symbols` actions are not offered (no PROG/INCL, no class text pool). ABAP Cloud language version and customer namespaces only. |
+| `SAPContext` | CLAS, INTF, DDLS, TABL — `action="impact"` for CDS blast radius. |
+| `SAPSearch` / `SAPNavigate` | Work; scope is released SAP objects plus custom Z/Y objects. Classic programs and includes are not searchable. |
+| `SAPQuery` | Freestyle SQL needs `SAP_ALLOW_FREE_SQL=true` (table/CDS previews need `SAP_ALLOW_DATA_PREVIEW=true`). Custom tables and released CDS entities (`I_LANGUAGE`, `I_COUNTRY`, …) work; SAP standard tables (`MARA`, `TADIR`, `DD02L`, …) are blocked — the error suggests CDS views. |
+| `SAPTransport` | Works, but `release` triggers a gCTS Git push, not a TMS export. |
+| `SAPActivate` / `SAPLint` | Unchanged (`SAPLint` runs client-side). |
+| `SAPDiagnose` | ATC works and uses the system's default check variant (`ABAP_CLOUD_DEVELOPMENT_DEFAULT`) unless you pass `variant`. |
+| `SAPManage` | `probe` reports `systemType: "btp"`. |
+
+## Writing objects on BTP
+
+Create/update is live-verified on the ABAP Environment (`CLAS create → activate → read → delete`).
+When the system type is `btp`, ARC-1 emits the **cloud-correct** create body automatically: it drops
+the on-premise `adtcore:masterSystem` / `adtcore:responsible` and adds
+`abapLanguageVersion="cloudDevelopment"`; the owner comes from your JWT.
+
+| Object family | Status |
+|---|---|
+| CLAS, INTF, DDIC (DOMA, DTEL, TABL, MSAG) | Live-verified |
+| RAP stack — BDEF, SRVD, SRVB create | Live-verified; SRVB `update` too (a full metadata replace merged over the existing binding, so a description-only edit keeps the bound `serviceDefinition`) |
+| Server-driven objects (DESD, DTSC, CSNM, EVTB, EVTO, COTA) | Live-verified; their minimal `blue:blueSource` body carries no owner/system attributes by construction |
+| DSFD, DTDC | Registered and `btp`-capable, but live-verified only on on-premise 7.58 / 8.16; discovery-gated like every server-driven type |
+| UIAD (launchpad app descriptor item) | Read in practice — SAP refuses `create` on on-premise ("LADI edits need the ABAP Cloud language version"); writing it on the ABAP Environment is unverified |
+
+Two prerequisites:
+
+1. **Enable writes** — `SAP_ALLOW_WRITES=true`.
+2. **Target a real development package.** `$TMP` does not exist on BTP, and the booster-provided
+   `ZLOCAL` is a *structure* package that cannot contain development objects. Create a development
+   sub-package under `ZLOCAL` (ARC-1 `SAPManage create_package`, or ADT), then allow it:
+
+   ```bash
+   SAP_ALLOW_WRITES=true
+   SAP_ALLOWED_PACKAGES=Z*          # or the exact package, e.g. ZARC1_DEV
+   ```
+
+!!! note "Creating packages on BTP"
+    `SAPManage(action="create_package")` emits the cloud-correct body when `systemType=btp`: it nests
+    the package under the structure `superPackage` (e.g. `ZLOCAL`), sets software component `ZLOCAL`,
+    and uses your **internal ABAP user** (e.g. `CB9980000000`) as `responsible` — the IAS email is
+    rejected and `responsible` cannot be omitted. ARC-1 resolves that internal user from the
+    `createdBy` of an object you created in the session; otherwise pass `responsible="<internal user>"`.
+    Only a brand-new tenant's first-ever package still needs a one-time Eclipse bootstrap
+    (`docs/research/2026-06-27-btp-package-create-solved.md`).
+
+## Constraints vs On-Premise
+
+| Area | Constraint |
+|---|---|
+| ABAP language | Restricted "ABAP for Cloud Development" |
+| APIs | Only C1-released objects are accessible |
+| Tooling | ADT only — no SAP GUI |
+| Packages | Customer namespaces (`Z*`/`Y*`) only |
+| Transports | gCTS / software components instead of classic TMS |
+| Table preview | Off by default; `SAP_ALLOW_DATA_PREVIEW=true` and the backend may still restrict standard tables |
+| Free SQL | `SAP_ALLOW_FREE_SQL=true` required; custom tables and released CDS views are the practical targets |
 
 ## Configuration Reference
-
-### Local service-key OAuth
-
-| Variable / Flag | Description |
-|---|---|
-| `SAP_BTP_SERVICE_KEY` / `--btp-service-key` | Inline service key JSON |
-| `SAP_BTP_SERVICE_KEY_FILE` / `--btp-service-key-file` | Path to service key JSON file |
-| `SAP_BTP_OAUTH_CALLBACK_PORT` / `--btp-oauth-callback-port` | Port for OAuth browser callback (default: auto-assigned) |
-| `SAP_SYSTEM_TYPE` / `--system-type` | System type: `auto` (default), `btp`, or `onprem` |
 
 ### Deployed BTP CF destination
 
 | Variable / Flag | Description |
 |---|---|
-| `SAP_BTP_DESTINATION` | Destination name with `Authentication=OAuth2UserTokenExchange` |
-| `SAP_PP_ENABLED=true` / `--pp-enabled` | Enables ARC-1's per-user destination path |
-| `SAP_PP_STRICT=true` / `--pp-strict` | Recommended strict topology; rejects API-key / non-JWT tool calls. Set explicit `false` to support PP and API keys in one instance, where API-key calls use the shared SAP identity. |
+| `SAP_BTP_DESTINATION` | Destination with `Authentication=OAuth2UserTokenExchange`. Resolved at startup; a change needs a restart. |
+| `SAP_BTP_PP_DESTINATION` | Optional separate per-user destination name; falls back to `SAP_BTP_DESTINATION`. |
+| `SAP_PP_ENABLED=true` / `--pp-enabled` | Enables the per-user destination path |
+| `SAP_PP_STRICT=true` / `--pp-strict` | Recommended; rejects API-key / non-JWT tool calls. Set `false` only to run PP and API keys in one instance (API-key calls then use the shared identity). |
 | `SAP_XSUAA_AUTH=true` / `--xsuaa-auth` | MCP clients authenticate through XSUAA OAuth |
-| `SAP_SYSTEM_TYPE=btp` / `--system-type btp` | Expose the BTP-adapted tool definitions from startup |
+| `SAP_SYSTEM_TYPE=btp` / `--system-type btp` | ABAP Cloud tool definitions from startup |
 
-### Recommended: Set SAP_SYSTEM_TYPE=btp
+### Local service-key OAuth
 
-When connecting to BTP ABAP, set `SAP_SYSTEM_TYPE=btp` for the best experience. This adapts tool definitions immediately at startup:
-
-- **SAPRead**: Removes classic-only types such as PROG, INCL, VIEW, TRAN, TEXT_ELEMENTS, VARIANTS, SOBJ, AUTH, FEATURE_TOGGLE/FTG2, ENHO, and version history actions
-- **SAPWrite**: Supports CLAS, INTF, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD, TABL/TABL/DT/TABL/DS, DOMA, DTEL, MSAG (ABAP Cloud syntax, custom namespaces)
-- **SAPQuery**: Warns about blocked SAP standard tables, suggests CDS views instead
-- **SAPTransport**: Explains gCTS behavior (release = Git push, not TMS export)
-- **SAPContext**: Supports CLAS, INTF, and DDLS (including CDS impact analysis for DDLS)
-
-Without this flag, ARC-1 auto-detects the system type on the first `SAPManage probe`, which works but means the first tool listing may show on-premise types.
-
-## How It Works
-
-1. **Service key parsing**: ARC-1 reads the service key to extract:
-   - `url` — The ABAP system base URL (where ADT API endpoints live)
-   - `uaa.url` — The XSUAA token endpoint
-   - `uaa.clientid` / `uaa.clientsecret` — OAuth client credentials
-
-2. **OAuth Authorization Code flow with PKCE**:
-   - ARC-1 starts a local callback server bound to `localhost` only (not `0.0.0.0`)
-   - Generates a PKCE code verifier/challenge and a random `state` parameter for CSRF protection
-   - Opens the browser to `{uaa.url}/oauth/authorize?client_id=...&redirect_uri=...&code_challenge=...&state=...`
-   - User authenticates in the browser
-   - Browser redirects to callback with authorization code; ARC-1 verifies the `state` parameter matches
-   - ARC-1 exchanges code + PKCE code verifier for JWT access token + refresh token
-   - No user action is required for these security enhancements — they are applied automatically
-
-3. **Bearer token auth**: All ADT API requests use `Authorization: Bearer <token>` instead of Basic Auth. CSRF token handling and cookie management work identically to on-premise.
-
-4. **Token lifecycle**: Access tokens are cached in memory. When they expire, ARC-1 uses the refresh token to get a new one. Only if the refresh token also expires does it trigger another browser login.
-
-## Writing objects on BTP
-
-Object create/update works on the ABAP Environment (live-verified: `CLAS create → activate → read → delete`). ARC-1 emits the **cloud-correct** create body automatically when the system type is `btp` — it drops the on-prem `adtcore:masterSystem`/`adtcore:responsible` and adds `abapLanguageVersion="cloudDevelopment"`; the object owner is taken from your JWT. The same cloud-correct body covers the **RAP stack — BDEF, SRVD and SRVB create is live-verified on the ABAP Environment** (they keep their existing content types; no extra handling needed). **SRVB (service binding) `update` is also supported** — it is a full metadata replace via the binding's v2 content type that merges your changes over the existing binding (so a description-only edit keeps the bound `serviceDefinition`); live-verified create → update → re-point SRVD → delete on the ABAP Environment. The **server-driven object types (DESD, DTSC, CSNM, EVTB, EVTO, COTA)** also create cleanly — their minimal `blue:blueSource` body carries no owner/system attributes by construction (live-verified on the ABAP Environment). `DSFD` (CDS Scalar Function Definition) and `DTDC` (CDS Dynamic Cache) are registered the same way and are `btp: true` by construction, but have only been live-verified on on-prem 758 + 816 — on the ABAP Environment they are discovery-gated like every other SDO type. (DTDC uses its own `<dtdc:dtdcSource>` metadata format, not `blue:blueSource`.) Two prerequisites:
-
-1. **Enable writes** — `SAP_ALLOW_WRITES=true`.
-2. **Target a real development package** — the booster-provided `ZLOCAL` is a *structure* package that cannot contain development objects, and `$TMP` does not exist on BTP. Create a development **sub-package under `ZLOCAL`** with ARC-1 (`SAPManage create_package` — see the note below) or ADT/Eclipse (e.g. `ZARC1_DEV`, software component `ZLOCAL`), then point the allowlist at it:
-
-   ```bash
-   SAP_ALLOW_WRITES=true
-   SAP_ALLOWED_PACKAGES=Z*          # or the exact package name, e.g. ZARC1_DEV
-   ```
-
-You also need the developer role assigned — see [Required: Run the Booster and Assign Developer Role](#required-run-the-booster-and-assign-developer-role).
-
-> **Creating packages on BTP.** `SAPManage(action="create_package")` emits the cloud-correct body when `systemType=btp`: it nests the new package under the structure `superPackage` (e.g. `ZLOCAL`), sets software component `ZLOCAL`, and uses your **internal ABAP user** (XUBNAME, e.g. `CB9980000000`) as `responsible` — the IAS email is rejected and `responsible` can't be omitted. ARC-1 auto-resolves the internal user from the `createdBy` of any object you create in the session (no whoami endpoint); otherwise pass `responsible="<your internal user>"` (from `SAPRead` `createdBy` on an object you own). Only a brand-new tenant's first-ever package — no objects yet, no explicit `responsible` — still needs a one-time Eclipse bootstrap. See `docs/research/2026-06-27-btp-package-create-solved.md`.
-
-## Constraints vs On-Premise
-
-BTP ABAP Environment has some limitations compared to on-premise:
-
-| Area | Constraint |
+| Variable / Flag | Description |
 |---|---|
-| ABAP Language | Restricted ABAP ("ABAP for Cloud Development") |
-| Released APIs only | Only C1-released objects accessible |
-| No SAP GUI | Only ADT (Eclipse/API) available |
-| Table preview is restricted and off by default | `SAP_ALLOW_DATA_PREVIEW=true` is required, and the ABAP backend may still restrict standard tables |
-| Package restrictions | Custom development in `Z*` or customer namespace only |
-| Transport system | Uses gCTS or software components instead of classic transports |
-| SAPQuery | `SAP_ALLOW_FREE_SQL=true` is required; custom tables and released CDS views are the practical targets, while many SAP standard tables are blocked |
+| `SAP_BTP_SERVICE_KEY_FILE` / `--btp-service-key-file` | Path to the service key JSON |
+| `SAP_BTP_SERVICE_KEY` / `--btp-service-key` | Inline service key JSON |
+| `SAP_BTP_OAUTH_CALLBACK_PORT` / `--btp-oauth-callback-port` | Loopback port for the OAuth callback (default: auto) |
+| `SAP_SYSTEM_TYPE` / `--system-type` | `auto` (default), `btp`, `onprem` |
 
-## Cross-Platform Support
-
-The browser login works on all platforms:
-- **macOS**: Opens with `open` command
-- **Linux**: Opens with `xdg-open` command
-- **Windows**: Opens with `start` command
-
-If the system cannot open a browser, the authorization URL is logged to stderr for manual copy-paste. The browser still has to reach the local callback listener, so this is practical on a laptop or WSL setup with local browser integration, but not for most remote/headless servers.
-
-## Testing the Connection
-
-### Quick Smoke Test (CLI)
-
-Before using with an MCP client, test the connection directly:
-
-```bash
-# Test with verbose logging to see the OAuth flow
-SAP_BTP_SERVICE_KEY_FILE=/path/to/service-key.json arc1 search "ZCL_*" --verbose
-```
-
-This will:
-1. Open browser for login
-2. After authentication, search for classes matching `ZCL_*`
-3. Print results as JSON
-
-### Manual Token Test (curl)
-
-> **Note:** Client credentials (`grant_type=client_credentials`) does NOT work for ADT endpoints — ADT requires a user context. Use the Authorization Code flow via ARC-1 or Eclipse ADT for interactive testing. The curl test below uses client_credentials for connectivity testing only — it will confirm the XSUAA URL and credentials are valid, but ADT will return 401.
-
-```bash
-# 1. Get values from your service key
-UAA_URL="https://your-subdomain.authentication.eu10.hana.ondemand.com"
-CLIENT_ID="sb-abap-12345..."
-CLIENT_SECRET="your-secret"
-ABAP_URL="https://your-system.abap.eu10.hana.ondemand.com"
-
-# 2. Get a token (client credentials — only tests XSUAA connectivity)
-TOKEN=$(curl -s -X POST "$UAA_URL/oauth/token" \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -u "$CLIENT_ID:$CLIENT_SECRET" \
-  -d "grant_type=client_credentials" | jq -r '.access_token')
-
-# 3. Verify token was obtained (non-empty = XSUAA is working)
-echo "Token length: ${#TOKEN}"
-
-# 4. Test ADT API access (expect 401 with client_credentials — this is normal)
-curl -s -o /dev/null -w "%{http_code}" "$ABAP_URL/sap/bc/adt/core/discovery" \
-  -H "Authorization: Bearer $TOKEN"
-# 401 = expected (client_credentials lacks user context for ADT)
-# 200 = connection works (unlikely with client_credentials)
-```
-
-For proper testing, use ARC-1 with the service key — it performs the Authorization Code flow with browser login to obtain a user-scoped token.
-
-### What to Expect on BTP ABAP
-
-When `SAP_SYSTEM_TYPE=btp` is set (or auto-detected), tool definitions and behavior adapt:
-
-| Tool | BTP Behavior |
-|---|---|
-| `SAPRead` | Types CLAS, INTF, FUNC/FUGR where released/custom, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD, TABL, DOMA, DTEL, TABLE_CONTENTS, TABLE_QUERY, DEVC, SYSTEM, COMPONENTS, MSAG (deprecated alias: MESSAGES), BSP/BSP_DEPLOY, API_STATE, INACTIVE_OBJECTS. PROG, INCL, VIEW, TRAN, TEXT_ELEMENTS, VARIANTS, SOBJ, AUTH, FEATURE_TOGGLE/FTG2, ENHO, VERSIONS, VERSION_SOURCE are removed — returns helpful error if the LLM tries them. |
-| `SAPSearch` | Works — returns released SAP objects and custom Z/Y objects. Classic programs and includes not searchable. |
-| `SAPWrite` | Supports CLAS, INTF, DDLS, DCLS, DDLX, BDEF, SRVD, SRVB, SKTD, TABL/TABL/DT/TABL/DS, DOMA, DTEL, MSAG. Must use ABAP Cloud language version and custom namespaces. |
-| `SAPActivate` | Works — no changes. |
-| `SAPQuery` | Only custom Z/Y tables and released CDS entities (I_LANGUAGE, I_COUNTRY, etc.). SAP standard tables (DD02L, TADIR, MARA, etc.) are blocked. Returns helpful error with CDS view suggestions. |
-| `SAPTransport` | Works, but release triggers gCTS Git push (not TMS export). Description explains this. |
-| `SAPLint` | Works — runs client-side (abaplint). |
-| `SAPDiagnose` | Works — ATC with ABAP_CLOUD_DEVELOPMENT_DEFAULT variant. |
-| `SAPContext` | Supports CLAS, INTF, and DDLS. Use `action="impact"` for CDS blast-radius analysis. |
-| `SAPNavigate` | Works — scope limited to released and custom objects. |
-| `SAPManage` | Returns `systemType: "btp"` in probe results. |
-
-## Automated Testing
-
-ARC-1 has two tiers of BTP ABAP integration tests. With the current direct service-key test harness, both are local in practice because first authentication uses the browser Authorization Code flow. Tests skip when credentials are absent.
-
-### Smoke Tests
-
-Smoke tests verify core BTP connectivity and API contracts without mutating repository objects. They still use the same service-key OAuth provider as local ARC-1, so the first run may open a browser unless a token is already valid in the running process.
-
-**What they test:**
-- Connectivity: establishes a connection and retrieves a CSRF token
-- System info shape: verifies expected fields (user, collections) are returned
-- Released object read: reads a standard released class (e.g., `CL_ABAP_RANDOM`)
-- Released object search: searches for released objects and validates result shape
-- BTP-specific behavior: confirms classic programs (e.g., `RSHOWTIM`) are not accessible
-
-**How to run:**
-```bash
-# With service key file
-TEST_BTP_SERVICE_KEY_FILE=~/.config/arc-1/btp-abap-service-key.json npm run test:integration:btp:smoke
-
-# With inline service key
-TEST_BTP_SERVICE_KEY='{"uaa":{...},...}' npm run test:integration:btp:smoke
-```
-
-**When the instance is down:** Tests skip gracefully when no credentials are configured. When credentials are present but the instance is stopped, tests fail with connectivity errors — this is expected for free-tier instances that stop nightly.
-
-### Extended Tests (Local Only)
-
-Extended tests cover interactive scenarios that require browser-based OAuth login. They are never run in CI.
-
-**What they test:**
-- Full OAuth browser login flow
-- Write operations (create, update, delete)
-- Code intelligence (find definition, where-used, completion)
-- Transport management
-- Restriction behavior (blocked operations, restricted objects)
-
-**How to run:**
-```bash
-TEST_BTP_SERVICE_KEY_FILE=~/.config/arc-1/btp-abap-service-key.json npm run test:integration:btp
-```
-
-**Why local only:**
-- BTP free tier instances are stopped each night and deleted after 90 days
-- OAuth Authorization Code flow requires an interactive browser login
-- Write operations need a running instance with developer access
-
-### Failure Taxonomy
-
-When BTP tests fail, failures fall into one of these categories:
-
-| Category | Symptoms | Cause |
-|----------|----------|-------|
-| **Auth** | 401 Unauthorized, token exchange failure | OAuth token expired, service key invalid or revoked |
-| **Connectivity** | ECONNREFUSED, ETIMEDOUT, DNS resolution failure | BTP instance stopped (free tier nightly), network unreachable |
-| **Assertion** | Test assertion failure (expect mismatch) | API contract changed, potential regression in ARC-1 |
-| **Backend unavailable** | 503 Service Unavailable, maintenance page | BTP platform maintenance, instance provisioning |
-
-Auth and connectivity failures are expected with free-tier instances. Assertion failures indicate a real issue that needs investigation.
-
-### Tenant Assumptions
-
-- Tests assume a BTP ABAP Environment with standard released objects (e.g., `CL_ABAP_RANDOM`, `IF_ABAP_RANDOM`)
-- Free-tier limitations: instances stop nightly, expire after 90 days, one instance per global account
-- BTP test execution is local-only by design in this project
+Full option semantics: [Configuration Reference](configuration-reference.md#b3-btp-abap-environment-direct-oauth).
 
 ## Troubleshooting
 
 ### Cross-subaccount principal propagation fails
 
-**Symptom:** Tool calls fail with `Principal propagation failed: Destination Service auth token error … Token header claim [kid] references unknown signing key` (or `Unable to map issuer: No identity provider found for issuer …`). MCP login itself works; only the SAP call fails, and the audit log shows `auth_pp_created` with `success:false`.
+**Symptom:** MCP login works, but every tool call fails with `Principal propagation failed:
+Destination Service auth token error … Token header claim [kid] references unknown signing key` (or
+`Unable to map issuer: No identity provider found for issuer …`), and the audit log shows
+`auth_pp_created success:false`.
 
-**Cause:** ARC-1 (its XSUAA) and the ABAP Environment are in **different BTP subaccounts**. `OAuth2UserTokenExchange` exchanges the MCP user's token at the ABAP env's XSUAA, but XSUAA tokens are subaccount-scoped — the ABAP env's XSUAA does not trust a signing key issued by another subaccount.
+**Cause:** ARC-1's XSUAA and the ABAP Environment are in **different BTP subaccounts**. XSUAA tokens
+are subaccount-scoped, so the ABAP environment's XSUAA does not trust a signing key from another
+subaccount. Reproduced end-to-end in [#434](https://github.com/arc-mcp/arc-1/issues/434); ARC-1
+surfaces the Destination service's own error.
 
-**Fix — pick one** (per SAP's [Routing via Destination](https://help.sap.com/docs/ABAP_ENVIRONMENT/250515df61b74848810389e964f8c367/97d7a02cd6fd4f579fd96f41ee0d0c1d.html)):
+**Fix — pick one** (SAP's rule in [Routing via Destination](https://help.sap.com/docs/ABAP_ENVIRONMENT/250515df61b74848810389e964f8c367/97d7a02cd6fd4f579fd96f41ee0d0c1d.html):
+same subaccount → `OAuth2UserTokenExchange`, different subaccounts → `SAMLAssertion`):
 
-1. **Same subaccount (simplest):** deploy ARC-1 in the **same subaccount** as the ABAP Environment and keep `OAuth2UserTokenExchange`. This is ARC-1's recommended one-instance-per-system model (see [BTP Setup for multiple systems](btp-cloud-foundry-deployment.md)).
-2. **Different subaccounts:** change the destination's `Authentication` to **`OAuth2SAMLBearerAssertion`** and establish trust — register the source subaccount's Destination Service as a trusted IdP in the ABAP env's subaccount (see [User Propagation via SAML 2.0 Bearer Assertion Flow](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/user-propagation-via-saml-2-0-bearer-assertion-flow)). ARC-1 needs no code change — it already handles the bearer token this destination type returns.
+1. **Same subaccount (simplest):** deploy ARC-1 into the ABAP Environment's subaccount and keep the
+   destination as-is. This is ARC-1's one-instance-per-system model.
+2. **Different subaccounts:** switch the destination to `SAMLAssertion` (or
+   `OAuth2SAMLBearerAssertion`) and register the source subaccount's Destination service as a trusted
+   IdP in the ABAP environment's subaccount — see
+   [OAuth SAML Bearer Assertion Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-saml-bearer-assertion-authentication)
+   and [Setting up Trust Between Systems](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/setting-up-trust-between-systems-for-saml-bearer-assertion-flows).
+   ARC-1 needs no change — it consumes both the assertion and the bearer token the Destination
+   service returns (this is the same code path S/4HANA Public Cloud uses, verified there rather than
+   on the ABAP Environment).
 
-To serve several ABAP systems across subaccounts from a single ARC-1 instance, use option 2 (trust set up once per backend).
+### 401 after a successful login
 
-### Classic login form (Benutzer/Kennwort) instead of SSO redirect
+The token was issued but SAP rejected it — usually the missing `SAP_BR_DEVELOPER` business role
+([prerequisites](btp-abap-prerequisites.md#3-assign-the-developer-role)). BTP role collections do not
+substitute for it.
 
-- The "Prepare an Account for ABAP Development" booster has not been run
-- Without the booster, trust to SAP Cloud Identity Services (IAS) is not configured
-- Run the booster first (see [Required: Run the Booster](#required-run-the-booster-and-assign-developer-role))
+### 403 on specific ADT endpoints
 
-### "You have not been successfully logged on" / Developer role missing
+Login works, one endpoint does not: the business role lacks that authorization, or a cross-system
+scenario (e.g. remote ATC) needs a communication arrangement. See the
+[SAP-side troubleshooting table](btp-abap-prerequisites.md#troubleshooting-sap-side).
 
-- The booster only assigns the administrator role, not the developer role
-- Open the admin launchpad → **Maintain Business Users** → find your user → add **`SAP_BR_DEVELOPER`** business role
-- Both Eclipse ADT and ARC-1 require the developer role for ADT API access
+### Browser opens but login fails / the browser never opens
 
-### "Entity is currently being edited by another user" when assigning roles
+Verify the service key is current (recreate it in the cockpit if unsure) and that its `uaa.url`
+matches the system's region. When ARC-1 cannot launch a browser it logs the authorization URL —
+copy/paste only works if that browser can reach the loopback callback, which rules out most remote
+and headless hosts. Use the [deployed destination path](#recommended-btp-deployment-with-a-per-user-destination)
+there.
 
-- A previous browser session or the booster may still hold a lock on the user record
-- Close all browser tabs accessing the admin launchpad, wait 1-2 minutes for the lock to expire, then try again
+### Connection works in `curl` but not in ARC-1
 
-### Browser opens but login fails
+Run with `--verbose` / `SAP_VERBOSE=true` and read stderr: it shows the resolved URL, the OAuth flow
+and every ADT request. Check the service-key path is readable, and that the URL is the `.abap.` API
+host.
 
-- Verify the service key is correct and not expired
-- Check that the XSUAA URL in the service key matches your BTP region
-- Try creating a fresh service key in BTP Cockpit
+### Timeouts / `ECONNREFUSED` on a free-tier system
 
-### 401 Unauthorized after login
+Free-tier instances are stopped automatically; restart from the Landscape Portal
+([prerequisites](btp-abap-prerequisites.md#1-provision-the-instance)).
 
-- The OAuth token was obtained but SAP rejected it
-- This can happen if your BTP user doesn't have developer access
-- Check that `SAP_BR_DEVELOPER` is assigned in the admin launchpad (not just BTP role collections)
+## References
 
-### 403 Forbidden on specific ADT endpoints
-
-- Some ADT endpoints may require Communication Arrangements on BTP
-- ATC checks may need `SAP_COM_0763` communication scenario
-- Check the ABAP system's Communication Management (in Fiori Launchpad)
-
-### Token expires and browser doesn't open for re-login
-
-- ARC-1 tries to refresh the token automatically using the refresh token
-- If refresh also fails, it should re-open the browser
-- Restart the MCP server if token issues persist
-
-### Connection works in curl but not in ARC-1
-
-- Enable verbose logging: `--verbose` or `SAP_VERBOSE=true`
-- Check stderr output for OAuth flow details
-- Verify the service key file path is correct and readable
-
-### Free tier provisioning fails
-
-- **Entitlement missing**: Assign `abap` / `free` in Global Account > Entitlements
-- **Region not supported**: Free plan may not be available in your region/commercial model
-- **Already have an instance**: Only one free instance per global account
-- **CF not enabled**: Enable Cloud Foundry in your subaccount first
-
-## Architecture Details
-
-For the research report covering authentication options, competitor analysis, and design decisions, see [btp-abap-environment-connectivity.md](https://github.com/arc-mcp/arc-1/blob/main/docs/plans/completed/2026-04-01-btp-abap-environment-connectivity.md) in the repo.
+- [SAP-Side Prerequisites](btp-abap-prerequisites.md) — provisioning, booster, developer role, service key
+- [BTP Cloud Foundry Deployment](btp-cloud-foundry-deployment.md) · [BTP Destination Setup](btp-destination-setup.md) · [Principal Propagation](principal-propagation-setup.md)
+- [S/4HANA Public Cloud](s4hana-public-cloud.md) — the sibling ABAP Cloud setup (`SAMLAssertion`)
+- SAP: [OAuth User Token Exchange Authentication](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/oauth-user-token-exchange-authentication) · [Destination Authentication Methods](https://help.sap.com/docs/btp/btp-admin-guide/destination-authentication-methods) · [Routing via Destination](https://help.sap.com/docs/ABAP_ENVIRONMENT/250515df61b74848810389e964f8c367/97d7a02cd6fd4f579fd96f41ee0d0c1d.html)
+- Testing ARC-1 against a BTP ABAP system (contributors): [Authentication Test Process](auth-test-process.md#btp-abap-environment-service-key)
+- Design background: [BTP ABAP Environment connectivity report](https://github.com/arc-mcp/arc-1/blob/main/docs/plans/completed/2026-04-01-btp-abap-environment-connectivity.md)

--- a/docs_page/btp-abap-prerequisites.md
+++ b/docs_page/btp-abap-prerequisites.md
@@ -1,0 +1,128 @@
+# BTP ABAP Environment: SAP-Side Prerequisites
+
+Everything that has to be true **in SAP and BTP before ARC-1 is configured**. None of it is
+ARC-1-specific — it is the same setup Eclipse ADT needs, and SAP owns the canonical procedures. This
+page is a checklist with the exact SAP Help entry points; the ARC-1 setup itself lives in
+[BTP ABAP Environment Setup](btp-abap-environment.md).
+
+If Eclipse ADT can already log on to the system and create an object, you are done here — skip
+straight to the [ARC-1 setup](btp-abap-environment.md).
+
+## Checklist
+
+| # | What | Owner | Why ARC-1 needs it |
+|---|---|---|---|
+| 1 | An ABAP Environment service instance | BTP subaccount admin | The ADT endpoints ARC-1 calls |
+| 2 | Trust to SAP Cloud Identity Services (the booster) | BTP subaccount admin | Without it there is no SSO login, only a dead classic login form |
+| 3 | `SAP_BR_DEVELOPER` business role for every user | ABAP env admin | ADT access is refused without it — for ADT *and* ARC-1 |
+| 4 | A service key of the instance | BTP subaccount admin | Local OAuth login, or the OAuth client the per-user destination uses |
+| 5 | A development package (not `ZLOCAL`, not `$TMP`) | ABAP developer | Only needed for writes — see [Writing objects on BTP](btp-abap-environment.md#writing-objects-on-btp) |
+
+## 1. Provision the instance
+
+Follow SAP's [Getting Started with a Customer Account in the ABAP Environment](https://help.sap.com/docs/btp/sap-business-technology-platform/getting-started-with-customer-account-in-abap-environment).
+The instance parameters (cockpit JSON or `cf create-service abap <plan> <name> -c params.json`) are:
+
+```json
+{
+  "admin_email": "your.email@example.com",
+  "is_development_allowed": true,
+  "sap_system_name": "H01"
+}
+```
+
+- `admin_email` must be a real address — a missing/invalid one is the cause of the broker error
+  `/admin_email must NOT have fewer than 6 characters, /admin_email must match pattern…`.
+- `sap_system_name` is a 3-character SID.
+- Provisioning takes **30–60 minutes**; watch it with `cf service <name>`.
+
+!!! note "Free tier"
+    The `free` plan needs a consumption-based commercial model (PAYG or BTPEA) and is limited to
+    **one system**, **90 days** (since 3 April 2024), and community support without an SLA. Within
+    those 90 days you can switch to the standard plan without data loss. Free-tier systems are
+    **stopped every night** and must be restarted manually from the **Landscape Portal** (scheduled
+    start/stop is not available on this plan) — a stopped system looks to ARC-1 like a connectivity
+    failure (`ECONNREFUSED` / timeouts), not an auth problem. Current
+    limits: [Service Plans and Metering](https://help.sap.com/docs/btp/sap-business-technology-platform/service-plans-and-metering-for-sap-btp-abap-environment).
+
+## 2. Run the booster
+
+A freshly provisioned instance has **no password-based login** — the classic *Benutzer/Kennwort* form
+appears but no credentials exist. The booster **Prepare an Account for ABAP Development**
+(BTP Cockpit → Global Account → **Boosters**) configures trust to SAP Cloud Identity Services (IAS),
+so login redirects to IAS, and makes your user the initial administrator.
+
+SAP tutorial: [Use a Booster for creating a Subaccount with an ABAP Environment](https://developers.sap.com/tutorials/btp-ea-onboard-05-abapb..html).
+
+If the subscription is missing afterwards, add **Web Access for ABAP** from the subaccount's Service
+Marketplace.
+
+## 3. Assign the developer role
+
+The booster assigns only the **administrator** role. Every human who will use ARC-1 (or ADT) also
+needs the **`SAP_BR_DEVELOPER`** business role:
+
+1. BTP Cockpit → your space → Service Instances → the ABAP instance → **View Dashboard** (the
+   administration launchpad).
+2. Open **Maintain Business Users**, select the user.
+3. **Assigned Business Roles** → **Add** → `SAP_BR_DEVELOPER` → save.
+
+SAP Help: [Assigning the ABAP Developer User to the ABAP Developer Role](https://help.sap.com/docs/btp/sap-business-technology-platform/assigning-abap-developer-user-to-abap-developer-role)
+· [Required Business Roles](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/required-business-roles).
+
+Without it, ADT and ARC-1 both fail with *"You have not been successfully logged on. Make sure the
+developer role is assigned to the user."*
+
+## 4. Create a service key
+
+BTP Cockpit → Subaccount → **Instances and Subscriptions** → the ABAP instance → **Service Keys** →
+create, then download the JSON:
+
+```json
+{
+  "uaa": {
+    "url": "https://<subdomain>.authentication.<region>.hana.ondemand.com",
+    "clientid": "sb-abap-12345...",
+    "clientsecret": "..."
+  },
+  "url": "https://<guid>.abap.<region>.hana.ondemand.com",
+  "abap": { "url": "https://<guid>.abap.<region>.hana.ondemand.com", "sapClient": "100" }
+}
+```
+
+ARC-1 uses this key in one of two ways — directly for [local browser login](btp-abap-environment.md#local-development-service-key-browser-login),
+or as the OAuth client of a [per-user destination](btp-abap-environment.md#recommended-btp-deployment-with-a-per-user-destination).
+
+!!! danger "A service key is a full-access SAP credential"
+    `uaa.clientid` + `uaa.clientsecret` + `url` grant OAuth access to the whole ABAP system. Keep it
+    outside the repository (e.g. `~/.config/arc-1/`) and never commit it. ARC-1's `.gitignore` /
+    `.dockerignore` / `.cfignore` match `*service-key*.json` as a backstop only.
+
+!!! warning "Use the `.abap.` host, not `.abap-web.`"
+    The service key's `url` is the **API host** (`https://<guid>.abap.<region>.hana.ondemand.com`) —
+    that is what ADT and ARC-1 call. The `.abap-web.` host is the Fiori launchpad and returns login
+    HTML instead of ADT responses ([#301](https://github.com/arc-mcp/arc-1/issues/301)).
+
+## 5. Verify with Eclipse ADT
+
+Before touching ARC-1, connect Eclipse ADT to the system and open one object. It exercises exactly
+the same login and authorization path, and it separates "SAP not ready" from "ARC-1 misconfigured".
+
+SAP Help: [Getting Started as a Developer in the ABAP Environment](https://help.sap.com/docs/btp/sap-business-technology-platform/getting-started-as-developer-in-abap-environment-dev)
+· [Connect to the ABAP System](https://help.sap.com/docs/btp/sap-business-technology-platform/connect-to-abap-system).
+
+## Troubleshooting (SAP side)
+
+| Symptom | Cause / fix |
+|---|---|
+| Classic *Benutzer/Kennwort* form instead of an SSO redirect | Booster not run — no IAS trust. Run it (step 2). |
+| "You have not been successfully logged on…" | `SAP_BR_DEVELOPER` missing (step 3). Business roles are separate from BTP role collections. |
+| "Entity is currently being edited by another user" while assigning roles | A booster or browser session still holds the user record. Close the launchpad tabs, wait 1–2 minutes, retry. |
+| Broker error on `admin_email` | Invalid/missing email in the instance parameters JSON (step 1). |
+| Provisioning fails | Missing `abap` entitlement, plan not available in the region/commercial model, an existing free instance, or Cloud Foundry not enabled in the subaccount. |
+| 403 on some ADT endpoints although login works | The business role lacks the authorization; cross-system ATC scenarios additionally need communication arrangements (`SAP_COM_0763` configuration, `SAP_COM_0901` test integration). |
+
+## Next
+
+[BTP ABAP Environment Setup](btp-abap-environment.md) — configure ARC-1 against the system you just
+prepared.

--- a/docs_page/btp-abap-prerequisites.md
+++ b/docs_page/btp-abap-prerequisites.md
@@ -1,12 +1,9 @@
 # BTP ABAP Environment: SAP-Side Prerequisites
 
-Everything that has to be true **in SAP and BTP before ARC-1 is configured**. None of it is
-ARC-1-specific — it is the same setup Eclipse ADT needs, and SAP owns the canonical procedures. This
-page is a checklist with the exact SAP Help entry points; the ARC-1 setup itself lives in
-[BTP ABAP Environment Setup](btp-abap-environment.md).
-
-If Eclipse ADT can already log on to the system and create an object, you are done here — skip
-straight to the [ARC-1 setup](btp-abap-environment.md).
+What must be true **in SAP and BTP before ARC-1 is configured**. None of it is ARC-1-specific — it is
+the setup Eclipse ADT needs, and SAP owns the procedures, so this page is a checklist plus the
+gotchas that bite, not a copy of SAP's instructions. If ADT can already log on and create an object,
+skip straight to [BTP ABAP Environment Setup](btp-abap-environment.md).
 
 ## Checklist
 
@@ -15,91 +12,58 @@ straight to the [ARC-1 setup](btp-abap-environment.md).
 | 1 | An ABAP Environment service instance | BTP subaccount admin | The ADT endpoints ARC-1 calls |
 | 2 | Trust to SAP Cloud Identity Services (the booster) | BTP subaccount admin | Without it there is no SSO login, only a dead classic login form |
 | 3 | `SAP_BR_DEVELOPER` business role for every user | ABAP env admin | ADT access is refused without it — for ADT *and* ARC-1 |
-| 4 | A service key of the instance | BTP subaccount admin | Local OAuth login, or the OAuth client the per-user destination uses |
-| 5 | A development package (not `ZLOCAL`, not `$TMP`) | ABAP developer | Only needed for writes — see [Writing objects on BTP](btp-abap-environment.md#writing-objects-on-btp) |
+| 4 | A service key of the instance | BTP subaccount admin | Local OAuth login, or the OAuth client of the per-user destination |
+| 5 | A development package (not `ZLOCAL`, not `$TMP`) | ABAP developer | Only for writes — see [Writing objects on BTP](btp-abap-environment.md#writing-objects-on-btp) |
 
 ## 1. Provision the instance
 
-Follow SAP's [Getting Started with a Customer Account in the ABAP Environment](https://help.sap.com/docs/btp/sap-business-technology-platform/getting-started-with-customer-account-in-abap-environment),
-or the tutorial [Get an Account on SAP BTP to Try Out Free Tier Service Plans](https://developers.sap.com/tutorials/btp-free-tier-account..html)
-if you still need the account itself. The instance parameters (cockpit JSON or
-`cf create-service abap <plan> <name> -c params.json`) are:
+[Getting Started with a Customer Account in the ABAP Environment](https://help.sap.com/docs/btp/sap-business-technology-platform/getting-started-with-customer-account-in-abap-environment)
+has the procedure; [Get an Account on SAP BTP to Try Out Free Tier Service Plans](https://developers.sap.com/tutorials/btp-free-tier-account..html)
+covers the account itself. Two things matter for ARC-1: create the instance with
+`"is_development_allowed": true` (ADT and therefore ARC-1 are refused otherwise), and expect
+provisioning to take 30–60 minutes.
 
-```json
-{
-  "admin_email": "your.email@example.com",
-  "is_development_allowed": true,
-  "sap_system_name": "H01"
-}
-```
-
-- `admin_email` must be a real address — a missing/invalid one is the cause of the broker error
-  `/admin_email must NOT have fewer than 6 characters, /admin_email must match pattern…`.
-- `sap_system_name` is a 3-character SID.
-- Provisioning takes **30–60 minutes**; watch it with `cf service <name>`.
+Without a customer account, SAP's trial track ends at the same place:
+[SAP BTP ABAP Environment: Create a Trial User](https://developers.sap.com/mission.abap-env-trial-user.html).
 
 !!! note "Free tier"
-    The `free` plan needs a consumption-based commercial model (PAYG or BTPEA) and is limited to
-    **one system**, **90 days** (since 3 April 2024), and community support without an SLA. Within
-    those 90 days you can switch to the standard plan without data loss. Free-tier systems are
-    **stopped every night** and must be restarted manually from the **Landscape Portal** (scheduled
-    start/stop is not available on this plan) — a stopped system looks to ARC-1 like a connectivity
-    failure (`ECONNREFUSED` / timeouts), not an auth problem. Current
-    limits: [Service Plans and Metering for SAP BTP ABAP environment](https://help.sap.com/docs/btp/sap-business-technology-platform/commercial-information).
-
-No customer account at all? SAP's trial track ends at the same place: mission
-[SAP BTP ABAP Environment: Create a Trial User](https://developers.sap.com/mission.abap-env-trial-user.html)
-· [Create an SAP BTP ABAP Environment Trial User](https://developers.sap.com/tutorials/abap-environment-trial-onboarding..html).
+    The `free` plan needs a consumption-based commercial model (PAYG or BTPEA), is limited to **one
+    system** and **90 days** (since 3 April 2024), and has no SLA; within those 90 days you can switch
+    to the standard plan without data loss. Free-tier systems are **stopped every night** and must be
+    restarted by hand from the **Landscape Portal** — to ARC-1 a stopped system looks like a
+    connectivity failure (`ECONNREFUSED` / timeouts), not an auth problem. Current limits:
+    [Service Plans and Metering](https://help.sap.com/docs/btp/sap-business-technology-platform/commercial-information).
 
 ## 2. Run the booster
 
 A freshly provisioned instance has **no password-based login** — the classic *Benutzer/Kennwort* form
-appears but no credentials exist. The booster **Prepare an Account for ABAP Development**
-(BTP Cockpit → Global Account → **Boosters**) configures trust to SAP Cloud Identity Services (IAS),
-so login redirects to IAS, and makes your user the initial administrator.
+appears, but no credentials exist. The booster **Prepare an Account for ABAP Development**
+(BTP Cockpit → Global Account → **Boosters**) establishes trust to SAP Cloud Identity Services so
+logon redirects to IAS, and makes you the initial administrator:
+[Use a Booster for creating a Subaccount with an ABAP Environment](https://developers.sap.com/tutorials/btp-ea-onboard-05-abapb..html).
 
-SAP tutorial: [Use a Booster for creating a Subaccount with an ABAP Environment](https://developers.sap.com/tutorials/btp-ea-onboard-05-abapb..html).
-
-If the subscription is missing afterwards, add **Web Access for ABAP** from the subaccount's Service
-Marketplace.
+If the **Web Access for ABAP** subscription is missing afterwards, add it from the subaccount's
+Service Marketplace — the admin apps in step 3 run there.
 
 ## 3. Assign the developer role
 
-The booster assigns only the **administrator** role. Every human who will use ARC-1 (or ADT) also
-needs the **`SAP_BR_DEVELOPER`** business role:
-
-1. BTP Cockpit → your space → Service Instances → the ABAP instance → **View Dashboard** (the
-   administration launchpad).
-2. Open **Maintain Business Users**, select the user.
-3. **Assigned Business Roles** → **Add** → `SAP_BR_DEVELOPER` → save.
-
-SAP Help: [Assigning the ABAP Developer User to the ABAP Developer Role](https://help.sap.com/docs/btp/sap-business-technology-platform/assigning-abap-developer-user-to-abap-developer-role)
+The booster assigns only the **administrator** role. Every human using ARC-1 (or ADT) also needs the
+**`SAP_BR_DEVELOPER`** business role, assigned in the instance's administration launchpad (**View
+Dashboard** → **Maintain Business Users**):
+[Assigning the ABAP Developer User to the ABAP Developer Role](https://help.sap.com/docs/btp/sap-business-technology-platform/assigning-abap-developer-user-to-abap-developer-role)
 · [Required Business Roles](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/required-business-roles).
-For more than a handful of developers, provision them from the identity provider instead of by hand:
+Beyond a handful of developers, provision them from the identity provider instead:
 [Provision Users into your SAP BTP ABAP Environment](https://developers.sap.com/tutorials/abap-environment-ips..html).
 
-Without it, ADT and ARC-1 both fail with *"You have not been successfully logged on. Make sure the
-developer role is assigned to the user."*
+Without the role, ADT and ARC-1 both fail with *"You have not been successfully logged on. Make sure
+the developer role is assigned to the user."*
 
 ## 4. Create a service key
 
-BTP Cockpit → Subaccount → **Instances and Subscriptions** → the ABAP instance → **Service Keys** →
-create, then download the JSON:
-
-```json
-{
-  "uaa": {
-    "url": "https://<subdomain>.authentication.<region>.hana.ondemand.com",
-    "clientid": "sb-abap-12345...",
-    "clientsecret": "..."
-  },
-  "url": "https://<guid>.abap.<region>.hana.ondemand.com",
-  "abap": { "url": "https://<guid>.abap.<region>.hana.ondemand.com", "sapClient": "100" }
-}
-```
-
-ARC-1 uses this key in one of two ways — directly for [local browser login](btp-abap-environment.md#local-development-service-key-browser-login),
-or as the OAuth client of a [per-user destination](btp-abap-environment.md#recommended-btp-deployment-with-a-per-user-destination).
+Create it on the ABAP instance in the cockpit and download the JSON. ARC-1 reads exactly four fields —
+`url` (the ABAP system), `uaa.url`, `uaa.clientid`, `uaa.clientsecret` — and uses them either for
+[local browser login](btp-abap-environment.md#local-development-service-key-browser-login) or as the
+OAuth client of a [per-user destination](btp-abap-environment.md#recommended-btp-deployment-with-a-per-user-destination).
 
 !!! danger "A service key is a full-access SAP credential"
     `uaa.clientid` + `uaa.clientsecret` + `url` grant OAuth access to the whole ABAP system. Keep it
@@ -113,42 +77,31 @@ or as the OAuth client of a [per-user destination](btp-abap-environment.md#recom
 
 ## 5. Verify with Eclipse ADT
 
-Before touching ARC-1, connect Eclipse ADT to the system and open one object. It exercises exactly
-the same login and authorization path, and it separates "SAP not ready" from "ARC-1 misconfigured".
-
-Tutorials: [Download the Eclipse IDE and add the ABAP Development Tools (ADT) Plugin](https://developers.sap.com/tutorials/abap-install-adt..html)
-→ [Create an ABAP Cloud Project](https://developers.sap.com/tutorials/abap-environment-create-abap-cloud-project..html)
+Connect ADT and open one object before touching ARC-1: same login and authorization path, so it
+separates "SAP not ready" from "ARC-1 misconfigured".
+[Install the ADT plugin](https://developers.sap.com/tutorials/abap-install-adt..html) →
+[Create an ABAP Cloud Project](https://developers.sap.com/tutorials/abap-environment-create-abap-cloud-project..html)
 (browser logon, or **Use a Service Key** with the key from step 4 — the same key ARC-1 uses).
 
-SAP Help: [Getting Started as a Developer in the ABAP Environment](https://help.sap.com/docs/btp/sap-business-technology-platform/getting-started-as-developer-in-abap-environment-dev)
-· [Connect to the ABAP System](https://help.sap.com/docs/btp/sap-business-technology-platform/connect-to-abap-system).
+## 6. A development package (writes only)
 
-## Optional: a development package for writes
-
-ARC-1 only needs this if you enable writes. `$TMP` does not exist in the ABAP Environment; the
-software component **`ZLOCAL`** plays that role, and its `ZLOCAL` *structure* package cannot hold
-development objects — you create a development sub-package under it. The SAP tutorial
-[Create Your First ABAP Console Application](https://developers.sap.com/tutorials/abap-environment-console-application..html)
-walks through exactly that step (right-click `ZLOCAL` → **New > ABAP Package**, package type
-*Development*), and ARC-1 can do it itself with `SAPManage(action="create_package")` — see
-[Writing objects on BTP](btp-abap-environment.md#writing-objects-on-btp).
-
-Background: SAP Help [Software Components](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/software-components)
-· [Manage Software Components](https://help.sap.com/docs/btp/sap-business-technology-platform/manage-software-components)
-(a transportable component instead of local `ZLOCAL`).
+`$TMP` does not exist here; the software component **`ZLOCAL`** plays that role and its `ZLOCAL`
+*structure* package cannot hold development objects, so create a development sub-package under it —
+[tutorial step](https://developers.sap.com/tutorials/abap-environment-console-application..html)
+("Create ABAP package"), or let ARC-1 do it with `SAPManage(action="create_package")`
+([Writing objects on BTP](btp-abap-environment.md#writing-objects-on-btp)). For transportable code
+instead of local `ZLOCAL`, create your own
+[software component](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/software-components).
 
 ## Troubleshooting (SAP side)
 
 | Symptom | Cause / fix |
 |---|---|
-| Classic *Benutzer/Kennwort* form instead of an SSO redirect | Booster not run — no IAS trust. Run it (step 2). |
+| Classic *Benutzer/Kennwort* form instead of an SSO redirect | Booster not run — no IAS trust (step 2). |
 | "You have not been successfully logged on…" | `SAP_BR_DEVELOPER` missing (step 3). Business roles are separate from BTP role collections. |
 | "Entity is currently being edited by another user" while assigning roles | A booster or browser session still holds the user record. Close the launchpad tabs, wait 1–2 minutes, retry. |
-| Broker error on `admin_email` | Invalid/missing email in the instance parameters JSON (step 1). |
-| Provisioning fails | Missing `abap` entitlement, plan not available in the region/commercial model, an existing free instance, or Cloud Foundry not enabled in the subaccount. |
-| 403 on some ADT endpoints although login works | The business role lacks the authorization; cross-system ATC scenarios additionally need communication arrangements (`SAP_COM_0763` configuration, `SAP_COM_0901` test integration). |
+| Broker error `/admin_email must NOT have fewer than 6 characters…` | Missing or invalid email in the instance parameters (step 1). |
+| Provisioning fails | Missing `abap` entitlement, plan unavailable in the region/commercial model, an existing free instance, or Cloud Foundry not enabled in the subaccount. |
+| 403 on some ADT endpoints although login works | The business role lacks that authorization; cross-system ATC scenarios additionally need communication arrangements (`SAP_COM_0763` configuration, `SAP_COM_0901` test integration). |
 
-## Next
-
-[BTP ABAP Environment Setup](btp-abap-environment.md) — configure ARC-1 against the system you just
-prepared.
+Then continue with [BTP ABAP Environment Setup](btp-abap-environment.md).

--- a/docs_page/btp-abap-prerequisites.md
+++ b/docs_page/btp-abap-prerequisites.md
@@ -20,8 +20,10 @@ straight to the [ARC-1 setup](btp-abap-environment.md).
 
 ## 1. Provision the instance
 
-Follow SAP's [Getting Started with a Customer Account in the ABAP Environment](https://help.sap.com/docs/btp/sap-business-technology-platform/getting-started-with-customer-account-in-abap-environment).
-The instance parameters (cockpit JSON or `cf create-service abap <plan> <name> -c params.json`) are:
+Follow SAP's [Getting Started with a Customer Account in the ABAP Environment](https://help.sap.com/docs/btp/sap-business-technology-platform/getting-started-with-customer-account-in-abap-environment),
+or the tutorial [Get an Account on SAP BTP to Try Out Free Tier Service Plans](https://developers.sap.com/tutorials/btp-free-tier-account..html)
+if you still need the account itself. The instance parameters (cockpit JSON or
+`cf create-service abap <plan> <name> -c params.json`) are:
 
 ```json
 {
@@ -43,7 +45,11 @@ The instance parameters (cockpit JSON or `cf create-service abap <plan> <name> -
     **stopped every night** and must be restarted manually from the **Landscape Portal** (scheduled
     start/stop is not available on this plan) — a stopped system looks to ARC-1 like a connectivity
     failure (`ECONNREFUSED` / timeouts), not an auth problem. Current
-    limits: [Service Plans and Metering](https://help.sap.com/docs/btp/sap-business-technology-platform/service-plans-and-metering-for-sap-btp-abap-environment).
+    limits: [Service Plans and Metering for SAP BTP ABAP environment](https://help.sap.com/docs/btp/sap-business-technology-platform/commercial-information).
+
+No customer account at all? SAP's trial track ends at the same place: mission
+[SAP BTP ABAP Environment: Create a Trial User](https://developers.sap.com/mission.abap-env-trial-user.html)
+· [Create an SAP BTP ABAP Environment Trial User](https://developers.sap.com/tutorials/abap-environment-trial-onboarding..html).
 
 ## 2. Run the booster
 
@@ -69,6 +75,8 @@ needs the **`SAP_BR_DEVELOPER`** business role:
 
 SAP Help: [Assigning the ABAP Developer User to the ABAP Developer Role](https://help.sap.com/docs/btp/sap-business-technology-platform/assigning-abap-developer-user-to-abap-developer-role)
 · [Required Business Roles](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/required-business-roles).
+For more than a handful of developers, provision them from the identity provider instead of by hand:
+[Provision Users into your SAP BTP ABAP Environment](https://developers.sap.com/tutorials/abap-environment-ips..html).
 
 Without it, ADT and ARC-1 both fail with *"You have not been successfully logged on. Make sure the
 developer role is assigned to the user."*
@@ -108,8 +116,26 @@ or as the OAuth client of a [per-user destination](btp-abap-environment.md#recom
 Before touching ARC-1, connect Eclipse ADT to the system and open one object. It exercises exactly
 the same login and authorization path, and it separates "SAP not ready" from "ARC-1 misconfigured".
 
+Tutorials: [Download the Eclipse IDE and add the ABAP Development Tools (ADT) Plugin](https://developers.sap.com/tutorials/abap-install-adt..html)
+→ [Create an ABAP Cloud Project](https://developers.sap.com/tutorials/abap-environment-create-abap-cloud-project..html)
+(browser logon, or **Use a Service Key** with the key from step 4 — the same key ARC-1 uses).
+
 SAP Help: [Getting Started as a Developer in the ABAP Environment](https://help.sap.com/docs/btp/sap-business-technology-platform/getting-started-as-developer-in-abap-environment-dev)
 · [Connect to the ABAP System](https://help.sap.com/docs/btp/sap-business-technology-platform/connect-to-abap-system).
+
+## Optional: a development package for writes
+
+ARC-1 only needs this if you enable writes. `$TMP` does not exist in the ABAP Environment; the
+software component **`ZLOCAL`** plays that role, and its `ZLOCAL` *structure* package cannot hold
+development objects — you create a development sub-package under it. The SAP tutorial
+[Create Your First ABAP Console Application](https://developers.sap.com/tutorials/abap-environment-console-application..html)
+walks through exactly that step (right-click `ZLOCAL` → **New > ABAP Package**, package type
+*Development*), and ARC-1 can do it itself with `SAPManage(action="create_package")` — see
+[Writing objects on BTP](btp-abap-environment.md#writing-objects-on-btp).
+
+Background: SAP Help [Software Components](https://help.sap.com/docs/sap-btp-abap-environment/abap-environment/software-components)
+· [Manage Software Components](https://help.sap.com/docs/btp/sap-business-technology-platform/manage-software-components)
+(a transportable component instead of local `ZLOCAL`).
 
 ## Troubleshooting (SAP side)
 

--- a/docs_page/deployment-best-practices.md
+++ b/docs_page/deployment-best-practices.md
@@ -322,12 +322,14 @@ Quick summary:
 ## BTP ABAP Environment Setup
 
 See [BTP ABAP Environment guide](btp-abap-environment.md) for:
-- Provisioning the BTP ABAP instance
-- Running the "Prepare an Account for ABAP Development" booster
-- Creating a service key for local OAuth or destination credentials
+- Configuring deployed ARC-1 with `OAuth2UserTokenExchange` (recommended)
 - Configuring ARC-1 locally with service-key browser OAuth
-- Configuring deployed ARC-1 with `OAuth2UserTokenExchange`
 - System type detection and tool adaptation
+
+See [BTP ABAP Prerequisites](btp-abap-prerequisites.md) for the SAP-side groundwork:
+- Provisioning the BTP ABAP instance
+- Running the "Prepare an Account for ABAP Development" booster and assigning `SAP_BR_DEVELOPER`
+- Creating a service key for local OAuth or destination credentials
 
 See [BTP CF Deployment](btp-cloud-foundry-deployment.md) for:
 - Cloud Foundry deployment with Docker

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Multi-System Setup (Multi-Target): multi-target-setup.md
       - Other SAP Environments:
           - BTP ABAP Environment: btp-abap-environment.md
+          - BTP ABAP Prerequisites (SAP side): btp-abap-prerequisites.md
           - S/4HANA Public Cloud: s4hana-public-cloud.md
       - Administration & Alternatives:
           - BTP Administration: btp-administration.md


### PR DESCRIPTION
## Why

`docs_page/btp-abap-environment.md` had grown to 631 lines where roughly half was not ARC-1 setup:
SAP-side onboarding (free-tier provisioning, the "Prepare an Account for ABAP Development" booster,
`SAP_BR_DEVELOPER` assignment, `admin_email` broker errors) and contributor test procedures. The
**recommended** deployed setup (CF + per-user `OAuth2UserTokenExchange` destination) sat at line 254,
below the laptop-only service-key flow.

## What changed

**[btp-abap-environment.md](https://github.com/arc-mcp/arc-1/blob/claude/arc-1-setup-docs-refactor-1f628d/docs_page/btp-abap-environment.md) — now only ARC-1 setup** (631 → 369 lines)

- Opens with the two connection modes side by side, recommended deployed path first.
- Deployed path: bind services → destination (incl. the `.abap.` vs `.abap-web.` host gotcha, [#301](https://github.com/arc-mcp/arc-1/issues/301)) → ARC-1 config → user access → log lines to verify. Links the repo's ready-made `manifest-btp-abap.yml`, which the page never mentioned.
- Local service key: config, MCP client tabs, first login, how the flow works, smoke test.
- Writes, tool surface, constraints, config reference, troubleshooting — kept, tightened.

**New: [btp-abap-prerequisites.md](https://github.com/arc-mcp/arc-1/blob/claude/arc-1-setup-docs-refactor-1f628d/docs_page/btp-abap-prerequisites.md) — the SAP-side groundwork**

A checklist (instance → booster → developer role → service key → dev package) that points at SAP's own
procedures rather than restating them, plus the SAP-side troubleshooting table. The hard-won gotchas
stay: no login before the booster, `SAP_BR_DEVELOPER` is separate from BTP role collections, the
locked-user-record error, the `admin_email` broker error.

**Moved: BTP integration tests → [auth-test-process.md](https://github.com/arc-mcp/arc-1/blob/claude/arc-1-setup-docs-refactor-1f628d/docs_page/auth-test-process.md#btp-abap-environment-service-key)**

Smoke/extended tiers, failure taxonomy and tenant assumptions now sit with the other test procedures
instead of in a setup guide.

## Accuracy fixes (verified against code and SAP docs)

- Tool-surface tables re-derived from `src/handlers/tool-registry.ts`: `TTYP` is on-prem-only, `SKTD`/`KTD` and the server-driven types (DESD, DTSC, CSNM, EVTB, EVTO, COTA, DSFD, DTDC, UIAD) are BTP types, `SAPContext` also covers `TABL`, and `edit_unit`/`edit_text_symbols` are not offered on BTP.
- ATC: ARC-1 does not force a variant — it uses the system default unless `variant` is passed.
- UIAD write status stated honestly (SAP refuses `create` on-prem; unverified on the ABAP Environment).
- Cross-subaccount fix now names SAP's documented `SAMLAssertion` next to `OAuth2SAMLBearerAssertion`, and says which path is verified where.
- Free tier: 90-day limit, consumption-based commercial model (PAYG/BTPEA), nightly stop with manual Landscape Portal restart. Dead-end `client_credentials` curl recipe dropped.
- SAP Help links checked against the SAP-docs GitHub mirrors; the renamed SAML-bearer links replaced.

## Verification

- `mkdocs build --strict` clean (only the pre-existing `release-notes.md` anchor INFO).
- Inbound anchors preserved, so `s4hana-public-cloud.md`, `principal-propagation-setup.md` and `enterprise-auth.md` keep resolving: `#recommended-btp-deployment-with-a-per-user-destination`, `#what-to-expect-on-btp-abap`, `#constraints-vs-on-premise`, `#cross-subaccount-principal-propagation-fails`.
- Docs-only; `docs:` prefix, so no release is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)