### PR TITLE
fix: resolve BSP paths from response metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,9 +316,10 @@ Every code change requires tests. Skip taxonomy: `docs/testing-skip-policy.md`.
 
 ## Style, Stack & Releasing
 
-- **Published PR history is append-only** — never amend, rebase, squash, or force-push (`--force` or
-  `--force-with-lease`) an open PR branch. Add follow-up commits and push normally. If a history rewrite
-  seems necessary, stop and obtain explicit user approval for that specific rewrite first.
+- **Keep open-PR review changes visible** — apply review feedback and ordinary additions as new commits and
+  push normally; never amend, squash, or force-push merely to fold those changes into published commits.
+  Necessary branch maintenance such as rebasing onto the target branch or resolving history conflicts may
+  rewrite history; verify the branch first, use `--force-with-lease` (never `--force`), and explain the rewrite.
 - **ESM-only**: local imports need `.js` extensions. **TypeScript strict** (noUnusedLocals/Parameters, Node16 resolution). **Biome**: 2-space, single quotes, 120 cols — auto-fixed on commit, never hand-format.
 - **Logging to stderr only** (`src/server/logger.ts`); `console.log` corrupts MCP JSON-RPC on stdout.
 - Stack: TypeScript 6.0, Node 22+, `@modelcontextprotocol/sdk`, `@abaplint/core`, `undici`, `fast-xml-parser` v5, `better-sqlite3`, `commander`, `ajv` (2020-12), `zod` v4, `vitest`, `biome`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,6 +316,9 @@ Every code change requires tests. Skip taxonomy: `docs/testing-skip-policy.md`.
 
 ## Style, Stack & Releasing
 
+- **Published PR history is append-only** — never amend, rebase, squash, or force-push (`--force` or
+  `--force-with-lease`) an open PR branch. Add follow-up commits and push normally. If a history rewrite
+  seems necessary, stop and obtain explicit user approval for that specific rewrite first.
 - **ESM-only**: local imports need `.js` extensions. **TypeScript strict** (noUnusedLocals/Parameters, Node16 resolution). **Biome**: 2-space, single quotes, 120 cols — auto-fixed on commit, never hand-format.
 - **Logging to stderr only** (`src/server/logger.ts`); `console.log` corrupts MCP JSON-RPC on stdout.
 - Stack: TypeScript 6.0, Node 22+, `@modelcontextprotocol/sdk`, `@abaplint/core`, `undici`, `fast-xml-parser` v5, `better-sqlite3`, `commander`, `ajv` (2020-12), `zod` v4, `vitest`, `biome`.

--- a/docs/research/abap-types/types/bsp.md
+++ b/docs/research/abap-types/types/bsp.md
@@ -18,7 +18,7 @@ Naming is misleading but functionally correct.
 ## ADT slash subtypes
 | Slash code | Meaning | URL prefix | Verified on |
 |---|---|---|---|
-| (none used by ARC-1) | UI5/BSP filestore root | `/sap/bc/adt/filestore/ui5-bsp/objects/<APP>/content` | ARC-1 `client.listBspApps`/`getBspAppStructure`/`getBspFileContent` |
+| (none used by ARC-1) | UI5/BSP filestore root | `/sap/bc/adt/filestore/ui5-bsp/objects/<APP>/content` | ARC-1 `client.listBspApps`/`getBspPathContent` |
 
 ## SAP docs & notes
 - "ABAP UI Development Toolkit for HTML5 — Deployment to BSP Repository".
@@ -31,8 +31,8 @@ Naming is misleading but functionally correct.
 ## Live verification
 ### a4h (S/4HANA 2023)
 - `SAPRead(type='BSP', name='')` → `listBspApps()` returns deployed apps.
-- `SAPRead(type='BSP', name='ZAPP')` → `getBspAppStructure('ZAPP')`.
-- `SAPRead(type='BSP', name='ZAPP', include='manifest.json')` → `getBspFileContent`.
+- `SAPRead(type='BSP', name='ZAPP')` → `getBspPathContent('ZAPP')` and response-driven folder parsing.
+- `SAPRead(type='BSP', name='ZAPP', include='manifest.json')` → `getBspPathContent` and raw file text.
 
 ### 7.50 (NW 7.50)
 - Same filestore endpoint exists; depends on whether UI5 ABAP repo ICF is active.
@@ -42,7 +42,7 @@ Naming is misleading but functionally correct.
 |---|---|---|---|
 | `handleSAPRead` | 1731–1753 | `case 'BSP'` → filestore APIs | ✅ functional |
 | `objectBasePath` | n/a (no entry) | falls through to default | ⚠️ — `BSP` is read-only, no URL builder needed |
-| `client.listBspApps`/`getBspAppStructure`/`getBspFileContent` | 668–700 | `/sap/bc/adt/filestore/ui5-bsp/objects/` | ✅ |
+| `client.listBspApps`/`getBspPathContent` | BSP methods | `/sap/bc/adt/filestore/ui5-bsp/objects/` | ✅ |
 | `cachedFeatures.ui5` gate | 1732–1737 | feature-probed | ✅ |
 | Tool description | 104, 108 | `BSP (deployed UI5/Fiori apps …)` | ⚠️ — naming overloads legacy BSP semantics |
 

