### PR TITLE
fix: correct TABLE_QUERY IN/NOT IN value guidance

### DIFF
--- a/docs/plans/2026-08-10-issue-690-table-query-quoting.md
+++ b/docs/plans/2026-08-10-issue-690-table-query-quoting.md
@@ -1,0 +1,33 @@
+# Plan: Correct the TABLE_QUERY value contract (#690)
+
+**Status:** Implemented and validated
+**Research:** [Issue 690 dossier](../research/issues/690-table-query-where-values.md)
+
+## Goal
+
+Prevent callers from following the `TABLE_QUERY` schema and silently receiving zero rows because they supplied SQL-quoted values to a builder that already quotes and escapes raw values.
+
+## Evidence-based scope
+
+- Live reproduction on SAP_BASIS 758 and 816 shows the documented quoted form succeeds with zero rows and the bare form returns the matching `TADIR` row.
+- `src/adt/client.ts` and `tests/unit/adt/table-query.test.ts` already implement and verify the intended raw-value behavior.
+- The mismatch is in the shared LLM-visible schema description in `src/handlers/tools.ts`, copied into the frozen tool-definition snapshots.
+
+## Implementation tasks
+
+1. Replace the `IN`/`NOT IN` schema wording with an explicit raw-value contract: comma-separated bare values, no caller quotes, ARC-1 quotes and escapes each element, with a bare `261,262` example.
+2. Add a focused `tests/unit/handlers/tools.test.ts` assertion against the generated `SAPRead` schema. Assert the positive guidance and the absence of the stale “single-quoted literals” wording.
+3. Regenerate the tool-definition snapshots with the repository snapshot command. Review that only the expected `where` description changes in the seven variants exposing the shared SAPRead schema.
+
+## Deliberate non-changes
+
+- Do not change `buildInList()` or scalar quoting behavior.
+- Do not accept a second pre-quoted input dialect by stripping quotes.
+- Do not change ADT requests, safety gates, or published prose that does not document this structured parameter.
+
+## Validation and review
+
+- Focused: `tests/unit/adt/table-query.test.ts`, `tests/unit/handlers/tools.test.ts`, and the tool-definition snapshot test.
+- Full: `npm test`, `npm run typecheck`, `npm run lint`, and the size/schema budget check if required by the changed surface.
+- Final review: inspect the complete diff, verify no stale quoted guidance remains in generated fixtures, confirm the builder/security tests are unchanged, and compare the final behavior to the live dossier.
+- Publish: create a focused commit, push a descriptive branch, and open a draft PR with the root cause, impact, live evidence, and checks.

