### PR TITLE
ci: wait for npm version before MCP Registry authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,9 +329,6 @@ jobs:
         run: |
           curl -sL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
-      - name: Authenticate to MCP Registry (GitHub OIDC)
-        run: ./mcp-publisher login github-oidc
-
       - name: Update version in server.json
         run: |
           set -o pipefail
@@ -378,8 +375,47 @@ jobs:
           fi
           mv server.tmp server.json
 
+      - name: Wait for npm package version
+        # npm trusted publishing can finish several minutes before the immutable
+        # version endpoint becomes visible. Wait before authentication because the
+        # MCP Registry token is valid for only five minutes.
+        env:
+          RELEASE_VERSION: ${{ needs.release-please.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          MAX_ATTEMPTS=30
+          RETRY_DELAY_SECONDS=20
+          NPM_VERSION_URL="https://registry.npmjs.org/arc-1/${RELEASE_VERSION}"
+
+          for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+            if METADATA="$(curl -fsSL \
+              -H "Accept: application/json" \
+              -H "Cache-Control: no-cache" \
+              "${NPM_VERSION_URL}?attempt=${attempt}")" && \
+              jq -e \
+                --arg version "$RELEASE_VERSION" \
+                --arg mcp_name "io.github.arc-mcp/arc-1" \
+                '.version == $version and .mcpName == $mcp_name' \
+                <<< "$METADATA" >/dev/null; then
+              echo "npm package arc-1@$RELEASE_VERSION is visible with the expected mcpName"
+              exit 0
+            fi
+
+            if (( attempt == MAX_ATTEMPTS )); then
+              echo "::error::npm package arc-1@$RELEASE_VERSION did not become visible after $MAX_ATTEMPTS attempts"
+              exit 1
+            fi
+
+            echo "::warning::npm package arc-1@$RELEASE_VERSION is not visible yet (attempt $attempt/$MAX_ATTEMPTS); retrying in $RETRY_DELAY_SECONDS seconds"
+            sleep "$RETRY_DELAY_SECONDS"
+          done
+
       - name: Validate server.json
         run: ./mcp-publisher validate server.json
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
         # npm can acknowledge a trusted publish before the new version is visible to

--- a/docs_page/release-notes.md
+++ b/docs_page/release-notes.md
@@ -26,6 +26,17 @@ until they are promoted.
     line — nobody runs them today, and the one part that still matters when jumping from an ancient version
     is the **v0.7.0 authorization break**, which is spelled out in full at the bottom of this page.
 
+## 1.1.2 — ATC completeness follows SAP's run lifecycle (2026-08-31)
+
+ATC result completeness no longer depends on an invented equality between SAP's informational finding
+counters and the visible finding rows. ARC-1 now follows the asynchronous run returned by ADT until SAP
+marks it `Completed`; systems without that run location keep the settled-worklist fallback. This removes
+false `incomplete` and `truncated` results when the counters legitimately differ from persisted findings.
+
+| Change | What it means | Action |
+|---|---|---|
+| Correct ATC completeness evidence ([#729](https://github.com/arc-mcp/arc-1/pull/729)) | Asynchronous ATC runs poll their canonical run location to `Completed`. Structured results expose `findingStatistics`, raw `runInfos`, `runStatus`, and `completionEvidence`; `expectedFindingCount` remains only as a deprecated informational alias and no longer controls completeness. Matching-worklist, object-set, processed-object, and malformed-row checks still fail closed. | `none` — runs previously misclassified as incomplete may now complete successfully |
+
 ## 1.1.1 — you get the scope you asked for (2026-08-20)
 
 Three correctness fixes with one theme: ARC-1 was quietly running a *different* query than the caller

--- a/tests/unit/server/release-mcp-registry-workflow.test.ts
+++ b/tests/unit/server/release-mcp-registry-workflow.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
 
 interface WorkflowStep {
+  env?: Record<string, string>;
   name?: string;
   run?: string;
 }
@@ -18,6 +19,9 @@ interface ReleaseWorkflow {
 
 const readReleaseWorkflow = async (): Promise<ReleaseWorkflow> =>
   parse(await readFile('.github/workflows/release.yml', 'utf8')) as ReleaseWorkflow;
+
+const githubExpression = (expression: string): string => `\${{ ${expression} }}`;
+const shellVariable = (name: string): string => `\${${name}}`;
 
 describe('release MCP Registry workflow', () => {
   it('waits for both package artifacts before publishing metadata', async () => {
@@ -43,5 +47,28 @@ describe('release MCP Registry workflow', () => {
     expect(publish?.run).toContain('if (( attempt == MAX_ATTEMPTS )); then');
     expect(publish?.run).toContain('sleep "$RETRY_DELAY_SECONDS"');
     expect(publish?.run).toContain('exit 1');
+  });
+
+  it('waits for the exact npm version before obtaining the short-lived registry token', async () => {
+    const workflow = await readReleaseWorkflow();
+    const steps = workflow.jobs['publish-mcp-registry'].steps;
+    const updateIndex = steps.findIndex((step) => step.name === 'Update version in server.json');
+    const waitIndex = steps.findIndex((step) => step.name === 'Wait for npm package version');
+    const validateIndex = steps.findIndex((step) => step.name === 'Validate server.json');
+    const authenticateIndex = steps.findIndex((step) => step.name === 'Authenticate to MCP Registry (GitHub OIDC)');
+    const publishIndex = steps.findIndex((step) => step.name === 'Publish to MCP Registry');
+    const wait = steps[waitIndex];
+
+    expect(updateIndex).toBeGreaterThanOrEqual(0);
+    expect(waitIndex).toBeGreaterThan(updateIndex);
+    expect(validateIndex).toBeGreaterThan(waitIndex);
+    expect(authenticateIndex).toBeGreaterThan(validateIndex);
+    expect(publishIndex).toBeGreaterThan(authenticateIndex);
+    expect(wait.env?.RELEASE_VERSION).toBe(githubExpression('needs.release-please.outputs.version'));
+    expect(wait.run).toContain('MAX_ATTEMPTS=30');
+    expect(wait.run).toContain('RETRY_DELAY_SECONDS=20');
+    expect(wait.run).toContain(`https://registry.npmjs.org/arc-1/${shellVariable('RELEASE_VERSION')}`);
+    expect(wait.run).toContain(`"${shellVariable('NPM_VERSION_URL')}?attempt=${shellVariable('attempt')}"`);
+    expect(wait.run).toContain('.version == $version and .mcpName == $mcp_name');
   });
 });


### PR DESCRIPTION
## Goal

Prevent MCP Registry publication from racing npm trusted-publish propagation, including delays longer than the post-authentication retry window seen in release run #609 for v1.1.2.

## Root cause

The npm publish job completed at 21:53:58Z, but npm recorded v1.1.2 as published at 21:57:02Z. The existing 12-attempt publisher retry ended at 21:56:20Z. Extending that loop substantially would risk expiring the MCP Registry token, which is valid for five minutes.

## Changes

- Poll npm's exact version endpoint for up to 10 minutes before MCP Registry authentication.
- Verify both the expected package version and `mcpName`, with cache-busting requests.
- Obtain the five-minute GitHub OIDC registry token only after npm propagation and metadata validation.
- Retain the short registry-side retry for CDN-edge differences.
- Expand workflow regression coverage for wait bounds and step ordering.
- Add the required 1.1.2 release-note annotation as a separate docs commit.

## Verification

- `npm test` (182 files, 5,374 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run validate:policy`
- `npm run check:sizes`
- `npm run docs:build`
- Executed the extracted npm wait step successfully against `arc-1@1.1.2`
- Re-ran failed release run #609 successfully