### PR TITLE
fix(read): auto-split nested BSP paths passed only in name

### DIFF
--- a/src/handlers/read.ts
+++ b/src/handlers/read.ts
@@ -744,21 +744,33 @@ export async function handleSAPRead(
             'for the reason (often a missing S_ADT_RES authorization), or set SAP_FEATURE_UI5=on to force it on.',
         );
       }
-      const include = args.include as string | undefined;
+      let include = args.include as string | undefined;
       if (!name) {
         // List all BSP apps (optional search via query param not used here since name is empty)
         const apps = await client.listBspApps();
         return textResult(toolJson(apps));
       }
+      // A caller sometimes puts the whole nested path in `name` instead of splitting it
+      // across name+include (e.g. name="ZAPP/controller" instead of name="ZAPP"
+      // include="controller"). getBspAppStructure/getBspFileContent uppercase their
+      // appName argument in full, so leaving this unsplit would uppercase the sub-path
+      // too and 404 against the (case-sensitive) filestore. Auto-split on the first '/'
+      // so both call shapes work the same.
+      let bspAppName = name;
+      if (!include && bspAppName.includes('/')) {
+        const slashIdx = bspAppName.indexOf('/');
+        include = bspAppName.slice(slashIdx + 1);
+        bspAppName = bspAppName.slice(0, slashIdx);
+      }
       if (!include) {
         // Browse root structure of the app
-        return textResult(toolJson(await client.getBspAppStructure(name)));
+        return textResult(toolJson(await client.getBspAppStructure(bspAppName)));
       }
       // If include contains a dot, treat as file read; otherwise browse subfolder
       if (include.includes('.')) {
-        return textResult(await client.getBspFileContent(name, include));
+        return textResult(await client.getBspFileContent(bspAppName, include));
       }
-      return textResult(toolJson(await client.getBspAppStructure(name, `/${include}`)));
+      return textResult(toolJson(await client.getBspAppStructure(bspAppName, `/${include}`)));
     }
     case 'BSP_DEPLOY': {
       const ui5repoFeature = getCachedFeatures()?.ui5repo;

--- a/tests/unit/handlers/read.test.ts
+++ b/tests/unit/handlers/read.test.ts
@@ -885,6 +885,53 @@ describe('SAPRead handler', () => {
       expect(result.content[0]!.text).toContain('sap.ui.define');
     });
 
+    it('auto-splits a subfolder path passed only in name (no include)', async () => {
+      // Regression test: passing "APP/sub" as name alone must not uppercase the
+      // sub-path along with the app name (it did before this fix — the whole
+      // string got treated as appName and .toUpperCase()'d, 404ing against the
+      // case-sensitive filestore).
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          200,
+          `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>ZAPP_BOOKING/webapp/i18n/i18n.properties</title>
+    <category term="file"/>
+    <content afr:etag="def456" xmlns:afr="http://www.sap.com/adt/filestore"/>
+  </entry>
+</feed>`,
+        ),
+      );
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'BSP',
+        name: 'ZAPP_BOOKING/webapp/i18n',
+      });
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse(result.content[0]!.text);
+      expect(parsed).toHaveLength(1);
+      const calledUrl = String(mockFetch.mock.calls[0]?.[0] ?? '');
+      expect(calledUrl).toContain('ZAPP_BOOKING%2Fwebapp%2Fi18n');
+      expect(calledUrl).not.toContain('WEBAPP');
+      expect(calledUrl).not.toContain('I18N');
+    });
+
+    it('auto-splits a file path passed only in name (no include)', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(mockResponse(200, '{"sap.app": {"id": "zapp.booking"}}'));
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'BSP',
+        name: 'ZAPP_BOOKING/webapp/manifest.json',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]!.text).toContain('sap.app');
+      const calledUrl = String(mockFetch.mock.calls[0]?.[0] ?? '');
+      expect(calledUrl).toContain('ZAPP_BOOKING%2Fwebapp%2Fmanifest.json');
+      expect(calledUrl).not.toContain('WEBAPP');
+      expect(calledUrl).not.toContain('MANIFEST.JSON');
+    });
+
     it('returns error when ui5 feature is unavailable', async () => {
       setCachedFeatures(featuresOff());
       try {


### PR DESCRIPTION
## Summary
- `SAPRead type=BSP` silently mangled a nested path when the caller put it entirely in `name` (e.g. `name="APP/controller"`) instead of splitting it across `name`+`include`. `getBspAppStructure`/`getBspFileContent` uppercase their `appName` argument in full, so an unsplit `name` got its sub-path uppercased too, producing a 404 against the case-sensitive filestore that reads exactly like "object does not exist" — with no hint to use `include`.
- Auto-split `name` on the first `/` when `include` is not also given, so both call shapes behave the same. No change needed in `client.ts` — `getBspAppStructure`/`getBspFileContent` are correct when called with a clean `appName`.

## Test plan
- [x] Added two regression tests (`tests/unit/handlers/read.test.ts`): subfolder case and file case, both asserting the outgoing request URL preserves the sub-path's original case instead of uppercasing it.
- [x] `npx vitest run tests/unit/handlers/read.test.ts` — 130/130 pass.
- [x] `npx vitest run tests/unit/adt/client.test.ts tests/unit/handlers/schemas.test.ts` — 375/375 pass (both also cover BSP).
- [x] Full unit suite — 4938/4950 pass; the 12 failures are pre-existing and unrelated (POSIX file-permission-mode assertions that don't hold on Windows, plus a few CI-script/workflow tests expecting a CI environment — confirmed by checking an untouched file fails the same lint check for the same repo-wide CRLF reason).
- [x] `tsc --noEmit` — no new errors (pre-existing errors are all missing optional BTP/xsuaa deps, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)