### PR TITLE
fix: support DDLS table functions on 7.50

### DIFF
--- a/docs/plans/2026-08-11-issue-692-ddls-table-function-delete-404.md
+++ b/docs/plans/2026-08-11-issue-692-ddls-table-function-delete-404.md
@@ -1,0 +1,156 @@
+# Plan — #692: allow DDLS table functions on 7.50 and classify post-lock delete 404s correctly
+
+**Evidence base:**
+[`docs/research/issues/692-ddls-table-function-guard-delete-404.md`](../research/issues/692-ddls-table-function-guard-delete-404.md)
+— live-verified 2026-08-11 on NW 7.50 SP02 (`SAP_BASIS 750`) and S/4HANA 2023
+(`SAP_BASIS 758`).
+
+**Status:** implemented and validated; amended during live review after 7.50 exposed a phantom-lock
+edge case.
+
+## Goal
+
+Restore valid `define table function` create/update behavior on NW 7.50, make `batch_create`
+enforce the same entity-only release guard as single writes, and stop describing a DDLS delete as
+"object not found" when metadata and mutation-stage evidence confirm it still existed after SAP
+rejected DELETE.
+
+## Verified facts this plan rests on
+
+| Fact | Evidence |
+|---|---|
+| `DEFINE TABLE FUNCTION` is supported in ABAP 7.50 | Official ABAP 7.50 release notes; active SAP demo on both live systems |
+| A custom table function works end to end on 7.50 | Create, source write, activation, readback, and delete succeeded through the current unguarded batch path |
+| The guard was designed for table entities only | Original completed plan, comment, and error all say `define table entity`; commit `c06d8847` accidentally added `|function` |
+| `batch_create` omits the release guard | Its source-validation phase runs RAP preflight and lint but not `guardCdsSyntax()` |
+| AMDP/runtime presence alone is not the delete blocker | Table-function delete succeeded with the active implementation class still present on 750 and 758 |
+| An active DDLS consumer triggers the reported response | Live 750 DELETE returned HTTP 404 with German `konnte nicht gelöscht werden`; removing the consumer made delete succeed |
+| The dependent resource existed when DELETE failed | Its metadata/source was readable before the attempt and remained readable afterward |
+| LOCK alone is insufficient evidence on 750 | A batch-rejected, TADIR-absent DDLS name still received a handle; DELETE then failed 423 with an invalid-lock message |
+| Text matching is insufficient | English logon language triggered the current phrase matcher; German did not; the status and dependency were otherwise identical |
+
+## Design
+
+### 1. Keep the release guard narrow and consistent
+
+`guardCdsSyntax()` will match only `define table entity`. Its existing release threshold, BTP
+exception, and fail-open behavior when no feature probe is cached remain unchanged.
+
+`batch_create` will call that same helper in its per-object source-validation block, before RAP
+preflight, lint, or any create request. A blocked item will be recorded using the existing
+per-object failure shape and the batch will stop, matching its other deterministic validation
+failures.
+
+No bypass parameter will be added: once table functions are removed from the false-positive match,
+the guard covers only syntax that the live 7.50 system genuinely cannot accept.
+
+### 2. Carry operation-stage evidence on the typed ADT error
+
+`AdtApiError` will gain an optional handler-owned `resourceKnownToExist` fact. This is classification
+metadata, not user-facing prose. The delete handler will set it only when a metadata read after the
+failure confirms the object and the successfully locked delete sequence threw an `AdtApiError`.
+Every post-lock 404 gets that follow-up read before classification; the extra request exists only on
+the error path and closes any race with earlier package metadata resolution.
+
+This preserves the distinction the HTTP status alone loses:
+
+- a failure while resolving or locking the object can still mean it is absent;
+- a 7.50 lock handle alone does not prove a DDLS exists;
+- a DELETE 404 plus independent successful post-failure metadata resolution cannot truthfully be
+  described as absence.
+
+### 3. Make dependency enrichment language-independent
+
+For DDLS, either the existing structured/message detector or a post-lock 404 will trigger
+`buildCdsDeleteDependencyHint()`. The existing detector remains useful for non-404 DDIC error 039
+responses and for other dependency-sensitive types. Restricting the new structural inference to
+the live-verified DDLS handler avoids labeling unrelated post-lock 404s as dependency failures. It
+still covers localized DDLS text without growing a fragile list of translations. Any 404 branch,
+including the existing English phrase matcher, requires the same independent existence
+confirmation so a phantom lock cannot add contradictory dependency guidance to a real not-found
+result.
+
+The dispatcher will check `resourceKnownToExist` before its generic not-found branch. It will retain
+the SAP message and explain that SAP's delete handler rejected the operation after a successful
+lock. Handler-provided dependency remediation stays last through `extraHint`.
+
+## Tasks
+
+### 1. Correct and synchronize the CDS guard
+
+- `src/handlers/cds-hints.ts`: remove `function` from the regex.
+- `src/handlers/write/create.ts`: run `guardCdsSyntax()` in batch source validation and report a
+  normal failed batch item when it blocks.
+
+### 2. Preserve successful-lock evidence
+
+- `src/adt/errors.ts`: add and document `resourceKnownToExist?: boolean` on `AdtApiError`.
+- `src/handlers/write/update-delete.ts`: combine a post-failure metadata read with lock-stage
+  evidence, annotate only confirmed ADT failures, and enrich confirmed DDLS post-lock 404s
+  independent of response language.
+- `src/handlers/dispatch.ts`: suppress the absent-object hint for marked 404s and emit a truthful
+  delete-handler hint instead.
+
+### 3. Add focused regression coverage
+
+- `tests/unit/handlers/cds-write-guard.test.ts`:
+  - single create and update allow `define table function` with cached 750 features;
+  - batch create allows a table function with cached 750 features;
+  - batch create rejects `define table entity` with cached 750 features before its create POST;
+  - retain coverage that single create/update still reject the table-entity syntax.
+- `tests/unit/handlers/transport.test.ts`:
+  - a German DDLS 404 after a successful lock gets dependency follow-up and no missing-object hint;
+  - a genuine pre-lock 404 keeps the normal missing-object hint;
+  - a 7.50-style phantom DDLS lock followed by DELETE 404 and metadata 404 still keeps the
+    missing-object hint;
+  - a non-CDS 404 after a successful lock gets the generic delete-handler explanation rather than
+    a dependency claim or missing-object hint.
+
+### 4. Validate locally and on both real systems
+
+- Run the focused handler tests, typecheck, lint, build, and the full unit suite.
+- On NW 7.50, create/update/activate/read a table function through the normal guarded path.
+- On NW 7.50, confirm a batched table entity is rejected before creation.
+- On NW 7.50 with German logon language, recreate the dependent-DDLS delete failure and confirm the
+  corrected diagnostics; delete the consumer and confirm cleanup succeeds.
+- On S/4HANA 2023, create/update/activate/read/delete a table function to check the newer-release
+  path for regressions.
+- Verify all temporary objects are absent afterward.
+
+## Plan review
+
+Reviewed against the live traces, the original CDS-robustness plan, the stateful CRUD sequence, and
+the dispatcher ordering. The review rejected three tempting but weaker changes:
+
+- adding only the German phrase would remain logon-language dependent;
+- treating every DDLS 404 as a dependency failure would misclassify genuine missing objects;
+- adding a user override would broaden writes without solving the guard's incorrect syntax match.
+
+The combined metadata/lifecycle fact is the narrowest reusable boundary: it is produced only by the
+handler that knows both the existence lookup and the mutation stage, while the generic formatter
+consumes it without learning CRUD internals. The review narrowed structural dependency inference
+from all dependency-sensitive types to DDLS, the only handler behavior established by the live
+trace. A first post-fix live pass then disproved lock-only evidence, so the implementation was
+tightened to require metadata confirmation as well. No schema, tool-definition fixture, ADT path,
+or authorization change is required. Final validation also moved the cohesive CDS guard suite out
+of `write-create-batch.test.ts` rather than raising that file's 3,000-line CI budget.
+
+## Validation results
+
+- Focused handler tests: 226 passed.
+- Full unit suite: 171 files / 4,991 tests passed.
+- Typecheck, Biome, build, file-size ratchet, and tool-schema budgets passed. Biome emitted only the
+  existing configuration-version/deprecation notices.
+- NW 7.50 (`SAP_BASIS 750`): single table-function create/update/activate/read passed; batch table
+  entity was blocked before creation; German dependent-DDLS delete 404 produced the corrected,
+  language-independent diagnostic; all temporary objects were absent after cleanup.
+- S/4HANA 2023 (`SAP_BASIS 758`): single table-function create/update/activate/read/delete passed;
+  the temporary object was absent after cleanup.
+
+## Out of scope
+
+- Discovering or deleting dependencies automatically.
+- Changing SAP object activation order or HANA runtime lifecycle.
+- Promising that the 7.50 usage-reference endpoint will enumerate every blocker; live testing
+  returned no rows, so the fallback remediation remains part of the result.
+- Changing minimal-error mode, which intentionally omits detailed remediation.

--- a/docs/plans/completed/2026-08-11-issue-692-ddls-table-function-delete-404.md
+++ b/docs/plans/completed/2026-08-11-issue-692-ddls-table-function-delete-404.md
@@ -1,12 +1,13 @@
 # Plan — #692: allow DDLS table functions on 7.50 and classify post-lock delete 404s correctly
 
 **Evidence base:**
-[`docs/research/issues/692-ddls-table-function-guard-delete-404.md`](../research/issues/692-ddls-table-function-guard-delete-404.md)
+[`docs/research/issues/692-ddls-table-function-guard-delete-404.md`](../../research/issues/692-ddls-table-function-guard-delete-404.md)
 — live-verified 2026-08-11 on NW 7.50 SP02 (`SAP_BASIS 750`) and S/4HANA 2023
 (`SAP_BASIS 758`).
 
-**Status:** implemented and validated; amended during live review after 7.50 exposed a phantom-lock
-edge case.
+**Status:** completed and validated; amended during live review after 7.50 exposed a phantom-lock
+edge case and during PR review to preserve truthful diagnostics when the confirmation probe itself
+fails.
 
 ## Goal
 
