### PR TITLE
fix: forward user=* when listing transports across owners

### DIFF
--- a/src/adt/transport.ts
+++ b/src/adt/transport.ts
@@ -136,12 +136,14 @@ export async function listTransports(
 ): Promise<TransportRequest[]> {
   checkTransport(safety, '', 'ListTransports', false);
 
-  // Build query params following sapcli's pattern:
-  //   user={user}&target=true&requestType=KWT&requestStatus=DR
+  // Build query params.
   // requestType=KWT covers Workbench, Customizing, Transport of Copies.
   // requestStatus is sent server-side; we also filter client-side as a fallback.
+  // user=* is sent as-is; URLSearchParams encodes it to user=%2A which SAP interprets
+  // as "all users" (system-wide organizer view). Omitting the param returns only the
+  // authenticated user's requests — which is NOT the same as all users.
   const params = new URLSearchParams();
-  if (user && user !== '*') {
+  if (user) {
     params.set('user', user);
   }
   params.set('target', 'true');

--- a/src/adt/transport.ts
+++ b/src/adt/transport.ts
@@ -139,9 +139,8 @@ export async function listTransports(
   // Build query params.
   // requestType=KWT covers Workbench, Customizing, Transport of Copies.
   // requestStatus is sent server-side; we also filter client-side as a fallback.
-  // user=* is sent as-is; URLSearchParams encodes it to user=%2A which SAP interprets
-  // as "all users" (system-wide organizer view). Omitting the param returns only the
-  // authenticated user's requests — which is NOT the same as all users.
+  // Keep user=* in the request: SAP treats '*' as a wildcard owner pattern.
+  // Omitting user defaults it to sy-uname on SAP_BASIS 7.50 and 7.58.
   const params = new URLSearchParams();
   if (user) {
     params.set('user', user);

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1577,7 +1577,11 @@ export function getToolDefinitions(
             description:
               'Transport layer for create (optional, advanced). Sent as the ?transportLayer= query param to override which consolidation route — and therefore which target — SAP resolves. OMIT IT by default: SAP resolves the target from the package automatically, which is correct for almost all cases. Never invent a value — if you need a specific layer, obtain it from action="layers" or from the user. Only effective when that layer has a classic STMS consolidation route; otherwise the request is local regardless.',
           },
-          user: { type: 'string', description: 'SAP user for list (default: current user; "*" means all users).' },
+          user: {
+            type: 'string',
+            description:
+              'SAP user for list (default: current user; "*" queries all users system-wide — results are still capped by maxResults and status).',
+          },
           status: {
             type: 'string',
             description: 'Transport status filter (for list). D=modifiable (default), R=released, "*"=all statuses.',

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1577,11 +1577,7 @@ export function getToolDefinitions(
             description:
               'Transport layer for create (optional, advanced). Sent as the ?transportLayer= query param to override which consolidation route — and therefore which target — SAP resolves. OMIT IT by default: SAP resolves the target from the package automatically, which is correct for almost all cases. Never invent a value — if you need a specific layer, obtain it from action="layers" or from the user. Only effective when that layer has a classic STMS consolidation route; otherwise the request is local regardless.',
           },
-          user: {
-            type: 'string',
-            description:
-              'SAP user for list (default: current user; "*" queries all users system-wide — results are still capped by maxResults and status).',
-          },
+          user: { type: 'string', description: 'List user (default: current SAP user; "*" means all visible owners).' },
           status: {
             type: 'string',
             description: 'Transport status filter (for list). D=modifiable (default), R=released, "*"=all statuses.',

--- a/src/handlers/transport.ts
+++ b/src/handlers/transport.ts
@@ -211,9 +211,8 @@ export async function handleSAPTransport(
       // per-request object lists, not the count — capping at 50 of 55 saved only 2%, while dropping
       // object lists saves 4.7x. So `list` summarises by default (the list→get workflow this tool
       // already documents); pass summary=false for the old full-object payload. maxResults stays as
-      // a backstop for a large backlog.
-      // Sort newest first: transport IDs embed a numeric sequence (e.g. DEVK900123) — higher = newer.
-      transports.sort((a, b) => b.id.localeCompare(a.id));
+      // a backstop for a large backlog. It bounds the returned tool payload after the full SAP
+      // response has been fetched; /cts/transportrequests has no server-side row-limit parameter.
       const limit = clampSearchResults(args.maxResults as number | undefined, DEFAULT_TRANSPORT_RESULTS);
       const page = transports.slice(0, limit);
       const truncated = transports.length > limit;
@@ -226,7 +225,7 @@ export async function handleSAPTransport(
           ...(truncated
             ? {
                 hint:
-                  `Showing ${page.length} of ${transports.length} transports${user === '*' ? ' (all users)' : ''}. ` +
+                  `Showing ${page.length} of ${transports.length} transports${user === '*' ? ' (all visible users)' : ''}. ` +
                   `Narrow with ${user === '*' ? 'user=<name>, ' : ''}status, or raise maxResults (max 1000).`,
               }
             : {}),

--- a/src/handlers/transport.ts
+++ b/src/handlers/transport.ts
@@ -224,8 +224,8 @@ export async function handleSAPTransport(
           ...(truncated
             ? {
                 hint:
-                  `Showing ${page.length} of ${transports.length} transports. Narrow with user/status, ` +
-                  `or raise maxResults (max 1000).`,
+                  `Showing ${page.length} of ${transports.length} transports${user === '*' ? ' (all users)' : ''}. ` +
+                  `Narrow with ${user === '*' ? 'user=<name>, ' : ''}status, or raise maxResults (max 1000).`,
               }
             : {}),
           transports: payload,

--- a/src/handlers/transport.ts
+++ b/src/handlers/transport.ts
@@ -212,6 +212,8 @@ export async function handleSAPTransport(
       // object lists saves 4.7x. So `list` summarises by default (the list→get workflow this tool
       // already documents); pass summary=false for the old full-object payload. maxResults stays as
       // a backstop for a large backlog.
+      // Sort newest first: transport IDs embed a numeric sequence (e.g. DEVK900123) — higher = newer.
+      transports.sort((a, b) => b.id.localeCompare(a.id));
       const limit = clampSearchResults(args.maxResults as number | undefined, DEFAULT_TRANSPORT_RESULTS);
       const page = transports.slice(0, limit);
       const truncated = transports.length > limit;

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -1591,7 +1591,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" means all users)."
+          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -1591,7 +1591,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
+          "description": "List user (default: current SAP user; \"*\" means all visible owners)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -894,7 +894,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" means all users)."
+          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -894,7 +894,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
+          "description": "List user (default: current SAP user; \"*\" means all visible owners)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -1706,7 +1706,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
+          "description": "List user (default: current SAP user; \"*\" means all visible owners)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -1706,7 +1706,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" means all users)."
+          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -1706,7 +1706,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
+          "description": "List user (default: current SAP user; \"*\" means all visible owners)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -1706,7 +1706,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" means all users)."
+          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -1706,7 +1706,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
+          "description": "List user (default: current SAP user; \"*\" means all visible owners)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -1706,7 +1706,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" means all users)."
+          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -918,7 +918,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
+          "description": "List user (default: current SAP user; \"*\" means all visible owners)."
         },
         "status": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -918,7 +918,7 @@
         },
         "user": {
           "type": "string",
-          "description": "SAP user for list (default: current user; \"*\" means all users)."
+          "description": "SAP user for list (default: current user; \"*\" queries all users system-wide — results are still capped by maxResults and status)."
         },
         "status": {
           "type": "string",

--- a/tests/unit/adt/transport.test.ts
+++ b/tests/unit/adt/transport.test.ts
@@ -84,13 +84,11 @@ describe('Transport Management', () => {
       expect(url).toContain('user=TESTUSER');
     });
 
-    it('sends user=* for system-wide query', async () => {
+    it("sends user=* for SAP's wildcard owner query", async () => {
       const http = mockHttp('<tm:root xmlns:tm="http://www.sap.com/cts/transports"/>');
       await listTransports(http, enabledSafety, '*');
       const url = (http.get as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
-      // user=* must be sent so SAP returns all users' transports.
-      // Omitting the param returns only the authenticated user's requests.
-      expect(url).toContain('user=*');
+      expect(new URL(url, 'https://sap.example').searchParams.get('user')).toBe('*');
     });
 
     it('sends requestType=KWT and target=true (sapcli pattern)', async () => {

--- a/tests/unit/adt/transport.test.ts
+++ b/tests/unit/adt/transport.test.ts
@@ -84,11 +84,13 @@ describe('Transport Management', () => {
       expect(url).toContain('user=TESTUSER');
     });
 
-    it('does not add user param for wildcard', async () => {
+    it('sends user=* for system-wide query', async () => {
       const http = mockHttp('<tm:root xmlns:tm="http://www.sap.com/cts/transports"/>');
       await listTransports(http, enabledSafety, '*');
       const url = (http.get as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
-      expect(url).not.toContain('user=');
+      // user=* must be sent so SAP returns all users' transports.
+      // Omitting the param returns only the authenticated user's requests.
+      expect(url).toContain('user=*');
     });
 
     it('sends requestType=KWT and target=true (sapcli pattern)', async () => {

--- a/tests/unit/handlers/transport.test.ts
+++ b/tests/unit/handlers/transport.test.ts
@@ -679,7 +679,7 @@ describe('SAPTransport + SAPWrite transport behavior', () => {
       expect(fetchUrl?.[0]).toContain('requestType=KWT');
     });
 
-    it('list with user=* sends user=* to SAP for system-wide query', async () => {
+    it("list with user=* forwards SAP's wildcard owner query", async () => {
       const xml = `<tm:root xmlns:tm="http://www.sap.com/cts/transports">
         <tm:request tm:number="DEVK900001" tm:owner="OTHER" tm:desc="Other user transport" tm:status="D" tm:type="K"/>
       </tm:root>`;
@@ -692,8 +692,8 @@ describe('SAPTransport + SAPWrite transport behavior', () => {
       const fetchUrl = mockFetch.mock.calls.find(
         (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('transportrequests'),
       );
-      // user=* must be forwarded to SAP — omitting it would return only the current user's requests
-      expect(fetchUrl?.[0]).toContain('user=*');
+      const requestUrl = new URL(String(fetchUrl?.[0]), 'https://sap.example');
+      expect(requestUrl.searchParams.get('user')).toBe('*');
       const parsed = JSON.parse(result.content[0]?.text ?? '{}');
       expect(parsed.total).toBe(1);
     });
@@ -717,7 +717,7 @@ describe('SAPTransport + SAPWrite transport behavior', () => {
       expect(parsed.truncated).toBe(true);
       // Hint should guide the LLM to narrow by user when querying all users
       expect(parsed.hint).toContain('user=');
-      expect(parsed.hint).toContain('(all users)');
+      expect(parsed.hint).toContain('(all visible users)');
     });
 
     it('list with status=* returns all statuses', async () => {

--- a/tests/unit/handlers/transport.test.ts
+++ b/tests/unit/handlers/transport.test.ts
@@ -736,6 +736,23 @@ describe('SAPTransport + SAPWrite transport behavior', () => {
       expect(parsed.transports).toHaveLength(2);
     });
 
+    it('list returns transports newest-first (sorted by id descending)', async () => {
+      const xml = `<tm:root xmlns:tm="http://www.sap.com/cts/transports">
+        <tm:request tm:number="DEVK900001" tm:owner="admin" tm:desc="Oldest" tm:status="D" tm:type="K"/>
+        <tm:request tm:number="DEVK900005" tm:owner="admin" tm:desc="Newest" tm:status="D" tm:type="K"/>
+        <tm:request tm:number="DEVK900003" tm:owner="admin" tm:desc="Middle" tm:status="D" tm:type="K"/>
+      </tm:root>`;
+      mockFetch.mockResolvedValue(mockResponse(200, xml, { 'x-csrf-token': 'T' }));
+      const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
+        action: 'list',
+      });
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]!.text).transports;
+      expect(parsed[0].id).toBe('DEVK900005'); // newest first
+      expect(parsed[1].id).toBe('DEVK900003');
+      expect(parsed[2].id).toBe('DEVK900001'); // oldest last
+    });
+
     const LIST_WITH_OBJECTS_XML = `<tm:root xmlns:tm="http://www.sap.com/cts/transports">
         <tm:request tm:number="DEVK900001" tm:owner="admin" tm:desc="Feature X" tm:status="D" tm:type="K">
           <tm:task tm:number="DEVK900002" tm:owner="admin" tm:desc="Task" tm:status="D">

--- a/tests/unit/handlers/transport.test.ts
+++ b/tests/unit/handlers/transport.test.ts
@@ -736,23 +736,6 @@ describe('SAPTransport + SAPWrite transport behavior', () => {
       expect(parsed.transports).toHaveLength(2);
     });
 
-    it('list returns transports newest-first (sorted by id descending)', async () => {
-      const xml = `<tm:root xmlns:tm="http://www.sap.com/cts/transports">
-        <tm:request tm:number="DEVK900001" tm:owner="admin" tm:desc="Oldest" tm:status="D" tm:type="K"/>
-        <tm:request tm:number="DEVK900005" tm:owner="admin" tm:desc="Newest" tm:status="D" tm:type="K"/>
-        <tm:request tm:number="DEVK900003" tm:owner="admin" tm:desc="Middle" tm:status="D" tm:type="K"/>
-      </tm:root>`;
-      mockFetch.mockResolvedValue(mockResponse(200, xml, { 'x-csrf-token': 'T' }));
-      const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
-        action: 'list',
-      });
-      expect(result.isError).toBeUndefined();
-      const parsed = JSON.parse(result.content[0]!.text).transports;
-      expect(parsed[0].id).toBe('DEVK900005'); // newest first
-      expect(parsed[1].id).toBe('DEVK900003');
-      expect(parsed[2].id).toBe('DEVK900001'); // oldest last
-    });
-
     const LIST_WITH_OBJECTS_XML = `<tm:root xmlns:tm="http://www.sap.com/cts/transports">
         <tm:request tm:number="DEVK900001" tm:owner="admin" tm:desc="Feature X" tm:status="D" tm:type="K">
           <tm:task tm:number="DEVK900002" tm:owner="admin" tm:desc="Task" tm:status="D">

--- a/tests/unit/handlers/transport.test.ts
+++ b/tests/unit/handlers/transport.test.ts
@@ -679,6 +679,47 @@ describe('SAPTransport + SAPWrite transport behavior', () => {
       expect(fetchUrl?.[0]).toContain('requestType=KWT');
     });
 
+    it('list with user=* sends user=* to SAP for system-wide query', async () => {
+      const xml = `<tm:root xmlns:tm="http://www.sap.com/cts/transports">
+        <tm:request tm:number="DEVK900001" tm:owner="OTHER" tm:desc="Other user transport" tm:status="D" tm:type="K"/>
+      </tm:root>`;
+      mockFetch.mockResolvedValue(mockResponse(200, xml, { 'x-csrf-token': 'T' }));
+      const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
+        action: 'list',
+        user: '*',
+      });
+      expect(result.isError).toBeUndefined();
+      const fetchUrl = mockFetch.mock.calls.find(
+        (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('transportrequests'),
+      );
+      // user=* must be forwarded to SAP — omitting it would return only the current user's requests
+      expect(fetchUrl?.[0]).toContain('user=*');
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}');
+      expect(parsed.total).toBe(1);
+    });
+
+    it('list with user=* and truncated results includes user=<name> hint', async () => {
+      const rows = Array.from(
+        { length: 60 },
+        (_, i) =>
+          `<tm:request tm:number="DEVK9${String(i).padStart(5, '0')}" tm:owner="USER${i}" tm:desc="R${i}" tm:status="D" tm:type="K"/>`,
+      ).join('');
+      mockFetch.mockResolvedValue(
+        mockResponse(200, `<tm:root xmlns:tm="http://www.sap.com/cts/transports">${rows}</tm:root>`, {
+          'x-csrf-token': 'T',
+        }),
+      );
+      const result = await handleToolCall(createTransportClient(), DEFAULT_CONFIG, 'SAPTransport', {
+        action: 'list',
+        user: '*',
+      });
+      const parsed = JSON.parse(result.content[0]!.text);
+      expect(parsed.truncated).toBe(true);
+      // Hint should guide the LLM to narrow by user when querying all users
+      expect(parsed.hint).toContain('user=');
+      expect(parsed.hint).toContain('(all users)');
+    });
+
     it('list with status=* returns all statuses', async () => {
       const xml = `<tm:root xmlns:tm="http://www.sap.com/cts/transports">
         <tm:request tm:number="DEVK900001" tm:owner="admin" tm:desc="Modifiable" tm:status="D" tm:type="K"/>


### PR DESCRIPTION
## Problem

`SAPTransport(action="list", user="*")` documented an all-owner query, but ARC-1 removed the `user` parameter before calling ADT. SAP therefore applied its default owner filter and returned the authenticated SAP user's view.

```ts
// Old behavior: user="*" was omitted
if (user && user !== '*') {
  params.set('user', user);
}
```

## Root cause

The special case is on the client side, not in SAP:

- On both SAP_BASIS 7.50 and 7.58, the CTS ADT controller reads the optional `user` query parameter and defaults an omitted/initial value to `sy-uname`.
- The downstream CTS request selection treats an owner containing `*` or `+` as ABAP range option `CP`; otherwise it uses `EQ`.
- Independent ADT clients also pass the selected user value through instead of removing `*`.

So omission and `user=*` are deliberately different requests.

## Fix

- Forward every non-empty `user` value, including `*`.
- Keep SAP's returned order; transport numbers are not last-change timestamps, so the unrelated "newest-first" ID sort was removed.
- Clarify that `*` means all owners visible to the authenticated SAP identity.
- Add low-level and handler-level regression tests that parse the outgoing URL and assert `searchParams.get("user") === "*"`.
- Improve the truncation hint for wildcard queries.

```ts
if (user) {
  params.set('user', user);
}
```

## Live verification

The built client from this PR was tested with the exact `user=*` value:

| System | SAP_BASIS | Default/omitted user | `user=*` | Result |
|---|---:|---:|---:|---|
| A4H | 7.58 | 66 | 1015 | wildcard is a superset |
| NPL | 7.50 | 6 | 7 | wildcard is a superset |

The currently deployed pre-fix server also reproduced the bug: exact `user="*"` returned the same counts as omission, while the equivalent pattern `user="**"` returned the larger sets.

## Validation

- Focused transport regression suite: 238 tests passed
- Full unit suite: 5,309 tests passed
- Typecheck, lint, action-policy validation, file/schema budgets: passed
- Root and AppRouter npm audits: no vulnerabilities
- Build, npx package smoke, and MTA validation: passed
- `git diff --check`: passed

## Payload note

`status="D"` is sent to SAP and also enforced client-side. `summary=true` and `maxResults` reduce the returned MCP payload, but only after ARC-1 has fetched and parsed SAP's complete matching CTS response; they are not server-side row limits. On systems with large transport backlogs, callers should prefer a specific owner when possible.