--- a/docs/research/issues/690-table-query-where-values.md
+++ b/docs/research/issues/690-table-query-where-values.md
@@ -1,0 +1,103 @@
+# Issue #690 — TABLE_QUERY documents the wrong quoting contract
+
+**Status:** Confirmed bug; root cause validated live on 2026-08-10 against A4H/S/4HANA 2023 (SAP_BASIS 758) and A4H/ABAP Platform 2025 (SAP_BASIS 816). The SQL builder is correct; the LLM-visible schema description is stale.
+
+## TL;DR
+
+`SAPRead(type="TABLE_QUERY")` accepts raw `where[].value` strings and quotes/escapes them in ARC-1. The `IN`/`NOT IN` schema text instead tells callers to supply SQL-quoted literals. A caller following that text receives a successful query with zero rows, because the quote characters become part of the compared value.
+
+This is a client documentation/schema bug, not an SAP release defect and not a SQL-injection issue. The minimum safe fix is to correct the schema description and its frozen tool-definition fixtures. The existing builder and unit tests should remain unchanged.
+
+## Claim and scope
+
+The issue reports that the `where` schema says `IN`/`NOT IN` values must be `"'261','262'"`, while `buildInList()` treats each input item as raw data, escapes it, and wraps it in quotes. It also notes that the same raw-value contract applies to scalar operators such as `=` and `LIKE`, although those examples already use bare values.
+
+Relevant HEAD code:
+
+- `src/adt/client.ts:192-204` documents and implements raw `IN` values: trim each item, escape single quotes, then wrap it in a SQL literal.
+- `src/adt/client.ts:286-293` applies the same raw-value treatment to `IN` and scalar comparisons.
+- `src/handlers/tools.ts:552-555` incorrectly asks the caller for pre-quoted `IN`/`NOT IN` literals.
+- `tests/unit/adt/table-query.test.ts:74-80` already asserts the intended raw-value behavior (`261,262` → `('261', '262')`).
+
+## Research evidence
+
+### ADT contract
+
+ARC-1 sends the generated statement to SAP's freestyle data-preview endpoint:
+
+`POST /sap/bc/adt/datapreview/freestyle?rowNumber=<n>`
+
+with `Content-Type: text/plain`. The local Eclipse ADT research notes identify this endpoint but do not define a structured `where` contract; the raw SQL text is the contract at the ADT boundary. ARC-1's structured `TABLE_QUERY` layer therefore owns the conversion from raw values to SQL literals.
+
+The SAP ABAP language reference confirms that single-quoted text field literals represent character values and that embedded quote characters are escaped by doubling them. It also documents that dynamic SQL values must be escaped before being concatenated. That matches the current builder's behavior and does not support passing the caller's delimiters through as data.
+
+### Reference implementation check
+
+The local `mcp-abap-adt-fr0ster` reference exposes freestyle SQL as a raw `sql_query` string and does not add a structured `IN`-list value layer. No reference implementation supplied evidence that ARC-1 should receive pre-quoted values.
+
+### Live validation
+
+Commands were run through the supported `arc1-cli` path with the existing A4H test credentials loaded from the local infrastructure reference. Only `SAP_ALLOW_DATA_PREVIEW=true` was enabled; no writes were enabled.
+
+The query shape was:
+
+```json
+{
+  "type": "TABLE_QUERY",
+  "name": "TADIR",
+  "columns": ["PGMID", "OBJECT", "OBJ_NAME"],
+  "where": [
+    {"field": "OBJ_NAME", "op": "IN", "value": "<value>"},
+    {"field": "OBJECT", "op": "=", "value": "TABL"}
+  ],
+  "maxRows": 10
+}
+```
+
+| System | Input | HTTP/tool result | Returned rows |
+|---|---|---|---|
+| A4H, SAP_BASIS 758 | `OBJ_NAME IN 'T000','T001'` | success | `[]` |
+| A4H, SAP_BASIS 758 | `OBJ_NAME IN T000,T001` | success | `R3TR/TABL/T000` |
+| A4H, SAP_BASIS 758 | `OBJ_NAME = 'T000'` | success | `[]` |
+| A4H, SAP_BASIS 758 | `OBJ_NAME = T000` | success | `R3TR/TABL/T000` |
+| A4H-2025, SAP_BASIS 816 | `OBJ_NAME IN 'T000','T001'` | success | `[]` |
+| A4H-2025, SAP_BASIS 816 | `OBJ_NAME IN T000,T001` | success | `R3TR/TABL/T000` |
+
+The successful empty responses are the dangerous part: this is a silent false negative, not an input validation error. The result is consistent across both releases, so no release-specific client workaround is indicated.
+
+## Root cause
+
+The schema and implementation disagree about who owns SQL quoting. For the documented input `"'T000','T001'"`, the builder splits the value into `"'T000'"` and `"'T001'"`, escapes each embedded quote, and wraps each item again. The emitted SQL is equivalent to:
+
+```sql
+OBJ_NAME IN ('''T000''', '''T001''')
+```
+
+Those literals contain quote characters as data, so the query is valid but does not match `T000` or `T001`.
+
+## Recommended fix and affected files
+
+Implement the narrow documentation fix:
+
+1. Update `src/handlers/tools.ts` to say that `IN`/`NOT IN` values are comma-separated bare values, that ARC-1 quotes and escapes each item, and that callers must not add quotes.
+2. Add a focused assertion in `tests/unit/handlers/tools.test.ts` for the corrected contract.
+3. Regenerate and review the frozen tool-definition fixtures. The wording appears in all seven fixture variants that expose the shared SAPRead schema.
+4. Leave `src/adt/client.ts` and `tests/unit/adt/table-query.test.ts` unchanged; their raw-value behavior is already correct and security-tested.
+
+## Out of scope
+
+- Do not strip caller quotes in `buildInList()` as part of this fix. That would add a second input dialect, is unnecessary once the schema is corrected, and would need separate semantics for escaped SQL literals.
+- Do not change scalar value semantics or the SAP ADT endpoint.
+- Do not relax data-preview safety gates.
+
+## Paste-able GitHub reply
+
+```markdown
+Confirmed — this is a real documentation/schema bug, and I reproduced it on both A4H SAP_BASIS 758 and A4H-2025 SAP_BASIS 816.
+
+`TABLE_QUERY` correctly treats `where[].value` as raw values and quotes/escapes them. Following the current `IN` example (`"'T000','T001'"`) therefore emits literals containing quote characters and returns a successful empty result. The bare form (`"T000,T001"`) returns the expected `TADIR` row. The same distinction is visible for `=`.
+
+The SQL builder and its unit tests already implement the intended raw-value contract, so the fix is to correct the LLM-visible schema description and frozen tool-definition fixtures. I’ll keep the change narrow and leave the safety-tested builder unchanged.
+```
+
+**Recommendation:** fix it with the schema/fixture update, then open a PR. Do not close as duplicate or works-as-designed.

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -551,7 +551,7 @@ export function getToolDefinitions(
             description:
               'For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. ' +
               'Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. ' +
-              "For IN/NOT IN: value must be a comma-separated list of single-quoted literals, e.g. \"'261','262'\". Subqueries are not allowed. " +
+              'For IN/NOT IN: use bare comma-separated values; do NOT quote them. ARC-1 quotes and escapes values, e.g. "261,262". No subqueries. ' +
               'Example: [{"field":"MATNR","op":"=","value":"300006888"},{"field":"BUDAT_MKPF","op":">=","value":"20250101"}].',
             items: {
               type: 'object',

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -144,7 +144,7 @@
         },
         "where": {
           "type": "array",
-          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: value must be a comma-separated list of single-quoted literals, e.g. \"'261','262'\". Subqueries are not allowed. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
+          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: use bare comma-separated values; do NOT quote them. ARC-1 quotes and escapes values, e.g. \"261,262\". No subqueries. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
           "items": {
             "type": "object",
             "properties": {

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -144,7 +144,7 @@
         },
         "where": {
           "type": "array",
-          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: value must be a comma-separated list of single-quoted literals, e.g. \"'261','262'\". Subqueries are not allowed. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
+          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: use bare comma-separated values; do NOT quote them. ARC-1 quotes and escapes values, e.g. \"261,262\". No subqueries. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
           "items": {
             "type": "object",
             "properties": {

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -162,7 +162,7 @@
         },
         "where": {
           "type": "array",
-          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: value must be a comma-separated list of single-quoted literals, e.g. \"'261','262'\". Subqueries are not allowed. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
+          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: use bare comma-separated values; do NOT quote them. ARC-1 quotes and escapes values, e.g. \"261,262\". No subqueries. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
           "items": {
             "type": "object",
             "properties": {

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -162,7 +162,7 @@
         },
         "where": {
           "type": "array",
-          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: value must be a comma-separated list of single-quoted literals, e.g. \"'261','262'\". Subqueries are not allowed. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
+          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: use bare comma-separated values; do NOT quote them. ARC-1 quotes and escapes values, e.g. \"261,262\". No subqueries. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
           "items": {
             "type": "object",
             "properties": {

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -162,7 +162,7 @@
         },
         "where": {
           "type": "array",
-          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: value must be a comma-separated list of single-quoted literals, e.g. \"'261','262'\". Subqueries are not allowed. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
+          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: use bare comma-separated values; do NOT quote them. ARC-1 quotes and escapes values, e.g. \"261,262\". No subqueries. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
           "items": {
             "type": "object",
             "properties": {

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -162,7 +162,7 @@
         },
         "where": {
           "type": "array",
-          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: value must be a comma-separated list of single-quoted literals, e.g. \"'261','262'\". Subqueries are not allowed. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
+          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: use bare comma-separated values; do NOT quote them. ARC-1 quotes and escapes values, e.g. \"261,262\". No subqueries. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
           "items": {
             "type": "object",
             "properties": {

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -162,7 +162,7 @@
         },
         "where": {
           "type": "array",
-          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: value must be a comma-separated list of single-quoted literals, e.g. \"'261','262'\". Subqueries are not allowed. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
+          "description": "For TABLE_QUERY: structured WHERE conditions, ANDed together. Each item: {field, op, value?}. Allowed ops: =, !=, <>, <, <=, >, >=, LIKE, NOT LIKE, IN, NOT IN, IS NULL, IS NOT NULL. For IN/NOT IN: use bare comma-separated values; do NOT quote them. ARC-1 quotes and escapes values, e.g. \"261,262\". No subqueries. Example: [{\"field\":\"MATNR\",\"op\":\"=\",\"value\":\"300006888\"},{\"field\":\"BUDAT_MKPF\",\"op\":\">=\",\"value\":\"20250101\"}].",
           "items": {
             "type": "object",
             "properties": {

--- a/tests/unit/handlers/tools.test.ts
+++ b/tests/unit/handlers/tools.test.ts
@@ -227,6 +227,18 @@ describe('Tool Definitions', () => {
     expect(names).toContain('SAPQuery');
   });
 
+  it('documents TABLE_QUERY IN values as raw values that ARC-1 quotes', () => {
+    const sapRead = getToolDefinitions(DEFAULT_CONFIG).find((t) => t.name === 'SAPRead')!;
+    const schema = sapRead.inputSchema as Record<string, any>;
+    const whereDescription = schema.properties.where.description as string;
+
+    expect(whereDescription).toContain('bare comma-separated values');
+    expect(whereDescription).toContain('do NOT quote them');
+    expect(whereDescription).toContain('ARC-1 quotes and escapes values');
+    expect(whereDescription).toContain('"261,262"');
+    expect(whereDescription).not.toContain('single-quoted literals');
+  });
+
   it('describes SAPRead sqlFilter as condition-only expression', () => {
     const tools = getToolDefinitions(DEFAULT_CONFIG);
     const sapRead = tools.find((t) => t.name === 'SAPRead')!;


### PR DESCRIPTION
## Summary

- Correct the LLM-visible SAPRead TABLE_QUERY schema: IN/NOT IN values are bare comma-separated values; ARC-1 quotes and escapes them.
- Add a focused schema regression assertion and refresh the seven generated tool-definition snapshots.
- Include the deep-research dossier and reviewed implementation plan.

## Root cause

The SQL builder already treats each value as raw data, escapes it, and wraps it in a SQL literal. The schema instructed callers to pass 'T000','T001', which emitted SQL equivalent to IN ('''T000''', '''T001'''): valid SQL that silently returned zero rows.

I reproduced the mismatch on A4H SAP_BASIS 758 and A4H-2025 SAP_BASIS 816. The documented quoted form returned []; the bare form returned the expected TADIR/T000 row on both systems.

## Scope

No changes to the SQL builder, ADT requests, data-preview safety gates, or quote-stripping compatibility behavior.

## Validation

- npm test -- --reporter=dot — 170 files, 4,974 tests passed
- Focused TABLE_QUERY/schema/snapshot/budget tests — 134 tests passed
- npm run typecheck
- npm run lint
- npm run build
- npm run check:sizes
- git diff --check

Research: https://github.com/arc-mcp/arc-1/blob/agent/issue-690-table-query-quoting/docs/research/issues/690-table-query-where-values.md
Plan: https://github.com/arc-mcp/arc-1/blob/agent/issue-690-table-query-quoting/docs/plans/2026-08-10-issue-690-table-query-quoting.md

Fixes #690
