### PR TITLE
docs: annotate the 1.1.1 release notes

### DIFF
--- a/docs_page/release-notes.md
+++ b/docs_page/release-notes.md
@@ -26,6 +26,29 @@ until they are promoted.
     line — nobody runs them today, and the one part that still matters when jumping from an ancient version
     is the **v0.7.0 authorization break**, which is spelled out in full at the bottom of this page.
 
+## 1.1.1 — you get the scope you asked for (2026-08-20)
+
+Three correctness fixes with one theme: ARC-1 was quietly running a *different* query than the caller
+asked for, and the result looked clean either way. ATC ran the Code Inspector variant literally named
+`DEFAULT` instead of the system's configured one, a transport listing for all owners silently narrowed
+to the calling user, and an ATC run that SAP never declared complete spent the caller's entire timeout
+before saying so. Nothing here needs configuration; the visible change is that findings and transport
+lists can differ from 1.1.0 because the scope is now the one you requested.
+
+| Change | What it means | Action |
+|---|---|---|
+| Bind the ATC check variant `SAPDiagnose` claims to run ([#708](https://github.com/arc-mcp/arc-1/pull/708)) | `SAPDiagnose(action="atc")` without `variant` sent no `checkVariant` at all, and SAP does **not** substitute the configured system variant in that case — it runs the Code Inspector variant literally named `DEFAULT`. ARC-1 now resolves `systemCheckVariant` from `/atc/customizing` and sends it explicitly, which is what SAP's own language server does. A `variant` name that does not exist is rejected instead of being silently swapped for `DEFAULT` behind an HTTP 200. `resultFormat="structured"` reports the bound variant and how it was chosen. **Findings can differ from 1.1.0**: on a validation system the bare run gained a priority-1 *"Objects of type PROG are not allowed in ABAP Cloud Development"* and lost two `DEFAULT`-only *Critical Statements* hits. Systems whose configured variant already is `DEFAULT` see no change. | `none` — but re-baseline any stored ATC finding counts |
+| Stop ATC polling once the worklist settles ([#710](https://github.com/arc-mcp/arc-1/pull/710)) | `runAtcCheck` waited for a nine-part completeness verdict, and some worklists never satisfy every part even after they stop changing — so the run consumed the whole budget before returning. Measured on NW 7.50: wall time tracked `--timeout` exactly (45 s → 46 s, 240 s → 240 s); it is now ~13 s at either budget. The verdict itself is unchanged — a settled-but-incomplete run still reports `complete: false`, still errors on the default payload, and `arc1-cli atc` still exits `3`. The default (non-`structured`) ATC payload now also carries `variant` and `variantSource`, and a variant used without validation reports `variantSource: "requestedUnverified"`. | `none` |
+| Forward `user=*` when listing transports across owners ([#706](https://github.com/arc-mcp/arc-1/pull/706)) | `SAPTransport(action="list", user="*")` documented an all-owner query but dropped the parameter before calling ADT, so SAP applied its default owner filter and returned only the calling user's requests. Omission and `user=*` are deliberately different requests on both 7.50 and 7.58. **Result sets grow**: on a validation system the same call went from 1 request to 400+. SAP's own ordering is kept — transport numbers are not change timestamps, so the previous "newest-first" ID sort was removed. | `none` — expect larger lists; narrow with `user=<name>` |
+
+**Tool-surface changes**
+
+- `SAPDiagnose` — the `atc` action description now states that omitting `variant` binds the system default and that an unknown variant is an error; the `variant` parameter description is unchanged.
+- `SAPTransport` — the `user` parameter description changed to "List user (default: current SAP user; `\*` means all visible owners)".
+- `SAPDiagnose action="atc"` results gained `variantSource` (`requested` | `requestedUnverified` | `systemDefault` | `sapFallback`), and the default payload gained `variant` + `variantSource` alongside `findings`.
+
+Background for the ATC changes: [check-variant dossier](https://github.com/arc-mcp/arc-1/blob/main/docs/research/2026-08-19-atc-default-check-variant.md) and [completeness-polling dossier](https://github.com/arc-mcp/arc-1/blob/main/docs/research/2026-08-20-atc-completeness-polling.md).
+
 ## 1.1.0 — a truthful CLI for SAP CI workflows (2026-08-18)
 
 The shipped Node CLI becomes a supported automation path rather than a thin, inconsistent wrapper around


### PR DESCRIPTION
Annotates [`docs_page/release-notes.md`](https://github.com/arc-mcp/arc-1/blob/docs/annotate-1-1-1-release-notes/docs_page/release-notes.md) for **1.1.1**, using the open release-please PR #707 as the source.

Per `AGENTS.md`: written **while the release PR is open** — `CHANGELOG.md` only gains the entry at merge and the guard asserts CHANGELOG ⊆ notes, so annotating first keeps `main` green. `docs:` commit, so it does not itself trigger a release and 1.1.1 stays 1.1.1.

## The three fixes in 1.1.1

One theme: ARC-1 was quietly running a *different* scope than the caller asked for, and the result looked clean either way.

| PR | What was wrong |
|---|---|
| [#708](https://github.com/arc-mcp/arc-1/pull/708) | `SAPDiagnose(action="atc")` without `variant` sent no `checkVariant`; SAP runs the CI variant literally named `DEFAULT`, not the configured one |
| [#706](https://github.com/arc-mcp/arc-1/pull/706) | `SAPTransport(action="list", user="*")` dropped the parameter, so SAP returned only the calling user's requests |
| [#710](https://github.com/arc-mcp/arc-1/pull/710) | An ATC run SAP never declared complete consumed the entire `--timeout` before returning the same verdict |

Both user-visible **result-set changes** are called out with the numbers the PRs measured live — the ATC finding delta (gains a priority-1 cloud-readiness finding, loses two `DEFAULT`-only hits) and the transport listing going from 1 to 400+ requests. `Action` is `none` for all three; the notes say plainly to re-baseline stored ATC counts and to expect larger transport lists.

A **Tool-surface changes** block records what an MCP client or LLM sees: the `SAPDiagnose` `atc` action description, the `SAPTransport` `user` parameter description (verified against the `tests/fixtures/tool-definitions/*.json` diff, not the PR titles), and the new `variantSource` field plus the two fields added to the default ATC payload.

## Verification

- `npx vitest run tests/unit/server/release-notes.test.ts` — 4/4 (the coverage guard now counts 1.1.1 as annotated)
- `npm test` — 5,328/5,328
- `npm run lint`, `npm run docs:build` (strict) — clean, every relative link resolves

Every claim traces to a diff that was read, per the `/release-notes` method — including #706, which I had no prior context on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