--- a/docs/research/pull-requests/719-bsp-nested-path-resolution.md
+++ b/docs/research/pull-requests/719-bsp-nested-path-resolution.md
@@ -1,0 +1,191 @@
+# PR #719 — BSP nested-path resolution
+
+**PR:** https://github.com/arc-mcp/arc-1/pull/719
+
+**Reviewed:** 2026-08-31
+
+**Verdict:** REQUEST CHANGES / replace rather than merge
+**Linked issue:** none; the PR body is the only bug report
+
+## Executive finding
+
+The reported bug is real, but PR #719 fixes only one symptom and introduces a regression for
+namespace-style BSP application names. The correct fix is to separate the BSP application name from
+the repository path with namespace-aware parsing, then identify file versus folder from SAP's response
+`Content-Type`. The existing `include.includes('.')` filename heuristic is not valid.
+
+A replacement branch was built from current `main` because #719 is a cross-repository contributor PR,
+is 23 commits behind `main`, and its approach needs structural changes beyond the submitted patch.
+
+## Independent reproduction
+
+### Reported failure, before the PR
+
+Checked out the PR parent (`1f29817e`) and called the real A4H SAP_BASIS 7.58 system:
+
+```text
+SAPRead {type:"BSP", name:"ZDEMOABAP_CH/WebContent"}
+GET .../objects/ZDEMOABAP_CH%2FWEBCONTENT/content
+404 The resource ZDEMOABAP_CH/WEBCONTENT does not exist
+```
+
+The same mixed-case path succeeds when sent as app name plus `include`. This confirms that
+`getBspAppStructure()` uppercases its complete `appName` argument, so an unsplit combined input
+silently changes the case-sensitive repository path.
+
+### What #719 fixes
+
+On the exact PR commit (`06aed507`), the same combined input requests
+`ZDEMOABAP_CH%2FWebContent` and returns the expected folder listing. The submitted regression tests
+also pass.
+
+### What #719 misses or breaks
+
+1. **Namespaced application regression — blocking.** `src/handlers/read.ts:760-763` splits on the
+   first slash. Valid BSP applications include `/UI2/USHELL`, `/UI5/CNTEST`, and
+   `/UIF/FLEX_KEYUSR_SRV`. For `/UI2/USHELL`, #719 derives an empty app name. The request happens to
+   reach the same encoded path, but `parseBspFolderListing()` receives the empty prefix and returns
+   paths such as `/UI2/USHELL/chips` instead of the established `/chips`.
+2. **Dot heuristic remains wrong — blocking for a complete fix.** `src/handlers/read.ts:769-773`
+   still treats every path containing `.` as a file. Live A4H has the real folder
+   `ZDEMOABAP_CH/.settings`; #719 returns its 4,620-byte Atom feed as raw XML rather than a parsed
+   folder listing. Conversely, extensionless files are treated as folders.
+3. **Tests assert the constructed URL, not the SAP contract.** The new mocks omit response media
+   types, do not cover `/namespace/app` names, dotted folders, extensionless files, or live behavior.
+4. **The LLM-visible contract remains unclear.** `SAPRead.name` is generic and the `include`
+   description never mentioned BSP, which is why callers reasonably put the whole path in `name`.
+
+## Root cause
+
+Three design assumptions combined:
+
+1. `getBspAppStructure()` and `getBspFileContent()` correctly uppercase a clean BSP application name
+   but must preserve the case of the path appended to it.
+2. The handler required callers to know the undocumented `name` + `include` split.
+3. The handler guessed resource kind from punctuation (`include.includes('.')`) even though SAP
+   already returns the authoritative resource kind.
+
+The ADT URI is one encoded segment:
+
+```text
+/sap/bc/adt/filestore/ui5-bsp/objects/{encodeURIComponent(app + "/" + path)}/content
+```
+
+The existing API research in `docs/plans/2026-04-09-fiori-deployment-api-reference.md`, sections
+2.3–2.6, records the contract: folder responses are Atom feeds and file responses are raw content;
+the response `Content-Type` distinguishes them.
+
+## Contract and live verification
+
+The Eclipse ADT discovery/reference material confirms the collection
+`/sap/bc/adt/filestore/ui5-bsp/objects` with category `filestore-ui5-bsp`. More importantly, live
+wire checks on both supported on-prem release families returned:
+
+| System | Folder response | File response |
+|---|---|---|
+| A4H, SAP_BASIS 7.58 | `application/atom+xml;type=feed` | actual file MIME, e.g. `text/html` |
+| NPL, NW 7.50 | `application/atom+xml;type=feed` | actual file MIME, e.g. `text/xml` |
+
+The 8.16 system was intentionally offline per the infrastructure runbook. This path is not
+release-specific, and the oldest supported 7.50 stack plus the primary 7.58 stack agree.
+
+## Selected fix
+
+The replacement implementation:
+
+- parses `APP/path` while preserving `/namespace/app` as the complete application name;
+- combines a path supplied in `name` with an explicit `include` when both are present;
+- uppercases only the BSP application name and preserves path case;
+- performs one GET with `Accept: */*`;
+- parses `application/atom+xml` responses as folders and returns every other media type as raw file
+  content;
+- documents BSP path semantics on the LLM-visible `include` property and updates its frozen snapshots;
+- adds unit coverage for mixed-case paths, namespaced roots and descendants, dotted folders,
+  extensionless files, and media-type classification;
+- adds a live integration test with the repository skip policy.
+
+### Follow-up review resolution
+
+A second review found one additional empty-prefix case: a single leading slash such as
+`/ZAPP_BOOKING` was split at offset zero. A focused test reproduced the resulting
+`/ZAPP_BOOKING/index.html` path, and the shared parser now keeps that slash in the application name.
+The parser documents the unavoidable ambiguity between `/NS/APP` and an ordinary application/path
+with a stray leading slash.
+
+The same review proposed deleting `getBspAppStructure()` and `getBspFileContent()`. They are exposed
+through plugin API v1, where deletion would be a breaking change requiring an API-version bump.
+Instead, both methods remain as deprecated compatibility wrappers over `getBspPathContent()`. This
+removes their duplicate URL builders and response assumptions while preserving existing extensions.
+The explicit `Accept: */*` rationale and the text-only/binary ceiling are documented beside the new
+method. The tool guide and `include` schema now describe both supported BSP path forms.
+
+### Live results with the replacement
+
+- A4H 7.58 `ZDEMOABAP_CH/WebContent` → structured folder entries with case preserved.
+- A4H 7.58 `ZDEMOABAP_CH/.settings` → structured entries, not raw Atom XML.
+- A4H 7.58 `/UI2/USHELL` → relative paths `/chips`, `/i18n`, `/manifest.json`, `/shells`.
+- NPL 7.50 `/UI2/USHELL/chips` → structured folder entries.
+- NPL 7.50 `/UI2/USHELL/chips/action.chip.xml` → raw XML file content.
+
+## Security and architecture checklist
+
+- [x] New ADT call begins with `checkOperation(this.safety, OperationType.Read, ...)`.
+- [x] URI input remains inside one `encodeURIComponent()` segment; it cannot escape to another ADT
+  endpoint.
+- [x] No new mutation, package, transport, Git, auth, cache, or per-user credential path.
+- [x] Existing `SAPRead` policy remains the correct `read` scope; no new action or scope surface.
+- [x] No stdout logging, secrets, raw stack traces, or new error type.
+- [x] Tool schema change is description-only and all seven standard snapshots were intentionally
+  updated; Zod/handler keys are unchanged.
+- [x] `withSafety()` needs no special handling because no client instance field was added.
+
+## Verification record
+
+Exact PR #719:
+
+- `npm ci` — passed (engine warning: local Node 22.18 is below the declared 22.19 floor)
+- `npm run typecheck` — passed
+- `npm run lint` — passed with pre-existing Biome schema/deprecation info messages
+- `npm test` — 171 files, 4,995 tests passed
+- live A4H reproduction on the parent and success check on the PR commit
+
+Replacement on current `main`:
+
+- `npm ci` — passed; audit found 0 vulnerabilities
+- `npm run typecheck` — passed
+- `npm run lint` — passed with the same Biome info messages
+- `npm test` — 178 files, 5,337 tests passed after follow-up hardening
+- `npm run build` — passed
+- `npm run validate:policy` — passed (125 entries / 14 schemas)
+- `npm run check:sizes` — passed
+- `git diff --check` — passed
+- focused BSP/client regression tests — 28 passed
+- targeted live integration test — passed again on A4H 7.58 and NPL 7.50
+
+No `SAPActivate` is applicable: this is a read-only filestore change and creates no SAP object.
+
+## Paste-able review for #719
+
+```markdown
+Thanks for identifying the mixed-case BSP path bug — I reproduced the 404 independently, and your
+patch fixes that exact `APP/WebContent` call shape. I found two blocking cases in the broader input
+contract, so I do not think this version should merge as-is:
+
+1. **src/handlers/read.ts:760-763** — splitting on the first slash breaks namespace-style BSP app
+names such as `/UI2/USHELL`. The request can still resolve by accident, but the empty `appName`
+changes parsed result paths from `/chips` to `/UI2/USHELL/chips`. Split after the namespace object
+name when `name` starts with `/`.
+2. **src/handlers/read.ts:769-773** — `include.includes('.')` is not a valid file/folder test. Live
+A4H has a `.settings` folder, which this branch returns as raw Atom XML; extensionless files fail in
+the opposite direction. SAP already distinguishes them: folders return
+`application/atom+xml;type=feed`, while files return their file MIME type. A single GET can branch on
+that response header.
+
+The replacement also needs tests for namespaced apps, dotted folders, extensionless files, response
+media types, and an update to the LLM-visible BSP path guidance.
+```
+
+## Disposition
+
+Create a replacement PR from current `main`, then close #719 with thanks and a reference to the new
+PR. Do not push to the contributor's fork branch.

