### PR TITLE
fix: read the CSRF token and session cookie atomically

### DIFF
--- a/src/adt/http.ts
+++ b/src/adt/http.ts
@@ -391,10 +391,6 @@ export class AdtHttpClient {
       headers['X-SAP-SAML2'] = 'disabled';
     }
 
-    if (isModifyingMethod(method)) {
-      headers['X-CSRF-Token'] = this.csrfToken;
-    }
-
     if (this.config.sessionType === 'stateful') {
       headers['X-sap-adt-sessiontype'] = 'stateful';
     }
@@ -414,6 +410,13 @@ export class AdtHttpClient {
     // re-read the cookie file before this request.
     if (this.cookiesCleared && this.isCookieAuthMode()) {
       this.reloadCookiesFromSource();
+    }
+
+    // Read the CSRF token together with the cookie header below — SAP binds the token to the
+    // session cookie, and a concurrent fetchCsrfToken() can replace both across the bearer
+    // await above; a torn pair 403s. The retry paths below already read them adjacently.
+    if (isModifyingMethod(method)) {
+      headers['X-CSRF-Token'] = this.csrfToken;
     }
 
     // Build cookie header from config cookies + cookie jar, with the jar winning

--- a/tests/unit/adt/http.test.ts
+++ b/tests/unit/adt/http.test.ts
@@ -368,6 +368,58 @@ describe('AdtHttpClient', () => {
       await client.get('/path');
       // csrfToken should still be empty — so next POST will fetch
     });
+
+    it('sends a token and session cookie from the same fetch when concurrent requests refresh both', async () => {
+      // SAP binds the CSRF token to the session cookie; a torn pair is a 403. With a
+      // bearerTokenProvider awaiting mid-build, a second request's CSRF fetch can swap
+      // both fields between the two reads. Park request A there and let B overwrite them.
+      let releaseA!: () => void;
+      const aReleased = new Promise<void>((resolve) => {
+        releaseA = resolve;
+      });
+      let aParked!: () => void;
+      const aIsParked = new Promise<void>((resolve) => {
+        aParked = resolve;
+      });
+
+      let discoveryCalls = 0;
+      const posts: Array<{ token?: string; cookie?: string }> = [];
+      mockFetch.mockImplementation(async (url: string, init: RequestInit) => {
+        const headers = (init.headers ?? {}) as Record<string, string>;
+        if (url.includes('/core/discovery')) {
+          const nth = ++discoveryCalls;
+          // Second (cold) fetch lands while A is parked, replacing token + cookie.
+          if (nth === 2) await aIsParked;
+          return mockResponse(200, '', { 'x-csrf-token': `TOKEN-S${nth}` }, [`SAP_SESSIONID_A4H_001=S${nth}; Path=/`]);
+        }
+        posts.push({ token: headers['X-CSRF-Token'], cookie: headers.Cookie });
+        if (posts.length === 1) releaseA(); // B is on the wire — let A finish building
+        return mockResponse(200, 'ok');
+      });
+
+      let parked = false;
+      const client = new AdtHttpClient({
+        ...getDefaultConfig(),
+        bearerTokenProvider: async () => {
+          // fetchCsrfToken() calls this too, before any discovery — park only the
+          // in-request call that sits between the token read and the cookie read.
+          if (!parked && discoveryCalls > 0) {
+            parked = true;
+            aParked();
+            await aReleased;
+          }
+          return 'bearer';
+        },
+      });
+
+      await Promise.all([client.post('/path', '<xml/>'), client.post('/path', '<xml/>')]);
+
+      expect(posts).toHaveLength(2);
+      for (const sent of posts) {
+        const session = /SAP_SESSIONID_A4H_001=(S\d)/.exec(sent.cookie ?? '')?.[1];
+        expect(sent.token).toBe(`TOKEN-${session}`);
+      }
+    });
   });
 
   // ─── Cookie Jar ────────────────────────────────────────────────────


### PR DESCRIPTION
## What

`requestInner` read two values that SAP requires to match, at two different instants:

- CSRF token captured at `http.ts:395`
- `await bearerTokenProvider()` at `http.ts:409`
- session cookie composed at `http.ts:421`

A concurrent request's `fetchCsrfToken()` completing inside that await replaces **both** `csrfToken` and the `cookieJar` session entry, so the first request ships session A's token with session B's cookie. SAP rejects that pair with `403 CSRF token validation failed`.

The fix moves the token capture down beside the cookie compose, so both come from one synchronous block — the same order the DB-retry (`:479`), 401-retry (`:638`) and 403-retry (`:677`) paths already use. No lock, no new state.

## Evidence

**Protocol behaviour, measured live against a 7.58 system** (basic auth, `/sap/bc/adt/datapreview/freestyle`):

| Experiment | Result |
|---|---|
| Refetch token twice in one session | Same token — SAP does not rotate |
| Two cold fetches | Distinct sessions **and** distinct tokens |
| POST `T_A` + session `S_A` / `T_B` + `S_B` | 200 |
| **POST `T_A` + session `S_B`** | **403 `CSRF token validation failed`** |

**Deterministic repro** against a mock ADT server reproducing that behaviour: with a `bearerTokenProvider` parked between the two reads, the client sent `TOK-S1` with session `S2` → 403, then self-healed via the 403 retry (3 requests instead of 2). With basic auth under identical timing and concurrency: no tear. After the fix, the bearer case is clean and takes 2 requests.

## Scope

- **Affected:** deployments with a `bearerTokenProvider` — BTP ABAP OAuth / Destination bearer tokens.
- **Not affected:** basic and cookie auth — no await sits in that window, verified by 26 live concurrent rounds (2–6 parallel; cold, warm and stale-token) plus a basic-auth control in the repro.
- **Impact:** one wasted SAP round-trip under concurrency. The existing 403 retry always recovered it, so this was never caller-visible.

Audited every other read of `csrfToken`/`composeCookieHeader()`; the three retry paths, `withStatefulSession` and `fetchCsrfToken` all read their pair adjacently. This was the only site.

## Test

`tests/unit/adt/http.test.ts` — two concurrent POSTs, mocked discovery handing out two session/token pairs, a bearer provider parked between the capture points. Asserts each POST's `X-CSRF-Token` matches the session in its own `Cookie`. Fails before the change (`expected 'TOKEN-S1' to be 'TOKEN-S2'`), passes after.

Gate: 4970/4970 unit tests, typecheck clean, lint clean, schema budget and action-policy validation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)