@@ -46,18 +47,21 @@ the guard covers only syntax that the live 7.50 system genuinely cannot accept.
 
 ### 2. Carry operation-stage evidence on the typed ADT error
 
-`AdtApiError` will gain an optional handler-owned `resourceKnownToExist` fact. This is classification
-metadata, not user-facing prose. The delete handler will set it only when a metadata read after the
-failure confirms the object and the successfully locked delete sequence threw an `AdtApiError`.
-Every post-lock 404 gets that follow-up read before classification; the extra request exists only on
-the error path and closes any race with earlier package metadata resolution.
+`AdtApiError` will gain an optional handler-owned `resourceExistenceAfterDelete` state. This is
+classification metadata, not user-facing prose. After a successfully locked DELETE returns 404,
+the delete handler records `exists` when the follow-up metadata read succeeds, `absent` only when
+that probe also returns 404, and `unknown` for any other probe failure. Every post-lock 404 gets
+that follow-up read before classification; the extra request exists only on the error path and
+closes any race with earlier package metadata resolution.
 
 This preserves the distinction the HTTP status alone loses:
 
 - a failure while resolving or locking the object can still mean it is absent;
 - a 7.50 lock handle alone does not prove a DDLS exists;
 - a DELETE 404 plus independent successful post-failure metadata resolution cannot truthfully be
-  described as absence.
+  described as absence;
+- a non-404 failure from the confirmation probe establishes neither existence nor absence, so the
+  formatter must report uncertainty rather than falling back to a missing-object claim.
 
 ### 3. Make dependency enrichment language-independent
 
@@ -65,14 +69,14 @@ For DDLS, either the existing structured/message detector or a post-lock 404 wil
 `buildCdsDeleteDependencyHint()`. The existing detector remains useful for non-404 DDIC error 039
 responses and for other dependency-sensitive types. Restricting the new structural inference to
 the live-verified DDLS handler avoids labeling unrelated post-lock 404s as dependency failures. It
-still covers localized DDLS text without growing a fragile list of translations. Any 404 branch,
-including the existing English phrase matcher, requires the same independent existence
-confirmation so a phantom lock cannot add contradictory dependency guidance to a real not-found
-result.
+still covers localized DDLS text without growing a fragile list of translations. A follow-up probe
+404 suppresses the existing English phrase matcher so a phantom lock cannot add contradictory
+dependency guidance to a real not-found result. If that probe instead fails inconclusively, the
+message-based matcher remains useful but structural DDLS inference is withheld.
 
-The dispatcher will check `resourceKnownToExist` before its generic not-found branch. It will retain
-the SAP message and explain that SAP's delete handler rejected the operation after a successful
-lock. Handler-provided dependency remediation stays last through `extraHint`.
+The dispatcher will check `resourceExistenceAfterDelete` before its generic not-found branch. It
+will distinguish confirmed existence, confirmed absence, and an inconclusive follow-up probe.
+Handler-provided dependency remediation stays last through `extraHint`.
 
 ## Tasks
 
@@ -84,12 +88,13 @@ lock. Handler-provided dependency remediation stays last through `extraHint`.
 
 ### 2. Preserve successful-lock evidence
 
-- `src/adt/errors.ts`: add and document `resourceKnownToExist?: boolean` on `AdtApiError`.
+- `src/adt/errors.ts`: add and document the tri-state `resourceExistenceAfterDelete` fact on
+  `AdtApiError`.
 - `src/handlers/write/update-delete.ts`: combine a post-failure metadata read with lock-stage
-  evidence, annotate only confirmed ADT failures, and enrich confirmed DDLS post-lock 404s
-  independent of response language.
-- `src/handlers/dispatch.ts`: suppress the absent-object hint for marked 404s and emit a truthful
-  delete-handler hint instead.
+  evidence, record `exists`/`absent`/`unknown`, and enrich confirmed DDLS post-lock 404s independent
+  of response language while retaining message-based evidence when the probe is inconclusive.
+- `src/handlers/dispatch.ts`: render confirmed existence and inconclusive probes truthfully instead
+  of falling through to the absent-object hint.
 
 ### 3. Add focused regression coverage
 
@@ -103,6 +108,8 @@ lock. Handler-provided dependency remediation stays last through `extraHint`.
   - a genuine pre-lock 404 keeps the normal missing-object hint;
   - a 7.50-style phantom DDLS lock followed by DELETE 404 and metadata 404 still keeps the
     missing-object hint;
+  - a message-based dependency 404 followed by an inconclusive metadata probe keeps dependency
+    remediation but does not claim either confirmed existence or absence;
   - a non-CDS 404 after a successful lock gets the generic delete-handler explanation rather than
     a dependency claim or missing-object hint.
 
@@ -126,19 +133,21 @@ the dispatcher ordering. The review rejected three tempting but weaker changes:
 - treating every DDLS 404 as a dependency failure would misclassify genuine missing objects;
 - adding a user override would broaden writes without solving the guard's incorrect syntax match.
 
-The combined metadata/lifecycle fact is the narrowest reusable boundary: it is produced only by the
-handler that knows both the existence lookup and the mutation stage, while the generic formatter
-consumes it without learning CRUD internals. The review narrowed structural dependency inference
-from all dependency-sensitive types to DDLS, the only handler behavior established by the live
-trace. A first post-fix live pass then disproved lock-only evidence, so the implementation was
-tightened to require metadata confirmation as well. No schema, tool-definition fixture, ADT path,
-or authorization change is required. Final validation also moved the cohesive CDS guard suite out
-of `write-create-batch.test.ts` rather than raising that file's 3,000-line CI budget.
+The tri-state metadata/lifecycle fact is the narrowest reusable boundary: it is produced only by
+the handler that knows both the existence lookup and the mutation stage, while the generic
+formatter consumes it without learning CRUD internals. The review narrowed structural dependency
+inference from all dependency-sensitive types to DDLS, the only handler behavior established by
+the live trace. A first post-fix live pass then disproved lock-only evidence, so the implementation
+was tightened to require metadata confirmation as well. No schema, tool-definition fixture, ADT
+path, or authorization change is required. Final validation also moved the cohesive CDS guard suite
+out of `write-create-batch.test.ts` rather than raising that file's 3,000-line CI budget. PR review
+then closed the remaining degraded path: a non-404 confirmation-probe failure now remains
+explicitly unknown and preserves existing message-based dependency remediation.
 
 ## Validation results
 
-- Focused handler tests: 226 passed.
-- Full unit suite: 171 files / 4,991 tests passed.
+- Focused handler tests: 227 passed.
+- Full unit suite: 171 files / 4,992 tests passed.
 - Typecheck, Biome, build, file-size ratchet, and tool-schema budgets passed. Biome emitted only the
   existing configuration-version/deprecation notices.
 - NW 7.50 (`SAP_BASIS 750`): single table-function create/update/activate/read passed; batch table

--- a/docs/plans/completed/2026-08-11-issue-692-ddls-table-function-delete-404.md
+++ b/docs/plans/completed/2026-08-11-issue-692-ddls-table-function-delete-404.md
@@ -75,7 +75,8 @@ dependency guidance to a real not-found result. If that probe instead fails inco
 message-based matcher remains useful but structural DDLS inference is withheld.
 
 The dispatcher will check `resourceExistenceAfterDelete` before its generic not-found branch. It
-will distinguish confirmed existence, confirmed absence, and an inconclusive follow-up probe.
+will distinguish confirmed existence, confirmed absence, and an inconclusive follow-up probe. An
+inconclusive result directs the caller to verify the current state with `SAPSearch` before retrying.
 Handler-provided dependency remediation stays last through `extraHint`.
 
 ## Tasks
@@ -146,8 +147,8 @@ explicitly unknown and preserves existing message-based dependency remediation.
 
 ## Validation results
 
-- Focused handler tests: 227 passed.
-- Full unit suite: 171 files / 4,992 tests passed.
+- Focused handler tests: 228 passed.
+- Full unit suite: 171 files / 4,993 tests passed.
 - Typecheck, Biome, build, file-size ratchet, and tool-schema budgets passed. Biome emitted only the
   existing configuration-version/deprecation notices.
 - NW 7.50 (`SAP_BASIS 750`): single table-function create/update/activate/read passed; batch table

--- a/docs/research/issues/692-ddls-table-function-guard-delete-404.md
+++ b/docs/research/issues/692-ddls-table-function-guard-delete-404.md
@@ -311,7 +311,8 @@ The robust signal is structural, not linguistic:
    - `tests/unit/handlers/transport.test.ts`: German post-lock DDLS 404 receives dependency guidance
      without a missing-object hint; a pre-lock 404 retains normal not-found guidance; a non-CDS
      post-lock delete 404 receives the generic delete-handler explanation; an English dependency
-     404 whose metadata probe fails non-404 retains remediation without claiming absence.
+     404 whose metadata probe fails non-404 retains remediation without claiming absence; a
+     non-CDS inconclusive probe directs the caller to verify current state with `SAPSearch`.
 
 No tool schema or public parameter changes are needed, so `tools.ts`, `schemas.ts`, and frozen tool
 definition fixtures stay unchanged.
@@ -323,8 +324,8 @@ the combined file exceeded the repository's 3,000-line size ratchet. The budget 
 
 Local validation after the final review:
 
-- focused handler suite: 227 tests passed;
-- full unit suite: 171 files and 4,992 tests passed;
+- focused handler suite: 228 tests passed;
+- full unit suite: 171 files and 4,993 tests passed;
 - `npm run typecheck`, `npm run lint`, `npm run build`, and `npm run check:sizes` passed;
 - lint reported only the repository's pre-existing Biome 2.5.5 schema / 2.5.7 CLI notices.
 

