### PR TITLE
chore(deps): drop stale ws override from BTP AppRouter

### DIFF
--- a/btp/approuter/package-lock.json
+++ b/btp/approuter/package-lock.json
@@ -87,6 +87,27 @@
         "node": "^22.0.0 || ^24.0.0"
       }
     },
+    "node_modules/@sap/approuter/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sap/audit-logging": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@sap/audit-logging/-/audit-logging-7.0.0.tgz",
@@ -2060,26 +2081,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/wtfnode": {
       "version": "0.10.1",

--- a/btp/approuter/package.json
+++ b/btp/approuter/package.json
@@ -13,7 +13,6 @@
   },
   "overrides": {
     "axios": "1.18.0",
-    "body-parser": "2.3.0",
-    "ws": "^8.17.1"
+    "body-parser": "2.3.0"
   }
 }

--- a/tests/unit/server/approuter-config.test.ts
+++ b/tests/unit/server/approuter-config.test.ts
@@ -15,6 +15,9 @@ describe('BTP UI AppRouter config', () => {
     expect(packageJson.overrides).toMatchObject({ axios: '1.18.0', 'body-parser': '2.3.0' });
     expect(packageLock.packages['node_modules/axios']?.version).toBe('1.18.0');
     expect(packageLock.packages['node_modules/body-parser']?.version).toBe('2.3.0');
+    // AppRouter pins its own patched ws (>= 7.5.10); never override it to a different major.
+    expect(packageJson.overrides.ws).toBeUndefined();
+    expect(packageLock.packages['node_modules/@sap/approuter/node_modules/ws']?.version).toBe('7.5.11');
   });
 
   it('requires admin scope for all UI routes', async () => {


### PR DESCRIPTION
Follow-up to #701 (`@sap/approuter` 22.0.3 → 23.0.0).

`@sap/approuter` 23.0.0 declares `ws@7.5.11`, which already contains the CVE-2024-37890 fix (landed in 7.5.10). The `"ws": "^8.17.1"` override added in #625 therefore no longer buys anything — it just forces a **ws major** (8.21.0 resolved) onto AppRouter's WebSocket proxy, which is written against the ws 7 API.

**Change:** remove the `ws` override. It now resolves to AppRouter's own `7.5.11` (nested under `node_modules/@sap/approuter/node_modules/ws`).

The `axios: 1.18.0` / `body-parser: 2.3.0` pins stay. 23.0.0 ships exactly those versions natively, so they are currently no-ops, but they keep the guarantee if AppRouter ever regresses.

**Verified locally:**
- `npm audit --prefix btp/approuter --audit-level=high --omit=optional` → 0 vulnerabilities
- `npm run typecheck` → clean
- `tests/unit/server/approuter-config.test.ts` → 3/3, extended with an assertion that no `ws` override is re-introduced and that the resolved version stays 7.5.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)