### PR TITLE
chore(btp): replace manual MTAR checks with tested inspection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,20 @@ jobs:
       - name: Validate mta.yaml + mta-overrides.mtaext.example
         run: npm run btp:validate
 
+  # The inspector replaces both Bash and PowerShell instructions. Linux coverage also runs
+  # in the full unit suite; this focused Windows job needs no SAP/CF credentials or unzip.
+  mtar-inspection-windows:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: 'npm'
+      - run: npm ci --ignore-scripts
+      - run: npx vitest run tests/unit/scripts/mtar-inspection.test.ts
+
   # Gates only the SAP-hitting jobs below based on PR title (conventional
   # commit prefix). Cheap checks in the `test` job always run. SAP jobs skip on
   # `docs:` and `chore:` PRs to save SAP work processes; auto-run for everything

--- a/biome.json
+++ b/biome.json
@@ -49,6 +49,6 @@
     }
   ],
   "files": {
-    "includes": ["src/**", "tests/**", "bin/**", "scripts/btp/*mtar*.mjs", "!tests/fixtures/tool-definitions"]
+    "includes": ["src/**", "tests/**", "bin/**", "scripts/btp/**", "!tests/fixtures/tool-definitions"]
   }
 }

--- a/biome.json
+++ b/biome.json
@@ -49,6 +49,6 @@
     }
   ],
   "files": {
-    "includes": ["src/**", "tests/**", "bin/**", "!tests/fixtures/tool-definitions"]
+    "includes": ["src/**", "tests/**", "bin/**", "scripts/btp/*mtar*.mjs", "!tests/fixtures/tool-definitions"]
   }
 }

--- a/docs/plans/2026-09-06-btp-mtar-inspection.md
+++ b/docs/plans/2026-09-06-btp-mtar-inspection.md
@@ -27,9 +27,9 @@ new documentation page in the site, or general-purpose secret scanner.
    Permit reviewed wrapper descriptors, but apply credential-name checks to the wrapper too.
    Apply module/operator-path checks to payloads; only the exact reviewed AppRouter root
    `.npmrc` is exempt. Report names, never file contents or raw parser errors.
-5. Hash the captured bytes; recheck the selected file before success to detect changes during
-   inspection. A later deploy is a separate action: the digest is not a signature and cannot
-   close the time gap after inspection.
+5. Read/hash the captured bytes once; recheck file identity, size and timestamps before success
+   to detect changes during inspection. A later deploy is a separate action: the digest is not a
+   signature and cannot close the time gap after inspection.
 6. Shorten the runbook to command, expected evidence, failure action and exact-file deploy.
    Link the administration identity check to the canonical PP procedure, not a second recipe.
 

