### PR TITLE
chore: retry MCP Registry publish after npm propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,7 +382,35 @@ jobs:
         run: ./mcp-publisher validate server.json
 
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+        # npm can acknowledge a trusted publish before the new version is visible to
+        # the MCP Registry's package validator. Retry the registry operation itself so
+        # its view of npm, rather than a potentially different npm CDN edge, is decisive.
+        run: |
+          set -uo pipefail
+
+          MAX_ATTEMPTS=12
+          RETRY_DELAY_SECONDS=10
+          PUBLISH_LOG="$(mktemp)"
+          trap 'rm -f "$PUBLISH_LOG"' EXIT
+
+          for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+            if ./mcp-publisher publish 2>&1 | tee "$PUBLISH_LOG"; then
+              exit 0
+            fi
+
+            if ! grep -Fq "A newly published release can take a moment" "$PUBLISH_LOG"; then
+              echo "::error::MCP Registry publish failed with a non-retryable error"
+              exit 1
+            fi
+
+            if (( attempt == MAX_ATTEMPTS )); then
+              echo "::error::MCP Registry publish failed after $MAX_ATTEMPTS attempts"
+              exit 1
+            fi
+
+            echo "::warning::MCP Registry publish failed (attempt $attempt/$MAX_ATTEMPTS); retrying in $RETRY_DELAY_SECONDS seconds"
+            sleep "$RETRY_DELAY_SECONDS"
+          done
 
   # Build Docker images natively per architecture (no QEMU emulation).
   # better-sqlite3 has no Node.js prebuilds — it always compiles via node-gyp,

--- a/tests/unit/server/release-mcp-registry-workflow.test.ts
+++ b/tests/unit/server/release-mcp-registry-workflow.test.ts
@@ -1,0 +1,47 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+}
+
+interface WorkflowJob {
+  needs?: string[];
+  steps: WorkflowStep[];
+}
+
+interface ReleaseWorkflow {
+  jobs: Record<string, WorkflowJob>;
+}
+
+const readReleaseWorkflow = async (): Promise<ReleaseWorkflow> =>
+  parse(await readFile('.github/workflows/release.yml', 'utf8')) as ReleaseWorkflow;
+
+describe('release MCP Registry workflow', () => {
+  it('waits for both package artifacts before publishing metadata', async () => {
+    const workflow = await readReleaseWorkflow();
+
+    expect(workflow.jobs['publish-mcp-registry'].needs).toEqual([
+      'release-please',
+      'publish-npm',
+      'publish-docker-merge',
+    ]);
+  });
+
+  it('retries while a newly published npm version propagates to the registry validator', async () => {
+    const workflow = await readReleaseWorkflow();
+    const publish = workflow.jobs['publish-mcp-registry'].steps.find((step) => step.name === 'Publish to MCP Registry');
+
+    expect(publish?.run).toContain('MAX_ATTEMPTS=12');
+    expect(publish?.run).toContain('RETRY_DELAY_SECONDS=10');
+    expect(publish?.run).toContain('set -uo pipefail');
+    expect(publish?.run).toContain('if ./mcp-publisher publish 2>&1 | tee "$PUBLISH_LOG"; then');
+    expect(publish?.run).toContain('grep -Fq "A newly published release can take a moment"');
+    expect(publish?.run).toContain('failed with a non-retryable error');
+    expect(publish?.run).toContain('if (( attempt == MAX_ATTEMPTS )); then');
+    expect(publish?.run).toContain('sleep "$RETRY_DELAY_SECONDS"');
+    expect(publish?.run).toContain('exit 1');
+  });
+});


### PR DESCRIPTION
## Goal

Prevent releases from failing when npm accepts a trusted publish before the new version is visible to the MCP Registry validator. This fixes the race seen in release run #606 for v1.1.1.

## Changes

- Retry `mcp-publisher publish` for up to 12 attempts at 10-second intervals when the registry reports its specific npm propagation error.
- Fail immediately for authentication, schema, permission, and other non-retryable errors.
- Add a workflow regression test covering artifact ordering and bounded retry behavior.

## Verification

- `npm test` (181 files, 5,360 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run validate:policy`
- `npm run check:sizes`