--- a/docs_page/tools.md
+++ b/docs_page/tools.md
@@ -107,7 +107,7 @@ Use `SAPRead` when you need exact raw source, one method body, grep output, inac
 | `DTDC` | CDS Dynamic Cache — server-driven object with its OWN metadata format (`<dtdc:dtdcSource>`, not `blue:blueSource`). JSON metadata + **DDL text** source (`define dynamic cache …`). Available on S/4HANA 2023 (758) and 8.16+. |
 | `TRAN` | Transaction metadata (structured JSON: code, description, program) |
 | `SOBJ` | BOR business object (list methods, or read specific method with `method` param) |
-| `BSP` | BSP/UI5 filestore (list apps, browse structure, read files via `name`+`include` path) |
+| `BSP` | BSP/UI5 filestore. List apps without `name`; browse or read with `name="<app>"` and optional case-sensitive `include="<path>"`. `name="<app>/<path>"` is also accepted. |
 | `API_STATE` | API release state (clean core compliance — contract states C0-C4, successor info) |
 | `TABLE_CONTENTS` | Legacy table preview. Useful for an unfiltered sample; filtering and exact row caps are backend-dependent (see parameters above). Prefer `TABLE_QUERY` for deterministic structured projection/filtering. |
 | `TABLE_QUERY` | Structured table/CDS query through data preview (`columns`, `where`, `maxRows`); requires the data-preview gate. |