--- a/docs/research/issues/692-ddls-table-function-guard-delete-404.md
+++ b/docs/research/issues/692-ddls-table-function-guard-delete-404.md
@@ -1,0 +1,367 @@
+# Issue #692 — DDLS table-function guard and delete 404 misclassification
+
+**Status:** Fixed and validated; root causes and implementation tested live on 2026-08-11 against
+NW 7.50 SP02 (`SAP_BASIS 750`) and S/4HANA 2023 (`SAP_BASIS 758`).
+
+## TL;DR
+
+Issue #692 contains two real ARC-1 defects and one unverified SAP-side hypothesis that the live
+tests disproved:
+
+1. `guardCdsSyntax()` is supposed to guard only `define table entity`, but its regex accidentally
+   includes `function`. A live 7.50 system contains active SAP-delivered CDS table functions and
+   can create, update, activate, and delete a custom one. ARC-1 nevertheless rejects the same
+   construct when startup feature evidence is cached, with an error about `define table entity`.
+2. `batch_create` omits `guardCdsSyntax()` entirely, so single create/update and batch create do not
+   enforce the same release rule. The fix is to restore the intended entity-only regex and run the
+   guard in the batch source-validation phase too.
+3. NW 7.50 overloads HTTP 404 for a DDLS delete rejected because an active DDLS consumer still
+   exists. ARC-1's dependency detector recognizes the English text but misses the German text, and
+   the dispatcher then unconditionally says the object was not found. Use independent metadata
+   resolution after the failed mutation as language-independent existence evidence, mark the error
+   `resourceKnownToExist`, use a confirmed post-lock DDLS 404 as a dependency signal, and suppress
+   the generic not-found hint whenever that evidence is present. A post-fix live review found that
+   7.50 can return a lock handle for an absent DDLS, so lock success alone is deliberately not used.
+
+The reporter's proposed underlying cause for delete — the table function's HANA runtime object or
+its AMDP implementation — is not the cause. Deleting an active table function while its active AMDP
+class still existed succeeded on both test systems. Adding an active DDLS consumer reproduced the
+404 on 7.50; deleting that consumer made the table-function delete succeed immediately.
+
+## Claim and scope
+
+The issue reports:
+
+- `SAPWrite(update, DDLS)` rejects a valid `define table function` on `SAP_BASIS 750`, before SAP is
+  called, using an error that names `define table entity` and requires release 757.
+- `batch_create` accepted the same table function because it does not call the CDS release guard.
+- A later DDLS delete returned HTTP 404 with German text `konnte nicht gelöscht werden`, but ARC-1
+  added `Object ... was not found` even though it had already locked the object.
+
+This dossier covers the DDLS source write guard, batch parity, and LLM-facing delete diagnostics. It
+does not change the ADT CRUD wire contract or add a bypass for genuinely unsupported
+`define table entity` syntax.
+
+## HEAD behavior and repository history
+
+### Table-function false positive
+
+`src/handlers/cds-hints.ts` currently contains:
+
+```ts
+if (/\bdefine\s+table\s+(entity|function)\b/i.test(source)) {
+```
+
+The surrounding comment and error both describe only `define table entity`. The approved plan,
+`docs/plans/completed/2026-04-13-cds-write-robustness.md`, also specified exactly:
+
+```ts
+/\bdefine\s+table\s+entity\b/i
+```
+
+Git history shows that commit `c06d8847` introduced the widened `(entity|function)` implementation
+even though its plan, commit message, tests, comment, and error string all described an entity-only
+guard. This is an implementation typo in the original feature, not a later release change.
+
+The guard is called from:
+
+- `src/handlers/write/create.ts` `writeActionCreate()`;
+- `src/handlers/write/update-delete.ts` `writeActionUpdate()`.
+
+It is not called from `src/handlers/write/create.ts` `writeActionBatchCreate()`, whose per-object
+source-validation block currently runs RAP preflight and lint only.
+
+### Delete misclassification
+
+`src/handlers/write/update-delete.ts` does the correct stateful sequence:
+
+```text
+LOCK object -> DELETE object?lockHandle=... -> UNLOCK
+```
+
+Its `isDeleteDependencyError()` recognizes DDIC diagnostic 039 and a list of English phrases. A
+German 404 without a T100 diagnostic misses both branches, so no `buildCdsDeleteDependencyHint()`
+result is attached.
+
+Separately, `src/handlers/dispatch.ts` treats every `AdtApiError.isNotFound` as proof that the named
+object is absent. The dispatcher lacks the handler's stronger lifecycle and metadata evidence.
+
+## ADT contract
+
+The local Eclipse ADT contract research gives the canonical DDLS resource and capabilities:
+
+- collection/object: `/sap/bc/adt/ddic/ddl/sources[/{name}]`;
+- source: `/sap/bc/adt/ddic/ddl/sources/{name}/source/main`;
+- DDLS advertises locking and native deletion;
+- lock: `POST {object}?_action=LOCK&accessMode=MODIFY`;
+- source update: `PUT {source}?lockHandle=...` with `Content-Type: text/plain`;
+- delete: `DELETE {object}?lockHandle=...`;
+- unlock: `POST {object}?_action=UNLOCK&lockHandle=...`.
+
+Sources:
+
+- `~/DEV/arc-1-eclipse-adt/api/01-rap-object-types-and-uris.md`;
+- `~/DEV/arc-1-eclipse-adt/api/05-lock-create-update-transport.md`.
+
+SAP's own adt-ls independently models DDLS as a supported source object and deletes an existing
+object only after resolving it by repository search, then deleting its metadata URI. See
+`~/DEV/arc-1-lsp/dist/adt-ls/lifecycle.js` and `docs/adt-ls-reference.md` section 5. It does not expose
+a client-side table-function release guard.
+
+The fr0ster reference client also routes `DDLS/DF` through its normal view update/delete lifecycle.
+It contains the same unsafe assumption that any 404 from its high-level delete means "not found",
+so it is evidence for the shared endpoint, not a model for correct error classification.
+
+The official ABAP language reference search returned `ABENNEWS-750-ABAP_CDS`, which explicitly lists
+`DEFINE TABLE FUNCTION` as new in release 7.50, plus the current
+`ABENCDS_F1_DEFINE_TABLE_FUNCTION` contract. No relevant SAP Note was found for the overloaded delete
+404; the live system behavior is sufficient and deterministic.
+
+## Live validation
+
+All mutations used unique `$TMP` objects and were deleted afterwards. TADIR lookup returned zero
+remaining test objects on both systems.
+
+### 1. SAP-delivered table functions are active on 750 and 758
+
+Command shape:
+
+```bash
+arc1-cli call SAPRead --json \
+  '{"type":"DDLS","name":"DEMO_CDS_GET_SCARR_SPFLI","version":"active"}'
+```
+
+| System | Result content |
+|---|---|
+| NW 7.50 SP02 / `SAP_BASIS 750` | Active source starts `define table function DEMO_CDS_GET_SCARR_SPFLI` and names `CL_DEMO_AMDP_FUNCTIONS=>GET_SCARR_SPFLI_FOR_CDS`. |
+| S/4HANA 2023 / `SAP_BASIS 758` | Active source contains the same table-function construct and AMDP implementation contract. |
+
+This proves the guarded token sequence is a real supported DDLS construct on the release named by
+the issue; it is not merely syntax accepted by a newer client.
+
+### 2. Current ARC-1 reproduces the false positive on live 750 evidence
+
+The startup-equivalent feature probe returned:
+
+```json
+{"release":"750","systemType":"onprem"}
+```
+
+Calling the normal `handleToolCall()` path for a `$TMP` DDLS create containing
+`define table function Z_I692_GUARD_ONLY ...` then returned in 5 ms, before any create request:
+
+```text
+"define table entity" syntax requires ABAP Cloud (BTP) or S/4HANA on-premise
+with SAP_BASIS >= 757. This system reports SAP_BASIS 750.
+```
+
+The requested object was never created.
+
+### 3. `batch_create` proves the same construct works end to end on 750
+
+Because current `batch_create` omits the guard, it was used to create the isolated
+`Z_I692_NPL_TF_0811` table function. The returned result was:
+
+```text
+Batch created 1 objects in package $TMP: Z_I692_NPL_TF_0811 (DDLS) ✓ [$TMP]
+```
+
+`SAPRead(version="active")` returned the exact active source, including
+`define table function Z_I692_NPL_TF_0811`. A matching AMDP class was then created and activated.
+This validates create, source write, and activation on the real 7.50 system rather than relying only
+on the SAP-delivered demo.
+
+### 4. Table function plus AMDP alone does not cause delete failure
+
+The same isolated table-function/AMDP pair was created and activated on 750 and 758. Deleting the
+DDLS while the active AMDP class still existed succeeded on both systems:
+
+```text
+Deleted DDLS Z_I692_NPL_TF_0811.   # 750
+Deleted DDLS Z_I692_TF_0811.       # 758
+```
+
+This disproves the issue's tentative HANA-runtime/AMDP-blocker theory.
+
+### 5. An active DDLS consumer reproduces the German 404 on 750
+
+On 750, the table function was recreated and an active classic CDS view
+`Z_I692_NPL_USE_0811` was added with `select from Z_I692_NPL_TF_0811`. Deleting the table function
+with `SAP_LANGUAGE=DE` produced:
+
+```text
+HTTP 404 DELETE
+/sap/bc/adt/ddic/ddl/sources/Z_I692_NPL_TF_0811?lockHandle=<redacted>
+
+Ddl Source Z_I692_NPL_TF_0811 konnte nicht gelöscht werden
+
+Hint: Object "Z_I692_NPL_TF_0811" (type DDLS) was not found.
+```
+
+The path contains a real lock handle obtained immediately before DELETE. The object was also still
+readable and active after the failure.
+
+Repeating only the delete with `SAP_LANGUAGE=EN` returned the same HTTP 404 and operation path, but
+the body changed to:
+
+```text
+DDL source Z_I692_NPL_TF_0811 could not be deleted
+```
+
+The English phrase triggered the current dependency enrichment, while the generic not-found hint
+still appeared before it. Thus the difference is client-side language matching, not different SAP
+semantics.
+
+Finally, deleting `Z_I692_NPL_USE_0811` first made the same table-function delete succeed. The AMDP
+class could be deleted independently. TADIR lookup then confirmed all three objects absent.
+
+### 6. Plan review found that lock success alone is insufficient on 750
+
+During the first post-fix live pass, `batch_create` correctly rejected `Z_I692_BAD_ENT` before its
+create POST and TADIR lookup confirmed the object was absent. A defensive cleanup delete against
+that absent name nevertheless received a lock handle from 7.50; DELETE then returned HTTP 423
+`Resource Data Definition ... is not locked (invalid lock handle ...)`.
+
+This falsified the first draft's assumption that LOCK success alone proves existence on this old
+stack. The refined design requires independent object metadata evidence as well:
+
+- every post-lock 404 triggers a follow-up metadata read, independent of package-gate settings;
+- only a successful post-failure metadata read plus the failed mutation sequence sets
+  `resourceKnownToExist`;
+- 404 phrase-based dependency matching is also ignored without that confirmation;
+- if metadata is 404/unavailable, the normal not-found classification remains.
+
+The reported dependent-DDLS object remains distinguishable: it was readable before the attempt and
+remained readable after the 404.
+
+### Result matrix
+
+| Scenario | 750 | 758 |
+|---|---|---|
+| Read active SAP-delivered table function | success | success |
+| Create/write/activate isolated table function | success via current batch path | success via normal create/update/activate |
+| Delete table function while AMDP class exists | success | success |
+| Delete table function with active DDLS consumer | HTTP 404; German body misses detector, English body hits it | Not needed to establish 750 issue; endpoint delete itself already validated |
+| Delete after consumer removal | success | n/a |
+| LOCK an absent, batch-rejected DDLS name | returns a handle; DELETE later fails 423 | n/a |
+
+## Root cause
+
+### Bug 1
+
+The regex's `|function` alternation is accidental. It contradicts the construct named by the comment
+and error, the original reviewed plan, official 7.50 release documentation, and both live systems.
+
+`batch_create` independently skipped the guard because its source-validation pipeline was copied
+without the `guardCdsSyntax()` call. This made the accidental single-object false positive visible:
+batch create reached SAP and worked, while update stopped client-side.
+
+### Bug 2
+
+The HTTP status is not sufficient to classify ADT delete failures. On NW 7.50's DDLS native-delete
+handler, 404 can mean "the deletion could not be completed" rather than "the object URI does not
+exist". The handler can combine a successful post-failure metadata resolution with its knowledge
+that the error came from DELETE, not the earlier lookup/lock stage.
+
+The existing dependency detector relies on English response text when no diagnostic number is
+present. The German body therefore misses enrichment. The dispatcher then compounds the problem by
+mapping every 404 to a missing object without considering operation stage.
+
+The robust signal is structural, not linguistic:
+
+- a 404 during metadata resolution or LOCK may still mean absent and should retain the generic
+  not-found hint;
+- LOCK alone is not proof on 7.50 because an absent DDLS can receive a handle;
+- a 404 from DELETE after LOCK plus successful post-failure metadata confirmation is a
+  delete-handler failure and must not be described as object absence;
+- for DDLS, the live-verified post-lock 404 should trigger existing where-used enrichment even when
+  the localized response text is unknown;
+- other object types should still suppress the false absence claim, but should not be labeled as a
+  dependency failure without their existing structured or message evidence.
+
+## Recommended fix and affected files
+
+1. `src/handlers/cds-hints.ts`
+   - narrow the table-entity regex to `\bdefine\s+table\s+entity\b`;
+   - keep the existing release threshold and no-feature-evidence fail-open behavior.
+2. `src/handlers/write/create.ts`
+   - invoke `guardCdsSyntax()` in the `batch_create` per-object source-validation block before any
+     object is created;
+   - record a per-item failure and stop consistently with the existing RAP/lint branches.
+3. `src/adt/errors.ts`
+   - add an optional handler-owned `resourceKnownToExist` fact to `AdtApiError`, analogous to
+     `extraHint` but used for classification rather than appended prose.
+4. `src/handlers/write/update-delete.ts`
+   - track whether LOCK succeeded;
+   - confirm existence with a metadata read after every post-lock 404;
+   - mark the error `resourceKnownToExist` only when metadata and lifecycle evidence agree;
+   - treat a confirmed post-lock DDLS 404 as a dependency signal independent of localized message
+     text, and reuse `buildCdsDeleteDependencyHint()`; retain the existing detector for other
+     sensitive types and non-404 errors, but require the same confirmation for its 404 matches.
+5. `src/handlers/dispatch.ts`
+   - when a 404 is marked `resourceKnownToExist`, explain that ARC-1 confirmed the object still
+     existed after SAP rejected DELETE and do not emit the missing-object hint;
+   - allow `extraHint` to remain the final, detailed remediation block.
+6. Focused tests:
+   - `tests/unit/handlers/cds-write-guard.test.ts`: table functions pass the 750 guard on single
+     create/update and batch; table entities remain blocked on 750, including batch;
+   - `tests/unit/handlers/transport.test.ts`: German post-lock DDLS 404 receives dependency guidance
+     without a missing-object hint; a pre-lock 404 retains normal not-found guidance; a non-CDS
+     post-lock delete 404 receives the generic delete-handler explanation.
+
+No tool schema or public parameter changes are needed, so `tools.ts`, `schemas.ts`, and frozen tool
+definition fixtures stay unchanged.
+
+The focused guard suite was split out of `write-create-batch.test.ts` during final review because
+the combined file exceeded the repository's 3,000-line size ratchet. The budget was not raised.
+
+## Fix validation
+
+Local validation after the final review:
+
+- focused handler suite: 226 tests passed;
+- full unit suite: 171 files and 4,991 tests passed;
+- `npm run typecheck`, `npm run lint`, `npm run build`, and `npm run check:sizes` passed;
+- lint reported only the repository's pre-existing Biome 2.5.5 schema / 2.5.7 CLI notices.
+
+Live validation of the built implementation:
+
+- 750: normal single create, update, activation, and active readback of `Z_I692_FIX_TF` passed;
+- 750: batched `define table entity` was rejected with the 750/757 guard and no TADIR object;
+- 750: an active `Z_I692_FIX_USE` consumer reproduced the German delete 404; the fixed response
+  retained the SAP text, said ARC-1 confirmed the object still existed, appended dependency
+  follow-up, and did not say `was not found`;
+- 758: normal single create, update, activation, active readback, and delete of
+  `Z_I692_FIX23_TF` passed;
+- final TADIR lookups confirmed all temporary names absent on both systems.
+
+## Out of scope
+
+- Do not add a `preflightBeforeWrite` or lint override for the deterministic table-entity release
+  guard. Correctly detected `define table entity` remains unsupported below 757; bypassing the guard
+  would only defer the same failure to SAP.
+- Do not add German-specific phrases as the primary fix. That would leave every other SAP logon
+  language vulnerable to the same misclassification.
+- Do not change ADT CRUD paths, media types, or stateful-session handling.
+- Do not claim the 7.50 where-used API always lists the blocker. On the test system it returned no
+  references for this dependency; the fallback guidance remains necessary.
+
+## Paste-able GitHub reply
+
+```markdown
+Confirmed both defects and reproduced them on a real NW 7.50 system, with a cross-check on S/4HANA 2023 / SAP_BASIS 758.
+
+The table-function rejection is an ARC-1 regex bug. The original reviewed plan guarded only `define table entity`, but the implementation accidentally shipped `(entity|function)`. SAP's own 7.50 demo `DEMO_CDS_GET_SCARR_SPFLI` is an active `define table function`, and an isolated `$TMP` table function also created, wrote, activated, read back, and deleted successfully on our 7.50 system. `batch_create` currently works only because it omits this guard.
+
+I also reproduced the exact German delete response on 7.50:
+
+`HTTP 404 ... Ddl Source Z_I692_NPL_TF_0811 konnte nicht gelöscht werden`
+
+The underlying blocker was an active DDLS consumer. After deleting that consumer, the table function deleted successfully. The AMDP class by itself did **not** block deletion on either 750 or 758, so the tentative HANA-runtime/AMDP theory is not the cause.
+
+The diagnostic bug has two layers: the dependency matcher is English-only, and the dispatcher treats every 404 as absence. Here a metadata read after the failed DELETE proves the object still exists. (Live review also showed that 7.50 may issue a lock handle for an absent DDLS, so lock alone is not used.) The fix will use that combined evidence instead of adding another translated phrase: confirmed post-lock 404s will no longer say "object not found", and DDLS will run the existing dependency enrichment regardless of response language.
+
+The implementation will therefore restore the entity-only guard, add the same guard to `batch_create`, and make post-lock delete classification language-independent, with regression coverage for German 404 and genuine pre-lock not-found behavior.
+```
+
+**Recommendation:** Fix both ARC-1 defects and open a PR linked to #692.