--- a/docs/plans/2026-09-06-btp-mtar-inspection.md
+++ b/docs/plans/2026-09-06-btp-mtar-inspection.md
@@ -1,0 +1,59 @@
+# BTP archive inspection and acceptance corrections
+
+## Summary
+
+Replace the deployment runbook's duplicated shell scripts with a local, explicit-artifact
+inspection command. Inspect and deploy the same named MTAR without rebuilding in between.
+Correct the administration guide's remaining claim that `SAPRead SYSTEM` proves the SAP login
+identity by linking to the existing backend-identity verification procedure.
+
+No runtime/auth changes, CF deployment, configuration wizard, prebuilt archive distribution,
+new documentation page in the site, or general-purpose secret scanner.
+
+## Implementation plan
+
+1. Add `npm run btp:inspect-mtar -- --archive <path> [--format json]`. Require one path,
+   never infer newest/version. Text and JSON share outcomes, digest, limits and findings.
+2. Use `yauzl` 3.4 as a direct **development-only** dependency (MIT, Node >=12;
+   maintained June 2026, one dependency). Its lazy-entry/stream APIs support stored and
+   deflated ZIPs; reject encryption and other compression. Check CRCs and expanded byte
+   counts explicitly. No OS unzip dependency or filesystem extraction.
+3. Bound the MTAR snapshot to 256 MiB, each expanded module ZIP/file to 128 MiB,
+   combined expanded bytes to 512 MiB and combined entries to 20,000. Metadata is limited
+   to 1 MiB. Stream file bodies; retain only metadata/module ZIPs and the small npm config.
+   Reject ambiguous/unsafe names, duplicates, symlinks/special files, missing/empty modules
+   and unsupported layouts. Do not recursively unpack arbitrary application archives.
+4. Check `META-INF/MANIFEST.MF`, deployment descriptor and declared module payloads together.
+   Permit reviewed wrapper descriptors, but apply credential-name checks to the wrapper too.
+   Apply module/operator-path checks to payloads; only the exact reviewed AppRouter root
+   `.npmrc` is exempt. Report names, never file contents or raw parser errors.
+5. Hash the captured bytes; recheck the selected file before success to detect changes during
+   inspection. A later deploy is a separate action: the digest is not a signature and cannot
+   close the time gap after inspection.
+6. Shorten the runbook to command, expected evidence, failure action and exact-file deploy.
+   Link the administration identity check to the canonical PP procedure, not a second recipe.
+
+## Verification and review
+
+- Synthetic base/UI fixtures and explicit selection among multiple archives.
+- Corrupt/truncated/empty payloads, missing/extra modules and manifest inconsistencies.
+- Forbidden wrapper/module paths; exact, altered and misplaced AppRouter `.npmrc`.
+- Traversal, absolute/backslash names, duplicates, symlinks, encryption, unsupported methods,
+  CRC/size mismatch and resource limits. No extraction or network/child-process calls.
+- CLI usage errors vs inspection failures; text/JSON agreement, filenames with spaces,
+  escaping of untrusted names, archive replacement/read errors.
+- Linux unit suite plus focused Windows CI in the existing Test workflow; macOS local smoke.
+- Build and inspect actual base/UI MTARs locally without deployment. Full unit suite,
+  typecheck, lint, MTA validation and strict documentation build.
+- Review the shortened task from Start Here. Do not claim measured usability improvement;
+  the optional before/after wrong-artifact task remains a later formative evaluation.
+
+Dependency reference: [yauzl API and limitations](https://github.com/thejoshwolfe/yauzl).
+Deployment context: [SAP Cloud MTA Build Tool](https://sap.github.io/cloud-mta-build-tool/).
+
+## Commit/review boundary
+
+One PR, two logical commits: tested local inspector; runbook/acceptance corrections and
+regression coverage. Keep the existing deployment npm scripts compatible, but the reviewed
+customer procedure names its selected artifact explicitly. Rollback must restore an
+explicit-artifact procedure before removing the command.

--- a/docs_page/btp-administration.md
+++ b/docs_page/btp-administration.md
@@ -307,9 +307,11 @@ active targets or quarantined configuration. It does not prove Destination Servi
 SAP authorization, data/SQL policy, or a usable tool catalog.
 
 For multi-target acceptance, call `SAPTargets` as an Admin, review exclusions and registry revision,
-then perform the same safe read as a Viewer through each endpoint style. For PP, `SAPRead SYSTEM`
-must identify the human SAP user. For shared Basic, it must identify only the approved technical
-user, and the ARC-1 audit record must identify the human XSUAA caller.
+then perform the same safe read as a Viewer through each endpoint style. `SAPRead SYSTEM` alone
+does not prove which SAP user processed the request. Follow
+[Verify the backend identity](principal-propagation-setup.md#verify-the-backend-identity): expect
+the human SAP user for PP or the approved technical user for shared Basic, and correlate the live
+request with SAP-side evidence. The ARC-1 audit record must identify the human XSUAA caller.
 
 ## Pre-customer acceptance
 

--- a/docs_page/btp-cloud-foundry-deployment.md
+++ b/docs_page/btp-cloud-foundry-deployment.md
@@ -229,133 +229,52 @@ npm run btp:build
 both checks succeed and MBT creates
 `mta_archives/arc1-mcp_<version>.mtar`.
 
-Before a customer deploy, inspect the archive in a protected workspace. Three things make a naive
-listing useless here:
-
-- **The MTAR is a wrapper.** Each deployed module is one nested `<module>/data.zip`, and the
-  application lives inside it. Listing the MTAR shows you `META-INF/` and those nested archives and
-  nothing about their contents. The UI variant (`npm run btp:build-ui-ext`) ships more than one
-  payload, so inspect every member rather than assuming one.
-- **`mta_archives/` accumulates every version you have built.** A glob matching several archives is
-  a false green: `unzip -l` treats the second path as a filter *inside* the first and reports
-  **0 files** (exit 11), while PowerShell's `OpenRead` fails outright. Resolve one archive and echo
-  which one.
-- **A gate that cannot find anything must fail, not pass.** No archive, no `data.zip` member, or an
-  unreadable payload has to be an error; otherwise a broken workspace reports a clean release.
-- **The UI AppRouter has one audited `.npmrc`.** Its `install-links=true` setting is required to
-  install the local `decode-uri-component` compatibility bridge reliably. The checks below allow
-  only the root `.npmrc` in `arc1-ui-router/data.zip`, and only when it is byte-for-byte identical
-  to the reviewed `btp/approuter/.npmrc`; every other `.npmrc` remains denied.
+Before a customer deploy, inspect the **exact archive you intend to deploy**, using the matching
+reviewed checkout. Replace the example path below with the exact path printed by MBT. Do not use a glob
+or select an archive by modification time.
 
 ```bash
-inspect_mtar() (
-  set -o pipefail
-  deny='\.env|\.npmrc|service-key|\.(key|pem|p12|pfx|pse|jks|keystore)$'
-  mtar=$(ls -t mta_archives/*.mtar 2>/dev/null | head -1)
-  [ -n "$mtar" ] || { echo 'FAIL: no archive in mta_archives/'; return 1; }
-  echo "$mtar"
-  unzip -l "$mtar" || { echo 'FAIL: unreadable archive'; return 1; }
-  members=$(unzip -Z1 "$mtar" | grep '/data\.zip$') ||
-    { echo 'FAIL: no <module>/data.zip member'; return 1; }
-  tmp=$(mktemp -d) || return 1
-  trap 'rm -rf "$tmp"' EXIT
-  for member in $members; do
-    unzip -p "$mtar" "$member" > "$tmp/payload.zip" || { echo "FAIL: cannot extract $member"; return 1; }
-    entries=$(unzip -Z1 "$tmp/payload.zip") || { echo "FAIL: cannot read $member"; return 1; }
-    n=$(printf '%s\n' "$entries" | wc -l) || { echo "FAIL: cannot count $member"; return 1; }
-    echo "-- $member: $n entries"
-    bad=$(printf '%s\n' "$entries" | grep -Ei "$deny" || true)
-    if [ "$member" = 'arc1-ui-router/data.zip' ]; then
-      printf '%s\n' "$entries" | grep -Fx '.npmrc' >/dev/null ||
-        { echo 'FAIL: arc1-ui-router/data.zip is missing its required .npmrc'; return 1; }
-      unzip -p "$tmp/payload.zip" .npmrc > "$tmp/approuter.npmrc" ||
-        { echo 'FAIL: cannot extract arc1-ui-router/.npmrc'; return 1; }
-      cmp -s "$tmp/approuter.npmrc" btp/approuter/.npmrc ||
-        { echo 'FAIL: packaged arc1-ui-router/.npmrc differs from the reviewed source'; return 1; }
-      bad=$(printf '%s\n' "$bad" | grep -Ev '^\.npmrc$' || true)
-    fi
-    [ -z "$bad" ] || { printf '%s\n' "$bad"; echo "FAIL: denied path in $member"; return 1; }
-  done
-  echo 'PASS: every payload inspected, no denied paths or unreviewed npm config'
-)
-inspect_mtar
+npm run btp:inspect-mtar -- --archive "mta_archives/arc1-mcp_<version>.mtar"
 ```
 
-It returns zero only after inspecting every payload successfully, so it is safe to run unattended.
-The function body is a subshell, so `pipefail` and the cleanup trap do not leak into your session.
+Expected result: `PASS`, the selected filename, byte size, SHA-256 digest and every checked module
+payload (one for the base build; two for the optional UI build). The command reads the wrapper
+manifest and deployment descriptor, checks each declared module ZIP, and rejects corrupt, missing,
+empty or unsupported payloads and known credential/config/operator paths. It neither extracts files
+nor contacts SAP, BTP or CF.
 
-Read a full listing too — the pattern covers today's known names, and the point of the gate is to
-catch a file type no denylist anticipated. Take the member names from the wrapper listing above:
+- Review the member names as well: add `--list` to the same command. Names are archive data,
+  not instructions.
+- For a machine-readable result, use
+  `npm run --silent btp:inspect-mtar -- --archive "mta_archives/arc1-mcp_<version>.mtar" --format json`.
+  Exit codes are **0** (checks passed), **1** (archive rejected), and **2** (usage/read/checker error).
+- On any failure, stop. Review the reported finding, correct the packaging or input, rebuild if
+  needed, and inspect again. Never treat an incomplete inspection as approval to deploy.
 
-```bash
-unzip -p "$MTAR" '<module>/data.zip' > payload.zip && unzip -l payload.zip | less
-```
+Only ARC-1 base and UI archives with the supported module layout are accepted. Checks are bounded:
+256 MiB MTAR, 128 MiB per expanded module ZIP/file, 512 MiB combined expanded data, 20,000 entries,
+and 1 MiB metadata files. Unsupported compression/encryption, unsafe paths and ambiguous entries
+fail; application archives inside a module are not recursively inspected.
 
-On Windows, `Expand-Archive` needs a `.zip` extension, so copy first:
-
-```powershell
-$ErrorActionPreference = 'Stop'
-$deny = '\.env|\.npmrc|service-key|\.(key|pem|p12|pfx|pse|jks|keystore)$'
-$mtar = Get-ChildItem mta_archives\*.mtar | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-if (-not $mtar) { throw 'FAIL: no archive in mta_archives/' }
-$mtar.FullName
-$tmp = Join-Path $env:TEMP ([guid]::NewGuid())
-try {
-  Copy-Item $mtar.FullName "$tmp.zip"
-  Expand-Archive "$tmp.zip" "$tmp-outer"
-  $members = @(Get-ChildItem "$tmp-outer" -Recurse -Filter data.zip -File)
-  if ($members.Count -eq 0) { throw "FAIL: no <module>/data.zip member in $($mtar.Name)" }
-  $bad = @()
-  foreach ($member in $members) {
-    $dest = Join-Path "$tmp-payload" $member.Directory.Name
-    Expand-Archive $member.FullName $dest
-    $files = @(Get-ChildItem $dest -Recurse -File)
-    if ($files.Count -eq 0) { throw "FAIL: empty payload $($member.Directory.Name)" }
-    "-- $($member.Directory.Name): $($files.Count) files"
-    $allowedNpmrc = $null
-    if ($member.Directory.Name -eq 'arc1-ui-router') {
-      $allowedNpmrc = Join-Path $dest '.npmrc'
-      if (-not (Test-Path $allowedNpmrc -PathType Leaf)) {
-        throw 'FAIL: arc1-ui-router/data.zip is missing its required .npmrc'
-      }
-      $sourceNpmrc = (Resolve-Path 'btp/approuter/.npmrc').Path
-      if ((Get-FileHash $allowedNpmrc -Algorithm SHA256).Hash -ne
-          (Get-FileHash $sourceNpmrc -Algorithm SHA256).Hash) {
-        throw 'FAIL: packaged arc1-ui-router/.npmrc differs from the reviewed source'
-      }
-    }
-    $bad += $files | Where-Object {
-      $_.Name -match $deny -and (!$allowedNpmrc -or $_.FullName -ne $allowedNpmrc)
-    }
-  }
-  if ($bad) { $bad.FullName; throw 'FAIL: denied path in payload' }
-  'PASS: every payload inspected, no denied paths or unreviewed npm config'
-} finally {
-  Remove-Item "$tmp.zip","$tmp-outer","$tmp-payload" -Recurse -Force -ErrorAction SilentlyContinue
-}
-```
-
-A checksum is not a substitute: it proves the archive did not change, not that no secret was packaged.
-
-The application payload must not contain `.env*`, service-key exports, customer `.mtaext` files,
-private keys, certificates, local MCP configuration, source tests, operator artifacts, or an
-`.npmrc` other than the exact reviewed `btp/approuter/.npmrc` in the UI AppRouter payload. The MTA
-build has an explicit denylist and CI coverage for critical names; archive inspection is still a
-release gate because a future file type can evade a denylist.
+The only allowed project `.npmrc` is the root file in `arc1-ui-router/data.zip`, byte-for-byte equal
+to the reviewed `btp/approuter/.npmrc`. Other `.npmrc` files, credentials, customer `.mtaext` files
+and known operator artifacts are rejected. **This is a packaging check, not a comprehensive secret
+scanner or customer-readiness check.** Review the contents and source separately; the SHA-256
+identifies checked bytes, not their trustworthiness.
 
 ## 6. Deploy the MTA
 
-Run from the reviewed checkout as the CF Space Developer:
+As the CF Space Developer, deploy the **same named archive** after reviewing its successful
+inspection. Use exactly the same archive path as above and the protected override validated in step 5:
 
 ```bash
-npm run btp:deploy-ext
+cf deploy "mta_archives/arc1-mcp_<version>.mtar" -e mta-overrides.mtaext
 ```
 
-Or build and deploy together:
-
-```bash
-npm run btp:build-deploy-ext
-```
+Do not rebuild or replace the file between inspection and deployment. If it changes, rerun the
+inspection and record the new digest. The command detects changes during its check, but does not
+lock the archive against changes after it exits. The existing `btp:build-deploy*` shortcuts remain
+available; they are not the inspected-artifact procedure because they rebuild before deployment.
 
 The deployment creates/updates:
 

--- a/mta.yaml
+++ b/mta.yaml
@@ -236,6 +236,7 @@ modules:
       supported-platforms: []
       ignore:
         - node_modules/
+        - test/
     parameters:
       memory: 128M
       disk-quota: 256M

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
         "tsx": "^4.23.12",
         "typescript": "~7.0.2",
         "vitest": "^4.1.1",
-        "yaml": "^2.9.0"
+        "yaml": "^2.9.0",
+        "yauzl": "^3.4.0"
       },
       "engines": {
         "node": ">=22.19"
@@ -4016,6 +4017,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5037,6 +5045,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "btp:validate": "npx mbt validate && npx mbt validate -e mta-overrides.mtaext.example && npx mbt validate -e mta-overrides.mtaext.example -e mta-ui-approuter.mtaext && npx mbt validate -e examples/btp/single-pp/profile.mtaext && npx mbt validate -e examples/btp/multi-pp/profile.mtaext",
     "btp:build": "npx mbt build",
     "btp:build-ui-ext": "npx mbt build -e mta-ui-approuter.mtaext",
+    "btp:inspect-mtar": "node scripts/btp/inspect-mtar.mjs",
     "btp:deploy": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar',{stdio:'inherit'})\"",
     "btp:deploy-ext": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-overrides.mtaext',{stdio:'inherit'})\"",
     "btp:deploy-ui-ext": "node scripts/btp/prepare-ui-mtaext.mjs && node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar -e mta-ui-deploy.mtaext',{stdio:'inherit'})\"",
@@ -145,6 +146,7 @@
     "tsx": "^4.23.12",
     "typescript": "~7.0.2",
     "vitest": "^4.1.1",
-    "yaml": "^2.9.0"
+    "yaml": "^2.9.0",
+    "yauzl": "^3.4.0"
   }
 }

--- a/scripts/btp/inspect-mtar.mjs
+++ b/scripts/btp/inspect-mtar.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import { inspectMtar } from './mtar-inspection.mjs';
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: reject control characters in literal CLI paths.
+const FORBIDDEN_ARGUMENT = /[*?[\]{}\x00-\x1f\x7f]/;
+
+const HELP = `Usage: npm run btp:inspect-mtar -- --archive <exact-path.mtar> [--format text|json] [--list]
+Inspect a locally built ARC-1 base/UI MTAR; no extraction, network access or deployment.
+One explicit archive is required (no globs/newest selection). --list prints all checked member names.
+Exit codes: 0 = PASS of stated checks, 1 = archive FAIL, 2 = usage/I/O/checker ERROR.
+For machine-readable stdout use npm run --silent btp:inspect-mtar -- --archive <path> --format json.
+PASS is not proof of absence of all secrets, valid CF configuration, or SAP identity.
+`;
+
+function options(args) {
+  const parsed = parseArgs({
+    args,
+    options: {
+      archive: { type: 'string' },
+      format: { type: 'string', default: 'text' },
+      list: { type: 'boolean', default: false },
+      help: { type: 'boolean', default: false },
+    },
+    tokens: true,
+    allowPositionals: false,
+  });
+  const seen = new Set();
+  for (const token of parsed.tokens) {
+    if (token.kind !== 'option') continue;
+    if (seen.has(token.name)) throw new Error('Repeated option');
+    seen.add(token.name);
+  }
+  if (!['text', 'json'].includes(parsed.values.format)) throw new Error('Unknown format');
+  if (!parsed.values.help && (!parsed.values.archive || FORBIDDEN_ARGUMENT.test(parsed.values.archive))) {
+    throw new Error('One literal archive path is required');
+  }
+  return parsed.values;
+}
+
+try {
+  const args = options(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(HELP);
+  } else {
+    const result = await inspectMtar(args.archive);
+    if (args.format === 'json') {
+      process.stdout.write(`${JSON.stringify(result)}\n`);
+    } else {
+      // JSON quoting keeps names inert in terminals and clearly identifies untrusted archive data.
+      process.stdout.write(`${result.outcome}: ${JSON.stringify(result.artifact.name)}\n`);
+      process.stdout.write(
+        `Bytes: ${result.artifact.sizeBytes ?? 'unknown'}; SHA-256: ${result.artifact.sha256 ?? 'unavailable'}\n`,
+      );
+      process.stdout.write(`Checked payloads: ${result.checkedPayloads.length}\n`);
+      for (const payload of result.checkedPayloads)
+        process.stdout.write(`  ${JSON.stringify(payload.member)}: ${payload.files} files\n`);
+      for (const finding of result.findings)
+        process.stdout.write(`${finding.code}: ${finding.message} ${JSON.stringify(finding.member ?? '')}\n`);
+      if (args.list) {
+        for (const member of result.members)
+          process.stdout.write(`${JSON.stringify(`${member.archive}:${member.path}`)} (${member.bytes} bytes)\n`);
+      }
+      process.stdout.write(`${result.qualification}\n`);
+    }
+    process.exitCode = result.outcome === 'PASS' ? 0 : result.outcome === 'FAIL' ? 1 : 2;
+  }
+} catch {
+  // Do not echo arguments or raw parser exceptions (may contain local secrets).
+  process.stderr.write(`Invalid inspection arguments.\n${HELP}`);
+  process.exitCode = 2;
+}

--- a/scripts/btp/mtar-inspection.mjs
+++ b/scripts/btp/mtar-inspection.mjs
@@ -264,11 +264,13 @@ export async function inspectMtar(path, { limits = LIMITS } = {}) {
     result.findings.push(
       error instanceof InspectionFailure
         ? { code: error.code, message: error.message, ...(error.member === undefined ? {} : { member: error.member }) }
-        : (ioErrors[error?.code] ?? {
-            code: 'CHECKER_ERROR',
-            message:
-              'Unexpected inspection error. Retry from the matching reviewed checkout and report persistent failures; do not deploy.',
-          }),
+        : Object.hasOwn(ioErrors, error?.code)
+          ? ioErrors[error.code]
+          : {
+              code: 'CHECKER_ERROR',
+              message:
+                'Unexpected inspection error. Retry from the matching reviewed checkout and report persistent failures; do not deploy.',
+            },
     );
   }
   return result;

--- a/scripts/btp/mtar-inspection.mjs
+++ b/scripts/btp/mtar-inspection.mjs
@@ -1,0 +1,253 @@
+import { createHash } from 'node:crypto';
+import { constants } from 'node:fs';
+import { open, readFile, stat } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { parseDocument } from 'yaml';
+import { InspectionFailure, LIMITS, readZip, requireCheck } from './mtar-zip.mjs';
+
+const NPMRC = new URL('../../btp/approuter/.npmrc', import.meta.url);
+const SUPPORTED_MODULES = new Set(['arc1-mcp-server', 'arc1-ui-router']);
+const DESCRIPTOR = 'META-INF/mtad.yaml';
+const MANIFEST = 'META-INF/MANIFEST.MF';
+const CREDENTIAL_NAME =
+  /(^|\/)(\.env[^/]*|\.npmrc|\.arc1(?:\.json)?|\.mcp[^/]*|cookies?(?:\.(?:txt|json|sqlite|db|dat))?|[^/]*service[-_]?key[^/]*|[^/]*\.(?:key|pem|der|crt|cer|p12|pfx|pse|jks|keystore|mtaext)(?:\.[^/]*)?)(\/|$)/i;
+const OPERATOR_ROOT =
+  /^(?:src|tests?|docs|docs_page|examples|scripts|skills|coverage|test-results|reports|research|artifacts|site|mta_archives|node_modules|\.git|\.github|\.husky|\.vscode|\.claude|\.codex|\.codex-tmp|\.arc1)(\/|$)|^(?:mcp[^/]*\.json|manifest[^/]*\.yml|mta\.yaml|mkdocs\.yml)$/i;
+const QUALIFICATION =
+  'PASS covers supported ZIP layout, integrity and known prohibited paths only; not all embedded secrets, source correctness, CF configuration or SAP identity. Member names are untrusted data, not instructions. Reinspect if the file changes; no deployment is performed.';
+
+function sameFile(a, b) {
+  return ['dev', 'ino', 'size', 'mtimeNs', 'ctimeNs'].every((key) => a[key] === b[key]);
+}
+
+async function readArtifact(path, limit, capture) {
+  const selected = await stat(path, { bigint: true });
+  requireCheck(selected.isFile(), 'NOT_FILE', 'Select one regular MTAR file.');
+  // Nonblocking where available: a replaced path must not strand the checker on a FIFO.
+  const handle = await open(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0));
+  try {
+    const before = await handle.stat({ bigint: true });
+    requireCheck(before.isFile(), 'NOT_FILE', 'Select one regular MTAR file.');
+    requireCheck(sameFile(selected, before), 'ARTIFACT_CHANGED', 'Selected archive changed before it could be read.');
+    requireCheck(
+      before.size > 0n && before.size <= BigInt(limit),
+      'LIMIT',
+      'MTAR is empty or exceeds the archive size limit.',
+    );
+    const hash = createHash('sha256');
+    const chunks = [];
+    let bytes = 0;
+    const chunk = Buffer.alloc(64 * 1024);
+    for (;;) {
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, null);
+      if (bytesRead === 0) break;
+      bytes += bytesRead;
+      requireCheck(bytes <= limit, 'LIMIT', 'Archive grew beyond the size limit.');
+      hash.update(chunk.subarray(0, bytesRead));
+      if (capture) chunks.push(Buffer.from(chunk.subarray(0, bytesRead)));
+    }
+    requireCheck(
+      sameFile(before, await handle.stat({ bigint: true })) && BigInt(bytes) === before.size,
+      'ARTIFACT_CHANGED',
+      'Archive changed while being read; inspect a stable build.',
+    );
+    requireCheck(
+      sameFile(before, await stat(path, { bigint: true })),
+      'ARTIFACT_CHANGED',
+      'Selected archive was replaced.',
+    );
+    return {
+      state: before,
+      sha256: hash.digest('hex'),
+      sizeBytes: bytes,
+      buffer: capture ? Buffer.concat(chunks, bytes) : undefined,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+function manifestRecords(buffer) {
+  const records = [];
+  // JAR-style continuation lines are emitted by archive builders for long field values.
+  const unfolded = buffer.toString('utf8').replace(/\r\n/g, '\n').replace(/\n /g, '');
+  for (const section of unfolded.split(/\n\n+/).filter((part) => part.trim())) {
+    const fields = new Map();
+    for (const line of section.trimEnd().split('\n')) {
+      const match = /^([A-Za-z-]+): (.+)$/.exec(line);
+      requireCheck(match && !fields.has(match[1].toLowerCase()), 'MANIFEST', 'Malformed/duplicate manifest field.');
+      fields.set(match[1].toLowerCase(), match[2]);
+    }
+    records.push(fields);
+  }
+  requireCheck(records.shift()?.get('manifest-version') === '1.0', 'MANIFEST', 'Missing supported manifest header.');
+  return records;
+}
+
+function validateLayout(files) {
+  requireCheck(files.has(MANIFEST) && files.has(DESCRIPTOR), 'LAYOUT', 'Missing MANIFEST.MF or mtad.yaml.');
+  let descriptor;
+  try {
+    const doc = parseDocument(files.get(DESCRIPTOR).toString('utf8'));
+    if (doc.errors.length || doc.warnings.length) throw new Error('Invalid YAML');
+    descriptor = doc.toJS({ maxAliasCount: 0 });
+  } catch {
+    throw new InspectionFailure('DESCRIPTOR', 'Deployment descriptor is invalid or uses unsupported aliases.');
+  }
+  const modules = descriptor?.modules;
+  requireCheck(
+    descriptor?.ID === 'arc1-mcp' && Array.isArray(modules) && modules.length >= 1,
+    'LAYOUT',
+    'Only ARC-1 base/UI module archives are supported.',
+  );
+  const expected = new Map();
+  for (const module of modules) {
+    requireCheck(
+      SUPPORTED_MODULES.has(module?.name) && module.path === module.name && !expected.has(module.name),
+      'LAYOUT',
+      'Unsupported, missing or duplicate module path.',
+    );
+    expected.set(module.name, `${module.name}/data.zip`);
+  }
+  requireCheck(expected.has('arc1-mcp-server'), 'LAYOUT', 'Missing ARC-1 server module.');
+  const records = manifestRecords(files.get(MANIFEST));
+  const listed = new Set();
+  const moduleRecords = new Set();
+  const resourceRecords = new Map();
+  for (const record of records) {
+    const name = record.get('name');
+    requireCheck(files.has(name) && !listed.has(name), 'MANIFEST', 'Missing/duplicate manifest member.');
+    listed.add(name);
+    const module = record.get('mta-module');
+    const resource = record.get('mta-resource');
+    if (module) {
+      requireCheck(
+        !resource &&
+          expected.get(module) === name &&
+          !moduleRecords.has(module) &&
+          record.get('content-type') === 'application/zip',
+        'MANIFEST',
+        'Module/manifest payload mismatch.',
+      );
+      moduleRecords.add(module);
+    } else if (resource) {
+      requireCheck(!resourceRecords.has(resource), 'MANIFEST', 'Duplicate resource payload.');
+      resourceRecords.set(resource, name);
+    } else {
+      requireCheck(name === DESCRIPTOR, 'MANIFEST', 'Unclassified wrapper member.');
+    }
+  }
+  for (const [module, path] of expected) {
+    requireCheck(files.has(path) && moduleRecords.has(module), 'LAYOUT', 'A required module payload is missing.', path);
+  }
+  const resources = descriptor.resources ?? [];
+  requireCheck(Array.isArray(resources), 'DESCRIPTOR', 'Invalid resource list.');
+  for (const [resource, path] of resourceRecords) {
+    requireCheck(
+      resources.some((item) => item?.name === resource && item.parameters?.path === path),
+      'MANIFEST',
+      'Resource/manifest payload mismatch.',
+    );
+  }
+  for (const resource of resources) {
+    if (resource?.parameters?.path !== undefined) {
+      requireCheck(
+        resourceRecords.get(resource.name) === resource.parameters.path,
+        'LAYOUT',
+        'Missing resource payload.',
+      );
+    }
+  }
+  for (const name of files.keys()) {
+    requireCheck(name === MANIFEST || listed.has(name), 'LAYOUT', 'Wrapper member is not declared in manifest.', name);
+    requireCheck(
+      [MANIFEST, DESCRIPTOR, 'xs-security.json', ...expected.values()].includes(name),
+      'LAYOUT',
+      'Unsupported wrapper member.',
+      name,
+    );
+  }
+  return expected;
+}
+
+/** Local inspection only. limits is injectable for tiny boundary-test fixtures, not a CLI bypass. */
+export async function inspectMtar(path, { limits = LIMITS } = {}) {
+  const budget = { limits, entries: 0, bytes: 0, members: [] };
+  /** @type {{schemaVersion: number, outcome: string,
+   * artifact: {name: string, sizeBytes: number | null, sha256: string | null},
+   * checkedPayloads: Array<{module: string, member: string, files: number}>,
+   * members: Array<{archive: string, path: string, bytes: number}>,
+   * findings: Array<{code: string, message: string, member?: string}>,
+   * limits: typeof LIMITS, qualification: string}} */
+  const result = {
+    schemaVersion: 1,
+    outcome: 'ERROR',
+    artifact: { name: basename(path), sizeBytes: null, sha256: null },
+    checkedPayloads: [],
+    members: budget.members,
+    findings: [],
+    limits,
+    qualification: QUALIFICATION,
+  };
+  try {
+    const snapshot = await readArtifact(path, limits.archiveBytes, true);
+    result.artifact = { name: basename(path), sizeBytes: snapshot.sizeBytes, sha256: snapshot.sha256 };
+    const files = await readZip(snapshot.buffer, 'wrapper', budget, (name) =>
+      name.endsWith('/data.zip') ? limits.entryBytes : limits.metadataBytes,
+    );
+    for (const name of files.keys()) {
+      requireCheck(
+        !CREDENTIAL_NAME.test(name),
+        'PROHIBITED_PATH',
+        'Prohibited credential/config path in wrapper.',
+        name,
+      );
+    }
+    const modules = validateLayout(files);
+    for (const [module, member] of modules) {
+      const payload = await readZip(files.get(member), module, budget, (name) =>
+        name === '.npmrc' ? 4096 : undefined,
+      );
+      requireCheck(payload.size > 0, 'EMPTY_PAYLOAD', 'Module payload contains no files.', member);
+      for (const name of payload.keys()) {
+        if (module === 'arc1-ui-router' && name === '.npmrc') continue;
+        requireCheck(
+          !CREDENTIAL_NAME.test(name) && !OPERATOR_ROOT.test(name),
+          'PROHIBITED_PATH',
+          'Prohibited credential/config/operator path in module.',
+          `${module}:${name}`,
+        );
+      }
+      if (module === 'arc1-ui-router') {
+        const approved = await readFile(NPMRC);
+        requireCheck(
+          payload.get('.npmrc')?.equals(approved),
+          'NPMRC',
+          'AppRouter .npmrc is missing or differs from reviewed checkout.',
+          member,
+        );
+      }
+      result.checkedPayloads.push({ module, member, files: payload.size });
+      files.delete(member); // release expanded module ZIP once it has been checked
+    }
+    const final = await readArtifact(path, limits.archiveBytes, false);
+    requireCheck(
+      sameFile(snapshot.state, final.state) && snapshot.sha256 === final.sha256,
+      'ARTIFACT_CHANGED',
+      'Selected archive changed during inspection; rebuild/reinspect before deployment.',
+    );
+    result.outcome = 'PASS';
+  } catch (error) {
+    result.outcome = error instanceof InspectionFailure ? 'FAIL' : 'ERROR';
+    result.findings.push(
+      error instanceof InspectionFailure
+        ? { code: error.code, message: error.message, ...(error.member === undefined ? {} : { member: error.member }) }
+        : {
+            code: 'IO_OR_CHECKER_ERROR',
+            message:
+              'Cannot read the selected archive/reviewed checkout, or checker failed. Check the path and permissions; do not deploy.',
+          },
+    );
+  }
+  return result;
+}

--- a/scripts/btp/mtar-inspection.mjs
+++ b/scripts/btp/mtar-inspection.mjs
@@ -6,21 +6,22 @@ import { parseDocument } from 'yaml';
 import { InspectionFailure, LIMITS, readZip, requireCheck } from './mtar-zip.mjs';
 
 const NPMRC = new URL('../../btp/approuter/.npmrc', import.meta.url);
+// Kept in sync with mta.yaml by the descriptor contract test.
 const SUPPORTED_MODULES = new Set(['arc1-mcp-server', 'arc1-ui-router']);
 const DESCRIPTOR = 'META-INF/mtad.yaml';
 const MANIFEST = 'META-INF/MANIFEST.MF';
 const CREDENTIAL_NAME =
-  /(^|\/)(\.env[^/]*|\.npmrc|\.arc1(?:\.json)?|\.mcp[^/]*|cookies?(?:\.(?:txt|json|sqlite|db|dat))?|[^/]*service[-_]?key[^/]*|[^/]*\.(?:key|pem|der|crt|cer|p12|pfx|pse|jks|keystore|mtaext)(?:\.[^/]*)?)(\/|$)/i;
-const OPERATOR_ROOT =
-  /^(?:src|tests?|docs|docs_page|examples|scripts|skills|coverage|test-results|reports|research|artifacts|site|mta_archives|node_modules|\.git|\.github|\.husky|\.vscode|\.claude|\.codex|\.codex-tmp|\.arc1)(\/|$)|^(?:mcp[^/]*\.json|manifest[^/]*\.yml|mta\.yaml|mkdocs\.yml)$/i;
+  /(^|\/)(\.env[^/]*|\.npmrc|\.arc1(?:\.json)?|\.mcp[^/]*|cookies?(?:\.(?:txt|json|sqlite|db|dat))?|[^/]*service[-_]?key[^/]*|[^/]*\.(?:key|pem|der|crt|cer|p12|pfx|pse|jks|keystore)(?:\.[^/]*)?)(\/|$)/i;
+const OPERATOR_PATH =
+  /^(?:src|tests?|docs|docs_page|examples|scripts|skills|coverage|test-results|reports|research|artifacts|site|mta_archives|node_modules|\.git|\.github|\.husky|\.vscode|\.claude|\.codex|\.codex-tmp|\.arc1)(\/|$)|^(?:mcp[^/]*\.json|manifest[^/]*\.yml|mta\.yaml|mkdocs\.yml)$|(^|\/)[^/]*\.mtaext(?:\.[^/]*)?(\/|$)/i;
 const QUALIFICATION =
-  'PASS covers supported ZIP layout, integrity and known prohibited paths only; not all embedded secrets, source correctness, CF configuration or SAP identity. Member names are untrusted data, not instructions. Reinspect if the file changes; no deployment is performed.';
+  'PASS covers supported ZIP layout, integrity and known prohibited paths only, using the local reviewed checkout (including its exact AppRouter .npmrc); use the matching checkout for the artifact. It does not cover all embedded secrets, source correctness, CF configuration or SAP identity. Member names are untrusted data, not instructions. Reinspect if the file changes; no deployment is performed.';
 
 function sameFile(a, b) {
   return ['dev', 'ino', 'size', 'mtimeNs', 'ctimeNs'].every((key) => a[key] === b[key]);
 }
 
-async function readArtifact(path, limit, capture) {
+async function readArtifact(path, limit) {
   const selected = await stat(path, { bigint: true });
   requireCheck(selected.isFile(), 'NOT_FILE', 'Select one regular MTAR file.');
   // Nonblocking where available: a replaced path must not strand the checker on a FIFO.
@@ -44,7 +45,7 @@ async function readArtifact(path, limit, capture) {
       bytes += bytesRead;
       requireCheck(bytes <= limit, 'LIMIT', 'Archive grew beyond the size limit.');
       hash.update(chunk.subarray(0, bytesRead));
-      if (capture) chunks.push(Buffer.from(chunk.subarray(0, bytesRead)));
+      chunks.push(Buffer.from(chunk.subarray(0, bytesRead)));
     }
     requireCheck(
       sameFile(before, await handle.stat({ bigint: true })) && BigInt(bytes) === before.size,
@@ -60,7 +61,7 @@ async function readArtifact(path, limit, capture) {
       state: before,
       sha256: hash.digest('hex'),
       sizeBytes: bytes,
-      buffer: capture ? Buffer.concat(chunks, bytes) : undefined,
+      buffer: Buffer.concat(chunks, bytes),
     };
   } finally {
     await handle.close();
@@ -98,14 +99,14 @@ function validateLayout(files) {
   requireCheck(
     descriptor?.ID === 'arc1-mcp' && Array.isArray(modules) && modules.length >= 1,
     'LAYOUT',
-    'Only ARC-1 base/UI module archives are supported.',
+    'Expected MTA ID arc1-mcp with base/UI modules. Use the matching reviewed checkout; check mta.yaml for layout changes.',
   );
   const expected = new Map();
   for (const module of modules) {
     requireCheck(
       SUPPORTED_MODULES.has(module?.name) && module.path === module.name && !expected.has(module.name),
       'LAYOUT',
-      'Unsupported, missing or duplicate module path.',
+      'Expected unique arc1-mcp-server/arc1-ui-router module paths. Check mta.yaml and the matching reviewed checkout.',
     );
     expected.set(module.name, `${module.name}/data.zip`);
   }
@@ -173,6 +174,7 @@ function validateLayout(files) {
 /** Local inspection only. limits is injectable for tiny boundary-test fixtures, not a CLI bypass. */
 export async function inspectMtar(path, { limits = LIMITS } = {}) {
   const budget = { limits, entries: 0, bytes: 0, members: [] };
+  let ioSource = 'selected archive';
   /** @type {{schemaVersion: number, outcome: string,
    * artifact: {name: string, sizeBytes: number | null, sha256: string | null},
    * checkedPayloads: Array<{module: string, member: string, files: number}>,
@@ -190,12 +192,13 @@ export async function inspectMtar(path, { limits = LIMITS } = {}) {
     qualification: QUALIFICATION,
   };
   try {
-    const snapshot = await readArtifact(path, limits.archiveBytes, true);
+    const snapshot = await readArtifact(path, limits.archiveBytes);
     result.artifact = { name: basename(path), sizeBytes: snapshot.sizeBytes, sha256: snapshot.sha256 };
     const files = await readZip(snapshot.buffer, 'wrapper', budget, (name) =>
       name.endsWith('/data.zip') ? limits.entryBytes : limits.metadataBytes,
     );
     for (const name of files.keys()) {
+      requireCheck(!OPERATOR_PATH.test(name), 'PROHIBITED_PATH', 'Prohibited operator path in wrapper.', name);
       requireCheck(
         !CREDENTIAL_NAME.test(name),
         'PROHIBITED_PATH',
@@ -212,14 +215,22 @@ export async function inspectMtar(path, { limits = LIMITS } = {}) {
       for (const name of payload.keys()) {
         if (module === 'arc1-ui-router' && name === '.npmrc') continue;
         requireCheck(
-          !CREDENTIAL_NAME.test(name) && !OPERATOR_ROOT.test(name),
+          !OPERATOR_PATH.test(name),
           'PROHIBITED_PATH',
-          'Prohibited credential/config/operator path in module.',
+          'Prohibited operator path in module.',
+          `${module}:${name}`,
+        );
+        requireCheck(
+          !CREDENTIAL_NAME.test(name),
+          'PROHIBITED_PATH',
+          'Prohibited credential/config path in module.',
           `${module}:${name}`,
         );
       }
       if (module === 'arc1-ui-router') {
+        ioSource = 'reviewed checkout AppRouter .npmrc';
         const approved = await readFile(NPMRC);
+        ioSource = 'selected archive';
         requireCheck(
           payload.get('.npmrc')?.equals(approved),
           'NPMRC',
@@ -230,23 +241,34 @@ export async function inspectMtar(path, { limits = LIMITS } = {}) {
       result.checkedPayloads.push({ module, member, files: payload.size });
       files.delete(member); // release expanded module ZIP once it has been checked
     }
-    const final = await readArtifact(path, limits.archiveBytes, false);
     requireCheck(
-      sameFile(snapshot.state, final.state) && snapshot.sha256 === final.sha256,
+      sameFile(snapshot.state, await stat(path, { bigint: true })),
       'ARTIFACT_CHANGED',
       'Selected archive changed during inspection; rebuild/reinspect before deployment.',
     );
     result.outcome = 'PASS';
   } catch (error) {
     result.outcome = error instanceof InspectionFailure ? 'FAIL' : 'ERROR';
+    const ioErrors = {
+      ENOENT: {
+        code: 'NOT_FOUND',
+        message: `Cannot find ${ioSource}. Check the path and matching checkout; do not deploy.`,
+      },
+      EACCES: { code: 'ACCESS_DENIED', message: `Permission denied reading ${ioSource}; do not deploy.` },
+      EPERM: { code: 'ACCESS_DENIED', message: `Permission denied reading ${ioSource}; do not deploy.` },
+      EIO: {
+        code: 'READ_ERROR',
+        message: `I/O failure reading ${ioSource}. Retry with a stable, readable file; do not deploy.`,
+      },
+    };
     result.findings.push(
       error instanceof InspectionFailure
         ? { code: error.code, message: error.message, ...(error.member === undefined ? {} : { member: error.member }) }
-        : {
-            code: 'IO_OR_CHECKER_ERROR',
+        : (ioErrors[error?.code] ?? {
+            code: 'CHECKER_ERROR',
             message:
-              'Cannot read the selected archive/reviewed checkout, or checker failed. Check the path and permissions; do not deploy.',
-          },
+              'Unexpected inspection error. Retry from the matching reviewed checkout and report persistent failures; do not deploy.',
+          }),
     );
   }
   return result;

--- a/scripts/btp/mtar-zip.mjs
+++ b/scripts/btp/mtar-zip.mjs
@@ -1,0 +1,163 @@
+import { crc32 } from 'node:zlib';
+import { fromBufferPromise } from 'yauzl';
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: reject control characters in untrusted archive names.
+const UNSAFE_NAME = /[\\:\x00-\x1f\x7f]/;
+
+export const LIMITS = Object.freeze({
+  archiveBytes: 256 * 1024 * 1024,
+  entryBytes: 128 * 1024 * 1024,
+  expandedBytes: 512 * 1024 * 1024,
+  metadataBytes: 1024 * 1024,
+  entries: 20_000,
+  nameBytes: 512,
+});
+
+export class InspectionFailure extends Error {
+  constructor(code, message, member = undefined) {
+    super(message);
+    this.code = code;
+    this.member = member;
+  }
+}
+
+export function requireCheck(condition, code, message, member = undefined) {
+  if (!condition) throw new InspectionFailure(code, message, member);
+}
+
+function safeName(name, limits) {
+  // Reject rather than normalize: two spellings must never denote the same deployment path.
+  const parts = name.replace(/\/$/, '').split('/');
+  requireCheck(
+    Buffer.byteLength(name) <= limits.nameBytes &&
+      !UNSAFE_NAME.test(name) &&
+      parts.every((part) => part !== '' && part !== '.' && part !== '..' && !/[. ]$/.test(part)),
+    'UNSAFE_PATH',
+    'Archive contains an unsafe or non-portable member name.',
+  );
+}
+
+/** Sequential, bounded ZIP reads. No extraction; bodies not requested by retain() are discarded. */
+export async function readZip(buffer, label, budget, retain) {
+  const limits = budget.limits;
+  const files = new Map();
+  const names = new Map();
+  const ranges = [];
+  let zip;
+  try {
+    zip = await fromBufferPromise(buffer, { lazyEntries: true, strictFileNames: true, validateEntrySizes: true });
+    requireCheck(zip.entryCount <= limits.entries - budget.entries, 'LIMIT', 'Archive entry limit exceeded.', label);
+    for await (const entry of zip.eachEntry()) {
+      const name = entry.fileName;
+      safeName(name, limits);
+      requireCheck(
+        Buffer.from(name, 'utf8').equals(entry.fileNameRaw),
+        'UNSUPPORTED_ENTRY',
+        'Legacy or conflicting filename encodings are not supported.',
+      );
+      const member = `${label}:${name}`;
+      const directory = name.endsWith('/');
+      const canonical = name.replace(/\/$/, '').toLowerCase();
+      requireCheck(!names.has(canonical), 'DUPLICATE_PATH', 'Duplicate or case-ambiguous member.', member);
+      names.set(canonical, directory);
+      const kind = (entry.externalFileAttributes >>> 16) & 0o170000;
+      requireCheck(
+        kind === 0 || kind === (directory ? 0o040000 : 0o100000),
+        'UNSUPPORTED_ENTRY',
+        'Symlinks and special files are not supported.',
+        member,
+      );
+      requireCheck(!entry.isEncrypted(), 'ENCRYPTED', 'Encrypted entries cannot be inspected.', member);
+      requireCheck(
+        [0, 8].includes(entry.compressionMethod),
+        'COMPRESSION',
+        'Only stored/deflated ZIPs are supported.',
+        member,
+      );
+      requireCheck((entry.generalPurposeBitFlag & ~0x80e) === 0, 'UNSUPPORTED_ENTRY', 'Unsupported ZIP flags.', member);
+      const local = await zip.readLocalFileHeaderPromise(entry);
+      ranges.push([entry.relativeOffsetOfLocalHeader, local.fileDataStart + entry.compressedSize]);
+      requireCheck(
+        local.fileName.equals(entry.fileNameRaw) &&
+          local.generalPurposeBitFlag === entry.generalPurposeBitFlag &&
+          local.compressionMethod === entry.compressionMethod,
+        'INTEGRITY',
+        'Local and central ZIP headers disagree.',
+        member,
+      );
+      if (!(entry.generalPurposeBitFlag & 8)) {
+        requireCheck(
+          local.crc32 === entry.crc32 &&
+            (local.compressedSize === 0xffffffff || local.compressedSize === entry.compressedSize) &&
+            (local.uncompressedSize === 0xffffffff || local.uncompressedSize === entry.uncompressedSize),
+          'INTEGRITY',
+          'Local and central ZIP sizes/CRC disagree.',
+          member,
+        );
+      }
+      requireCheck(++budget.entries <= limits.entries, 'LIMIT', 'Archive entry limit exceeded.', member);
+      const keepLimit = retain(name);
+      const max = directory ? 0 : Math.min(limits.entryBytes, keepLimit ?? limits.entryBytes);
+      requireCheck(entry.uncompressedSize <= max, 'LIMIT', 'Expanded entry size limit exceeded.', member);
+      requireCheck(
+        entry.uncompressedSize <= limits.expandedBytes - budget.bytes,
+        'LIMIT',
+        'Combined expanded size limit exceeded.',
+        member,
+      );
+      const chunks = [];
+      let bytes = 0;
+      let checksum = 0;
+      const stream = await zip.openReadStreamPromise(entry);
+      try {
+        for await (const chunk of stream) {
+          bytes += chunk.length;
+          budget.bytes += chunk.length;
+          requireCheck(
+            bytes <= max && budget.bytes <= limits.expandedBytes,
+            'LIMIT',
+            'Expansion limit exceeded.',
+            member,
+          );
+          checksum = crc32(chunk, checksum);
+          if (keepLimit !== undefined) chunks.push(chunk);
+        }
+      } finally {
+        stream.destroy();
+      }
+      requireCheck(
+        bytes === entry.uncompressedSize && checksum === entry.crc32,
+        'INTEGRITY',
+        'ZIP size/CRC mismatch.',
+        member,
+      );
+      if (!directory) {
+        files.set(name, keepLimit === undefined ? undefined : Buffer.concat(chunks, bytes));
+        budget.members.push({ archive: label, path: name, bytes });
+      }
+    }
+    // Also reject a file that is used as another entry's parent directory.
+    ranges.sort((a, b) => a[0] - b[0]);
+    for (let i = 1; i < ranges.length; i++) {
+      requireCheck(ranges[i][0] >= ranges[i - 1][1], 'INTEGRITY', 'Overlapping ZIP members.', label);
+    }
+    for (const name of names.keys()) {
+      const parts = name.split('/');
+      for (let i = 1; i < parts.length; i++) {
+        requireCheck(
+          names.get(parts.slice(0, i).join('/')) !== false,
+          'DUPLICATE_PATH',
+          'File/directory collision.',
+          label,
+        );
+      }
+    }
+    return files;
+  } catch (error) {
+    if (error instanceof InspectionFailure) throw error;
+    // ZIP exceptions can contain attacker-controlled filenames: never print the raw exception.
+    throw new InspectionFailure('INVALID_ZIP', 'ZIP is corrupt, truncated or unsupported.', label);
+  } finally {
+    zip?.close();
+  }
+}

--- a/tests/helpers/mtar-fixtures.ts
+++ b/tests/helpers/mtar-fixtures.ts
@@ -1,0 +1,89 @@
+import { crc32, deflateRawSync } from 'node:zlib';
+
+export interface ZipFixtureEntry {
+  name: string;
+  data?: Buffer | string;
+  method?: number;
+  flags?: number;
+  mode?: number;
+  crc?: number;
+  declaredSize?: number;
+  localName?: string;
+  extra?: Buffer;
+}
+
+/** Tiny deterministic ZIP writer for adversarial fixtures, not application archive production. */
+export function zipFixture(entries: ZipFixtureEntry[]): Buffer {
+  const locals: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+  for (const entry of entries) {
+    const data = Buffer.from(entry.data ?? '');
+    const name = Buffer.from(entry.name);
+    const localName = Buffer.from(entry.localName ?? entry.name);
+    const extra = entry.extra ?? Buffer.alloc(0);
+    const method = entry.method ?? 8;
+    const compressed = method === 8 ? deflateRawSync(data) : data;
+    const crc = entry.crc ?? crc32(data);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(entry.flags ?? 0x800, 6);
+    local.writeUInt16LE(method, 8);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(entry.declaredSize ?? data.length, 22);
+    local.writeUInt16LE(localName.length, 26);
+    local.writeUInt16LE(extra.length, 28);
+    locals.push(local, localName, extra, compressed);
+    const header = Buffer.alloc(46);
+    header.writeUInt32LE(0x02014b50);
+    header.writeUInt16LE(0x314, 4); // Unix, ZIP 2.0
+    header.writeUInt16LE(20, 6);
+    local.copy(header, 8, 6, 26);
+    header.writeUInt16LE(name.length, 28);
+    header.writeUInt16LE(extra.length, 30);
+    header.writeUInt32LE(((entry.mode ?? 0o100644) << 16) >>> 0, 38);
+    header.writeUInt32LE(offset, 42);
+    central.push(header, name, extra);
+    offset += local.length + localName.length + extra.length + compressed.length;
+  }
+  const directory = Buffer.concat(central);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(directory.length, 12);
+  end.writeUInt32LE(offset, 16);
+  return Buffer.concat([...locals, directory, end]);
+}
+
+export const SERVER = 'arc1-mcp-server';
+export const ROUTER = 'arc1-ui-router';
+export const MANIFEST = 'META-INF/MANIFEST.MF';
+export const DESCRIPTOR = 'META-INF/mtad.yaml';
+
+export function mtarEntries(
+  modules: Record<string, Buffer> = { [SERVER]: zipFixture([{ name: 'dist/index.js', data: 'code' }]) },
+): ZipFixtureEntry[] {
+  const names = Object.keys(modules);
+  const descriptor = {
+    '_schema-version': '3.1',
+    ID: 'arc1-mcp',
+    version: '1.2.0',
+    modules: names.map((name) => ({ name, type: 'javascript.nodejs', path: name })),
+    resources: [{ name: 'arc1-xsuaa', parameters: { path: 'xs-security.json' } }],
+  };
+  const manifest = [
+    'manifest-Version: 1.0\nCreated-By: synthetic fixture',
+    ...names.map((name) => `Name: ${name}/data.zip\nMTA-Module: ${name}\nContent-Type: application/zip`),
+    'Name: xs-security.json\nMTA-Resource: arc1-xsuaa\nContent-Type: application/json',
+    `Name: ${DESCRIPTOR}\nContent-Type: text/plain`,
+  ].join('\n\n');
+  return [
+    { name: MANIFEST, data: manifest },
+    { name: DESCRIPTOR, data: JSON.stringify(descriptor) },
+    ...names.map((name) => ({ name: `${name}/data.zip`, data: modules[name] })),
+    { name: 'xs-security.json', data: '{"scopes":[]}' },
+  ];
+}

--- a/tests/unit/scripts/mtar-inspection.test.ts
+++ b/tests/unit/scripts/mtar-inspection.test.ts
@@ -1,0 +1,359 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { crc32 } from 'node:zlib';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { inspectMtar } from '../../../scripts/btp/mtar-inspection.mjs';
+import { LIMITS } from '../../../scripts/btp/mtar-zip.mjs';
+import {
+  DESCRIPTOR,
+  MANIFEST,
+  mtarEntries,
+  ROUTER,
+  SERVER,
+  type ZipFixtureEntry,
+  zipFixture,
+} from '../../helpers/mtar-fixtures.js';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>();
+  return { ...actual, open: vi.fn(actual.open) };
+});
+const realFs = await vi.importActual<typeof fs>('node:fs/promises');
+
+let directory: string;
+let archive: string;
+const cli = resolve('scripts/btp/inspect-mtar.mjs');
+const npmrc = await fs.readFile('btp/approuter/.npmrc');
+beforeEach(async () => {
+  directory = await fs.mkdtemp(join(tmpdir(), 'arc1-mtar-'));
+  archive = join(directory, 'selected archive.mtar');
+});
+afterEach(async () => {
+  vi.mocked(fs.open).mockImplementation(realFs.open);
+  vi.clearAllMocks();
+  await fs.rm(directory, { recursive: true, force: true });
+});
+
+async function inspect(entries = mtarEntries(), limits = LIMITS) {
+  await fs.writeFile(archive, zipFixture(entries));
+  return inspectMtar(archive, { limits });
+}
+async function payload(entries: ZipFixtureEntry[], module = SERVER) {
+  return inspect(
+    mtarEntries({ [SERVER]: zipFixture([{ name: 'dist/index.js', data: 'code' }]), [module]: zipFixture(entries) }),
+  );
+}
+function failure(result: Awaited<ReturnType<typeof inspectMtar>>, code?: string) {
+  expect(result.outcome).toBe('FAIL');
+  expect(result.findings).toHaveLength(1);
+  if (code) expect(result.findings[0]?.code).toBe(code);
+}
+
+describe('explicit MTAR inspection', () => {
+  it('identifies the exact base archive, ignoring a newer unsafe archive', async () => {
+    const buffer = zipFixture(mtarEntries());
+    await fs.writeFile(archive, buffer);
+    await fs.writeFile(join(directory, 'newer.mtar'), 'not a zip');
+    const before = await fs.readdir(directory);
+    const result = await inspectMtar(archive);
+    expect(result.outcome).toBe('PASS');
+    expect(result.artifact).toEqual({
+      name: 'selected archive.mtar',
+      sizeBytes: buffer.length,
+      sha256: createHash('sha256').update(buffer).digest('hex'),
+    });
+    expect(result.checkedPayloads).toEqual([{ module: SERVER, member: `${SERVER}/data.zip`, files: 1 }]);
+    expect(result.members).toContainEqual({ archive: SERVER, path: 'dist/index.js', bytes: 4 });
+    expect(await fs.readdir(directory)).toEqual(before);
+    expect(await fs.readFile(archive)).toEqual(buffer);
+  });
+
+  it('checks every UI payload and permits only the exact reviewed root npmrc', async () => {
+    const result = await payload(
+      [
+        { name: '.npmrc', data: npmrc },
+        { name: 'xs-app.json', data: '{}' },
+      ],
+      ROUTER,
+    );
+    expect(result.outcome).toBe('PASS');
+    expect(result.checkedPayloads).toHaveLength(2);
+  });
+
+  it.each([
+    '.env',
+    'sub/.env.production',
+    'key.PEM',
+    'key.der',
+    'my-service-key.json',
+    '.arc1/token',
+    '.mcp.json',
+    'cookies.txt',
+    'customer.mtaext',
+    'customer.mtaext.backup',
+    'scripts/deploy.mjs',
+    'tests/a.ts',
+    '.git/config',
+    '.codex/token.json',
+  ])('rejects forbidden module path %s without contents', async (name) => {
+    const result = await payload([{ name, data: 'DO_NOT_DISCLOSE_SECRET' }]);
+    failure(result, 'PROHIBITED_PATH');
+    expect(JSON.stringify(result)).not.toContain('DO_NOT_DISCLOSE_SECRET');
+  });
+
+  it('does not mistake the runtime cookies helper for a credential export', async () => {
+    expect((await payload([{ name: 'dist/adt/cookies.js', data: 'code' }])).outcome).toBe('PASS');
+  });
+
+  it('accepts stored files and UTF-8 names without shell expansion', async () => {
+    expect((await payload([{ name: 'assets/ümlaut space.txt', method: 0, data: 'content' }])).outcome).toBe('PASS');
+  });
+
+  it('rejects conflicting Unicode filename metadata that could hide a prohibited path', async () => {
+    const replacement = Buffer.from('safe-name');
+    const extra = Buffer.alloc(9 + replacement.length);
+    extra.writeUInt16LE(0x7075, 0);
+    extra.writeUInt16LE(5 + replacement.length, 2);
+    extra[4] = 1;
+    extra.writeUInt32LE(crc32(Buffer.from('.env')), 5);
+    replacement.copy(extra, 9);
+    failure(await payload([{ name: '.env', extra, data: 'hidden' }]), 'UNSUPPORTED_ENTRY');
+  });
+
+  it('stops excess expansion inside a tiny compressed nested module', async () => {
+    const entries = mtarEntries({ [SERVER]: zipFixture([{ name: 'large', data: 'x'.repeat(20_000) }]) });
+    failure(await inspect(entries, { ...LIMITS, expandedBytes: 5_000 }), 'LIMIT');
+    failure(await inspect(entries, { ...LIMITS, entryBytes: 5_000 }), 'LIMIT');
+  });
+
+  it('has no direct network/child-process surface in the repository inspector', async () => {
+    const allowed = new Set([
+      'node:crypto',
+      'node:fs',
+      'node:fs/promises',
+      'node:path',
+      'node:util',
+      'node:zlib',
+      'yaml',
+      'yauzl',
+      './mtar-inspection.mjs',
+      './mtar-zip.mjs',
+    ]);
+    for (const file of ['inspect-mtar.mjs', 'mtar-inspection.mjs', 'mtar-zip.mjs']) {
+      const source = await fs.readFile(`scripts/btp/${file}`, 'utf8');
+      for (const match of source.matchAll(/from ['"]([^'"]+)['"]/g)) expect(allowed.has(match[1]!)).toBe(true);
+      expect(source).not.toMatch(/\b(?:fetch|import|require|execFile|spawn)\s*\(/);
+    }
+  });
+
+  it.each(['.env', 'service-key.json', '.npmrc'])('rejects credential paths in the wrapper: %s', async (name) => {
+    failure(await inspect([...mtarEntries(), { name, data: 'hidden' }]), 'PROHIBITED_PATH');
+  });
+
+  it.each([
+    [SERVER, '.npmrc', 'install-links=true\n', 'PROHIBITED_PATH'],
+    [ROUTER, 'sub/.npmrc', 'install-links=true\n', 'PROHIBITED_PATH'],
+    [ROUTER, '.npmrc', 'install-links=false\n', 'NPMRC'],
+    [ROUTER, 'package.json', '{}', 'NPMRC'],
+  ])('fails misplaced/missing/altered npmrc in %s/%s', async (module, name, data, code) => {
+    failure(await payload([{ name, data }], module), code);
+  });
+
+  it.each([MANIFEST, DESCRIPTOR, `${SERVER}/data.zip`, 'xs-security.json'])(
+    'fails a missing required member: %s',
+    async (name) => {
+      failure(await inspect(mtarEntries().filter((entry) => entry.name !== name)));
+    },
+  );
+
+  it.each([
+    Buffer.from('not ZIP'),
+    zipFixture([]),
+    zipFixture([{ name: 'dir/', mode: 0o040755 }]),
+    zipFixture([{ name: 'x', data: 'y' }]).subarray(0, 35),
+  ])('fails missing/corrupt/empty payload', async (data) => {
+    failure(await inspect(mtarEntries({ [SERVER]: data })));
+  });
+
+  it.each([
+    '../escape',
+    '/absolute',
+    'C:/absolute',
+    'dir\\file',
+    './alias',
+    'a//b',
+    'a/../b',
+    'control\u001bname',
+    'file.',
+  ])('rejects unsafe archive member %j', async (name) => {
+    failure(await payload([{ name, data: 'bad' }]));
+    expect(await fs.readdir(directory)).toEqual(['selected archive.mtar']);
+  });
+
+  it.each(
+    [
+      [{ name: 'x' }, { name: 'x' }],
+      [{ name: 'X' }, { name: 'x' }],
+      [{ name: 'x' }, { name: 'x/a' }],
+      [{ name: 'x/a' }, { name: 'x' }],
+    ].map((entries) => ({ entries })),
+  )('rejects duplicate/colliding member names', async ({ entries }) =>
+    failure(await payload(entries), 'DUPLICATE_PATH'),
+  );
+
+  it.each([
+    [{ name: 'link', data: '/etc/passwd', mode: 0o120777 }, 'UNSUPPORTED_ENTRY'],
+    [{ name: 'pipe', mode: 0o010644 }, 'UNSUPPORTED_ENTRY'],
+    [{ name: 'encrypted', flags: 1 }, 'ENCRYPTED'],
+    [{ name: 'unsupported', method: 12 }, 'COMPRESSION'],
+    [{ name: 'bad-crc', data: 'data', crc: 123 }, 'INTEGRITY'],
+    [{ name: 'safe', localName: '.env', data: 'data' }, 'INTEGRITY'],
+  ] as const)('rejects unsupported/inconsistent entry %#', async (entry, code) =>
+    failure(await payload([entry]), code),
+  );
+
+  it('fails a forged expanded size during decompression', async () => {
+    failure(await payload([{ name: 'x', data: 'more than declared', declaredSize: 1 }]));
+  });
+
+  it.each(['archiveBytes', 'entryBytes', 'expandedBytes', 'metadataBytes', 'entries', 'nameBytes'] as const)(
+    'fails closed at the %s resource limit',
+    async (limit) => {
+      failure(await inspect(mtarEntries(), { ...LIMITS, [limit]: 1 }), limit === 'nameBytes' ? 'UNSAFE_PATH' : 'LIMIT');
+    },
+  );
+
+  it('does not descend into arbitrary nested application ZIPs', async () => {
+    expect((await payload([{ name: 'assets/something.zip', data: 'not ZIP, application content' }])).outcome).toBe(
+      'PASS',
+    );
+  });
+
+  it.each([
+    (entries: ZipFixtureEntry[]) => [...entries, { name: 'undeclared/data.zip', data: zipFixture([{ name: 'x' }]) }],
+    (entries: ZipFixtureEntry[]) =>
+      entries.map((entry) =>
+        entry.name === MANIFEST
+          ? { ...entry, data: String(entry.data).replace('MTA-Module: arc1-mcp-server', 'MTA-Module: wrong') }
+          : entry,
+      ),
+    (entries: ZipFixtureEntry[]) =>
+      entries.map((entry) =>
+        entry.name === MANIFEST
+          ? { ...entry, data: `${entry.data}\n\nName: xs-security.json\nMTA-Resource: arc1-xsuaa` }
+          : entry,
+      ),
+    (entries: ZipFixtureEntry[]) =>
+      entries.map((entry) => (entry.name === DESCRIPTOR ? { ...entry, data: 'modules: [\nbad' } : entry)),
+    (entries: ZipFixtureEntry[]) =>
+      entries.map((entry) =>
+        entry.name === DESCRIPTOR
+          ? { ...entry, data: String(entry.data).replace('"path":"arc1-mcp-server"', '"path":"wrong"') }
+          : entry,
+      ),
+  ])('rejects ambiguous or inconsistent manifest/descriptor layouts %#', async (change) =>
+    failure(await inspect(change(mtarEntries()))),
+  );
+
+  it('accepts CRLF and manifest continuation lines', async () => {
+    const entries = mtarEntries().map((entry) =>
+      entry.name === MANIFEST
+        ? {
+            ...entry,
+            data: String(entry.data)
+              .replace('arc1-mcp-server/data.zip', 'arc1-mcp-\n server/data.zip')
+              .replaceAll('\n', '\r\n'),
+          }
+        : entry,
+    );
+    expect((await inspect(entries)).outcome).toBe('PASS');
+  });
+
+  it('detects archive replacement between snapshot and final verification', async () => {
+    await fs.writeFile(archive, zipFixture(mtarEntries()));
+    let opens = 0;
+    vi.mocked(fs.open).mockImplementation(async (...args) => {
+      if (String(args[0]) === archive && ++opens === 2)
+        await fs.writeFile(
+          archive,
+          zipFixture(mtarEntries({ [SERVER]: zipFixture([{ name: 'different', data: 'x' }]) })),
+        );
+      return realFs.open(...args);
+    });
+    failure(await inspectMtar(archive), 'ARTIFACT_CHANGED');
+  });
+
+  it('returns ERROR for missing/unreadable input, not a misleading PASS', async () => {
+    const result = await inspectMtar(archive);
+    expect(result.outcome).toBe('ERROR');
+    expect(result.artifact.sha256).toBeNull();
+    expect(JSON.stringify(result)).not.toContain(directory);
+  });
+
+  it('rejects a directory as the selected archive', async () => {
+    failure(await inspectMtar(directory), 'NOT_FILE');
+  });
+
+  it('treats an I/O failure during the final verification as ERROR without raw exception disclosure', async () => {
+    await fs.writeFile(archive, zipFixture(mtarEntries()));
+    vi.mocked(fs.open).mockImplementationOnce(realFs.open).mockRejectedValueOnce(new Error('DO_NOT_DISCLOSE_SECRET'));
+    const result = await inspectMtar(archive);
+    expect(result.outcome).toBe('ERROR');
+    expect(JSON.stringify(result)).not.toContain('DO_NOT_DISCLOSE_SECRET');
+  });
+});
+
+describe('inspection command', () => {
+  const run = (args: string[]) =>
+    spawnSync(process.execPath, [cli, ...args], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      cwd: directory,
+      env: { ...process.env, PATH: directory },
+    });
+
+  it.each(
+    [
+      [],
+      ['--archive', '*.mtar'],
+      ['--archive', 'a', '--archive', 'b'],
+      ['--archive', 'a', 'b'],
+      ['--archive', 'a', '--format', 'xml'],
+      ['--deploy'],
+    ].map((args) => ({ args })),
+  )('rejects invalid arguments $args', ({ args }) => {
+    const result = run(args);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Usage:');
+    expect(result.stdout).toBe('');
+  });
+
+  it('runs without CF/unzip/shell helpers, emits matching text/JSON, and lists inert names', async () => {
+    await inspect();
+    const json = run(['--archive', archive, '--format', 'json']);
+    expect(json.status).toBe(0);
+    expect(json.stderr).toBe('');
+    const result = JSON.parse(json.stdout);
+    const text = run(['--archive', archive, '--list']);
+    expect(text.status).toBe(0);
+    expect(text.stdout).toContain(result.artifact.sha256);
+    expect(text.stdout).toContain(`${SERVER}:dist/index.js`);
+    expect(text.stdout).toContain('no deployment is performed');
+    expect(result.artifact.name).toBe('selected archive.mtar');
+    expect(await fs.readdir(directory)).toEqual(['selected archive.mtar']);
+  });
+
+  it('reports archive FAIL as exit 1 and I/O ERROR as exit 2', async () => {
+    await fs.writeFile(archive, 'not zip');
+    const bad = run(['--archive', archive, '--format', 'json']);
+    expect(bad.status).toBe(1);
+    expect(JSON.parse(bad.stdout).outcome).toBe('FAIL');
+    await fs.rm(archive);
+    const missing = run(['--archive', archive, '--format', 'json']);
+    expect(missing.status).toBe(2);
+    expect(JSON.parse(missing.stdout).outcome).toBe('ERROR');
+  });
+});

--- a/tests/unit/scripts/mtar-inspection.test.ts
+++ b/tests/unit/scripts/mtar-inspection.test.ts
@@ -372,6 +372,9 @@ describe('explicit MTAR inspection', () => {
   it.each([
     ['EIO', 'READ_ERROR'],
     [undefined, 'CHECKER_ERROR'],
+    ['toString', 'CHECKER_ERROR'],
+    ['constructor', 'CHECKER_ERROR'],
+    ['__proto__', 'CHECKER_ERROR'],
   ])('distinguishes final verification I/O errors from unexpected failures: %s', async (code, expected) => {
     await fs.writeFile(archive, zipFixture(mtarEntries()));
     vi.mocked(fs.stat)
@@ -380,7 +383,7 @@ describe('explicit MTAR inspection', () => {
       .mockRejectedValueOnce(Object.assign(new Error('DO_NOT_DISCLOSE_SECRET'), { code }));
     const result = await inspectMtar(archive);
     expect(result.outcome).toBe('ERROR');
-    expect(result.findings[0]?.code).toBe(expected);
+    expect(JSON.parse(JSON.stringify(result)).findings).toEqual([{ code: expected, message: expect.any(String) }]);
     expect(JSON.stringify(result)).not.toContain('DO_NOT_DISCLOSE_SECRET');
   });
 });

--- a/tests/unit/scripts/mtar-inspection.test.ts
+++ b/tests/unit/scripts/mtar-inspection.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { crc32 } from 'node:zlib';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parse } from 'yaml';
 import { inspectMtar } from '../../../scripts/btp/mtar-inspection.mjs';
 import { LIMITS } from '../../../scripts/btp/mtar-zip.mjs';
 import {
@@ -19,7 +20,7 @@ import {
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof fs>();
-  return { ...actual, open: vi.fn(actual.open) };
+  return { ...actual, open: vi.fn(actual.open), stat: vi.fn(actual.stat), readFile: vi.fn(actual.readFile) };
 });
 const realFs = await vi.importActual<typeof fs>('node:fs/promises');
 
@@ -33,6 +34,8 @@ beforeEach(async () => {
 });
 afterEach(async () => {
   vi.mocked(fs.open).mockImplementation(realFs.open);
+  vi.mocked(fs.stat).mockImplementation(realFs.stat);
+  vi.mocked(fs.readFile).mockImplementation(realFs.readFile);
   vi.clearAllMocks();
   await fs.rm(directory, { recursive: true, force: true });
 });
@@ -69,6 +72,8 @@ describe('explicit MTAR inspection', () => {
     expect(result.members).toContainEqual({ archive: SERVER, path: 'dist/index.js', bytes: 4 });
     expect(await fs.readdir(directory)).toEqual(before);
     expect(await fs.readFile(archive)).toEqual(buffer);
+    expect(fs.open).toHaveBeenCalledTimes(1);
+    expect(fs.stat).toHaveBeenCalledTimes(3);
   });
 
   it('checks every UI payload and permits only the exact reviewed root npmrc', async () => {
@@ -81,6 +86,32 @@ describe('explicit MTAR inspection', () => {
     );
     expect(result.outcome).toBe('PASS');
     expect(result.checkedPayloads).toHaveLength(2);
+    expect(result.qualification).toContain('local reviewed checkout (including its exact AppRouter .npmrc)');
+    expect(result.qualification).toContain('use the matching checkout for the artifact');
+  });
+
+  it('accepts the MTA ID and module names from the real build descriptor', async () => {
+    const descriptor = parse(await fs.readFile('mta.yaml', 'utf8'));
+    const modules = Object.fromEntries(
+      descriptor.modules.map((module: { name: string; path: string }) => [
+        module.name,
+        zipFixture([
+          {
+            name: module.path === 'btp/approuter' ? '.npmrc' : 'dist/index.js',
+            data: module.path === 'btp/approuter' ? npmrc : 'code',
+          },
+        ]),
+      ]),
+    );
+    const entries = mtarEntries(modules).map((entry) =>
+      entry.name === DESCRIPTOR
+        ? { ...entry, data: JSON.stringify({ ...JSON.parse(String(entry.data)), ID: descriptor.ID }) }
+        : entry,
+    );
+    expect(
+      (await inspect(entries)).outcome,
+      'Update the inspector when mta.yaml changes its ID or module layout.',
+    ).toBe('PASS');
   });
 
   it.each([
@@ -94,6 +125,8 @@ describe('explicit MTAR inspection', () => {
     'cookies.txt',
     'customer.mtaext',
     'customer.mtaext.backup',
+    'sub/customer.mtaext',
+    'sub/customer.mtaext.backup',
     'scripts/deploy.mjs',
     'tests/a.ts',
     '.git/config',
@@ -152,6 +185,17 @@ describe('explicit MTAR inspection', () => {
   it.each(['.env', 'service-key.json', '.npmrc'])('rejects credential paths in the wrapper: %s', async (name) => {
     failure(await inspect([...mtarEntries(), { name, data: 'hidden' }]), 'PROHIBITED_PATH');
   });
+
+  it.each(['customer.mtaext', 'sub/customer.MTAEXT.backup'])(
+    'classifies packaged overrides as operator files, not credentials: %s',
+    async (name) => {
+      for (const result of [await payload([{ name }]), await inspect([...mtarEntries(), { name }])]) {
+        failure(result, 'PROHIBITED_PATH');
+        expect(result.findings[0]?.message).toContain('operator path');
+        expect(result.findings[0]?.message).not.toContain('credential');
+      }
+    },
+  );
 
   it.each([
     [SERVER, '.npmrc', 'install-links=true\n', 'PROHIBITED_PATH'],
@@ -274,34 +318,69 @@ describe('explicit MTAR inspection', () => {
 
   it('detects archive replacement between snapshot and final verification', async () => {
     await fs.writeFile(archive, zipFixture(mtarEntries()));
-    let opens = 0;
-    vi.mocked(fs.open).mockImplementation(async (...args) => {
-      if (String(args[0]) === archive && ++opens === 2)
-        await fs.writeFile(
-          archive,
-          zipFixture(mtarEntries({ [SERVER]: zipFixture([{ name: 'different', data: 'x' }]) })),
-        );
-      return realFs.open(...args);
+    let stats = 0;
+    vi.mocked(fs.stat).mockImplementation(async (...args) => {
+      if (String(args[0]) === archive && ++stats === 3) {
+        const replacement = join(directory, 'replacement.mtar');
+        await fs.writeFile(replacement, zipFixture(mtarEntries()));
+        await fs.rename(replacement, archive);
+      }
+      return realFs.stat(...args);
     });
     failure(await inspectMtar(archive), 'ARTIFACT_CHANGED');
   });
 
-  it('returns ERROR for missing/unreadable input, not a misleading PASS', async () => {
+  it('identifies a missing selected archive without exposing the absolute path', async () => {
     const result = await inspectMtar(archive);
     expect(result.outcome).toBe('ERROR');
     expect(result.artifact.sha256).toBeNull();
+    expect(result.findings[0]).toMatchObject({
+      code: 'NOT_FOUND',
+      message: expect.stringContaining('Cannot find selected archive'),
+    });
     expect(JSON.stringify(result)).not.toContain(directory);
+  });
+
+  it.each(['EACCES', 'EPERM'])('distinguishes %s from a missing file or checker failure', async (code) => {
+    vi.mocked(fs.stat).mockRejectedValueOnce(Object.assign(new Error('DO_NOT_DISCLOSE_SECRET'), { code }));
+    const result = await inspectMtar(archive);
+    expect(result.outcome).toBe('ERROR');
+    expect(result.findings[0]).toMatchObject({
+      code: 'ACCESS_DENIED',
+      message: expect.stringContaining('Permission denied reading selected archive'),
+    });
+    expect(JSON.stringify(result)).not.toContain('DO_NOT_DISCLOSE_SECRET');
+  });
+
+  it('identifies a missing reviewed checkout file separately from a missing archive', async () => {
+    vi.mocked(fs.readFile).mockRejectedValueOnce(
+      Object.assign(new Error('DO_NOT_DISCLOSE_SECRET'), { code: 'ENOENT' }),
+    );
+    const result = await payload([{ name: '.npmrc', data: npmrc }], ROUTER);
+    expect(result.outcome).toBe('ERROR');
+    expect(result.findings[0]).toMatchObject({
+      code: 'NOT_FOUND',
+      message: expect.stringContaining('Cannot find reviewed checkout AppRouter .npmrc'),
+    });
+    expect(JSON.stringify(result)).not.toContain('DO_NOT_DISCLOSE_SECRET');
   });
 
   it('rejects a directory as the selected archive', async () => {
     failure(await inspectMtar(directory), 'NOT_FILE');
   });
 
-  it('treats an I/O failure during the final verification as ERROR without raw exception disclosure', async () => {
+  it.each([
+    ['EIO', 'READ_ERROR'],
+    [undefined, 'CHECKER_ERROR'],
+  ])('distinguishes final verification I/O errors from unexpected failures: %s', async (code, expected) => {
     await fs.writeFile(archive, zipFixture(mtarEntries()));
-    vi.mocked(fs.open).mockImplementationOnce(realFs.open).mockRejectedValueOnce(new Error('DO_NOT_DISCLOSE_SECRET'));
+    vi.mocked(fs.stat)
+      .mockImplementationOnce(realFs.stat)
+      .mockImplementationOnce(realFs.stat)
+      .mockRejectedValueOnce(Object.assign(new Error('DO_NOT_DISCLOSE_SECRET'), { code }));
     const result = await inspectMtar(archive);
     expect(result.outcome).toBe('ERROR');
+    expect(result.findings[0]?.code).toBe(expected);
     expect(JSON.stringify(result)).not.toContain('DO_NOT_DISCLOSE_SECRET');
   });
 });
@@ -355,5 +434,7 @@ describe('inspection command', () => {
     const missing = run(['--archive', archive, '--format', 'json']);
     expect(missing.status).toBe(2);
     expect(JSON.parse(missing.stdout).outcome).toBe('ERROR');
+    expect(JSON.parse(missing.stdout).findings[0].code).toBe('NOT_FOUND');
+    expect(run(['--archive', archive]).stdout).toContain('Cannot find selected archive');
   });
 });

--- a/tests/unit/server/approuter-config.test.ts
+++ b/tests/unit/server/approuter-config.test.ts
@@ -65,23 +65,17 @@ describe('BTP UI AppRouter config', () => {
     expect(packageLock.packages['node_modules/decode-uri-component']?.version).toBe(wrappedVersion);
   });
 
-  it('allows only the reviewed AppRouter npm config through the MTAR inspection gate', async () => {
+  it('keeps the reviewed AppRouter npm configuration narrowly scoped', async () => {
     const npmrc = await readFile('btp/approuter/.npmrc', 'utf8');
     const activeSettings = npmrc
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter((line) => line !== '' && !line.startsWith('#'));
-    const runbook = await readFile('docs_page/btp-cloud-foundry-deployment.md', 'utf8');
 
     // Keep the one allowed project config non-secret and narrowly scoped.
     expect(activeSettings).toEqual(['install-links=true']);
-    // Both documented inspection implementations must compare the packaged file with source.
-    expect(runbook).toContain(`[ "$member" = 'arc1-ui-router/data.zip' ]`);
-    expect(runbook).toContain('cmp -s "$tmp/approuter.npmrc" btp/approuter/.npmrc');
-    expect(runbook).toContain("$member.Directory.Name -eq 'arc1-ui-router'");
-    expect(runbook).toContain('Get-FileHash $allowedNpmrc -Algorithm SHA256');
-    // The blanket filename deny remains in place for every other module and path.
-    expect(runbook.match(/deny\s*=\s*['"]\\\.env\|\\\.npmrc/g)).toHaveLength(2);
+    // Packaged bytes and misplaced/altered configs are exercised with real ZIP fixtures in
+    // tests/unit/scripts/mtar-inspection.test.ts, not assertions on copied shell implementations.
   });
 
   it('requires admin scope for all UI routes', async () => {

--- a/tests/unit/server/btp-docs-contract.test.ts
+++ b/tests/unit/server/btp-docs-contract.test.ts
@@ -39,6 +39,31 @@ function assertParity(markdown: string): void {
 }
 
 describe('BTP documentation contracts', () => {
+  it('inspects and deploys the same explicitly named archive without a rebuild step', () => {
+    const runbook = read('docs_page/btp-cloud-foundry-deployment.md');
+    const inspected = /npm run btp:inspect-mtar -- --archive "([^"]+)"/.exec(runbook)?.[1];
+    const deployment = runbook.split('## 6. Deploy the MTA')[1]?.split('## 7.')[0] ?? '';
+    expect(inspected).toBe('mta_archives/arc1-mcp_<version>.mtar');
+    expect(deployment).toContain(`cf deploy "${inspected}" -e mta-overrides.mtaext`);
+    const commands = [...deployment.matchAll(/```[^\n]*\n([\s\S]*?)```/g)].map((match) => match[1]).join('\n');
+    expect(commands).not.toMatch(/btp:build|btp:deploy|mbt build/);
+    expect(runbook).not.toMatch(/inspect_mtar\(\)|\$MTAR|Sort-Object LastWriteTime|ls -t mta_archives/);
+    const pkg = JSON.parse(read('package.json'));
+    expect(pkg.scripts['btp:inspect-mtar']).toBe('node scripts/btp/inspect-mtar.mjs');
+  });
+
+  it('routes administration acceptance to SAP-side identity evidence, not SYSTEM.user', () => {
+    const admin = read('docs_page/btp-administration.md');
+    expect(admin).toContain('principal-propagation-setup.md#verify-the-backend-identity');
+    expect(admin).not.toContain('must identify the human SAP user');
+  });
+
+  it('does not package the AppRouter regression-test directory', () => {
+    const descriptor = parse(read('mta.yaml'));
+    const router = descriptor.modules.find((module: { name: string }) => module.name === 'arc1-ui-router');
+    expect(router['build-parameters'].ignore).toContain('test/');
+  });
+
   it('uses the observed CF route rather than deriving OAuth URLs from the space', () => {
     const xsuaa = read('docs_page/xsuaa-setup.md');
     expect(xsuaa).toContain('cf app <app-name>');


### PR DESCRIPTION
## Goal

Combine the two post-merge documentation corrections with the planned local MTAR inspector. Make the customer runbook shorter and ensure the archive inspected is the archive subsequently deployed. No new public documentation page, wizard, prebuilt MTAR distribution, or runtime/auth changes.

## Changes

- Add `npm run btp:inspect-mtar -- --archive <exact-path> [--format json] [--list]`. One literal path is required; no newest-file or package-version fallback. Reports artifact size, SHA-256, checked modules, findings and explicit limitations.
- Inspect wrapper manifest, deployment descriptor and every declared module ZIP without extraction, network access or deployment. Fail on missing/empty/corrupt payloads, conflicting headers/names, unsupported compression/encryption, prohibited paths and fixed resource limits. Check CRCs and detect selected-file changes during inspection.
- Preserve only the byte-exact reviewed AppRouter root `.npmrc` exception. Real UI-build testing found the AppRouter regression tests were shipped; exclude its `test/` directory.
- Replace the Bash/PowerShell procedures with the shared command and an explicit-path `cf deploy` step. No rebuilding between inspection and deployment. The runbook is **81 lines shorter**, and existing deployment npm scripts remain compatible.
- Correct the remaining administration claim that `SAPRead SYSTEM` proves the backend SAP user. Link to the existing SAP-side identity verification procedure.
- Add 93 focused fixture/CLI tests, documentation regression coverage, and a focused Windows job in the existing Test workflow. Include the inspector in Biome checks. `yauzl` 3.4 (MIT) is a direct dev-only dependency; no production dependency changes.

## Validation

- [x] Full unit suite: **195 files / 5,867 tests passed** on macOS/Node 24.
- [x] 93 focused archive tests, including corrupt/empty/missing payloads, traversal, duplicates, symlinks, encrypted/unsupported entries, CRC/size mismatch, Unicode-name conflicts, expansion limits, exact `.npmrc`, replacement/read errors, CLI exit codes and explicit selection among multiple archives.
- [x] Typecheck, lint (two existing Biome configuration infos), policy validation and size/schema budgets.
- [x] All five MTA descriptor validations; strict MkDocs build.
- [x] Actual local base and UI MBT builds inspected successfully: 1 server payload / 2 server+AppRouter payloads respectively. No CF/SAP deployment or live system changes.
- [x] Dependency audit: no vulnerabilities found.
- [x] Latest-head CI: Linux Node 22/24 full checks, focused Windows inspection tests, documentation, MTA validation, dependency review and CodeQL all passed after the error-code lookup fix. SAP integration/E2E jobs intentionally skipped for this local tooling/docs change.

## Review follow-up

- Applied findings 1 and 3–7: read/hash the archive once, then compare file identity/size/timestamps; test supported MTA ID/module names against `mta.yaml`; classify `.mtaext` as operator configuration, including nested paths and backups; distinguish missing files, permission failures, I/O errors and unexpected checker failures without raw error disclosure.
- Lint the whole `scripts/btp/**` directory, including the adjacent UI helper, instead of a filename-shaped glob. Broader CI/spike-script lint cleanup stays out of scope.
- Qualification output explicitly depends on the matching reviewed local checkout, including byte-exact AppRouter `.npmrc`.
- Retained the existing tested ZIP integrity/resource safeguards (finding 2); no additional archive-hardening framework or public documentation was introduced.
- Fresh real MBT builds pass inspection after the fixes: base 1 payload / 672 files; UI 2 payloads / 672 + 6 files. No deployment.

- Second review: restrict error-code lookup to own properties. Regression tests reproduce `toString`, `constructor` and `__proto__` before the fix and verify structured `CHECKER_ERROR` JSON afterward. Existing real UI MTAR reinspected successfully.

## Review boundaries

`PASS` is limited to supported archive layout/integrity and known prohibited paths. It is not a comprehensive secret scan, source review, cloud preflight, or proof of SAP identity. Application archives inside module payloads are not recursively inspected. A later change to the MTAR requires reinspection; a digest is not a signature or an atomic deployment lock.

Limits: 256 MiB MTAR; 128 MiB per expanded module ZIP/file; 512 MiB combined expanded data; 20,000 entries; 1 MiB metadata; 512-byte member names. Unsupported layouts fail instead of claiming readiness.

No measured human/LLM usability improvement is claimed. This replaces duplicated operator code with tested behavior; the optional comparative task trial remains separate.

## Commits

1. `chore(btp): add bounded explicit-artifact MTAR inspection`
2. `docs(btp): align archive deployment and backend identity acceptance`
3. `chore(btp): simplify MTAR review checks and diagnostics`
4. `chore(btp): guard inspector error-code lookup`

Implementation plan: `docs/plans/2026-09-06-btp-mtar-inspection.md`.