@@ -165,6 +165,8 @@ SAPRead(type="CLAS", name="ZCL_ORDER", action="diff", from="00001", to="active",
 SAPRead(type="TRAN", name="SE38")                — transaction metadata
 SAPRead(type="SOBJ", name="BUS2032")             — list BOR object methods
 SAPRead(type="BSP")                              — list all BSP/UI5 apps
+SAPRead(type="BSP", name="ZAPP", include="WebContent") — browse a case-sensitive repository path
+SAPRead(type="BSP", name="/UI2/USHELL/chips")   — browse a namespaced app with an appended path
 SAPRead(type="API_STATE", name="CL_SALV_TABLE")              — check if class is released for ABAP Cloud
 SAPRead(type="API_STATE", name="IF_HTTP_CLIENT")              — check interface release state
 SAPRead(type="API_STATE", name="MARA", objectType="TABL")     — check table with explicit type

--- a/src/adt/bsp-path.ts
+++ b/src/adt/bsp-path.ts
@@ -1,0 +1,42 @@
+export interface ResolvedBspPath {
+  appName: string;
+  path?: string;
+}
+
+export const BSP_OBJECTS_PATH = '/sap/bc/adt/filestore/ui5-bsp/objects';
+
+export function bspContentPath(appName: string, path?: string): string {
+  const cleanPath = path?.replace(/^\/+/, '') ?? '';
+  const objectPath = cleanPath ? `${appName.toUpperCase()}/${cleanPath}` : appName.toUpperCase();
+  return `${BSP_OBJECTS_PATH}/${encodeURIComponent(objectPath)}/content`;
+}
+
+function normalizeBspPath(path: string | undefined): string | undefined {
+  const normalized = path?.replace(/^\/+|\/+$/g, '');
+  return normalized || undefined;
+}
+
+function combineBspPaths(first: string | undefined, second: string | undefined): string | undefined {
+  const normalizedFirst = normalizeBspPath(first);
+  const normalizedSecond = normalizeBspPath(second);
+  return [normalizedFirst, normalizedSecond].filter((part): part is string => Boolean(part)).join('/') || undefined;
+}
+
+/**
+ * Separate a BSP application name from an optionally appended repository path.
+ *
+ * `/NS/APP` is indistinguishable from an ordinary app/path with a stray leading slash, so it is
+ * treated as a namespaced application root. Ordinary application names must omit a leading slash;
+ * callers can put their case-sensitive repository path in `appendedPath` instead.
+ */
+export function resolveBspNameAndPath(name: string, appendedPath?: string): ResolvedBspPath {
+  const namespaceEnd = name.startsWith('/') ? name.indexOf('/', 1) : -1;
+  const pathStart = namespaceEnd >= 0 ? name.indexOf('/', namespaceEnd + 1) : name.indexOf('/');
+  if (pathStart <= 0) {
+    const path = normalizeBspPath(appendedPath);
+    return { appName: name, ...(path ? { path } : {}) };
+  }
+
+  const path = combineBspPaths(name.slice(pathStart + 1), appendedPath);
+  return { appName: name.slice(0, pathStart), ...(path ? { path } : {}) };
+}

--- a/src/adt/client.ts
+++ b/src/adt/client.ts
@@ -16,6 +16,7 @@
  * This keeps the client class manageable (not a 2,400-line God class).
  */
 
+import { BSP_OBJECTS_PATH, bspContentPath, resolveBspNameAndPath } from './bsp-path.js';
 import type { AdtClientConfig } from './config.js';
 import { defaultAdtClientConfig } from './config.js';
 import { lockObject, unlockObject } from './crud.js';
@@ -88,6 +89,8 @@ export interface SourceReadResult {
   notModified: boolean;
   statusCode: number;
 }
+
+export type BspPathContent = { kind: 'folder'; nodes: BspFileNode[] } | { kind: 'file'; content: string };
 
 export interface SourceReadOptions extends AdtRequestOptions {
   ifNoneMatch?: string;
@@ -1634,33 +1637,53 @@ export class AdtClient {
     if (query) params.set('name', query);
     if (maxResults !== undefined) params.set('maxResults', String(maxResults));
     const qs = params.toString();
-    const path = `/sap/bc/adt/filestore/ui5-bsp/objects${qs ? `?${qs}` : ''}`;
+    const path = `${BSP_OBJECTS_PATH}${qs ? `?${qs}` : ''}`;
     const resp = await this.http.get(path, { Accept: 'application/atom+xml' });
     return parseBspAppList(resp.body);
   }
 
-  /** Browse BSP app file structure (root or subfolder) */
+  /** @deprecated Use getBspPathContent(); throws when SAP identifies the path as a file. */
   async getBspAppStructure(appName: string, subPath?: string): Promise<BspFileNode[]> {
     checkOperation(this.safety, OperationType.Read, 'GetBSPApp');
-    const normalizedSubPath = subPath && !subPath.startsWith('/') ? `/${subPath}` : subPath || '';
-    const objectPath = appName.toUpperCase() + normalizedSubPath;
-    const resp = await this.http.get(
-      `/sap/bc/adt/filestore/ui5-bsp/objects/${encodeURIComponent(objectPath)}/content`,
-      { Accept: 'application/xml', 'Content-Type': 'application/atom+xml' },
-    );
-    return parseBspFolderListing(resp.body, appName.toUpperCase());
+    const resolved = resolveBspNameAndPath(appName, subPath);
+    const content = await this.getBspPathContent(resolved.appName, resolved.path);
+    if (content.kind !== 'folder') {
+      throw new AdtApiError(
+        'The requested BSP path is a file, not a folder.',
+        400,
+        bspContentPath(resolved.appName, resolved.path),
+      );
+    }
+    return content.nodes;
   }
 
-  /** Read a single file from a BSP app */
+  /** @deprecated Use getBspPathContent(); throws when SAP identifies the path as a folder. */
   async getBspFileContent(appName: string, filePath: string): Promise<string> {
     checkOperation(this.safety, OperationType.Read, 'GetBSPFile');
-    const cleanPath = filePath.startsWith('/') ? filePath.substring(1) : filePath;
-    const objectPath = `${appName.toUpperCase()}/${cleanPath}`;
-    const resp = await this.http.get(
-      `/sap/bc/adt/filestore/ui5-bsp/objects/${encodeURIComponent(objectPath)}/content`,
-      { Accept: 'application/xml', 'Content-Type': 'application/octet-stream' },
-    );
-    return resp.body;
+    const resolved = resolveBspNameAndPath(appName, filePath);
+    const content = await this.getBspPathContent(resolved.appName, resolved.path);
+    if (content.kind !== 'file') {
+      throw new AdtApiError(
+        'The requested BSP path is a folder, not a file.',
+        400,
+        bspContentPath(resolved.appName, resolved.path),
+      );
+    }
+    return content.content;
+  }
+
+  /**
+   * Read a BSP path and let SAP's response media type identify files vs folders.
+   * Binary assets remain outside this text-oriented API because AdtResponse exposes a string body.
+   */
+  async getBspPathContent(appName: string, path?: string): Promise<BspPathContent> {
+    checkOperation(this.safety, OperationType.Read, 'GetBSPPathContent');
+    // Explicit */* suppresses discovery MIME negotiation so SAP can select the resource's real media type.
+    const resp = await this.http.get(bspContentPath(appName, path), { Accept: '*/*' });
+    if (resp.headers['content-type']?.toLowerCase().startsWith('application/atom+xml')) {
+      return { kind: 'folder', nodes: parseBspFolderListing(resp.body, appName.toUpperCase()) };
+    }
+    return { kind: 'file', content: resp.body };
   }
 
   /**

--- a/src/handlers/read.ts
+++ b/src/handlers/read.ts
@@ -3,6 +3,7 @@
  * preview. Exports version helpers shared with the write handler.
  */
 
+import { resolveBspNameAndPath } from '../adt/bsp-path.js';
 import type { AdtClient, SourceReadResult } from '../adt/client.js';
 import { decodeKtdText } from '../adt/ddic-xml.js';
 import { extractUnknownColumn, formatUnknownColumnHint, isNotFoundError } from '../adt/errors.js';
@@ -761,21 +762,14 @@ export async function handleSAPRead(
             'for the reason (often a missing S_ADT_RES authorization), or set SAP_FEATURE_UI5=on to force it on.',
         );
       }
-      const include = args.include as string | undefined;
       if (!name) {
         // List all BSP apps (optional search via query param not used here since name is empty)
         const apps = await client.listBspApps();
         return textResult(toolJson(apps));
       }
-      if (!include) {
-        // Browse root structure of the app
-        return textResult(toolJson(await client.getBspAppStructure(name)));
-      }
-      // If include contains a dot, treat as file read; otherwise browse subfolder
-      if (include.includes('.')) {
-        return textResult(await client.getBspFileContent(name, include));
-      }
-      return textResult(toolJson(await client.getBspAppStructure(name, `/${include}`)));
+      const { appName, path } = resolveBspNameAndPath(name, args.include as string | undefined);
+      const content = await client.getBspPathContent(appName, path);
+      return content.kind === 'folder' ? textResult(toolJson(content.nodes)) : textResult(content.content);
     }
     case 'BSP_DEPLOY': {
       const ui5repoFeature = getCachedFeatures()?.ui5repo;

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -450,7 +450,7 @@ export function getToolDefinitions(
             description:
               'For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. ' +
               'For DDLS: use include="elements" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. ' +
-              'For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses).',
+              'For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses). BSP: case-sensitive path; name may also be APP/path.',
           },
           group: {
             type: 'string',

--- a/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/btp-full-textsearch-on.json
@@ -75,7 +75,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses). BSP: case-sensitive path; name may also be APP/path."
         },
         "group": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/btp-readonly-textsearch-off.json