--- a/docs/research/issues/692-ddls-table-function-guard-delete-404.md
+++ b/docs/research/issues/692-ddls-table-function-guard-delete-404.md
@@ -18,10 +18,11 @@ tests disproved:
 3. NW 7.50 overloads HTTP 404 for a DDLS delete rejected because an active DDLS consumer still
    exists. ARC-1's dependency detector recognizes the English text but misses the German text, and
    the dispatcher then unconditionally says the object was not found. Use independent metadata
-   resolution after the failed mutation as language-independent existence evidence, mark the error
-   `resourceKnownToExist`, use a confirmed post-lock DDLS 404 as a dependency signal, and suppress
-   the generic not-found hint whenever that evidence is present. A post-fix live review found that
-   7.50 can return a lock handle for an absent DDLS, so lock success alone is deliberately not used.
+   resolution after the failed mutation as language-independent existence evidence and record a
+   tri-state result (`exists`, `absent`, or `unknown`). Use a confirmed post-lock DDLS 404 as a
+   dependency signal, suppress the generic not-found hint when existence is confirmed, and report
+   uncertainty when the follow-up probe itself fails. A post-fix live review found that 7.50 can
+   return a lock handle for an absent DDLS, so lock success alone is deliberately not used.
 
 The reporter's proposed underlying cause for delete — the table function's HANA runtime object or
 its AMDP implementation — is not the cause. Deleting an active table function while its active AMDP
