### PR TITLE
docs(btp): correct deployment and XSUAA recovery guidance

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,13 +20,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: '24'
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.12'
       - name: Install documentation dependencies
         run: pip install -r requirements-docs.txt
       - name: Build documentation strictly (no SAP credentials)
-        run: npm run docs:build
+        run: mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+name: Validate Documentation
+
+# Always run: required docs checks must not stay pending because of a path/title filter.
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.12'
+      - name: Install documentation dependencies
+        run: pip install -r requirements-docs.txt
+      - name: Build documentation strictly (no SAP credentials)
+        run: npm run docs:build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,9 @@ on:
       - 'overrides/**'
       - 'README.md'
       - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - 'package.json'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -26,18 +29,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install MkDocs
-        run: pip install "mkdocs-material>=9.5,<10" "mkdocs-redirects>=1.2,<2"
+        run: pip install -r requirements-docs.txt
 
       - name: Build docs
-        run: mkdocs build
+        run: mkdocs build --strict
 
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Python
@@ -46,7 +45,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/
 
@@ -59,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/docs/plans/2026-09-05-btp-operational-corrections.md
+++ b/docs/plans/2026-09-05-btp-operational-corrections.md
@@ -43,7 +43,13 @@ do not define the route. Migration instructions make URL changes conditional. Ad
 the actual-route command and remove the remaining derived-host examples; retain the existing
 correctness/strict-build checks without expanding the operator documentation.
 
-## Implementation evidence
+The independent review also removes Node/full-history checkout from the docs build, pins all
+actions in the two touched workflows, and enables MkDocs' built-in anchor warnings under strict
+mode. Reconcile verified-orphan recovery and IdP-origin links across the existing guides; avoid
+generic role grants, collection deletion or token uploads as troubleshooting steps. Prove a broken
+anchor fails, then rebuild the clean tree. No custom link checker or additional public page.
+
+## Initial implementation evidence
 
 - Full unit suite: 193 files / 5,760 tests passed; focused contracts: 58 tests passed.
 - Type checks and strict MkDocs build passed on Node 24.11.1.

--- a/docs/plans/2026-09-05-btp-operational-corrections.md
+++ b/docs/plans/2026-09-05-btp-operational-corrections.md
@@ -36,6 +36,13 @@ No cloud credentials, browser login, role changes or deployment are required.
 - New PR workflow has no secrets, deployment, or write permissions.
 - Changes remain documentation, documentation tests and CI only.
 
+## Review refinement (2026-09-06)
+
+Use the observed CF/custom public route throughout the OAuth examples; space-qualified XSUAA names
+do not define the route. Migration instructions make URL changes conditional. Add a regression for
+the actual-route command and remove the remaining derived-host examples; retain the existing
+correctness/strict-build checks without expanding the operator documentation.
+
 ## Implementation evidence
 
 - Full unit suite: 193 files / 5,760 tests passed; focused contracts: 58 tests passed.

--- a/docs/plans/2026-09-05-btp-operational-corrections.md
+++ b/docs/plans/2026-09-05-btp-operational-corrections.md
@@ -1,0 +1,47 @@
+# BTP documentation corrections — implementation plan
+
+## Summary
+
+Correct misleading capability and XSUAA recovery instructions, and run a credential-free strict
+documentation build on pull requests. No runtime, IAM or deployment change. Approved as PR 01 of
+the BTP setup improvement series; implemented independently from the later example/navigation PRs.
+
+## Baseline and refined scope
+
+Rechecked `origin/main` at `5c36f2a734870081780a5d4be734f605b1036318` (package 1.2.0).
+The specialist multi-target guide already describes the right capability boundary; only summaries
+disagree. Unit CI already runs for docs PRs. `docs:build` passes in strict mode on the baseline.
+
+1. Preserve specialist guidance; add a compact action table checked against the runtime schema.
+2. Correct the deployment and acceptance summaries, distinguishing mutations from ATC/Unit workloads.
+3. Route MTA users to inspection/assignment; label manual creation/binding as an advanced alternative.
+4. Diagnose unknown scope, missing/empty roles, wrong origin, stale SSO and cached client state
+   separately. Preserve role assignments/mappings; remove destructive generic recovery recipes.
+5. Share MkDocs dependencies between publication and a new read-only PR build; pin new actions.
+6. Test source/table parity, workflow safety and a deliberately invalid table/link; review rendered
+   pages and the MTA/unknown-scope/stale-session scenarios before opening the PR.
+
+## Verification and boundaries
+
+Run focused multi-target/policy/docs tests, strict docs build, formatting, type checking and diff
+review. Verify negative cases actually fail. Record exact results in the PR description. Human/LLM
+benchmarking is optional; no measured usability improvement or live customer readiness is claimed.
+No cloud credentials, browser login, role changes or deployment are required.
+
+## Final review checklist
+
+- Public page URLs and existing linked step anchors remain usable.
+- A read role is never presented as permission to mutate or as proof of SAP access.
+- Unknown scope names do not lead to cookie deletion or wider roles.
+- New PR workflow has no secrets, deployment, or write permissions.
+- Changes remain documentation, documentation tests and CI only.
+
+## Implementation evidence
+
+- Full unit suite: 193 files / 5,760 tests passed; focused contracts: 58 tests passed.
+- Type checks and strict MkDocs build passed on Node 24.11.1.
+- Deliberately missing/invented actions fail the parity guard. A temporary nonexistent local link
+  made MkDocs abort in strict mode; the fixture was removed and the clean build repeated.
+- Rendered ownership and recovery sections inspected in the local browser. Walkthroughs for
+  MTA-owned service, unknown scope and stale session lead to different, non-destructive actions.
+- No live SAP/BTP or paid-model evaluation performed; no customer deployment claim.

--- a/docs_page/authorization.md
+++ b/docs_page/authorization.md
@@ -513,7 +513,10 @@ stopped. Do not enable gzip merely to make an unexplained authorization failure 
 
 ### MCP sign-in ends on a blank page / "this site can't be reached" / "Missing required parameters … code, state, nonce"
 