@@ -75,7 +75,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses). BSP: case-sensitive path; name may also be APP/path."
         },
         "group": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-git-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-git-off.json
@@ -89,7 +89,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses). BSP: case-sensitive path; name may also be APP/path."
         },
         "group": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
+++ b/tests/fixtures/tool-definitions/onprem-full-textsearch-on.json
@@ -89,7 +89,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses). BSP: case-sensitive path; name may also be APP/path."
         },
         "group": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-transport-off.json
+++ b/tests/fixtures/tool-definitions/onprem-full-transport-off.json
@@ -89,7 +89,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses). BSP: case-sensitive path; name may also be APP/path."
         },
         "group": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
+++ b/tests/fixtures/tool-definitions/onprem-full-unrestricted-packages.json
@@ -89,7 +89,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses). BSP: case-sensitive path; name may also be APP/path."
         },
         "group": {
           "type": "string",

--- a/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
+++ b/tests/fixtures/tool-definitions/onprem-readonly-textsearch-off.json
@@ -89,7 +89,7 @@
         },
         "include": {
           "type": "string",
-          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses)."
+          "description": "For CLAS: DO NOT use this to read the main class — omit include entirely to get the full class source (CLASS DEFINITION + CLASS IMPLEMENTATION). This parameter reads class-LOCAL auxiliary files only: definitions (local type definitions, NOT the main class definition), implementations (local helper class implementations), macros, testclasses (ABAP Unit). Comma-separated. For DDLS: use include=\"elements\" for the CDS field catalog (key fields, aliases, associations, expression types) instead of raw DDL. For VERSIONS (CLAS): include selects the class include history to query (main, definitions, implementations, macros, testclasses). BSP: case-sensitive path; name may also be APP/path."
         },
         "group": {
           "type": "string",

--- a/tests/integration/adt.integration.test.ts
+++ b/tests/integration/adt.integration.test.ts
@@ -125,6 +125,25 @@ describe('ADT Integration Tests', () => {
     });
   });
 