@@ -226,10 +227,10 @@ This falsified the first draft's assumption that LOCK success alone proves exist
 stack. The refined design requires independent object metadata evidence as well:
 
 - every post-lock 404 triggers a follow-up metadata read, independent of package-gate settings;
-- only a successful post-failure metadata read plus the failed mutation sequence sets
-  `resourceKnownToExist`;
-- 404 phrase-based dependency matching is also ignored without that confirmation;
-- if metadata is 404/unavailable, the normal not-found classification remains.
+- a successful post-failure metadata read records `exists`;
+- only a metadata-probe 404 records `absent` and suppresses 404 phrase-based dependency matching;
+- any other metadata-probe failure records `unknown`, avoids a false missing-object claim, and
+  preserves message-based dependency enrichment without inferring a localized DDLS dependency.
 
 The reported dependent-DDLS object remains distinguishable: it was readable before the attempt and
 remained readable after the 404.
@@ -274,6 +275,8 @@ The robust signal is structural, not linguistic:
 - LOCK alone is not proof on 7.50 because an absent DDLS can receive a handle;
 - a 404 from DELETE after LOCK plus successful post-failure metadata confirmation is a
   delete-handler failure and must not be described as object absence;
+- a non-404 failure from the follow-up probe is inconclusive and must not be converted into an
+  absent-object claim; existing structured/message dependency evidence remains valid on that path;
 - for DDLS, the live-verified post-lock 404 should trigger existing where-used enrichment even when
   the localized response text is unknown;
 - other object types should still suppress the false absence claim, but should not be labeled as a
@@ -289,25 +292,26 @@ The robust signal is structural, not linguistic:
      object is created;
    - record a per-item failure and stop consistently with the existing RAP/lint branches.
 3. `src/adt/errors.ts`
-   - add an optional handler-owned `resourceKnownToExist` fact to `AdtApiError`, analogous to
-     `extraHint` but used for classification rather than appended prose.
+   - add an optional handler-owned `resourceExistenceAfterDelete` state to `AdtApiError`, analogous
+     to `extraHint` but used for classification rather than appended prose.
 4. `src/handlers/write/update-delete.ts`
    - track whether LOCK succeeded;
    - confirm existence with a metadata read after every post-lock 404;
-   - mark the error `resourceKnownToExist` only when metadata and lifecycle evidence agree;
+   - record `exists`, `absent`, or `unknown` from the follow-up metadata probe;
    - treat a confirmed post-lock DDLS 404 as a dependency signal independent of localized message
      text, and reuse `buildCdsDeleteDependencyHint()`; retain the existing detector for other
      sensitive types and non-404 errors, but require the same confirmation for its 404 matches.
 5. `src/handlers/dispatch.ts`
-   - when a 404 is marked `resourceKnownToExist`, explain that ARC-1 confirmed the object still
-     existed after SAP rejected DELETE and do not emit the missing-object hint;
+   - distinguish confirmed existence, confirmed absence, and an inconclusive metadata probe;
+   - never emit the missing-object hint when the probe is inconclusive;
    - allow `extraHint` to remain the final, detailed remediation block.
 6. Focused tests:
    - `tests/unit/handlers/cds-write-guard.test.ts`: table functions pass the 750 guard on single
      create/update and batch; table entities remain blocked on 750, including batch;
    - `tests/unit/handlers/transport.test.ts`: German post-lock DDLS 404 receives dependency guidance
      without a missing-object hint; a pre-lock 404 retains normal not-found guidance; a non-CDS
-     post-lock delete 404 receives the generic delete-handler explanation.
+     post-lock delete 404 receives the generic delete-handler explanation; an English dependency
+     404 whose metadata probe fails non-404 retains remediation without claiming absence.
 
 No tool schema or public parameter changes are needed, so `tools.ts`, `schemas.ts`, and frozen tool
 definition fixtures stay unchanged.
@@ -319,8 +323,8 @@ the combined file exceeded the repository's 3,000-line size ratchet. The budget 
 
 Local validation after the final review:
 
-- focused handler suite: 226 tests passed;
-- full unit suite: 171 files and 4,991 tests passed;
+- focused handler suite: 227 tests passed;
+- full unit suite: 171 files and 4,992 tests passed;
 - `npm run typecheck`, `npm run lint`, `npm run build`, and `npm run check:sizes` passed;
 - lint reported only the repository's pre-existing Biome 2.5.5 schema / 2.5.7 CLI notices.
 