-These client-side symptoms almost always share one server-side cause: XSUAA authenticated the user but rejected the authorization with **`invalid_scope`** ("this user is not allowed any of the requested scopes"), so no `code` was issued. The MCP client's loopback callback then receives no `code` — and its listener may already be closed, which is why the browser shows `ERR_CONNECTION_REFUSED`.
+One possible cause is a rejected XSUAA authorization, so no `code` was issued. For example,
+`invalid_scope` with "this user is not allowed any of the requested scopes" points to the user's
+grant. A closed loopback listener can produce `ERR_CONNECTION_REFUSED`, but that symptom alone
+does not identify the authorization problem.
 
 Confirm the real error in the server log — it lands on ARC-1's callback, not the client:
 
@@ -524,20 +527,27 @@ cf logs arc1-mcp-server --recent | grep '/oauth/callback?error='
 
 Since v0.9.8 ARC-1 renders this reason on its `/oauth/callback` error page (instead of bouncing to the dead loopback), so the browser shows the cause directly.
 
-`invalid_scope` means the signed-in identity holds **no ARC-1 role collection** — usually because the role was assigned under a **different IdP origin** than the one the login uses. Fix it with the next two entries.
+For the specific message **"this user is not allowed any of the requested scopes"**, check the
+collection's roles and the signed-in IdP origin below. `invalid_scope` can also mean an unknown or
+malformed requested scope; use the [XSUAA diagnosis table](xsuaa-setup.md#insufficient-scope-invalid_scope)
+before changing roles or browser state.
 
 ### "I changed the user's role but the new scopes don't appear"
 
-XSUAA caches the user's authorities in their browser session. When you change role-collection assignments in BTP Cockpit, **existing JWTs keep the old scopes until they expire** (typically 1 hour) AND the user's SSO session at XSUAA / IAS still references the old authorities.
+Changing role collections does not rewrite already issued JWTs. Their claims remain unchanged
+until expiry; an XSUAA browser session can also retain old authorities. Check the actual grant
+and token lifetime rather than assuming a reconnect refreshes either.
 
-To force fresh scopes immediately:
+After a verified role change:
 
-1. If sign-in failed with `invalid_scope`, have an administrator assign the correct ARC-1 role collection under the identity provider used for login.
+1. Verify the required role collection contains current application roles and is assigned under the IdP used for login. An unknown scope name needs configuration repair, not another role.
 2. On ARC-1's failure page, select **Role assigned? Refresh access**. ARC-1 sends the browser through XSUAA's logout endpoint with its bound client ID and a fixed, allowlisted return URL.
-3. After **Access refreshed** appears, return to the MCP client and disconnect/reconnect or retry sign-in. A new identity-provider login may be required.
+3. After **Access refreshed** appears, use the MCP client's re-authentication flow and refresh its tool catalog. Reconnecting alone may reuse a token. A new identity-provider login may be required.
 4. If the deployment predates this recovery action, retry in a private browser window or clear the XSUAA-domain cookies manually. See [XSUAA Setup → invalid_scope](xsuaa-setup.md#insufficient-scope-invalid_scope).
 
-After that, the new JWT will be issued from a fresh session and carry only the user's currently assigned scopes. You can verify by reading the JWT at [jwt.ms](https://jwt.ms) - the `scope` claim should match the role collection's scopes.
+A fresh token should reflect the current grant. If claim inspection is needed, inspect it locally;
+do not paste bearer tokens into websites, tickets or chat. Decoding claims alone does not validate
+the token or prove SAP access.
 
 The recovery action does not revoke access tokens already issued to other sessions. Do not construct a logout URL from request parameters or use an arbitrary redirect: XSUAA application logout requires an allowlisted redirect to prevent open redirects.
 
@@ -553,11 +563,12 @@ From the CLI, assign under the right origin — `--of-idp` is the critical part.
 # list the IdP origins (the IAS "business users" trust is the usual app-login IdP)
 btp list security/trust --subaccount <subaccount-id>
 
-# assign under the origin the OAuth flow actually uses
-btp assign security/role-collection "ARC-1 Admin" --subaccount <subaccount-id> --to-user <email> --of-idp sap.custom
+# Example only: substitute the required collection and the verified origin from the trust list.
+btp assign security/role-collection "ARC-1 Viewer (<space>)" --subaccount <subaccount-id> --to-user <email> --of-idp sap.custom
 ```
 
-Assigning under only `sap.default` while logging in via the IAS tenant is the single most common cause of `invalid_scope`.
+Assigning under only `sap.default` while logging in via another origin is one cause of the
+"not allowed any requested scopes" error. Do not assume every IAS tenant uses `sap.custom`.
 
 ---
 

--- a/docs_page/btp-administration.md
+++ b/docs_page/btp-administration.md
@@ -324,7 +324,8 @@ Record evidence rather than only checking configuration screens.
 - [ ] Multi-target Admin `SAPTargets` shows no unexpected quarantine, duplicate, shadow, or policy narrowing.
 - [ ] Pinned, aggregate, unknown-target, lowercase-route, bare `/mcp`, and absent `/targets` behavior match the selected topology.
 - [ ] Named data preview and SQL work only where both instance and destination allow them.
-- [ ] Multi-target routes expose no mutation, transport, Git, ATC, ABAP Unit, plugin, UI, or hyperfocused capability.
+- [ ] Multi-target routes expose no writes, activation, transport/Git mutations, SAP-backed formatter/settings actions, plugins, UI, or hyperfocused mode. Permitted lint/transport reads match the [reviewed action surface](multi-target-setup.md#allowed-tools).
+- [ ] ATC and ABAP Unit workload access is deliberately retained or denied; neither is run as a routine deployment smoke test.
 - [ ] Shared Basic, if enabled, uses a least-privilege non-`SAP_ALL` user, monitored lockout/expiry, one CF process, and a rehearsed non-rolling update.
 - [ ] PP-only scale testing includes total process concurrency and consistent registry revisions.
 - [ ] VS Code/GitHub Copilot, Cursor, and any customer-required MCP client completed OAuth, reconnect, catalog refresh, and one safe call.

--- a/docs_page/btp-administration.md
+++ b/docs_page/btp-administration.md
@@ -112,10 +112,13 @@ The MTA creates seven role collections with the CF space suffix, for example
 4. Assign the least-privilege collection before the user's first MCP login.
 5. Have the user sign in again and restart/reconnect the MCP client if its tool catalog is cached.
 
-An older or recreated XSUAA instance can leave same-name collections with empty/orphaned roles. Do
-not infer that an assignable collection exists merely because a role template exists. If a
-collection is empty, remove the orphaned collection, perform the reviewed MTA deployment, inspect
-the recreated roles, and reassign users.
+An older or recreated XSUAA instance can leave same-name collections with empty/orphaned roles.
+First [inspect and reconcile the collection with its owner](xsuaa-setup.md#repair-missing-or-stale-collection-roles-with-the-owner);
+empty roles alone do not justify deletion. Only when the owner confirms an orphaned collection
+requires replacement, record its roles, user/group assignments and IdP mappings before removal.
+Then perform the reviewed MTA deployment, inspect the recreated roles, restore the approved
+assignments/mappings and verify a fresh user grant. This is not a generic login fix and does not
+require deleting XSUAA.
 
 When changing the roles contained in a predefined collection, prefer a newly named/versioned
 collection: deploy it, inspect it, assign users/groups, reauthenticate and test, then remove old

--- a/docs_page/btp-cloud-foundry-deployment.md
+++ b/docs_page/btp-cloud-foundry-deployment.md
@@ -492,9 +492,12 @@ For a single-target instance, widen the application ceiling in the reviewed `.mt
 assign the least-privilege XSUAA collection, and retest the negative boundary. Data, SQL, writes,
 transports, Git, and package scope are independent decisions.
 
-For multi-target v1, only named data preview and SQL can be added. They require both application
-ceilings and target-local destination opt-ins. Writes, activation, transport/Git mutations, ATC,
-ABAP Unit, SAPLint, plugins, UI, and hyperfocused mode remain unavailable.
+For multi-target v1, data preview and SQL require both application ceilings and target-local
+destination opt-ins. The [reviewed tool/action surface](multi-target-setup.md#allowed-tools) also
+includes offline lint, read-only transport inspection, ATC and ABAP Unit. ATC/Unit execute SAP
+workloads: keep them out of routine deployment smoke tests, and deny their actions when not approved.
+Writes, activation, transport/Git mutations, SAP-backed formatter/settings actions, plugins, UI,
+and hyperfocused mode remain unavailable.
 
 When data preview or SQL is enabled, keep the shipped 2 MiB cumulative response allowance and two
 process-wide data-result slots initially. Wide rows can reach the byte ceiling below the 10,000-row

--- a/docs_page/multi-target-setup.md
+++ b/docs_page/multi-target-setup.md
@@ -327,6 +327,7 @@ non-rolling stop/start strategy.
 <a id="exact-v1-tool-surface"></a>
 <a id="v1-safety-boundary"></a>
 <a id="aggregate-tool-behavior"></a>
+<a id="allowed-tools"></a>
 
 ## What multi-target v1 exposes
 
@@ -334,14 +335,21 @@ Both pinned and aggregate routes draw from the same set of up to eight permitted
 tools. Tool lists are narrowed by configured instance/target policy and XSUAA scope where the schema
 permits it:
 
-- `SAPRead`
-- `SAPSearch`
-- `SAPQuery`
-- `SAPNavigate`
-- `SAPLint` (`lint`, `lint_and_fix`, and `list_rules` only; all run offline in ARC-1)
-- `SAPDiagnose`
-- `SAPContext`
-- `SAPTransport` (`list`, `get`, `check`, and `history` only)
+<!-- multi-target-action-contract:start — checked against the runtime schema -->
+| Tool | Permitted actions / purpose |
+|---|---|
+| `SAPRead` | Source/metadata reads; data operations require additional gates |
+| `SAPSearch` | Repository search; database-backed variants require SQL gates |
+| `SAPQuery` | SQL queries, only with the required data/SQL policy and scopes |
+| `SAPNavigate` | Code navigation |
+| `SAPLint` | `lint`, `lint_and_fix`, `list_rules` (offline in ARC-1; does not save fixes to SAP) |
+| `SAPDiagnose` | `syntax`, `unittest`, `atc`, `atc_variants`, `cds_testcases`, `dumps`, `traces`, `trace_requests`, `system_messages`, `gateway_errors`, `object_state`, `quickfix`, `odata_perf`, `cds_sql`, `sql_trace_state`, `sql_trace_directory`, `authorization_trace` |
+| `SAPContext` | Dependency context |
+| `SAPTransport` | `list`, `get`, `check`, `history` |
+<!-- multi-target-action-contract:end -->
+
+This is the maximum reviewed action set, not a promise of access. Diagnostic data actions still
+require data policy/scopes; SAP release support, authorization and deny-actions can narrow it.
 
 On the aggregate route, `SAPTransport.target` is the required SAP system/client selector. The
 single-target transport-creation field with the same name is omitted because `create` is not part of

--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -81,10 +81,10 @@ roles before assigning users.
 > the collection for *your* space (Step 3). The route uses CF's generated default host unless
 > overridden; read the actual route from `cf app <app-name>` instead of guessing it from the space.
 >
-> **Migrating an existing instance** onto per-space naming changes its route host
-> and `xsappname`: update the MCP client URL, re-assign users to the new
-> `ARC-1 … (<space>)` collections, and set `ARC1_DCR_SIGNING_SECRET` before the
-> redeploy so cached OAuth `client_id`s survive the `xsappname` change.
+> **Migrating an existing instance:** compare its current `xsappname`, collections and route
+> with the reviewed deployment. Re-assign users if the collection/application identifier changes;
+> update MCP client URLs only if the actual route changes. Preserve the
+> [stable DCR signing key](#stable-dcr-signing-key-recommended) across redeployments.
 >
 > Updating an existing XSUAA service with
 > `cf update-service arc1-xsuaa -c xs-security.json` updates the scopes and role
@@ -162,16 +162,21 @@ to distinguish an invalid requested scope from missing authorization or stale cl
 
 ## Step 4: Verify OAuth Discovery
 
+Read the route from `cf app <app-name>`; do not derive it from the space or copy another region's
+hostname. If using a custom public URL, use that reviewed URL. Replace `<arc1-route>` in the client
+examples below with this same host.
+
 ```bash
-curl -s https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/.well-known/oauth-authorization-server | jq .
+ARC1_URL="https://<arc1-route>"
+curl -fsS "$ARC1_URL/.well-known/oauth-authorization-server" | jq .
 ```
 
 Expected response:
 ```json
 {
-  "issuer": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/",
-  "authorization_endpoint": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/authorize",
-  "token_endpoint": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/token",
+  "issuer": "https://<arc1-route>/",
+  "authorization_endpoint": "https://<arc1-route>/authorize",
+  "token_endpoint": "https://<arc1-route>/token",
   "scopes_supported": ["read", "write", "data", "sql", "transports", "git", "admin"],
   "response_types_supported": ["code"],
   "code_challenge_methods_supported": ["S256"],
@@ -209,7 +214,7 @@ Add to `claude_desktop_config.json`:
 {
   "mcpServers": {
     "arc1-sap": {
-      "url": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp"
+      "url": "https://<arc1-route>/mcp"
     }
   }
 }
@@ -224,7 +229,7 @@ In Cursor settings → MCP Servers, add:
 ```json
 {
   "arc1-sap": {
-    "url": "https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp"
+    "url": "https://<arc1-route>/mcp"
   }
 }
 ```
@@ -233,7 +238,7 @@ In Cursor settings → MCP Servers, add:
 
 Connect to:
 ```
-https://arc1-mcp-<space>.cfapps.us10-001.hana.ondemand.com/mcp
+https://<arc1-route>/mcp
 ```
 
 The inspector will perform OAuth discovery and redirect to XSUAA login.

--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -7,6 +7,7 @@ This guide sets up BTP XSUAA authentication so MCP-native clients (Claude Deskto
 MCP-native clients use RFC 8414 OAuth discovery to find authorization endpoints at the MCP server's URL. ARC-1 proxies the OAuth flow to XSUAA using the MCP SDK's `ProxyOAuthServerProvider`.
 
 **Auth flow:**
+
 1. Client discovers OAuth via `/.well-known/oauth-authorization-server`
 2. Client redirects user to ARC-1's `/authorize` endpoint
 3. ARC-1 proxies to XSUAA's login page
@@ -22,7 +23,22 @@ MCP-native clients use RFC 8414 OAuth discovery to find authorization endpoints 
 - CF CLI installed and logged in
 - ARC-1 deployed on BTP CF (see [BTP Cloud Foundry deployment](btp-cloud-foundry-deployment.md))
 
-## Step 1: Create XSUAA Service Instance
+<a id="step-1-create-xsuaa-service-instance"></a>
+
+## Step 1: Identify the XSUAA lifecycle owner
+
+**Deployed with the repository MTA?** It already creates/binds XSUAA and enables
+`SAP_XSUAA_AUTH`. Do not create a second service or bind it again. Check `cf target`, then
+`cf services` and `cf app <app-name>` in the intended space. Record the bound XSUAA instance and
+its application identifier; inspect credentials locally only when needed and never paste them
+into chat or a ticket. Continue to [Step 3](#step-3-assign-role-collections).
+
+**Using a manually managed app or customer-owned service?** Agree on the owner first. The create
+command below is only for a new, manually managed XSUAA instance. For an existing instance, inspect
+it and agree on descriptor updates instead of recreating it. MTA and manual lifecycle changes must
+not compete for ownership. See [configuration ownership](btp-administration.md#configuration-ownership).
+
+### Manual path: create only when a new instance is intended
 
 The `xs-security.json` file defines scopes, roles, and OAuth configuration:
 
@@ -42,7 +58,10 @@ The included `xs-security.json` defines 7 scopes:
 | `git`          | Authorize gated abapGit mutation/egress actions; gCTS mutations remain quarantined | `SAPGit.external_info`/`clone`/`pull`/`push`/branch/unlink actions after server gates          |
 | `admin`        | Implies ALL other scopes at runtime                            | Everything                                                                                   |
 
-And 7 pre-defined role collections (defined in `mta.yaml`, assignable to users in BTP Cockpit):
+The MTA additionally defines 7 role collections (assignable in BTP Cockpit). The manual
+`create-service` command above reads only `xs-security.json`; it does not apply the collections in
+`mta.yaml`. A manual owner must create the required collections and add the current application
+roles before assigning users.
 
 | Role Collection           | Scopes                                                   | Use Case                                  |
 |---------------------------|----------------------------------------------------------|-------------------------------------------|
@@ -54,12 +73,13 @@ And 7 pre-defined role collections (defined in `mta.yaml`, assignable to users i
 | ARC-1 Developer + SQL     | `read`, `write`, `data`, `sql`, `transports`, `git`      | Developer + data + freestyle SQL          |
 | ARC-1 Admin               | all 7                                                    | Administrative access                     |
 
-> **Multi-space deployments.** `mta.yaml` derives the route host, the XSUAA
-> `xsappname`, and these role-collection names from the deploy-time `${space}`
+> **Multi-space deployments.** `mta.yaml` derives the XSUAA
+> `xsappname` and these role-collection names from the deploy-time `${space}`
 > placeholder, so the same mtar can be deployed into several spaces of one
 > subaccount side by side. The collections therefore appear in the cockpit with
 > the space appended — e.g. `ARC-1 Viewer (dev)` in space `dev`. Assign users to
-> the collection for *your* space (Step 3).
+> the collection for *your* space (Step 3). The route uses CF's generated default host unless
+> overridden; read the actual route from `cf app <app-name>` instead of guessing it from the space.
 >
 > **Migrating an existing instance** onto per-space naming changes its route host
 > and `xsappname`: update the MCP client URL, re-assign users to the new
@@ -88,7 +108,12 @@ Role collections are only the user-permission gate. Server flags still have to a
 
 See [authorization.md](authorization.md) for the full three-layer authorization model.
 
-## Step 2: Bind Service and Configure
+<a id="step-2-bind-service-and-configure"></a>
+
+## Step 2: Manual path — bind service and configure
+
+Skip these changes for a completed repository MTA deployment. For a manually managed app, replace
+the example app/service names with the reviewed names and confirm `cf target` before changing it.
 
 ```bash
 # Bind XSUAA to your app
@@ -122,11 +147,18 @@ cf logs arc1-mcp-server --recent | grep XSUAA
 **Assign before you hand out the MCP URL.** The assignment creates the shadow user, so it works for users who have never logged in — use the **Users** tab above, or:
 
 ```bash
-btp assign security/role-collection "ARC-1 Admin (<space>)" \
+btp assign security/role-collection "ARC-1 Viewer (<space>)" \
   --subaccount <subaccount-id> --to-user <email> --of-idp <origin-key>
 ```
 
-Order matters. If the user logs in first, that failed login leaves a cached XSUAA session behind, and every retry keeps returning `invalid_scope` after you grant the role — until they clear their browser cookies. A self-service rollout ("here's the URL, try it") produces that order by default, so it hits essentially every user once. See [`invalid_scope`](#insufficient-scope-invalid_scope) if you are already in that state.
+Choose the least-privilege collection for the task (normally Viewer for source-read acceptance),
+not Admin simply to make login work. Use the **application** identity-provider origin; a platform
+CLI/cockpit login is not proof of the user's application assignment.
+
+Assigning before first sign-in avoids one possible stale-session case. If a user signed in before
+the grant, they may need **Role assigned? Refresh access** and a new MCP sign-in. Cookie deletion
+is not a required setup step. First use the [`invalid_scope` decision table](#insufficient-scope-invalid_scope)
+to distinguish an invalid requested scope from missing authorization or stale client state.
 
 ## Step 4: Verify OAuth Discovery
 
@@ -377,7 +409,12 @@ Events flow through the existing audit sinks (stderr / file / BTP Audit Log Serv
 
 ## Updating xs-security.json
 
-If you need to add redirect URIs or change scopes:
+For MTA-owned services, change the reviewed source descriptor/extension and follow the normal
+MTA deployment procedure so its effective application name, roles and configuration stay aligned.
+Do not replace MTA's merged configuration with the bare base file as a troubleshooting shortcut.
+
+For a **manually managed** service, its owner can add approved redirect URIs or scopes and apply
+the matching descriptor:
 
 ```bash
 # Edit xs-security.json
@@ -501,35 +538,59 @@ Then run `cf update-service arc1-xsuaa -c xs-security.json`.
 API key tokens now include a synthetic expiration (1 year). If you see this error, ensure you're running the latest version of ARC-1.
 
 ### "XSUAA credentials not found"
-Ensure the XSUAA service is bound: `cf services` should show `arc1-xsuaa` bound to your app. If not: `cf bind-service arc1-mcp-server arc1-xsuaa && cf restage arc1-mcp-server`.
+Confirm `cf target` and inspect `cf services` for the intended binding. For MTA-owned resources,
+review the deployment operation and descriptor with its owner. Use [manual binding](#step-2-bind-service-and-configure)
+only for a manually managed app; do not attach a similarly named XSUAA instance just to clear the error.
 
 ### "Insufficient scope" / "invalid_scope"
-The user doesn't have the required role collection assigned. Go to BTP Cockpit → Security → Role Collections and assign the appropriate collection to the user.
+`invalid_scope` is not a diagnosis by itself. OAuth permits it for unknown or malformed scopes as
+well as scopes exceeding the grant ([RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1)).
+Read the exact error description, selected endpoint and intended application identity before
+changing roles or clearing state. Do not share full callback URLs, tokens or binding credentials.
 
-If the collection **is** already assigned and you still get `invalid_scope`, it is one of three things, in the order worth checking.
+| Evidence | Owner and next check |
+|---|---|
+| Scope name reported as invalid/unknown, e.g. an application-qualified `user_attributes` | Application/deployment owner: compare the request, endpoint metadata and effective XSUAA descriptor. Fix the unsupported scope/name qualification. Do not invent an application scope or grant Admin to suppress the error. |
+| User is not allowed any requested scopes | IAM owner: check the required collection is assigned to the correct application identity and contains roles for the bound application identifier. An assignment alone does not prove those roles exist. |
+| Collection exists but has no roles or references an old application identifier | IAM and deployment owners: inspect current role templates and collection contents; use the owner-safe repair below. |
+| Email is assigned but login uses another IdP origin | IAM owner: match the application trust's origin and user identity. Platform CLI/cockpit access does not establish application access. |
+| Correct current roles/origin are verified, but the browser session predates the change | User: try the application refresh action below, then start sign-in again from the MCP client. |
+| Sign-in succeeds but old permissions/tools remain | User: obtain a fresh token through the client's re-authentication flow, then refresh/reload its tool catalog. Reconnecting alone may reuse a cached token. |
 
-**1. Stale XSUAA browser session — the common one.** After an administrator assigns a role collection, the browser can still hold the XSUAA SSO session created before the grant. The failed ARC-1 sign-in page therefore includes **Role assigned? Refresh access**. Use it after the role assignment, wait for the **Access refreshed** page, then return to the MCP client and connect or retry sign-in. A new identity-provider login may be required.
+A fast callback or an absent login form is **not proof** of stale permissions: SSO can also return
+a current grant failure without an interactive form. Preserve a sanitized error code and request
+correlation for the owner instead of drawing conclusions from timing.
+
+#### Refresh access after a verified assignment
+
+After an administrator assigns a role collection, the browser can still hold an older XSUAA SSO
+session. The failed ARC-1 sign-in page includes **Role assigned? Refresh access**. Use it after
+checking the assignment, wait for **Access refreshed**, then return to the MCP client and retry
+sign-in. A new identity-provider login may be required. This cannot repair an unknown scope name.
 
 The action calls XSUAA's documented `/logout.do` endpoint with ARC-1's bound `client_id` and a fixed, allowlisted ARC-1 return URL. Callback query parameters never select the logout host or redirect. Standard Cloud Foundry routes are covered by the `https://*.hana.ondemand.com/**` entry in `xs-security.json`; if `ARC1_PUBLIC_URL` uses a custom domain or path, add its `/oauth/logged-out` URL to `oauth2-configuration.redirect-uris` before deploying.
 
-The action clears the browser SSO session; it does not revoke access tokens already issued to other sessions. If an MCP client cached an old token, disconnect/reconnect it after refreshing access. On ARC-1 versions without the action, use a private browser window or delete cookies for the XSUAA domain (`<identityzone>.authentication.<region>.hana.ondemand.com`) and retry. Read the exact domain from the `url` field under **Cockpit → Application → Service Bindings → arc1-xsuaa → Credentials**.
+The action ends the XSUAA browser SSO session; it does not revoke already issued access tokens or
+necessarily sign out the upstream IdP. Use the MCP client's re-authentication flow if it retains an
+old token, then refresh its tool catalog. On older ARC-1 versions without the action, a fresh private
+browser session is a useful comparison. Only if necessary, clear site data for the verified XSUAA
+domain—not all browser cookies. Read that domain from the intended binding locally, without
+copying its credentials into a support request.
 
 Do not use a bare `<xsuaa-url>/logout` or `/logout.do` URL. XSUAA requires the application client and an allowlisted return URL for a reliable application logout.
 
-Diagnostic, in `cf logs <app-name> --recent`:
+#### Repair missing or stale collection roles with the owner
 
-```
-GET /authorize?...                         302
-GET /oauth/callback?error=invalid_scope    400   ← <200ms later
-```
+In **Security → Role Collections → the intended collection → Roles**, compare the role template
+and application identifier with the currently bound XSUAA application. For example, a Viewer
+collection needs `MCPViewer` from that application, not a similarly named old instance. Roles and
+collections are different objects; templates existing under **Roles** is insufficient evidence.
 
-`/authorize` → `/oauth/callback?error=invalid_scope` in under ~200 ms with no IAS login form in between is a cached session, not a missing role collection — a genuine grant problem costs a full interactive login first. Corollary: if a retry never shows a login form, the cookie is still there.
-
-**2. Role collection with no roles.** Deleting and recreating an XSUAA service instance orphans its role collections — collections are subaccount-scoped and survive the instance, their roles do not. A later `cf deploy` will not re-link them, because the `role-collections` config in `mta.yaml` only creates collections whose names don't already exist.
-
-Check **Cockpit → Security → Role Collections → "ARC-1 Admin (<space>)" → Roles**: it must list role `MCPAdmin` with Application Identifier `arc1-mcp-<space>!t<idx>`. An empty **Roles** tab is the tell. Fix: delete the role collection in the cockpit, `cf deploy` again, re-assign.
-
-**3. Wrong IdP origin.** If the subaccount has a custom IAS tenant (trust configuration shows `sap.custom`), role collections must be assigned with the correct IdP origin. Assigning via `sap.default` when the user logs in via `sap.custom` will result in `invalid_scope`. Platform IdP users (origin `<tenant>-platform`) are for cockpit and CLI access only — a role collection assigned there does nothing for application logon.
+Service replacement can leave stale references. Before repair, record the collection's roles,
+user/group assignments, IdP mappings and lifecycle owner. Have that owner reconcile the current
+roles through the approved MTA/IAM process and verify a fresh user grant. Do not delete/recreate
+collections or XSUAA as a generic login fix: that can disrupt other users and lose assignments or
+mappings. A redeploy alone is not proof that existing collections were repaired.
 
 ### "Invalid client_id" (Copilot Studio)
 DCR registrations are stateless and survive ordinary restart, push, restage, and scale-out while the

--- a/docs_page/xsuaa-setup.md
+++ b/docs_page/xsuaa-setup.md
@@ -86,10 +86,10 @@ roles before assigning users.
 > update MCP client URLs only if the actual route changes. Preserve the
 > [stable DCR signing key](#stable-dcr-signing-key-recommended) across redeployments.
 >
-> Updating an existing XSUAA service with
+> For a manually managed service, applying the base file with
 > `cf update-service arc1-xsuaa -c xs-security.json` updates the scopes and role
 > templates only. It does **not** create role collections declared in
-> `mta.yaml`. Run a full MTA deployment when adopting these collections, then
+> `mta.yaml`. Agree on lifecycle ownership before adopting the MTA, then
 > verify in **Security → Role Collections** that all seven collections exist and
 > contain the expected roles. This matters especially for older deployments:
 > seeing `MCPViewer`, `MCPDataViewer`, or `MCPSqlUser` under **Roles** does not
@@ -530,14 +530,14 @@ The first successful validation wins. This means:
 ## Troubleshooting
 
 ### "AADSTS50011: Redirect URI mismatch"
-The redirect URI used by the MCP client isn't in `xs-security.json`. Add the URI pattern:
-```json
-"redirect-uris": [
-  "http://localhost:*/**",
-  "https://*.cfapps.us10-001.hana.ondemand.com/**"
-]
-```
-Then run `cf update-service arc1-xsuaa -c xs-security.json`.
+Identify the issuer reporting the mismatch. `AADSTS50011` is a Microsoft Entra error: the IAM
+owner must compare the redirect URI and application ID in the error with the intended Entra
+registration ([Microsoft troubleshooting](https://learn.microsoft.com/en-us/troubleshoot/entra/entra-id/app-integration/error-code-aadsts50011-redirect-uri-mismatch)).
+Changing ARC-1's XSUAA allowlist does not repair that upstream registration.
+
+For a mismatch reported by XSUAA instead, review the intended URI in `xs-security.json` and follow
+[Updating xs-security.json](#updating-xs-securityjson) for the MTA or manual lifecycle. Do not add
+another region's wildcard or apply the bare base file to an MTA-owned instance as a shortcut.
 
 ### "Token has no expiration time"
 API key tokens now include a synthetic expiration (1 year). If you see this error, ensure you're running the latest version of ARC-1.
@@ -558,7 +558,7 @@ changing roles or clearing state. Do not share full callback URLs, tokens or bin
 | Scope name reported as invalid/unknown, e.g. an application-qualified `user_attributes` | Application/deployment owner: compare the request, endpoint metadata and effective XSUAA descriptor. Fix the unsupported scope/name qualification. Do not invent an application scope or grant Admin to suppress the error. |
 | User is not allowed any requested scopes | IAM owner: check the required collection is assigned to the correct application identity and contains roles for the bound application identifier. An assignment alone does not prove those roles exist. |
 | Collection exists but has no roles or references an old application identifier | IAM and deployment owners: inspect current role templates and collection contents; use the owner-safe repair below. |
-| Email is assigned but login uses another IdP origin | IAM owner: match the application trust's origin and user identity. Platform CLI/cockpit access does not establish application access. |
+| Email is assigned but login uses another IdP origin | IAM owner: use the [IdP-origin check and `--of-idp` example](authorization.md#i-have-two-marianexamplecom-users-in-btp-and-only-one-shows-the-role-i-changed) to match the application login identity. Platform CLI/cockpit access does not establish application access. |
 | Correct current roles/origin are verified, but the browser session predates the change | User: try the application refresh action below, then start sign-in again from the MCP client. |
 | Sign-in succeeds but old permissions/tools remain | User: obtain a fresh token through the client's re-authentication flow, then refresh/reload its tool catalog. Reconnecting alone may reuse a cached token. |
 
@@ -596,6 +596,8 @@ user/group assignments, IdP mappings and lifecycle owner. Have that owner reconc
 roles through the approved MTA/IAM process and verify a fresh user grant. Do not delete/recreate
 collections or XSUAA as a generic login fix: that can disrupt other users and lose assignments or
 mappings. A redeploy alone is not proof that existing collections were repaired.
+For the exceptional, owner-approved replacement of a verified orphaned collection, see
+[Role and user administration](btp-administration.md#role-and-user-administration).
 
 ### "Invalid client_id" (Copilot Studio)
 DCR registrations are stateless and survive ordinary restart, push, restage, and scale-out while the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,10 @@ edit_uri: edit/main/docs_page/
 
 docs_dir: docs_page
 
+validation:
+  links:
+    anchors: warn
+
 theme:
   name: material
   custom_dir: overrides

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+# Shared by strict PR validation and Pages publication. Stay on the MkDocs 1.x platform.
+mkdocs>=1.6,<2
+mkdocs-material>=9.5,<10
+mkdocs-redirects>=1.2,<2

--- a/tests/unit/server/btp-docs-contract.test.ts
+++ b/tests/unit/server/btp-docs-contract.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+import { getToolDefinitions } from '../../../src/handlers/tools.js';
+import { multiTargetToolDefinitions } from '../../../src/server/multi-target-tools.js';
+import { DEFAULT_CONFIG } from '../../../src/server/types.js';
+
+const read = (path: string) => readFileSync(new URL(`../../../${path}`, import.meta.url), 'utf8');
+const guide = read('docs_page/multi-target-setup.md');
+const config = { ...DEFAULT_CONFIG, allowDataPreview: true, allowFreeSQL: true };
+
+function documentedActions(markdown: string): Map<string, string[]> {
+  const block = markdown
+    .split('<!-- multi-target-action-contract:start')[1]
+    ?.split('<!-- multi-target-action-contract:end -->')[0];
+  if (!block) throw new Error('Missing maintained action table');
+  const rows = new Map<string, string[]>();
+  for (const line of block.split('\n')) {
+    const row = /^\| `(SAP\w+)` \| (.*) \|$/.exec(line);
+    if (!row) continue;
+    if (rows.has(row[1]!)) throw new Error('Duplicate tool row');
+    rows.set(
+      row[1]!,
+      [...row[2]!.matchAll(/`([a-z_]+)`/g)].map((match) => match[1]!),
+    );
+  }
+  return rows;
+}
+
+function assertParity(markdown: string): void {
+  const rows = documentedActions(markdown);
+  const definitions = multiTargetToolDefinitions(getToolDefinitions(config), config);
+  expect([...rows.keys()].sort()).toEqual(definitions.map((tool) => tool.name).sort());
+  for (const name of ['SAPLint', 'SAPDiagnose', 'SAPTransport']) {
+    const tool = definitions.find((item) => item.name === name)!;
+    const properties = tool.inputSchema.properties as Record<string, { enum?: string[] }>;
+    expect(rows.get(name)?.toSorted(), name).toEqual(properties.action?.enum?.toSorted());
+  }
+}
+
+describe('BTP documentation contracts', () => {
+  it('keeps the maintained maximum action table in sync with the real schema', () => assertParity(guide));
+
+  it('detects a missing or invented action (guard regression)', () => {
+    expect(() => assertParity(guide.replace('`lint_and_fix`, ', ''))).toThrow();
+    expect(() => assertParity(guide.replace('`list_rules` (offline', '`list_rules`, `format` (offline'))).toThrow();
+  });
+
+  it('builds docs for every PR without SAP credentials or deployment permissions', () => {
+    const text = read('.github/workflows/docs.yml');
+    const workflow = parse(text);
+    expect(workflow.on).toHaveProperty('pull_request');
+    expect(workflow.on.pull_request).toBeNull();
+    expect(workflow.on).not.toHaveProperty('pull_request_target');
+    expect(workflow.permissions).toEqual({ contents: 'read' });
+    expect(workflow.jobs.docs).not.toHaveProperty('if');
+    expect(text).not.toContain('secrets.');
+    expect(
+      workflow.jobs.docs.steps.filter((step: { run?: string }) => step.run).map((step: { run: string }) => step.run),
+    ).toEqual(['pip install -r requirements-docs.txt', 'npm run docs:build']);
+    for (const step of workflow.jobs.docs.steps) {
+      if (step.uses) expect(step.uses).toMatch(/@[a-f0-9]{40}$/);
+    }
+    const pages = parse(read('.github/workflows/pages.yml'));
+    expect(pages.jobs.build.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ run: 'pip install -r requirements-docs.txt' }),
+        expect.objectContaining({ run: 'mkdocs build --strict' }),
+      ]),
+    );
+  });
+});

--- a/tests/unit/server/btp-docs-contract.test.ts
+++ b/tests/unit/server/btp-docs-contract.test.ts
@@ -39,6 +39,14 @@ function assertParity(markdown: string): void {
 }
 
 describe('BTP documentation contracts', () => {
+  it('uses the observed CF route rather than deriving OAuth URLs from the space', () => {
+    const xsuaa = read('docs_page/xsuaa-setup.md');
+    expect(xsuaa).toContain('cf app <app-name>');
+    expect(xsuaa).toContain('curl -fsS "$ARC1_URL/.well-known/oauth-authorization-server"');
+    expect(xsuaa).not.toContain('https://arc1-mcp-<space>.');
+    expect(xsuaa).not.toContain('onto per-space naming changes its route host');
+  });
+
   it('keeps the maintained maximum action table in sync with the real schema', () => assertParity(guide));
 
   it('detects a missing or invented action (guard regression)', () => {

--- a/tests/unit/server/btp-docs-contract.test.ts
+++ b/tests/unit/server/btp-docs-contract.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { parse } from 'yaml';
+import { parse, parseDocument } from 'yaml';
 import { getToolDefinitions } from '../../../src/handlers/tools.js';
 import { multiTargetToolDefinitions } from '../../../src/server/multi-target-tools.js';
 import { DEFAULT_CONFIG } from '../../../src/server/types.js';
@@ -65,16 +65,26 @@ describe('BTP documentation contracts', () => {
     expect(text).not.toContain('secrets.');
     expect(
       workflow.jobs.docs.steps.filter((step: { run?: string }) => step.run).map((step: { run: string }) => step.run),
-    ).toEqual(['pip install -r requirements-docs.txt', 'npm run docs:build']);
-    for (const step of workflow.jobs.docs.steps) {
-      if (step.uses) expect(step.uses).toMatch(/@[a-f0-9]{40}$/);
-    }
+    ).toEqual(['pip install -r requirements-docs.txt', 'mkdocs build --strict']);
     const pages = parse(read('.github/workflows/pages.yml'));
+    for (const job of [workflow.jobs.docs, pages.jobs.build, pages.jobs.deploy]) {
+      for (const step of job.steps) {
+        if (step.uses) {
+          expect(step.uses).toMatch(/@[a-f0-9]{40}$/);
+          expect(step.uses).not.toContain('actions/setup-node');
+        }
+        expect(step.with?.['fetch-depth']).not.toBe(0);
+      }
+    }
     expect(pages.jobs.build.steps).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ run: 'pip install -r requirements-docs.txt' }),
         expect.objectContaining({ run: 'mkdocs build --strict' }),
       ]),
     );
+  });
+
+  it('makes broken local anchors fail the strict documentation build', () => {
+    expect(parseDocument(read('mkdocs.yml')).getIn(['validation', 'links', 'anchors'])).toBe('warn');
   });
 });


### PR DESCRIPTION
## Goal

Correct BTP deployment and authorization recovery guidance without changing ARC-1 runtime behavior. PR 01; recommended merge order: #752 → #753 → #754.

## Changes

- Check the maintained multi-target action table against actual runtime schemas; distinguish mutation-free actions from ATC/Unit workloads.
- Separate MTA and manual XSUAA ownership. Use observed routes rather than deriving OAuth hosts from space names.
- Diagnose unsupported scopes, missing/stale roles, wrong IdP origin, stale browser state and cached client tokens separately.
- Reconcile collection repair with the administration guide: inspection first, replacement only for an owner-confirmed orphan with assignments/mappings preserved.
- Link the actual IdP-origin commands; remove generic Admin grants and external token-inspection advice. Correct the upstream Entra redirect-error diagnosis.
- Keep a minimal read-only docs PR workflow: Python/MkDocs only, shared MkDocs 1.x requirements, no full-history checkout. SHA-pin all actions in the two touched docs workflows.
- Enable native MkDocs anchor validation; no custom link checker or new public page.

## Verification (final review, 2026-09-06)

- Reviewed each PR against origin/main `5c36f2a7`; all three merge cleanly in the recommended order.
- Combined tree: **194 unit files / 5,771 tests passed** on Node 24.11.1.
- Typecheck and lint passed (two pre-existing Biome informational notices); all five MTA descriptor/extension validations passed.
- Strict MkDocs builds passed independently and combined. A temporary broken local anchor caused the combined strict build to fail; removed the fixture and confirmed a clean rebuild.
- Rendered Start Here/runbook and recovery links checked; raw Markdown reviewed. Built `llms.txt` matches its source; the canonical page and raw-source alternative return HTTP 200.
- No runtime source or lockfile changes. No live SAP/BTP deployment, IAM changes, customer acceptance, or measured human/LLM usability claim.

Final review: no remaining merge blocker. All triggered GitHub checks passed on the reviewed head (including Node 22/24); credentialed integration/E2E jobs were skipped by the docs-change policy. No merge performed.