### PR TITLE
feat: add ARC-1 newsletter signup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'docs_page/**'
       - 'docs/overrides/**'
+      - 'overrides/**'
       - 'README.md'
       - 'mkdocs.yml'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ ARC-1 connects AI assistants (Claude, GitHub Copilot, Copilot Studio, and any MC
 [![CodeQL](https://github.com/arc-mcp/arc-1/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/arc-mcp/arc-1/security/code-scanning)
 [![Dependency Review](https://github.com/arc-mcp/arc-1/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/arc-mcp/arc-1/actions/workflows/dependency-review.yml)
 
-**[Full Documentation](https://docs.arc-1-mcp.com/)** | **[Quickstart](https://docs.arc-1-mcp.com/quickstart/)** | **[Tool Reference](https://docs.arc-1-mcp.com/tools/)** | **[Blog Series](https://blog.zeis.de/tags/ai-abap-development-series/)**
+**[Full Documentation](https://docs.arc-1-mcp.com/)** | **[Quickstart](https://docs.arc-1-mcp.com/quickstart/)** | **[Tool Reference](https://docs.arc-1-mcp.com/tools/)** | **[ARC-1 Updates](https://docs.arc-1-mcp.com/newsletter/)** | **[Blog Series](https://blog.zeis.de/tags/ai-abap-development-series/)**
+
+> 📬 **Stay current with ARC-1** — get major releases, upgrade and security notes, practical guides, and occasional questions where your feedback can shape what comes next. **[Join ARC-1 Updates →](https://docs.arc-1-mcp.com/newsletter/)**
 
 > 📖 **New: AI ABAP Development blog series** — long-form posts on AI for ABAP, ARC-1 design, and real-world BTP / Copilot Studio / Joule walkthroughs. **[Read the series →](https://blog.zeis.de/tags/ai-abap-development-series/)**
 

--- a/docs_page/index.md
+++ b/docs_page/index.md
@@ -6,7 +6,7 @@ ARC-1 is a TypeScript MCP server (distributed as an npm package and Docker image
 
 !!! tip "Stay current with ARC-1"
 
-    Get major releases, upgrade and security notes, practical guides, and occasional questions where your feedback can shape what comes next. Usually one email per month. [Join ARC-1 Updates →](newsletter.md)
+    Get major releases, upgrade and security notes, practical guides, and occasional questions where your feedback can shape what comes next. [Join ARC-1 Updates →](newsletter.md)
 
 ## Why ARC-1?
 

--- a/docs_page/index.md
+++ b/docs_page/index.md
@@ -4,6 +4,10 @@
 
 ARC-1 is a TypeScript MCP server (distributed as an npm package and Docker image) that implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) and translates AI tool calls into [SAP ABAP Development Tools (ADT)](https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide/about-abap-development-tools) REST API requests. It works with Claude, GitHub Copilot, VS Code, and any MCP-compatible client.
 
+!!! tip "Stay current with ARC-1"
+
+    Get major releases, upgrade and security notes, practical guides, and occasional questions where your feedback can shape what comes next. Usually one email per month. [Join ARC-1 Updates →](newsletter.md)
+
 ## Why ARC-1?
 
 As an **admin**, you control what the AI can and cannot do via positive-opt-in flags:

--- a/docs_page/newsletter.md
+++ b/docs_page/newsletter.md
@@ -1,0 +1,40 @@
+# ARC-1 Updates
+
+Important product news, without the noise.
+
+Subscribe for major ARC-1 releases, upgrade and security information, practical SAP/AI guides,
+and occasional questions where your feedback can shape what comes next. Expect roughly one email
+per month; urgent security information may be sent separately.
+
+<a class="md-button md-button--primary" href="https://t7f41a12d.emailsys1a.net/299/1775/e9729d7391/subscribe/form.html?_g=1788439997">Join ARC-1 Updates</a>
+
+The signup form opens on rapidmail's hosted page. This keeps third-party form scripts and CAPTCHA
+resources off the ARC-1 documentation site until you choose to subscribe.
+
+## What you will receive
+
+- Major releases and the changes that matter when you operate or upgrade ARC-1
+- Security and compatibility notices
+- Practical guides that are useful beyond a changelog
+- Occasional requests for feedback on priorities and real-world usage
+
+ARC-1 is open source, so public bug reports and feature proposals still belong in
+[GitHub Issues](https://github.com/arc-mcp/arc-1/issues). The newsletter adds a lower-noise channel
+for people who do not watch every repository notification.
+
+## Privacy
+
+The signup form asks only for your email address. rapidmail sends a confirmation email, and you are
+subscribed only after clicking its double-opt-in link. Every newsletter includes an unsubscribe
+link.
+
+IT Consulting Marian Zeis uses rapidmail to manage subscriptions and deliver the newsletter.
+Subscriber data is processed in Germany. Opening and clicking behavior is not tracked for ARC-1
+Updates; delivery, bounce, and unsubscribe events are still processed so the service can operate.
+The rapidmail form is hosted separately, so no rapidmail form or captcha resources are loaded merely
+by visiting this documentation page.
+
+You can withdraw your consent or request access, correction, or deletion by emailing
+[marian@zeis.de](mailto:marian@zeis.de). See the
+[legal notice](https://zeis.de/#/impressum) and
+[rapidmail data protection information](https://www.rapidmail.de/datenschutz) for more details.

--- a/docs_page/newsletter.md
+++ b/docs_page/newsletter.md
@@ -3,8 +3,7 @@
 Important product news, without the noise.
 
 Subscribe for major ARC-1 releases, upgrade and security information, practical SAP/AI guides,
-and occasional questions where your feedback can shape what comes next. Expect roughly one email
-per month; urgent security information may be sent separately.
+and occasional questions where your feedback can shape what comes next.
 
 <a class="md-button md-button--primary" href="https://t7f41a12d.emailsys1a.net/299/1775/e9729d7391/subscribe/form.html?_g=1788439997">Join ARC-1 Updates</a>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ docs_dir: docs_page
 
 theme:
   name: material
+  custom_dir: overrides
   palette:
     # `media` = follow the OS light/dark setting on first visit; the toggle then pins a choice.
     - media: '(prefers-color-scheme: light)'
@@ -26,6 +27,7 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
+    - announce.dismiss
     - navigation.path
     - navigation.sections
     - navigation.top
@@ -40,6 +42,7 @@ theme:
 
 nav:
   - Home: index.md
+  - Newsletter: newsletter.md
   - Quickstart: quickstart.md
   - Agent Plugin: agent-plugin.md
   - Install in Claude: install-in-claude.md

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  ARC-1 release, upgrade, and security news —
+  <a href="{{ 'newsletter/' | url }}"><strong>join ARC-1 Updates →</strong></a>
+{% endblock %}


### PR DESCRIPTION
## Summary

- add an ARC-1 Updates page with the rapidmail-hosted signup link and privacy information
- promote the newsletter in the documentation announcement bar, navigation, homepage, and README
- trigger Pages builds for root-level MkDocs theme overrides

## Validation

- npm run docs:build
- git diff --check

## Deployment

Merging to main triggers the existing GitHub Pages workflow. After Pages publishes the new /newsletter/ page, complete one end-to-end double-opt-in signup test.