--- a/src/adt/errors.ts
+++ b/src/adt/errors.ts
@@ -77,12 +77,12 @@ export class AdtApiError extends AdtError {
   extraHint?: string;
 
   /**
-   * Handler-owned lifecycle evidence that the resource was confirmed by metadata
-   * resolution as well as the stateful mutation sequence. Lets generic formatting
-   * avoid misclassifying an operation failure as an absent object without teaching
-   * it the handler's request sequence.
+   * Handler-owned result of the metadata probe after a failed post-lock DELETE.
+   * Only a probe 404 proves absence; other probe failures are explicitly unknown.
+   * Lets generic formatting avoid claiming an object is absent without teaching it
+   * the handler's request sequence.
    */
-  resourceKnownToExist?: boolean;
+  resourceExistenceAfterDelete?: 'exists' | 'absent' | 'unknown';
 
   constructor(
     message: string,

--- a/src/adt/errors.ts
+++ b/src/adt/errors.ts
@@ -76,6 +76,14 @@ export class AdtApiError extends AdtError {
    */
   extraHint?: string;
 
+  /**
+   * Handler-owned lifecycle evidence that the resource was confirmed by metadata
+   * resolution as well as the stateful mutation sequence. Lets generic formatting
+   * avoid misclassifying an operation failure as an absent object without teaching
+   * it the handler's request sequence.
+   */
+  resourceKnownToExist?: boolean;
+
   constructor(
     message: string,
     public readonly statusCode: number,

--- a/src/handlers/cds-hints.ts
+++ b/src/handlers/cds-hints.ts
@@ -411,16 +411,6 @@ export function guardCdsSyntax(
     }
   }
 
-  // Advisory: warn about CDS reserved keywords used as field names
-  const keywordWarning = warnCdsReservedKeywords(source);
-  if (keywordWarning) {
-    // Non-blocking — return undefined to proceed, but the warning will be
-    // appended to the success message by the caller if needed.
-    // For now we return it as an advisory error only when the keyword is
-    // highly likely to cause issues (position is the most common).
-    // We don't block the write — just append it as advisory context.
-  }
-
   return undefined;
 }
 

--- a/src/handlers/cds-hints.ts
+++ b/src/handlers/cds-hints.ts
@@ -396,7 +396,7 @@ export function guardCdsSyntax(
   if (type !== 'DDLS' || !source) return undefined;
 
   // Guard: "define table entity" requires ABAP Cloud (BTP) or SAP_BASIS >= 757
-  if (/\bdefine\s+table\s+(entity|function)\b/i.test(source)) {
+  if (/\bdefine\s+table\s+entity\b/i.test(source)) {
     const release = features?.abapRelease;
     const isBtp = features?.systemType === 'btp';
     if (!isBtp && release) {

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -146,6 +146,13 @@ function buildBaseErrorMessage(
     }
 
     if (err.isNotFound) {
+      if (err.resourceKnownToExist) {
+        return (
+          `${enriched}\n\n` +
+          'Hint: ARC-1 confirmed this object still existed after SAP rejected DELETE, so this 404 does not mean the object was absent. ' +
+          "SAP's delete handler rejected the operation. Check the SAP error and any follow-up guidance, resolve dependencies or active-version state if applicable, then retry."
+        );
+      }
       const diagnosticsHint = buildDiagnosticsNotFoundHint(tool, args);
       if (diagnosticsHint) {
         return `${enriched}\n\nHint: ${diagnosticsHint}`;

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -146,12 +146,14 @@ function buildBaseErrorMessage(
     }
 
     if (err.isNotFound) {
-      if (err.resourceKnownToExist) {
+      if (err.resourceExistenceAfterDelete === 'exists') {
         return (
           `${enriched}\n\n` +
-          'Hint: ARC-1 confirmed this object still existed after SAP rejected DELETE, so this 404 does not mean the object was absent. ' +
-          "SAP's delete handler rejected the operation. Check the SAP error and any follow-up guidance, resolve dependencies or active-version state if applicable, then retry."
+          "Hint: ARC-1 confirmed this object still existed after SAP rejected DELETE, so this 404 means SAP's delete handler rejected the operation rather than that the object was absent."
         );
+      }
+      if (err.resourceExistenceAfterDelete === 'unknown') {
+        return `${enriched}\n\nHint: SAP returned 404 after DELETE, but ARC-1 could not determine whether the object still exists because the follow-up metadata check failed.`;
       }
       const diagnosticsHint = buildDiagnosticsNotFoundHint(tool, args);
       if (diagnosticsHint) {

--- a/src/handlers/dispatch.ts
+++ b/src/handlers/dispatch.ts
@@ -153,7 +153,8 @@ function buildBaseErrorMessage(
         );
       }
       if (err.resourceExistenceAfterDelete === 'unknown') {
-        return `${enriched}\n\nHint: SAP returned 404 after DELETE, but ARC-1 could not determine whether the object still exists because the follow-up metadata check failed.`;
+        const name = String(args.name ?? '');
+        return `${enriched}\n\nHint: SAP returned 404 after DELETE, but ARC-1 could not determine whether the object still exists because the follow-up metadata check failed. Use SAPSearch with query "${name}" to verify the current object state before retrying DELETE.`;
       }
       const diagnosticsHint = buildDiagnosticsNotFoundHint(tool, args);
       if (diagnosticsHint) {

--- a/src/handlers/write/create.ts
+++ b/src/handlers/write/create.ts
@@ -1004,6 +1004,18 @@ export async function writeActionBatchCreate(ctx: SapWriteContext): Promise<Tool
       // Pre-validate source with lint BEFORE creating the object to avoid orphaned objects.
       // Metadata objects (DOMA/DTEL) are XML-only and intentionally skip source lint.
       if (!metadataObject && objSource) {
+        const cdsGuard = guardCdsSyntax(objType, objSource, getCachedFeatures());
+        if (cdsGuard) {
+          results.push({
+            type: objType,
+            name: objName,
+            packageName: objPackage,
+            status: 'failed',
+            error: cdsGuard.content[0].text,
+          });
+          break;
+        }
+
         const preflightWarnings = runRapPreflightValidation(
           objSource,
           objType,

--- a/src/handlers/write/update-delete.ts
+++ b/src/handlers/write/update-delete.ts
@@ -260,11 +260,14 @@ export async function writeActionUpdate(ctx: SapWriteContext): Promise<ToolResul
 export async function writeActionDelete(ctx: SapWriteContext): Promise<ToolResult> {
   const { client, type, name, transport, objectUrl, invalidateWrittenObject, enforcePackageForExistingObject } = ctx;
   await enforcePackageForExistingObject();
+  let resourceKnownToExist = false;
+  let lockSucceeded = false;
 
   // Lock, delete, unlock pattern (works for all types including SKTD) — auto-propagate lock corrNr if no explicit transport
   try {
     await client.http.withStatefulSession(async (session) => {
       const lock = await lockObject(session, client.safety, objectUrl, 'MODIFY', getCachedFeatures()?.abapRelease);
+      lockSucceeded = true;
       const effectiveTransport = transport ?? (lock.corrNr || undefined);
       try {
         await deleteObject(session, client.safety, objectUrl, lock.lockHandle, effectiveTransport);
@@ -277,18 +280,34 @@ export async function writeActionDelete(ctx: SapWriteContext): Promise<ToolResul
       }
     });
   } catch (err) {
-    if (
-      err instanceof AdtApiError &&
-      CDS_DEPENDENCY_SENSITIVE_TYPES.has(canonicalTablType(type)) &&
-      isDeleteDependencyError(err)
-    ) {
-      const hint = await buildCdsDeleteDependencyHint(client, type, name, objectUrl);
-      if (hint) {
-        // Attach via extraHint so the LLM-facing formatter renders it after
-        // DDIC diagnostics ("what happened → diagnostics → how to fix").
-        // Mutating err.message would surface the hint before diagnostics and
-        // leak into any other consumer of the same error instance.
-        err.extraHint = hint;
+    // NW 7.50 can issue a lock handle for an absent DDLS, so LOCK alone is not
+    // proof of existence. Confirm with a metadata read after the failed DELETE
+    // before overriding generic 404 semantics. This also closes the race between
+    // the package-gate metadata read and the mutation sequence.
+    if (err instanceof AdtApiError && err.isNotFound && lockSucceeded) {
+      try {
+        await client.getObjectMetadata(objectUrl);
+        resourceKnownToExist = true;
+      } catch {
+        // No independent existence evidence — retain normal 404 classification.
+      }
+    }
+    if (err instanceof AdtApiError && lockSucceeded && resourceKnownToExist) {
+      err.resourceKnownToExist = true;
+    }
+    if (err instanceof AdtApiError && CDS_DEPENDENCY_SENSITIVE_TYPES.has(canonicalTablType(type))) {
+      const confirmedPostLockNotFound = Boolean(err.isNotFound && err.resourceKnownToExist);
+      const detectedDependency = isDeleteDependencyError(err) && (!err.isNotFound || confirmedPostLockNotFound);
+      const inferredDdlsDependency = canonicalTablType(type) === 'DDLS' && confirmedPostLockNotFound;
+      if (detectedDependency || inferredDdlsDependency) {
+        const hint = await buildCdsDeleteDependencyHint(client, type, name, objectUrl);
+        if (hint) {
+          // Attach via extraHint so the LLM-facing formatter renders it after
+          // DDIC diagnostics ("what happened → diagnostics → how to fix").
+          // Mutating err.message would surface the hint before diagnostics and
+          // leak into any other consumer of the same error instance.
+          err.extraHint = hint;
+        }
       }
     }
     throw err;

--- a/src/handlers/write/update-delete.ts
+++ b/src/handlers/write/update-delete.ts
@@ -260,7 +260,6 @@ export async function writeActionUpdate(ctx: SapWriteContext): Promise<ToolResul
 export async function writeActionDelete(ctx: SapWriteContext): Promise<ToolResult> {
   const { client, type, name, transport, objectUrl, invalidateWrittenObject, enforcePackageForExistingObject } = ctx;
   await enforcePackageForExistingObject();
-  let resourceKnownToExist = false;
   let lockSucceeded = false;
 
   // Lock, delete, unlock pattern (works for all types including SKTD) — auto-propagate lock corrNr if no explicit transport
@@ -287,17 +286,20 @@ export async function writeActionDelete(ctx: SapWriteContext): Promise<ToolResul
     if (err instanceof AdtApiError && err.isNotFound && lockSucceeded) {
       try {
         await client.getObjectMetadata(objectUrl);
-        resourceKnownToExist = true;
-      } catch {
-        // No independent existence evidence — retain normal 404 classification.
+        err.resourceExistenceAfterDelete = 'exists';
+      } catch (probeErr) {
+        // Only a 404 from the follow-up probe establishes absence. Authorization,
+        // transport, and server failures leave existence unknown and must not turn
+        // the original DELETE response into a definite "object not found" claim.
+        err.resourceExistenceAfterDelete =
+          probeErr instanceof AdtApiError && probeErr.isNotFound ? 'absent' : 'unknown';
       }
     }
-    if (err instanceof AdtApiError && lockSucceeded && resourceKnownToExist) {
-      err.resourceKnownToExist = true;
-    }
     if (err instanceof AdtApiError && CDS_DEPENDENCY_SENSITIVE_TYPES.has(canonicalTablType(type))) {
-      const confirmedPostLockNotFound = Boolean(err.isNotFound && err.resourceKnownToExist);
-      const detectedDependency = isDeleteDependencyError(err) && (!err.isNotFound || confirmedPostLockNotFound);
+      const confirmedPostLockNotFound = Boolean(err.isNotFound && err.resourceExistenceAfterDelete === 'exists');
+      const inconclusivePostLockNotFound = Boolean(err.isNotFound && err.resourceExistenceAfterDelete === 'unknown');
+      const detectedDependency =
+        isDeleteDependencyError(err) && (!err.isNotFound || confirmedPostLockNotFound || inconclusivePostLockNotFound);
       const inferredDdlsDependency = canonicalTablType(type) === 'DDLS' && confirmedPostLockNotFound;
       if (detectedDependency || inferredDdlsDependency) {
         const hint = await buildCdsDeleteDependencyHint(client, type, name, objectUrl);

--- a/tests/unit/handlers/cds-write-guard.test.ts
+++ b/tests/unit/handlers/cds-write-guard.test.ts
@@ -1,0 +1,174 @@
+/** CDS pre-write release guard tests, including issue #692 table-function coverage. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_CONFIG } from '../../../src/server/types.js';
+import { mockResponse } from '../../helpers/mock-fetch.js';
+import { featuresOff } from './handler-test-config.js';
+import { createClient, mockFetch } from './setup-undici-mock.js';
+
+const { handleToolCall } = await import('../../../src/handlers/dispatch.js');
+const { resetCachedFeatures, setCachedFeatures } = await import('../../../src/handlers/feature-cache.js');
+
+describe('CDS pre-write validation (table entity version guard)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    resetCachedFeatures();
+    mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+  });
+
+  afterEach(() => {
+    resetCachedFeatures();
+  });
+
+  it('rejects "define table entity" on SAP_BASIS 756', async () => {
+    setCachedFeatures({ ...featuresOff(), abapRelease: '756', systemType: 'onprem' });
+    const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+      action: 'create',
+      type: 'DDLS',
+      name: 'ZI_FOOTBALL',
+      source: 'define table entity ZI_Football {\n  key id : abap.int4;\n  name : abap.char(40);\n}',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('define table entity');
+    expect(result.content[0]?.text).toContain('757');
+    expect(result.content[0]?.text).toContain('756');
+  });
+
+  it('allows "define table entity" on BTP', async () => {
+    setCachedFeatures({ ...featuresOff(), abapRelease: '756', systemType: 'btp' });
+    const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+      action: 'create',
+      type: 'DDLS',
+      name: 'ZI_FOOTBALL',
+      source: 'define table entity ZI_Football {\n  key id : abap.int4;\n}',
+      description: 'Football entity',
+    });
+    if (result.isError) expect(result.content[0]?.text).not.toContain('define table entity');
+  });
+
+  it('allows "define table entity" on SAP_BASIS 757+', async () => {
+    setCachedFeatures({ ...featuresOff(), abapRelease: '757', systemType: 'onprem' });
+    const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+      action: 'create',
+      type: 'DDLS',
+      name: 'ZI_FOOTBALL',
+      source: 'define table entity ZI_Football {\n  key id : abap.int4;\n}',
+      description: 'Football entity',
+    });
+    if (result.isError) expect(result.content[0]?.text).not.toContain('define table entity');
+  });
+
+  it('proceeds without blocking when cachedFeatures is not available', async () => {
+    const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+      action: 'create',
+      type: 'DDLS',
+      name: 'ZI_FOOTBALL',
+      source: 'define table entity ZI_Football {\n  key id : abap.int4;\n}',
+      description: 'Football entity',
+    });
+    if (result.isError) expect(result.content[0]?.text).not.toContain('define table entity');
+  });
+
+  it('rejects "define table entity" in update path on old release', async () => {
+    setCachedFeatures({ ...featuresOff(), abapRelease: '750', systemType: 'onprem' });
+    const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+      action: 'update',
+      type: 'DDLS',
+      name: 'ZI_FOOTBALL',
+      source: 'define table entity ZI_Football {\n  key id : abap.int4;\n}',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('define table entity');
+    expect(result.content[0]?.text).toContain('750');
+  });
+
+  it('allows "define table function" in create and update paths on SAP_BASIS 750', async () => {
+    setCachedFeatures({ ...featuresOff(), abapRelease: '750', systemType: 'onprem' });
+    mockFetch.mockResolvedValue(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+    const config = { ...DEFAULT_CONFIG, lintBeforeWrite: false };
+    const source = `@EndUserText.label: 'Issue 692'
+define table function ZI_692_TF
+returns { CARRID: s_carr_id; }
+implemented by method ZCL_692_AMDP=>GET_DATA`;
+
+    const createResult = await handleToolCall(createClient(), config, 'SAPWrite', {
+      action: 'create',
+      type: 'DDLS',
+      name: 'ZI_692_TF',
+      package: '$TMP',
+      source,
+    });
+    expect(createResult.content[0]?.text).not.toContain('define table entity');
+    expect(
+      mockFetch.mock.calls.some(
+        ([url, options]) =>
+          new URL(String(url)).pathname === '/sap/bc/adt/ddic/ddl/sources' &&
+          (options as RequestInit | undefined)?.method === 'POST',
+      ),
+    ).toBe(true);
+
+    mockFetch.mockClear();
+    const updateResult = await handleToolCall(createClient(), config, 'SAPWrite', {
+      action: 'update',
+      type: 'DDLS',
+      name: 'ZI_692_TF',
+      source,
+    });
+    expect(updateResult.content[0]?.text).not.toContain('define table entity');
+    expect(mockFetch.mock.calls.some(([url]) => String(url).includes('_action=LOCK'))).toBe(true);
+  });
+
+  it('allows "define table function" in batch_create on SAP_BASIS 750', async () => {
+    setCachedFeatures({ ...featuresOff(), abapRelease: '750', systemType: 'onprem' });
+    mockFetch.mockResolvedValue(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+
+    const result = await handleToolCall(createClient(), { ...DEFAULT_CONFIG, lintBeforeWrite: false }, 'SAPWrite', {
+      action: 'batch_create',
+      package: '$TMP',
+      objects: [
+        {
+          type: 'DDLS',
+          name: 'ZI_692_TF',
+          source:
+            "@EndUserText.label: 'Issue 692'\ndefine table function ZI_692_TF\nreturns { CARRID: s_carr_id; }\nimplemented by method ZCL_692_AMDP=>GET_DATA",
+        },
+      ],
+    });
+
+    expect(result.content[0]?.text).not.toContain('define table entity');
+    expect(
+      mockFetch.mock.calls.some(
+        ([url, options]) =>
+          new URL(String(url)).pathname === '/sap/bc/adt/ddic/ddl/sources' &&
+          (options as RequestInit | undefined)?.method === 'POST',
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects "define table entity" in batch_create on SAP_BASIS 750 before create', async () => {
+    setCachedFeatures({ ...featuresOff(), abapRelease: '750', systemType: 'onprem' });
+    mockFetch.mockResolvedValue(mockResponse(200, '<xml>ok</xml>', { 'x-csrf-token': 'T' }));
+
+    const result = await handleToolCall(createClient(), { ...DEFAULT_CONFIG, lintBeforeWrite: false }, 'SAPWrite', {
+      action: 'batch_create',
+      package: '$TMP',
+      objects: [
+        {
+          type: 'DDLS',
+          name: 'ZI_692_ENTITY',
+          source: 'define table entity ZI_692_ENTITY { key id : abap.int4; }',
+        },
+      ],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('define table entity');
+    expect(result.content[0]?.text).toContain('750');
+    expect(
+      mockFetch.mock.calls.some(
+        ([url, options]) =>
+          new URL(String(url)).pathname === '/sap/bc/adt/ddic/ddl/sources' &&
+          (options as RequestInit | undefined)?.method === 'POST',
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/handlers/transport.test.ts
+++ b/tests/unit/handlers/transport.test.ts
@@ -1966,6 +1966,45 @@ describe('SAPTransport + SAPWrite transport behavior', () => {
       expect(text).not.toContain('Delete dependency follow-up');
     });
 
+    it('gives a non-CDS verification step when the post-delete metadata probe is inconclusive', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>PLH1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>';
+      let deleteAttempted = false;
+      let metadataReadAfterDelete = false;
+
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = (opts?.method ?? 'GET').toUpperCase();
+        const parsed = new URL(String(url));
+        if (method === 'POST' && parsed.searchParams.get('_action') === 'LOCK') {
+          return Promise.resolve(mockResponse(200, lockBody, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'DELETE') {
+          deleteAttempted = true;
+          return Promise.resolve(mockResponse(404, 'Program could not be deleted'));
+        }
+        if (deleteAttempted && method === 'GET' && parsed.pathname === '/sap/bc/adt/programs/programs/ZPROGRAM') {
+          metadataReadAfterDelete = true;
+          return Promise.resolve(mockResponse(403, 'Metadata probe forbidden'));
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'delete',
+        type: 'PROG',
+        name: 'ZPROGRAM',
+      });
+
+      expect(result.isError).toBe(true);
+      const text = result.content[0]!.text;
+      expect(metadataReadAfterDelete).toBe(true);
+      expect(text).toContain('could not determine whether the object still exists');
+      expect(text).toContain('Use SAPSearch with query "ZPROGRAM" to verify the current object state');
+      expect(text).not.toContain('Object "ZPROGRAM" (type PROG) was not found');
+      expect(text).not.toContain('Delete dependency follow-up');
+    });
+
     it('still shows the DDIC save hint for create failures (regression guard)', async () => {
       // The delete fix narrowed the save hint to save actions; make sure we
       // didn't accidentally suppress it for create/update/batch_create too.

--- a/tests/unit/handlers/transport.test.ts
+++ b/tests/unit/handlers/transport.test.ts
@@ -1897,6 +1897,46 @@ describe('SAPTransport + SAPWrite transport behavior', () => {
       expect(text).not.toContain('Delete dependency follow-up');
     });
 
+    it('preserves message-based dependency guidance when the post-delete metadata probe is inconclusive', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>DLH1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>';
+      let deleteAttempted = false;
+      let metadataReadAfterDelete = false;
+
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = (opts?.method ?? 'GET').toUpperCase();
+        const parsed = new URL(String(url));
+        if (method === 'POST' && parsed.searchParams.get('_action') === 'LOCK') {
+          return Promise.resolve(mockResponse(200, lockBody, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'DELETE') {
+          deleteAttempted = true;
+          return Promise.resolve(mockResponse(404, 'DDL source ZI_ROOT could not be deleted'));
+        }
+        if (deleteAttempted && method === 'GET' && parsed.pathname === '/sap/bc/adt/ddic/ddl/sources/ZI_ROOT') {
+          metadataReadAfterDelete = true;
+          return Promise.resolve(mockResponse(403, 'Metadata probe forbidden'));
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'delete',
+        type: 'DDLS',
+        name: 'ZI_ROOT',
+      });
+
+      expect(result.isError).toBe(true);
+      const text = result.content[0]!.text;
+      expect(metadataReadAfterDelete).toBe(true);
+      expect(text).toContain('could not be deleted');
+      expect(text).toContain('could not determine whether the object still exists');
+      expect(text).toContain('Delete dependency follow-up for DDLS ZI_ROOT');
+      expect(text).not.toContain('Object "ZI_ROOT" (type DDLS) was not found');
+      expect(text).not.toContain('confirmed this object still existed after SAP rejected DELETE');
+    });
+
     it('does not claim a non-CDS object is missing when DELETE returns 404 after lock', async () => {
       const lockBody =
         '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>PLH1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>';

--- a/tests/unit/handlers/transport.test.ts
+++ b/tests/unit/handlers/transport.test.ts
@@ -1794,6 +1794,138 @@ describe('SAPTransport + SAPWrite transport behavior', () => {
       expect(text).not.toContain('@AbapCatalog annotations');
     });
 
+    it('classifies a German DDLS 404 after lock as a delete dependency failure, not a missing object', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>DLH1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>';
+      const deleteErrorXml = `<?xml version="1.0" encoding="utf-8"?>
+<exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework">
+  <exc:localizedMessage lang="DE">Ddl Source ZI_ROOT konnte nicht gelöscht werden</exc:localizedMessage>
+</exc:exception>`;
+      const emptyWhereUsedXml = `<?xml version="1.0" encoding="utf-8"?>
+<usageReferences:usageReferenceResult xmlns:usageReferences="http://www.sap.com/adt/ris/usageReferences">
+  <usageReferences:referencedObjects/>
+</usageReferences:usageReferenceResult>`;
+
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = (opts?.method ?? 'GET').toUpperCase();
+        const urlStr = String(url);
+        if (method === 'POST' && urlStr.includes('_action=LOCK')) {
+          return Promise.resolve(mockResponse(200, lockBody, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'DELETE' && urlStr.includes('/sap/bc/adt/ddic/ddl/sources/ZI_ROOT')) {
+          return Promise.resolve(mockResponse(404, deleteErrorXml, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'POST' && urlStr.includes('/sap/bc/adt/repository/informationsystem/usageReferences?uri=')) {
+          return Promise.resolve(mockResponse(200, emptyWhereUsedXml, { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'delete',
+        type: 'DDLS',
+        name: 'ZI_ROOT',
+      });
+
+      expect(result.isError).toBe(true);
+      const text = result.content[0]!.text;
+      expect(text).toContain('konnte nicht gelöscht werden');
+      expect(text).toContain('confirmed this object still existed after SAP rejected DELETE');
+      expect(text).toContain('Delete dependency follow-up for DDLS ZI_ROOT');
+      expect(text).not.toContain('was not found');
+    });
+
+    it('retains the missing-object hint when DDLS lock itself returns 404', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = (opts?.method ?? 'GET').toUpperCase();
+        if (method === 'POST' && String(url).includes('_action=LOCK')) {
+          return Promise.resolve(mockResponse(404, 'Object not found', { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'delete',
+        type: 'DDLS',
+        name: 'ZI_MISSING',
+      });
+
+      expect(result.isError).toBe(true);
+      const text = result.content[0]!.text;
+      expect(text).toContain('Object "ZI_MISSING" (type DDLS) was not found');
+      expect(text).not.toContain('confirmed this object still existed after SAP rejected DELETE');
+      expect(text).not.toContain('Delete dependency follow-up');
+    });
+
+    it('does not treat a DDLS lock handle alone as proof of existence on SAP_BASIS 750', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>PHANTOM</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>';
+      let deleteAttempted = false;
+      let metadataReadAfterDelete = false;
+
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = (opts?.method ?? 'GET').toUpperCase();
+        const parsed = new URL(String(url));
+        if (method === 'POST' && parsed.searchParams.get('_action') === 'LOCK') {
+          return Promise.resolve(mockResponse(200, lockBody, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'DELETE') {
+          deleteAttempted = true;
+          return Promise.resolve(mockResponse(404, 'Ddl Source ZI_MISSING could not be deleted'));
+        }
+        if (deleteAttempted && method === 'GET' && parsed.pathname === '/sap/bc/adt/ddic/ddl/sources/ZI_MISSING') {
+          metadataReadAfterDelete = true;
+          return Promise.resolve(mockResponse(404, 'Object not found'));
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'delete',
+        type: 'DDLS',
+        name: 'ZI_MISSING',
+      });
+
+      expect(result.isError).toBe(true);
+      const text = result.content[0]!.text;
+      expect(metadataReadAfterDelete).toBe(true);
+      expect(text).toContain('Object "ZI_MISSING" (type DDLS) was not found');
+      expect(text).not.toContain('confirmed this object still existed after SAP rejected DELETE');
+      expect(text).not.toContain('Delete dependency follow-up');
+    });
+
+    it('does not claim a non-CDS object is missing when DELETE returns 404 after lock', async () => {
+      const lockBody =
+        '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>PLH1</LOCK_HANDLE><CORRNR></CORRNR><IS_LOCAL>X</IS_LOCAL></DATA></asx:values></asx:abap>';
+
+      mockFetch.mockReset();
+      mockFetch.mockImplementation((url: string | URL, opts?: { method?: string }) => {
+        const method = (opts?.method ?? 'GET').toUpperCase();
+        if (method === 'POST' && String(url).includes('_action=LOCK')) {
+          return Promise.resolve(mockResponse(200, lockBody, { 'x-csrf-token': 'T' }));
+        }
+        if (method === 'DELETE') {
+          return Promise.resolve(mockResponse(404, 'Program could not be deleted', { 'x-csrf-token': 'T' }));
+        }
+        return Promise.resolve(mockResponse(200, '', { 'x-csrf-token': 'T' }));
+      });
+
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
+        action: 'delete',
+        type: 'PROG',
+        name: 'ZPROGRAM',
+      });
+
+      expect(result.isError).toBe(true);
+      const text = result.content[0]!.text;
+      expect(text).toContain('confirmed this object still existed after SAP rejected DELETE');
+      expect(text).not.toContain('was not found');
+      expect(text).not.toContain('Delete dependency follow-up');
+    });
+
     it('still shows the DDIC save hint for create failures (regression guard)', async () => {
       // The delete fix narrowed the save hint to save actions; make sure we
       // didn't accidentally suppress it for create/update/batch_create too.

--- a/tests/unit/handlers/write-create-batch.test.ts
+++ b/tests/unit/handlers/write-create-batch.test.ts
@@ -3,15 +3,14 @@
  * The undici mock + AdtClient + createClient live in ./setup-undici-mock.ts — import that helper
  * and keep all other src-module imports dynamic (see its header for the ordering rules).
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { unrestrictedSafetyConfig } from '../../../src/adt/safety.js';
 import { DEFAULT_CONFIG } from '../../../src/server/types.js';
 import { mockResponse } from '../../helpers/mock-fetch.js';
-import { featuresOff } from './handler-test-config.js';
 import { AdtClient, createClient, mockFetch } from './setup-undici-mock.js';
 
 const { handleToolCall } = await import('../../../src/handlers/dispatch.js');
-const { resetCachedFeatures, setCachedFeatures } = await import('../../../src/handlers/feature-cache.js');
+const { resetCachedFeatures } = await import('../../../src/handlers/feature-cache.js');
 const { buildCreateXml } = await import('../../../src/handlers/write-helpers.js');
 
 function respondToFunctionModuleMetadataLifecycle(
@@ -2862,93 +2861,6 @@ lv = CONV string( 1 ).`,
       expect(text).toContain('uppercase');
       expect(text).toContain('Z_HELLO_WORLD');
       expect(mockFetch).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('CDS pre-write validation (table entity version guard)', () => {
-    afterEach(() => {
-      resetCachedFeatures();
-    });
-
-    it('rejects "define table entity" on SAP_BASIS 758 (< 757 threshold actually means < 757)', async () => {
-      // 758 >= 757, so this should be allowed. Let's test with 756 instead.
-    });
-
-    it('rejects "define table entity" on SAP_BASIS 756', async () => {
-      setCachedFeatures({ ...featuresOff(), abapRelease: '756', systemType: 'onprem' });
-      // Mock: first call = CSRF, subsequent calls = whatever
-      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
-        action: 'create',
-        type: 'DDLS',
-        name: 'ZI_FOOTBALL',
-        source: 'define table entity ZI_Football {\n  key id : abap.int4;\n  name : abap.char(40);\n}',
-      });
-      expect(result.isError).toBe(true);
-      expect(result.content[0]?.text).toContain('define table entity');
-      expect(result.content[0]?.text).toContain('757');
-      expect(result.content[0]?.text).toContain('756');
-    });
-
-    it('allows "define table entity" on BTP', async () => {
-      setCachedFeatures({ ...featuresOff(), abapRelease: '756', systemType: 'btp' });
-      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
-        action: 'create',
-        type: 'DDLS',
-        name: 'ZI_FOOTBALL',
-        source: 'define table entity ZI_Football {\n  key id : abap.int4;\n}',
-        description: 'Football entity',
-      });
-      // Should proceed past the guard (may fail later on mock, but not with version error)
-      if (result.isError) {
-        expect(result.content[0]?.text).not.toContain('define table entity');
-      }
-    });
-
-    it('allows "define table entity" on SAP_BASIS 757+', async () => {
-      setCachedFeatures({ ...featuresOff(), abapRelease: '757', systemType: 'onprem' });
-      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
-        action: 'create',
-        type: 'DDLS',
-        name: 'ZI_FOOTBALL',
-        source: 'define table entity ZI_Football {\n  key id : abap.int4;\n}',
-        description: 'Football entity',
-      });
-      if (result.isError) {
-        expect(result.content[0]?.text).not.toContain('define table entity');
-      }
-    });
-
-    it('proceeds without blocking when cachedFeatures is not available', async () => {
-      resetCachedFeatures();
-      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
-        action: 'create',
-        type: 'DDLS',
-        name: 'ZI_FOOTBALL',
-        source: 'define table entity ZI_Football {\n  key id : abap.int4;\n}',
-        description: 'Football entity',
-      });
-      // Should not fail with the version guard error
-      if (result.isError) {
-        expect(result.content[0]?.text).not.toContain('define table entity');
-      }
-    });
-
-    it('rejects "define table entity" in update path on old release', async () => {
-      setCachedFeatures({ ...featuresOff(), abapRelease: '750', systemType: 'onprem' });
-      mockFetch.mockResolvedValue(mockResponse(200, '', { 'x-csrf-token': 'T' }));
-      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPWrite', {
-        action: 'update',
-        type: 'DDLS',
-        name: 'ZI_FOOTBALL',
-        source: 'define table entity ZI_Football {\n  key id : abap.int4;\n}',
-      });
-      expect(result.isError).toBe(true);
-      expect(result.content[0]?.text).toContain('define table entity');
-      expect(result.content[0]?.text).toContain('750');
     });
   });
 });


### PR DESCRIPTION
## What

- Restore the pre-7.57 CDS guard to reject only `DEFINE TABLE ENTITY`, while allowing supported `DEFINE TABLE FUNCTION` sources through normal single-create, update, and batch-create paths.
- Make batch DDLS creation use the same release guard as single-object writes so it cannot bypass the compatibility check.
- Correct delete diagnostics when older SAP systems return HTTP 404 for a DDLS dependency failure by classifying the follow-up metadata probe as `exists`, `absent`, or `unknown`.
- Add focused regression coverage and document the issue investigation, reviewed plan, live evidence, and rejected alternatives.

## Why

Issue #692 combined two independent defects:

1. Commit `c06d8847` accidentally widened an entity-only compatibility regex to include table functions, although `DEFINE TABLE FUNCTION` is supported on SAP_BASIS 750.
2. NW 7.50 can report an active DDLS consumer as a localized German HTTP 404 during DELETE. The prior English phrase matcher missed it, and the dispatcher then incorrectly said the target object was absent.

Live investigation disproved the suspected AMDP/runtime dependency: isolated table functions delete cleanly on both SAP_BASIS 750 and 758. An active DDLS consumer reproduced the 750 failure. A further 750 edge case showed that an old stack can return a phantom lock handle for an absent object, so lock success alone is insufficient evidence.

The implementation probes metadata after a post-lock DELETE 404. A successful probe confirms existence, a probe 404 confirms absence, and any other probe failure remains explicitly inconclusive. The inconclusive path preserves structured\/message-based dependency remediation without claiming that the object is missing and directs the caller to verify current state with SAPSearch before retrying.

## Impact

- Valid CDS table functions work through the standard guarded write paths on 7.50.
- CDS table entities remain blocked below 7.57, including batch creation.
- Confirmed overloaded DELETE 404 responses preserve SAP's localized message and receive dependency guidance instead of a false object-not-found hint.
- Genuine missing objects retain normal not-found behavior.
- Inconclusive follow-up probes no longer discard existing dependency guidance or fabricate an absence result, and now include an explicit SAPSearch verification step.
- No MCP schema, authorization, or public API changes. The additional metadata request occurs only on the failed post-lock DELETE-404 path.

## Validation

- `npm test` — 171 files, 4,993 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run check:sizes`
- `npm run build`
- Focused DDLS/write suite — 228 tests passed
- Post-commit guard/delete suite — 96 tests passed
- Live SAP NetWeaver 7.50: single create/update/activate/read/delete, batch guard, dependent-delete German 404 classification, and final cleanup verified
- Live S/4HANA 2023 / SAP_BASIS 758: single create/update/activate/read/delete and final cleanup verified

Fixes #692