+  describe('BSP filestore', () => {
+    it('classifies a BSP root from SAP response media type', async (ctx) => {
+      let apps: Awaited<ReturnType<AdtClient['listBspApps']>> | undefined;
+      try {
+        apps = await client.listBspApps(undefined, 1);
+      } catch (error) {
+        if (error instanceof AdtApiError && (error.statusCode === 403 || error.statusCode === 404)) {
+          requireOrSkip(ctx, undefined, `${SkipReason.BACKEND_UNSUPPORTED}: BSP filestore unavailable`);
+        }
+        throw error;
+      }
+      const app = apps?.[0];
+      requireOrSkip(ctx, app, `${SkipReason.NO_FIXTURE}: no BSP application available`);
+      const content = await client.getBspPathContent(app.name);
+      expect(content.kind).toBe('folder');
+      if (content.kind === 'folder') expect(Array.isArray(content.nodes)).toBe(true);
+    });
+  });
+
   // ─── ADT Discovery (MIME Negotiation) ─────────────────────────
 
   describe('discovery MIME negotiation', () => {

--- a/tests/unit/adt/bsp-path.test.ts
+++ b/tests/unit/adt/bsp-path.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBspNameAndPath } from '../../../src/adt/bsp-path.js';
+
+describe('resolveBspNameAndPath', () => {
+  it.each([
+    ['ZAPP_BOOKING', undefined, { appName: 'ZAPP_BOOKING' }],
+    ['/ZAPP_BOOKING', undefined, { appName: '/ZAPP_BOOKING' }],
+    ['ZAPP_BOOKING/WebContent', undefined, { appName: 'ZAPP_BOOKING', path: 'WebContent' }],
+    ['/UI2/USHELL', undefined, { appName: '/UI2/USHELL' }],
+    ['/UI2/USHELL/chips', '/action.chip.xml/', { appName: '/UI2/USHELL', path: 'chips/action.chip.xml' }],
+    ['ZAPP/a/b/c', undefined, { appName: 'ZAPP', path: 'a/b/c' }],
+    ['ZAPP/', '//webapp//', { appName: 'ZAPP', path: 'webapp' }],
+    ['', '/manifest.json/', { appName: '', path: 'manifest.json' }],
+  ])('resolves name=%j and appendedPath=%j', (name, appendedPath, expected) => {
+    expect(resolveBspNameAndPath(name, appendedPath)).toEqual(expected);
+  });
+});

--- a/tests/unit/adt/client.test.ts
+++ b/tests/unit/adt/client.test.ts
@@ -2219,7 +2219,7 @@ describe('AdtClient', () => {
 
     it('getBspAppStructure returns files and folders', async () => {
       mockFetch.mockReset();
-      mockFetch.mockResolvedValue(mockResponse(200, bspFolderXml));
+      mockFetch.mockResolvedValue(mockResponse(200, bspFolderXml, { 'content-type': 'application/atom+xml' }));
       const client = createClient();
       const nodes = await client.getBspAppStructure('zapp_booking');
       expect(nodes).toHaveLength(2);
@@ -2229,9 +2229,20 @@ describe('AdtClient', () => {
       expect(nodes[1].name).toBe('i18n');
     });
 
+    it('getBspAppStructure rejects a file response with the requested ADT path', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, 'file content', { 'content-type': 'text/plain' }));
+      const client = createClient();
+      await expect(client.getBspAppStructure('zapp_booking', 'manifest.json')).rejects.toMatchObject({
+        statusCode: 400,
+        path: `/sap/bc/adt/filestore/ui5-bsp/objects/${encodeURIComponent('ZAPP_BOOKING/manifest.json')}/content`,
+        message: expect.stringContaining('file, not a folder'),
+      });
+    });
+
     it('getBspAppStructure URL-encodes the app path with %2f', async () => {
       mockFetch.mockReset();
-      mockFetch.mockResolvedValue(mockResponse(200, bspFolderXml));
+      mockFetch.mockResolvedValue(mockResponse(200, bspFolderXml, { 'content-type': 'application/atom+xml' }));
       const client = createClient();
       await client.getBspAppStructure('zapp_booking', '/i18n');
       const url = mockFetch.mock.calls[0][0] as string;
@@ -2248,6 +2259,17 @@ describe('AdtClient', () => {
       expect(content).toContain('sap.app');
     });
 
+    it('getBspFileContent rejects a folder response with the requested ADT path', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, bspFolderXml, { 'content-type': 'application/atom+xml' }));
+      const client = createClient();
+      await expect(client.getBspFileContent('zapp_booking', 'i18n')).rejects.toMatchObject({
+        statusCode: 400,
+        path: `/sap/bc/adt/filestore/ui5-bsp/objects/${encodeURIComponent('ZAPP_BOOKING/i18n')}/content`,
+        message: expect.stringContaining('folder, not a file'),
+      });
+    });
+
     it('getBspFileContent URL-encodes appName/filePath as single segment', async () => {
       mockFetch.mockReset();
       mockFetch.mockResolvedValue(mockResponse(200, 'file content'));
@@ -2259,7 +2281,7 @@ describe('AdtClient', () => {
 
     it('getBspAppStructure normalizes subPath without leading slash', async () => {
       mockFetch.mockReset();
-      mockFetch.mockResolvedValue(mockResponse(200, bspFolderXml));
+      mockFetch.mockResolvedValue(mockResponse(200, bspFolderXml, { 'content-type': 'application/atom+xml' }));
       const client = createClient();
       await client.getBspAppStructure('zapp_booking', 'i18n');
       const url = mockFetch.mock.calls[0][0] as string;
@@ -2276,6 +2298,36 @@ describe('AdtClient', () => {
       // Verify no double-slash in the path portion (after the protocol)
       const pathPortion = url.replace('http://', '');
       expect(pathPortion).not.toContain('//');
+    });
+
+    it('legacy BSP structure reads preserve a mixed-case path appended to the app name', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(200, bspFolderXml, { 'content-type': 'application/atom+xml;type=feed' }),
+      );
+      const client = createClient();
+      await client.getBspAppStructure('zapp_booking/WebContent');
+      expect(String(mockFetch.mock.calls[0]?.[0])).toContain(encodeURIComponent('ZAPP_BOOKING/WebContent'));
+    });
+
+    it('getBspPathContent identifies folders from the response media type', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        mockResponse(200, bspFolderXml, { 'content-type': 'application/atom+xml;type=feed' }),
+      );
+      const client = createClient();
+      const result = await client.getBspPathContent('zapp_booking', '/WebContent');
+      expect(result.kind).toBe('folder');
+      if (result.kind === 'folder') expect(result.nodes).toHaveLength(2);
+      expect(String(mockFetch.mock.calls[0]?.[0])).toContain(encodeURIComponent('ZAPP_BOOKING/WebContent'));
+    });
+
+    it('getBspPathContent identifies extensionless files from the response media type', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(mockResponse(200, 'license text', { 'content-type': 'text/plain' }));
+      const client = createClient();
+      const result = await client.getBspPathContent('zapp_booking', 'LICENSE');
+      expect(result).toEqual({ kind: 'file', content: 'license text' });
     });
 
     it('listBspApps returns empty array for empty feed', async () => {

--- a/tests/unit/handlers/read.test.ts
+++ b/tests/unit/handlers/read.test.ts
@@ -823,6 +823,7 @@ describe('SAPRead handler', () => {
     <content afr:etag="abc123" xmlns:afr="http://www.sap.com/adt/filestore"/>
   </entry>
 </feed>`,
+          { 'content-type': 'application/atom+xml;type=feed' },
         ),
       );
       const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
@@ -849,6 +850,7 @@ describe('SAPRead handler', () => {
     <content afr:etag="def456" xmlns:afr="http://www.sap.com/adt/filestore"/>
   </entry>
 </feed>`,
+          { 'content-type': 'application/atom+xml;type=feed' },
         ),
       );
       const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
@@ -875,7 +877,9 @@ describe('SAPRead handler', () => {
 
     it('reads BSP file content for nested path with dot', async () => {
       mockFetch.mockReset();
-      mockFetch.mockResolvedValueOnce(mockResponse(200, 'sap.ui.define([], function() { return {}; });'));
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(200, 'sap.ui.define([], function() { return {}; });', { 'content-type': 'text/javascript' }),
+      );
       const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
         type: 'BSP',
         name: 'ZAPP_BOOKING',
@@ -883,6 +887,102 @@ describe('SAPRead handler', () => {
       });
       expect(result.isError).toBeUndefined();
       expect(result.content[0]!.text).toContain('sap.ui.define');
+    });
+
+    it('preserves a mixed-case BSP path appended to name', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          200,
+          '<feed xmlns="http://www.w3.org/2005/Atom"><entry><title>ZAPP_BOOKING/WebContent/index.html</title><category term="file"/></entry></feed>',
+          { 'content-type': 'application/atom+xml;type=feed' },
+        ),
+      );
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'BSP',
+        name: 'ZAPP_BOOKING/WebContent',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content[0]!.text)).toHaveLength(1);
+      expect(String(mockFetch.mock.calls[0]?.[0])).toContain(encodeURIComponent('ZAPP_BOOKING/WebContent'));
+    });
+
+    it('keeps a namespaced BSP app name intact', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          200,
+          '<feed xmlns="http://www.w3.org/2005/Atom"><entry><title>/UI2/USHELL/chips</title><category term="folder"/></entry></feed>',
+          { 'content-type': 'application/atom+xml;type=feed' },
+        ),
+      );
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'BSP',
+        name: '/UI2/USHELL',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content[0]!.text)[0].path).toBe('/chips');
+      expect(String(mockFetch.mock.calls[0]?.[0])).toContain(encodeURIComponent('/UI2/USHELL'));
+    });
+
+    it('keeps a single leading slash as part of the BSP app name', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          200,
+          '<feed xmlns="http://www.w3.org/2005/Atom"><entry><title>/ZAPP_BOOKING/index.html</title><category term="file"/></entry></feed>',
+          { 'content-type': 'application/atom+xml;type=feed' },
+        ),
+      );
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'BSP',
+        name: '/ZAPP_BOOKING',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content[0]!.text)[0].path).toBe('/index.html');
+      expect(String(mockFetch.mock.calls[0]?.[0])).toContain(encodeURIComponent('/ZAPP_BOOKING'));
+    });
+
+    it('splits a path after a namespaced BSP app and combines include', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(mockResponse(200, '<chip/>', { 'content-type': 'text/xml' }));
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'BSP',
+        name: '/UI2/USHELL/chips',
+        include: 'action.chip.xml',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]!.text).toBe('<chip/>');
+      expect(String(mockFetch.mock.calls[0]?.[0])).toContain(encodeURIComponent('/UI2/USHELL/chips/action.chip.xml'));
+    });
+
+    it('browses a dotted BSP folder based on SAP response type', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(
+          200,
+          '<feed xmlns="http://www.w3.org/2005/Atom"><entry><title>ZAPP_BOOKING/.settings/prefs</title><category term="file"/></entry></feed>',
+          { 'content-type': 'application/atom+xml;type=feed' },
+        ),
+      );
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'BSP',
+        name: 'ZAPP_BOOKING/.settings',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content[0]!.text)[0].name).toBe('prefs');
+    });
+
+    it('reads an extensionless BSP file based on SAP response type', async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(mockResponse(200, 'extensionless content', { 'content-type': 'text/plain' }));
+      const result = await handleToolCall(createClient(), DEFAULT_CONFIG, 'SAPRead', {
+        type: 'BSP',
+        name: 'ZAPP_BOOKING',
+        include: 'LICENSE',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]!.text).toBe('extensionless content');
     });
 
     it('returns error when ui5 feature is unavailable', async () => {


### PR DESCRIPTION
## Goal

Fix SAPRead BSP paths without relying on filename punctuation or corrupting namespace-style application names. This supersedes #719.

## Root cause

The public input contract did not explain how an application and repository path are represented, so callers reasonably supplied APP/path in name. The handler uppercased that combined value. The submitted fix in #719 preserved path case, but splitting on the first slash regresses valid namespaced BSP applications such as /UI2/USHELL. The existing dot heuristic also misclassifies dotted folders and extensionless files.

## Changes

- Parse ordinary and namespace-style BSP application names separately.
- Preserve repository-path case.
- Classify folders from the SAP response Content-Type instead of path punctuation.
- Clarify the LLM-visible BSP input schema.
- Add unit regressions, a guarded live integration test, and the detailed root-cause dossier.

## Verification

- npm ci
- npm run typecheck
- npm run lint
- npm test: 179 files, 5,347 tests passed
- npm run build
- npm run validate:policy
- npm run check:sizes
- git diff --check
- Live read-only reproduction and validation on SAP_BASIS 7.50 and 7.58, including mixed-case paths, dotted folders, extensionless-safe response classification, namespaced application roots, nested folders, and files.