### PR TITLE
docs: add single-target Basic BTP setup

### DIFF
--- a/docs_page/btp-cloud-foundry-deployment.md
+++ b/docs_page/btp-cloud-foundry-deployment.md
@@ -18,7 +18,7 @@ mutation-free in v1 regardless of the single-target ceiling.
 
 | Topology | Public MCP URL | SAP identity | Capabilities | Start here |
 |---|---|---|---|---|
-| One general SAP target | `/mcp` | Principal Propagation recommended; shared Basic is possible | Full ARC-1 feature set, still constrained by instance flags and roles | This page, then [Destination Reference](btp-destination-setup.md) |
+| One general SAP target | `/mcp` | Principal Propagation recommended; shared Basic is possible | Full ARC-1 feature set, still constrained by instance flags and roles | This page — [single-PP](#single-target-read-only-pp-profile) or [single-Basic](#single-target-read-only-shared-basic-profile) profile |
 | Many SAP system/clients | `/<SYSTEM>/<CLIENT>/mcp` and `/multi/mcp` | PP recommended; optional shared Basic exception | Mutation-free v1: read/search/query/navigate/diagnose/context | This page, then [Multi-System Setup](multi-target-setup.md) |
 | One `/mcp` beside multi-target routes | All of the above | Configured independently | `/mcp` may be writable; multi routes never are | Read [side-by-side risks](multi-target-administration.md#optional-single-target-mcp) first |
 | BTP ABAP Environment | `/mcp` | `OAuth2UserTokenExchange` | Single target | [BTP ABAP Environment](btp-abap-environment.md) |
@@ -195,14 +195,15 @@ needed. Keep `SAP_BTP_DESTINATION` and `SAP_BTP_PP_DESTINATION` absent, includin
 
 All three examples keep mutation/data/SQL flags off, UI/plugins off and cache none. They also deny
 ATC/Unit workloads and disable non-ADT gCTS, FLP and UI5 Repository probes for initial acceptance;
-that is a profile choice, not a general single- or multi-target limitation. The PP profiles keep
-strict PP on, while single-Basic explicitly turns it off. Do not combine the profiles or add UI
-overlays.
+single-target deployments can enable additional capabilities after acceptance. Multi-target v1
+keeps its [restricted tool surface](multi-target-setup.md#allowed-tools), which excludes `SAPGit`
+and `SAPManage` regardless of feature toggles. The PP profiles keep strict PP on,
+while single-Basic explicitly turns it off. Do not combine the profiles or add UI overlays.
 
 Replace names, virtual URLs, real SID/client and descriptions in your private destination files.
 Keep clients such as `001` quoted. Add `CloudConnectorLocationId` only if the Connector owner
 supplies one. JSON files show the destination fields to create in the cockpit; they do not provision
-anything or guarantee a particular import format. Keep startup credentials in the owner's secure
+anything or guarantee a particular import format. Keep SAP credentials in the owner's secure
 process, not in a PR or LLM prompt.
 
 For single-Basic, ask the Connector owner for a principal-type-None mapping with internal HTTPS and

--- a/docs_page/btp-cloud-foundry-deployment.md
+++ b/docs_page/btp-cloud-foundry-deployment.md
@@ -30,9 +30,10 @@ diagnostics and a writable `/mcp`. For a customer beta or cutover, a separate CF
 replacing an existing app in place: the shipped XSUAA application and role-collection names are
 space-qualified.
 
-Principal Propagation is the normal customer path because SAP receives the human identity. Shared
-Basic is a default-off compatibility exception: SAP sees a reusable technical user, and a
-multi-target app containing any Basic destination must run exactly one non-rolling CF process.
+Principal Propagation is the normal customer path because SAP receives the human identity.
+Single-target shared Basic is supported when a reusable technical SAP identity is an accepted
+trade-off; it must explicitly disable the base MTA's PP settings. The one-process/non-rolling
+restriction applies only to multi-target mode containing a Basic destination.
 
 ## 2. Assign owners
 
@@ -146,6 +147,25 @@ file; a skipped copy does not mean the selected profile was applied.
 The real `mta-overrides.mtaext` is gitignored. Store the reviewed copy in the customer's protected
 configuration process. Never add secrets to it and never edit generated `mtad.yaml`.
 
+### Single-target read-only shared Basic profile
+
+Use this profile when XSUAA should authenticate MCP callers but every SAP request may use one
+approved technical user:
+
+```bash
+cp -n examples/btp/single-basic/profile.mtaext mta-overrides.mtaext
+```
+
+Prepare a private copy of `examples/btp/single-basic/basic.destination.json` under the ignored
+`.arc1/btp/` directory. Replace the fictional values, supply the credentials through the
+destination owner's protected process, and update `SAP_BTP_DESTINATION` in the extension to the
+same name. The profile explicitly sets both `SAP_PP_ENABLED=false` and `SAP_PP_STRICT=false`
+because the base MTA enables PP.
+
+This initial profile is ADT-only. It disables the gCTS, FLP and UI5 Repository feature probes so
+the Cloud Connector mapping can expose only `/sap/bc/adt` with all sub-paths. Add a non-ADT path
+and re-enable its feature only as one reviewed capability change.
+
 ### Single-target read-only PP profile
 
 For an on-premise `/mcp`, the current runtime uses a Basic destination to resolve the startup target
@@ -171,11 +191,13 @@ Prepare private copies of the two `examples/btp/multi-pp/*.destination.json` fil
 additional target if needed. These are subaccount-level PP destinations; no startup destination is
 needed. Keep `SAP_BTP_DESTINATION` and `SAP_BTP_PP_DESTINATION` absent, including in existing app env.
 
-### Prepare the selected PP profile
+### Prepare the selected profile
 
-Both examples keep strict PP on, all mutation/data/SQL flags off, UI/plugins off and cache none.
-They also deny ATC/Unit workloads for initial acceptance; that is a profile choice, not a general
-multi-target limitation. Do not combine the profiles or add UI overlays.
+All three examples keep mutation/data/SQL flags off, UI/plugins off and cache none. They also deny
+ATC/Unit workloads and disable non-ADT gCTS, FLP and UI5 Repository probes for initial acceptance;
+that is a profile choice, not a general single- or multi-target limitation. The PP profiles keep
+strict PP on, while single-Basic explicitly turns it off. Do not combine the profiles or add UI
+overlays.
 
 Replace names, virtual URLs, real SID/client and descriptions in your private destination files.
 Keep clients such as `001` quoted. Add `CloudConnectorLocationId` only if the Connector owner
@@ -183,11 +205,17 @@ supplies one. JSON files show the destination fields to create in the cockpit; t
 anything or guarantee a particular import format. Keep startup credentials in the owner's secure
 process, not in a PR or LLM prompt.
 
-Ask the Connector/Basis owners to complete [Principal Propagation Setup](principal-propagation-setup.md)
-and create/review the destinations using [Destination Reference](btp-destination-setup.md).
-**For single PP, both destinations must exist before deploying this profile:** startup resolves
-the startup destination and fails if it is missing. Multi PP can start empty, but requires all
-processes to restart after destinations are added. Then continue to step 5 below.
+For single-Basic, ask the Connector owner for a principal-type-None mapping with internal HTTPS and
+only the approved resource paths; then create/review the destination using
+[Destination Reference](btp-destination-setup.md#shared-basic-mcp). For PP, ask the Connector/Basis
+owners to complete [Principal Propagation Setup](principal-propagation-setup.md) and create/review
+the destinations using [Destination Reference](btp-destination-setup.md).
+
+**Both single-target profiles require their configured destination data before deployment.**
+Single-Basic resolves its one destination at startup. Single-PP resolves the Basic startup
+destination at startup and needs the PP request destination for user calls. Multi-PP can start
+empty, but requires all processes to restart after destinations are added. Then continue to step 5
+below.
 
 ### Multi-target with a shared Basic exception
 
@@ -364,8 +392,9 @@ The deployment creates/updates:
 - Destination and Connectivity service instances and bindings; and
 - a health check on `/health`.
 
-The unconfigured base application and multi-target mode can start with no SAP targets. The
-single-PP profile is different: its startup destination must already exist, as checked in step 4.
+The unconfigured base application and multi-target mode can start with no SAP targets. The two
+single-target profiles are different: their configured destination data must already exist, as
+checked in step 4.
 
 Verify platform state:
 
@@ -432,7 +461,8 @@ mapping in CERTRULE before testing ARC-1.
 
 Then create the destinations using [BTP Destination Reference](btp-destination-setup.md):
 
-- single target: the explicitly named startup and PP destinations in the extension;
+- single target with shared Basic: the one explicitly named Basic destination in the extension;
+- single target with PP: the explicitly named startup and PP destinations in the extension;
 - multi-target: one subaccount destination per SAP system/client, normally PP, with
   `sap-sysid`, `sap-client`, `Description`, and `arc1.enabled=true`.
 

--- a/docs_page/btp-destination-setup.md
+++ b/docs_page/btp-destination-setup.md
@@ -54,7 +54,8 @@ Password=<managed-secret>
 sap-client=100
 ```
 
-Point the application at it and explicitly disable the PP defaults inherited from the base MTA:
+Under `modules[].properties` for `arc1-mcp-server` in the customer's `mta-overrides.mtaext`, point
+the application at it and explicitly disable the PP defaults inherited from the base MTA:
 
 ```yaml
 SAP_BTP_DESTINATION: "A4H_100_BASIC"
@@ -67,6 +68,11 @@ The tracked
 provides the complete read-only extension and destination template. ARC-1 resolves this destination
 at startup for the single target. Use internal HTTPS between Cloud Connector and SAP even if the
 destination uses the virtual `http://` URL.
+
+Use a Cloud Connector mapping with principal type **None**. Have Basis verify that the ADT ICF
+service accepts HTTP Basic for the selected SAP client and technical user; a destination password
+alone cannot make an SSO-only service accept Basic. This topology does not need a PP destination
+or user-certificate mapping in CERTRULE.
 
 This is a shared SAP identity. XSUAA can still identify the MCP caller to ARC-1, but SAP audit sees
 the technical user. Use a dedicated least-privileged user; never use an administrator's account or
@@ -239,17 +245,26 @@ Use restrictive resource mappings:
 | URL path | Policy | Needed for |
 |---|---|---|
 | `/sap/bc/adt` | Path and all sub-paths | ARC-1 core ADT operations and all multi-target v1 routes |
-| `/sap/bc/cts_abapvcs` | Path and all sub-paths | Optional gCTS operations and the `SAP_FEATURE_GCTS=auto` startup probe |
-| `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` | Path and all sub-paths | Optional single-target FLP management and the `SAP_FEATURE_FLP=auto` startup probe |
-| `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` | Path and all sub-paths | Optional single-target UI5 repository operations and the `SAP_FEATURE_UI5REPO=auto` startup probe |
+| `/sap/bc/cts_abapvcs` | Path and all sub-paths | Optional single-target gCTS operations and the `SAP_FEATURE_GCTS=auto` probe |
+| `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` | Path and all sub-paths | Optional single-target FLP management and the `SAP_FEATURE_FLP=auto` probe |
+| `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` | Path and all sub-paths | Optional UI5 Repository metadata reads (`SAPRead` type `BSP_DEPLOY`) and the `SAP_FEATURE_UI5REPO=auto` probe |
 
-The tracked initial BTP profiles set `SAP_FEATURE_GCTS=off`, `SAP_FEATURE_FLP=off`, and
+The three tracked profiles under `examples/btp/` set `SAP_FEATURE_GCTS=off`, `SAP_FEATURE_FLP=off`, and
 `SAP_FEATURE_UI5REPO=off`, so an ADT-only deployment needs only `/sap/bc/adt`. Without those
-overrides, the default `auto` mode sends a lightweight startup request to each feature endpoint;
-an unmapped or unauthorized endpoint is classified as unavailable, but can produce an expected
-401/403/404 in connectivity traces. Do not expose a path merely to silence that probe. Add the
-exact optional path and change its feature setting to `auto` or `on` only when the capability is
-approved.
+overrides, `auto` sends GET requests to the feature endpoints even when users only request ADT
+operations. Single targets probe at startup; discovered multi-targets probe on demand during SAP
+tool calls. For an existing ADT-only deployment, set all three flags to `"off"` in the module's
+`.mtaext` properties and redeploy. When enabling an optional capability, add its exact resource
+path and change the associated flag to `auto` or `on` after approval. Multi-target v1 excludes
+`SAPGit` and `SAPManage`, so keep gCTS and FLP probes off there. Its optional `SAPRead` type
+`BSP_DEPLOY` uses the UI5 Repository path and is outside this initial ADT-only profile.
+
+A single-target optional probe returning 401/403/404 marks that feature unavailable; it does not
+by itself establish why the MCP connection failed. A 401/403 at the single-Basic startup preflight
+path `/sap/bc/adt/core/discovery` blocks shared SAP tool calls and requires repair followed by a
+restart. Discovered Basic targets have a separate [authentication guard](multi-target-administration.md#basic-shared-identity-controls)
+that can block the shared credentials after any SAP 401, including a feature probe. Diagnose the
+exact failed request path and layer before treating an error as an expected optional-feature miss.
 
 Do not expose `/` just to make troubleshooting easier. Cloud Connector path matching is
 case-sensitive. The internal Cloud Connector-to-SAP connection should use HTTPS with normal
@@ -294,8 +309,9 @@ change matrix.
 | PP setup succeeds but SAP returns `401` | STRUST/trusted proxy/ICF/CERTRULE/SU01, not destination discovery |
 | SAP returns `403` after login | Propagated/technical user's SAP authorization |
 | Basic destination returns SSO HTML | ADT ICF does not accept Basic; ARC-1 rejects the login page |
-| ADT works but a feature probe reports `401`/`403`/`404` | Optional non-ADT path is unmapped/unauthorized; keep the feature `off` for ADT-only or approve and map its exact path |
-| Basic password changed but call remains blocked | Verify both fields were saved; a rejected generation is bounded, while a changed valid generation proceeds immediately |
+| Single-target ADT works but an optional probe reports `401`/`403`/`404` | Check that probe's mapping, service activation and SAP authorization; keep unused features `off` for ADT-only |
+| Single-target Basic password changed but call remains blocked | Verify the destination credentials and restart every app instance; this destination is resolved at startup |
+| Multi-target Basic password changed but call remains blocked | Verify both fields were saved; the next protected request detects a changed credential generation |
 | Connectivity exposure error | Virtual host/location/resource path mismatch |
 
 Use a request ID and diagnose from route → XSUAA → registry → Destination/Connectivity → Cloud

--- a/docs_page/btp-destination-setup.md
+++ b/docs_page/btp-destination-setup.md
@@ -54,7 +54,17 @@ Password=<managed-secret>
 sap-client=100
 ```
 
-Point the application at it with `SAP_BTP_DESTINATION=A4H_100_BASIC`. ARC-1 resolves this destination
+Point the application at it and explicitly disable the PP defaults inherited from the base MTA:
+
+```yaml
+SAP_BTP_DESTINATION: "A4H_100_BASIC"
+SAP_PP_ENABLED: "false"
+SAP_PP_STRICT: "false"
+```
+
+The tracked
+[single-Basic profile](btp-cloud-foundry-deployment.md#single-target-read-only-shared-basic-profile)
+provides the complete read-only extension and destination template. ARC-1 resolves this destination
 at startup for the single target. Use internal HTTPS between Cloud Connector and SAP even if the
 destination uses the virtual `http://` URL.
 
@@ -229,13 +239,21 @@ Use restrictive resource mappings:
 | URL path | Policy | Needed for |
 |---|---|---|
 | `/sap/bc/adt` | Path and all sub-paths | ARC-1 core ADT operations and all multi-target v1 routes |
-| `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` | Path and all sub-paths | Optional single-target FLP management |
-| `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` | Path and all sub-paths | Optional single-target UI5 repository operations |
+| `/sap/bc/cts_abapvcs` | Path and all sub-paths | Optional gCTS operations and the `SAP_FEATURE_GCTS=auto` startup probe |
+| `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` | Path and all sub-paths | Optional single-target FLP management and the `SAP_FEATURE_FLP=auto` startup probe |
+| `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` | Path and all sub-paths | Optional single-target UI5 repository operations and the `SAP_FEATURE_UI5REPO=auto` startup probe |
 
-Do not expose `/` just to make troubleshooting easier. Add optional paths only when the associated
-single-target feature is enabled and approved. Cloud Connector path matching is case-sensitive.
-The internal Cloud Connector-to-SAP connection should use HTTPS with normal hostname/certificate
-verification.
+The tracked initial BTP profiles set `SAP_FEATURE_GCTS=off`, `SAP_FEATURE_FLP=off`, and
+`SAP_FEATURE_UI5REPO=off`, so an ADT-only deployment needs only `/sap/bc/adt`. Without those
+overrides, the default `auto` mode sends a lightweight startup request to each feature endpoint;
+an unmapped or unauthorized endpoint is classified as unavailable, but can produce an expected
+401/403/404 in connectivity traces. Do not expose a path merely to silence that probe. Add the
+exact optional path and change its feature setting to `auto` or `on` only when the capability is
+approved.
+
+Do not expose `/` just to make troubleshooting easier. Cloud Connector path matching is
+case-sensitive. The internal Cloud Connector-to-SAP connection should use HTTPS with normal
+hostname/certificate verification.
 
 For PP, select strict user-certificate propagation with no system-certificate fallback. In newer
 Cloud Connector versions this is an X.509 mapping with the separate system-certificate-for-logon
@@ -276,6 +294,7 @@ change matrix.
 | PP setup succeeds but SAP returns `401` | STRUST/trusted proxy/ICF/CERTRULE/SU01, not destination discovery |
 | SAP returns `403` after login | Propagated/technical user's SAP authorization |
 | Basic destination returns SSO HTML | ADT ICF does not accept Basic; ARC-1 rejects the login page |
+| ADT works but a feature probe reports `401`/`403`/`404` | Optional non-ADT path is unmapped/unauthorized; keep the feature `off` for ADT-only or approve and map its exact path |
 | Basic password changed but call remains blocked | Verify both fields were saved; a rejected generation is bounded, while a changed valid generation proceeds immediately |
 | Connectivity exposure error | Virtual host/location/resource path mismatch |
 

--- a/docs_page/btp-overview.md
+++ b/docs_page/btp-overview.md
@@ -17,13 +17,16 @@ its artifact; ask the deployment owner if that revision is unknown. Proposed set
     Follow [BTP Cloud Foundry Deployment](btp-cloud-foundry-deployment.md). Step 4 selects a
     single-PP or multi-PP example from the same checkout; keep following that runbook through acceptance.
 
+    If Principal Propagation is not available and the shared SAP identity is acceptable, the same
+    step provides a complete single-Basic profile. XSUAA still authenticates the MCP users.
+
     Start with the topology table below only when that recommendation does not fit your landscape.
 
 ## Choose the topology
 
 | Your SAP landscape | ARC-1 shape | SAP identity | Continue with |
 |--------------------|-------------|--------------|---------------|
-| One on-premise SAP system/client | One `/mcp` endpoint | Principal Propagation recommended | [Cloud Foundry Deployment](btp-cloud-foundry-deployment.md) — single-PP profile |
+| One on-premise SAP system/client | One `/mcp` endpoint | Principal Propagation recommended; shared Basic supported | [Cloud Foundry Deployment](btp-cloud-foundry-deployment.md) — choose single-PP or single-Basic |
 | Several on-premise systems or clients, mutation-free access | Pinned `/<SYSTEM>/<CLIENT>/mcp` routes plus `/multi/mcp` | Principal Propagation recommended; shared Basic is an explicit exception | [Cloud Foundry Deployment](btp-cloud-foundry-deployment.md) — multi-PP profile |
 | One general `/mcp` endpoint beside mutation-free multi-target routes | Independent single-target and multi-target configurations in one app | Configure each path independently | Read the [side-by-side risks](multi-target-administration.md#optional-single-target-mcp) before deployment |
 | BTP ABAP Environment | One `/mcp` endpoint | `OAuth2UserTokenExchange` | [BTP ABAP Environment](btp-abap-environment.md) |
@@ -47,8 +50,8 @@ its artifact; ask the deployment owner if that revision is unknown. Proposed set
 
 Follow the [deployment runbook](btp-cloud-foundry-deployment.md) from prerequisites through
 acceptance. It brings in the Destination, Connector, Basis and IAM owners at the required steps;
-single-PP startup destinations must exist before the configured app starts. Do not treat the
-specialist pages as additional deployments to perform afterward.
+the selected single-target destination or destination pair must exist before the configured app
+starts. Do not treat the specialist pages as additional deployments to perform afterward.
 
 For an existing deployment, use the [task map below](#find-the-right-page-quickly) to add a target,
 change access, diagnose a failure or plan an upgrade. Destination changes and role changes have

--- a/docs_page/btp-overview.md
+++ b/docs_page/btp-overview.md
@@ -17,8 +17,9 @@ its artifact; ask the deployment owner if that revision is unknown. Proposed set
     Follow [BTP Cloud Foundry Deployment](btp-cloud-foundry-deployment.md). Step 4 selects a
     single-PP or multi-PP example from the same checkout; keep following that runbook through acceptance.
 
-    If Principal Propagation is not available and the shared SAP identity is acceptable, the same
-    step provides a complete single-Basic profile. XSUAA still authenticates the MCP users.
+    If a shared SAP identity is acceptable for one target, use the
+    [single-Basic profile](btp-cloud-foundry-deployment.md#single-target-read-only-shared-basic-profile)
+    in the same runbook. XSUAA still authenticates the MCP users.
 
     Start with the topology table below only when that recommendation does not fit your landscape.
 
@@ -26,7 +27,7 @@ its artifact; ask the deployment owner if that revision is unknown. Proposed set
 
 | Your SAP landscape | ARC-1 shape | SAP identity | Continue with |
 |--------------------|-------------|--------------|---------------|
-| One on-premise SAP system/client | One `/mcp` endpoint | Principal Propagation recommended; shared Basic supported | [Cloud Foundry Deployment](btp-cloud-foundry-deployment.md) — choose single-PP or single-Basic |
+| One on-premise SAP system/client | One `/mcp` endpoint | Principal Propagation recommended; shared Basic supported | Cloud Foundry Deployment — [single-PP](btp-cloud-foundry-deployment.md#single-target-read-only-pp-profile) or [single-Basic](btp-cloud-foundry-deployment.md#single-target-read-only-shared-basic-profile) |
 | Several on-premise systems or clients, mutation-free access | Pinned `/<SYSTEM>/<CLIENT>/mcp` routes plus `/multi/mcp` | Principal Propagation recommended; shared Basic is an explicit exception | [Cloud Foundry Deployment](btp-cloud-foundry-deployment.md) — multi-PP profile |
 | One general `/mcp` endpoint beside mutation-free multi-target routes | Independent single-target and multi-target configurations in one app | Configure each path independently | Read the [side-by-side risks](multi-target-administration.md#optional-single-target-mcp) before deployment |
 | BTP ABAP Environment | One `/mcp` endpoint | `OAuth2UserTokenExchange` | [BTP ABAP Environment](btp-abap-environment.md) |

--- a/docs_page/btp-setup-worksheet.md
+++ b/docs_page/btp-setup-worksheet.md
@@ -11,7 +11,7 @@ Record secret-storage references, never passwords, tokens, private keys or raw b
 
 | Input | Agree with |
 |---|---|
-| Selected source revision and topology: single PP or multi PP | Deployment owner |
+| Selected source revision and topology: single Basic, single PP, or multi PP | Deployment owner |
 | Subaccount, CF API/org/space and service ownership | CF/IAM owners |
 | Real SAP SID/client, destination names and descriptions | Destination/Basis owners |
 | Cloud Connector virtual/internal mapping, verified HTTPS and location ID if used | Connector owner |

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -341,6 +341,11 @@ When a feature is `off` (either set explicitly or detected as unavailable), ever
 
 `auto` probes one specific endpoint per feature and classifies the response: 2xx/400/405/5xx → available; 401/403/404 → unavailable. The reason is surfaced in startup logs and in the `SAPManage.system_info` response.
 
+For restrictive BTP Cloud Connector mappings, `gcts`, `flp`, and `ui5repo` probe paths outside
+`/sap/bc/adt`. The tracked initial BTP profiles set those three features to `off`; see the
+[Cloud Connector path reference](btp-destination-setup.md#cloud-connector-url-path-reference) before
+changing them to `auto` or `on`.
+
 ---
 
 ## Code-quality gates

--- a/docs_page/configuration-reference.md
+++ b/docs_page/configuration-reference.md
@@ -323,9 +323,13 @@ All ARC-1 logging goes to **stderr** to keep stdout clean for MCP JSON-RPC. Neve
 
 ## ABAP feature toggles
 
-Each toggle gates a class of ADT tools that depend on a SAP component being installed or active. All default to `auto` — ARC-1 probes the SAP system once on startup and decides. Override to `on`/`off` when probing is wrong, slow, or you want deterministic behaviour in tests.
+Each toggle controls a SAP-dependent feature. All default to `auto`: single-target deployments
+probe at startup, while discovered multi-targets probe on demand during SAP tool calls. `off`
+skips the feature's probe and disables it; `on` skips the probe and assumes the feature is available.
 
-When a feature is `off` (either set explicitly or detected as unavailable), every tool action that depends on it is hidden from tool listings *and* rejected at call time with a clear error.
+Feature-dependent handlers use the resolved availability, but not every unavailable action is
+removed from tool listings. Feature toggles do not replace the instance's action policy or Cloud
+Connector resource mappings.
 
 | Flag | Env var | Default | Effect |
 |---|---|---|---|
@@ -334,15 +338,19 @@ When a feature is `off` (either set explicitly or detected as unavailable), ever
 | `--feature-rap` | `SAP_FEATURE_RAP` | `auto` | RAP behavior definitions, services, drafts. Required for `SAPWrite` of BDEF/SRVD/SRVB and the RAP-specific code-intel and preflight tools. |
 | `--feature-amdp` | `SAP_FEATURE_AMDP` | `auto` | ABAP Managed Database Procedures. Required for AMDP-specific read/write paths. |
 | `--feature-ui5` | `SAP_FEATURE_UI5` | `auto` | UI5 application development tools (general). |
-| `--feature-ui5repo` | `SAP_FEATURE_UI5REPO` | `auto` | UI5 ABAP Repository OData service. Required for `SAPManage` UI5 repo upload/download actions. |
-| `--feature-flp` | `SAP_FEATURE_FLP` | `auto` | FLP `PAGE_BUILDER_CUST` OData service. Required for `SAPManage` FLP page/role mutations. |
+| `--feature-ui5repo` | `SAP_FEATURE_UI5REPO` | `auto` | UI5 ABAP Repository OData service used by `SAPRead` type `BSP_DEPLOY` to read deployed app metadata. |
+| `--feature-flp` | `SAP_FEATURE_FLP` | `auto` | FLP `PAGE_BUILDER_CUST` OData service used by `SAPManage` FLP catalog/group/tile reads and mutations. |
 | `--feature-transport` | `SAP_FEATURE_TRANSPORT` | `auto` | CTS transport endpoints. Required for `SAPTransport` (even reads). |
 | `--feature-hana` | `SAP_FEATURE_HANA` | `auto` | HANA-specific developer tools. |
 
-`auto` probes one specific endpoint per feature and classifies the response: 2xx/400/405/5xx → available; 401/403/404 → unavailable. The reason is surfaced in startup logs and in the `SAPManage.system_info` response.
+`auto` probes one specific endpoint per feature and classifies the response: 2xx/400/405/5xx →
+available; 401/403/404 → unavailable. On single-target `/mcp`, inspect the cached result using
+`SAPManage` with `action: "features"`. Discovered targets apply additional
+[authentication controls](multi-target-administration.md#basic-shared-identity-controls);
+`SAPManage` is not part of their tool surface.
 
 For restrictive BTP Cloud Connector mappings, `gcts`, `flp`, and `ui5repo` probe paths outside
-`/sap/bc/adt`. The tracked initial BTP profiles set those three features to `off`; see the
+`/sap/bc/adt`. The three tracked profiles under `examples/btp/` set those features to `off`; see the
 [Cloud Connector path reference](btp-destination-setup.md#cloud-connector-url-path-reference) before
 changing them to `auto` or `on`.
 

--- a/docs_page/deployment.md
+++ b/docs_page/deployment.md
@@ -33,7 +33,7 @@ For single-developer setups on your own laptop, use [local-development.md](local
 | Answer | Path |
 |---|---|
 | Docker on any VM / container host | [Docker deployment](#docker-on-any-vm) |
-| BTP Cloud Foundry, one on-prem SAP target | [BTP CF with PP](#btp-cloud-foundry-with-principal-propagation) |
+| BTP Cloud Foundry, one on-prem SAP target | [BTP Cloud Foundry deployment](btp-cloud-foundry-deployment.md) — choose single-PP or single-Basic |
 | BTP Cloud Foundry, many on-prem SAP system/clients | [Multi-System Setup](multi-target-setup.md) |
 | BTP Cloud Foundry, BTP ABAP backend | [BTP CF + BTP ABAP](#btp-cloud-foundry-btp-abap-environment) |
 | BTP Cloud Foundry, S/4HANA Public Cloud backend | [S/4HANA Public Cloud (PP via SAMLAssertion)](s4hana-public-cloud.md) |

--- a/docs_page/deployment.md
+++ b/docs_page/deployment.md
@@ -33,7 +33,7 @@ For single-developer setups on your own laptop, use [local-development.md](local
 | Answer | Path |
 |---|---|
 | Docker on any VM / container host | [Docker deployment](#docker-on-any-vm) |
-| BTP Cloud Foundry, one on-prem SAP target | [BTP Cloud Foundry deployment](btp-cloud-foundry-deployment.md) — choose single-PP or single-Basic |
+| BTP Cloud Foundry, one on-prem SAP target | BTP Cloud Foundry deployment — [single-PP](btp-cloud-foundry-deployment.md#single-target-read-only-pp-profile) or [single-Basic](btp-cloud-foundry-deployment.md#single-target-read-only-shared-basic-profile) |
 | BTP Cloud Foundry, many on-prem SAP system/clients | [Multi-System Setup](multi-target-setup.md) |
 | BTP Cloud Foundry, BTP ABAP backend | [BTP CF + BTP ABAP](#btp-cloud-foundry-btp-abap-environment) |
 | BTP Cloud Foundry, S/4HANA Public Cloud backend | [S/4HANA Public Cloud (PP via SAMLAssertion)](s4hana-public-cloud.md) |
@@ -100,6 +100,10 @@ For this shared-user mode, ARC-1 runs a startup auth preflight (`/sap/bc/adt/cor
 The recommended deployment path for per-user SAP identity with on-premise SAP. XSUAA identifies the
 MCP user; Destination and Connectivity services plus Cloud Connector propagate that identity;
 SAP certificate mapping and authorization decide the final access.
+
+For one target with an accepted shared SAP identity, use the
+[single-Basic profile](btp-cloud-foundry-deployment.md#single-target-read-only-shared-basic-profile).
+XSUAA remains the MCP authentication layer in that topology too.
 
 If you have not chosen between single-target, multi-target, BTP ABAP, or S/4HANA Public Cloud yet,
 start with the [SAP BTP documentation map](btp-overview.md).

--- a/docs_page/enterprise-auth.md
+++ b/docs_page/enterprise-auth.md
@@ -33,7 +33,8 @@ After starting, check the server's first INFO log line: `auth: MCP=[...] SAP=[..
 | **Team server** (role-based access) | API Keys (multi) | Basic Auth | [API Key Setup](api-key-setup.md) |
 | **Enterprise** (per-user identity) | OIDC / JWT | Basic Auth (shared user) | [OAuth / JWT Setup](oauth-jwt-setup.md) |
 | **Enterprise + SAP audit trail** | OIDC / JWT | Principal Propagation | [OAuth / JWT](oauth-jwt-setup.md) + [PP Setup](principal-propagation-setup.md) |
-| **BTP Cloud Foundry + on-prem SAP** | XSUAA OAuth | Principal Propagation via Destination Service / Cloud Connector | [XSUAA Setup](xsuaa-setup.md) + [Destination Setup](btp-destination-setup.md) |
+| **BTP Cloud Foundry + on-prem SAP, per-user identity** | XSUAA OAuth | Principal Propagation via Destination Service / Cloud Connector | [BTP deployment](btp-cloud-foundry-deployment.md) — single-PP profile |
+| **BTP Cloud Foundry + on-prem SAP, shared identity** | XSUAA OAuth | Basic destination via Cloud Connector | [BTP deployment](btp-cloud-foundry-deployment.md) — single-Basic profile |
 | **BTP CF multi-target read gateway** | XSUAA OAuth | Principal Propagation (recommended), with explicit shared Basic destinations where PP is unavailable | [Multi-System Setup](multi-target-setup.md) |
 | **BTP Cloud Foundry + BTP ABAP Environment** | XSUAA OAuth | Per-user destination (`OAuth2UserTokenExchange`) | [BTP ABAP Setup](btp-abap-environment.md) |
 | **BTP ABAP Environment** (local) | None (stdio) | Service-key browser OAuth | [BTP ABAP Setup](btp-abap-environment.md) |
@@ -135,9 +136,12 @@ These methods control how ARC-1 proves its identity to the SAP system.
 
 Username and password sent with every HTTP request to SAP. The simplest SAP auth method.
 
-**Upsides:** Zero SAP-side setup. Works with any SAP system.
+**Upsides:** Simple ARC-1 configuration. Works with on-premise systems whose ADT ICF service accepts
+HTTP Basic for the selected client and user.
 **Downsides:** Credentials stored in config. Single SAP user for all MCP users. No per-user audit trail.
-**When to use:** Local dev, shared servers where SAP identity doesn't matter.
+**When to use:** Local dev or an explicitly accepted shared-user server. On BTP CF, keep credentials
+in a Basic destination rather than application configuration. Basic is not a fallback for
+Principal Propagation and is not the normal BTP ABAP Environment path.
 **Prerequisites:** A SAP user with appropriate authorization (see [Authorization & Roles](authorization.md#the-model-in-one-picture)).
 
 ```bash

--- a/docs_page/principal-propagation-setup.md
+++ b/docs_page/principal-propagation-setup.md
@@ -137,22 +137,16 @@ back to the startup user. See [BTP Destination Reference](btp-destination-setup.
    accept an IP SAN when the internal host is an IP literal. Do not solve a name mismatch by disabling
    backend certificate checks.
 
+<a id="required-cloud-connector-resource-paths"></a>
+
 ### Cloud Connector Resource Paths
 
-For the initial ADT-only profiles, expose `/sap/bc/adt` with all sub-paths. Add the other exact
-paths only when the corresponding capability is approved:
-
-| URL Path | Access Policy | Purpose |
-|----------|---------------|---------|
-| `/sap/bc/adt` | Path and all sub-paths | ADT API used by ARC-1 core read/write operations |
-| `/sap/bc/cts_abapvcs` | Path and all sub-paths | Optional gCTS operations and feature probe |
-| `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` | Path and all sub-paths | Optional FLP launchpad management and feature probe |
-| `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` | Path and all sub-paths | Optional UI5 ABAP Repository operations and feature probe |
-
-The default `auto` feature modes probe the three optional paths at startup. The tracked initial BTP
-profiles set `SAP_FEATURE_GCTS=off`, `SAP_FEATURE_FLP=off`, and `SAP_FEATURE_UI5REPO=off` to avoid
-those requests in an ADT-only deployment. Map a path before re-enabling its feature. Avoid exposing
-`/` unless another documented integration needs it.
+For the initial ADT-only profiles, expose `/sap/bc/adt` with **Path and all sub-paths**. These
+profiles disable the gCTS, FLP and UI5 Repository probes. The
+[Cloud Connector URL path reference](btp-destination-setup.md#cloud-connector-url-path-reference)
+owns the optional paths, feature settings and probe behavior. Use it when enabling additional
+capabilities within the selected topology's supported tool surface. Avoid exposing `/` unless
+another documented integration needs it.
 
 ## Step 3: Configure SAP System
 

--- a/docs_page/principal-propagation-setup.md
+++ b/docs_page/principal-propagation-setup.md
@@ -137,19 +137,22 @@ back to the startup user. See [BTP Destination Reference](btp-destination-setup.
    accept an IP SAN when the internal host is an IP literal. Do not solve a name mismatch by disabling
    backend certificate checks.
 
-### Required Cloud Connector Resource Paths
+### Cloud Connector Resource Paths
 
-If you use restrictive Cloud Connector resource whitelisting, expose at least these paths:
+For the initial ADT-only profiles, expose `/sap/bc/adt` with all sub-paths. Add the other exact
+paths only when the corresponding capability is approved:
 
 | URL Path | Access Policy | Purpose |
 |----------|---------------|---------|
 | `/sap/bc/adt` | Path and all sub-paths | ADT API used by ARC-1 core read/write operations |
-| `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` | Path and all sub-paths | FLP launchpad management via `SAPManage` FLP actions |
-| `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` | Path and all sub-paths | UI5 ABAP Repository OData (BSP deploy metadata) |
+| `/sap/bc/cts_abapvcs` | Path and all sub-paths | Optional gCTS operations and feature probe |
+| `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` | Path and all sub-paths | Optional FLP launchpad management and feature probe |
+| `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV` | Path and all sub-paths | Optional UI5 ABAP Repository operations and feature probe |
 
-Use `/sap/bc/adt` with **Path and all sub-paths** for multi-target v1. Add the optional OData paths
-only when those features are enabled. Avoid exposing `/` unless another documented integration needs
-it.
+The default `auto` feature modes probe the three optional paths at startup. The tracked initial BTP
+profiles set `SAP_FEATURE_GCTS=off`, `SAP_FEATURE_FLP=off`, and `SAP_FEATURE_UI5REPO=off` to avoid
+those requests in an ADT-only deployment. Map a path before re-enabling its feature. Avoid exposing
+`/` unless another documented integration needs it.
 
 ## Step 3: Configure SAP System
 

--- a/examples/btp/README.md
+++ b/examples/btp/README.md
@@ -1,20 +1,22 @@
-# BTP Principal Propagation examples
+# BTP deployment examples
 
 These fictional examples are starting configurations for a **new, MTA-owned deployment**.
 They are not customer-ready files or a migration procedure.
 
 | Example | Use it for | Files |
 |---|---|---|
-| [Single system](single-pp/README.md) | One SAP system/client through `/mcp` | One extension, a Basic startup destination and a per-user PP destination |
+| [Single system, shared Basic](single-basic/README.md) | One SAP system/client through `/mcp`, with a shared SAP user | One extension and one Basic destination |
+| [Single system, Principal Propagation](single-pp/README.md) | One SAP system/client through `/mcp`, with per-user SAP identity | One extension, a Basic startup destination and a PP request destination |
 | [Multiple systems/clients](multi-pp/README.md) | Experimental, mutation-free pinned and aggregate routes | One extension and two per-user PP destinations |
 
 Follow the [deployment runbook](../../docs_page/btp-cloud-foundry-deployment.md) from your selected
 checkout. Its step 4 selects one of these profiles; later steps prepare destinations, deploy and
 verify it. Do not copy a profile and then overwrite it with the generic extension example.
 
-Both profiles keep strict PP enabled and data/SQL, mutations, UI/plugins and ATC/Unit workloads off.
-They inherit the checkout's MTA-owned XSUAA, Destination and Connectivity services. An existing
-deployment needs a separate [configuration review](../../docs_page/btp-administration.md#configuration-ownership).
+The PP profiles keep strict PP enabled; the Basic profile explicitly disables it. All profiles keep
+data/SQL, mutations, UI/plugins, non-ADT feature probes and ATC/Unit workloads off. They inherit the
+checkout's MTA-owned XSUAA, Destination and Connectivity services. An existing deployment needs a
+separate [configuration review](../../docs_page/btp-administration.md#configuration-ownership).
 
 Maintainers: `npm run btp:validate` and `tests/unit/server/btp-pp-profiles.test.ts` check these files.
 Those checks do not prove a customer's connectivity or SAP identity.

--- a/examples/btp/multi-pp/README.md
+++ b/examples/btp/multi-pp/README.md
@@ -19,8 +19,10 @@ This profile has no independent `/mcp`: keep `SAP_BTP_DESTINATION` and `SAP_BTP_
 absent, including from existing app environment settings. It does not enable shared Basic access.
 
 The initial profile disables gCTS, FLP and UI5 Repository feature probes so Cloud Connector needs
-only `/sap/bc/adt` with all sub-paths. Multi-target v1 does not expose the FLP or UI5 Repository
-actions; add the gCTS resource path and re-enable that feature only if it is explicitly approved.
+only `/sap/bc/adt` with all sub-paths. Multi-target v1 excludes `SAPGit` and `SAPManage`, so gCTS
+and FLP actions cannot be enabled through feature toggles. The optional `SAPRead` type
+`BSP_DEPLOY` reads UI5 Repository metadata outside ADT; it is disabled by this initial profile's
+`SAP_FEATURE_UI5REPO=off`. Keep all three probes off for ADT-only acceptance.
 
 After destination changes, restart every ARC-1 process. `SAPTargets` lists configured targets,
 not proven SAP access, and current v1 does not filter that list per user. Verify safe reads and

--- a/examples/btp/multi-pp/README.md
+++ b/examples/btp/multi-pp/README.md
@@ -18,6 +18,10 @@ X.509 user-certificate propagation. Adding a destination does not create the SAP
 This profile has no independent `/mcp`: keep `SAP_BTP_DESTINATION` and `SAP_BTP_PP_DESTINATION`
 absent, including from existing app environment settings. It does not enable shared Basic access.
 
+The initial profile disables gCTS, FLP and UI5 Repository feature probes so Cloud Connector needs
+only `/sap/bc/adt` with all sub-paths. Multi-target v1 does not expose the FLP or UI5 Repository
+actions; add the gCTS resource path and re-enable that feature only if it is explicitly approved.
+
 After destination changes, restart every ARC-1 process. `SAPTargets` lists configured targets,
 not proven SAP access, and current v1 does not filter that list per user. Verify safe reads and
 [backend identity](../../../docs_page/principal-propagation-setup.md#verify-the-backend-identity)

--- a/examples/btp/multi-pp/profile.mtaext
+++ b/examples/btp/multi-pp/profile.mtaext
@@ -20,4 +20,8 @@ modules:
       SAP_ALLOW_FREE_SQL: "false"
       SAP_ALLOW_TRANSPORT_WRITES: "false"
       SAP_ALLOW_GIT_WRITES: "false"
+      # Keep the initial Cloud Connector exposure on /sap/bc/adt only.
+      SAP_FEATURE_GCTS: "off"
+      SAP_FEATURE_UI5REPO: "off"
+      SAP_FEATURE_FLP: "off"
       SAP_DENY_ACTIONS: "SAPDiagnose.atc,SAPDiagnose.unittest"

--- a/examples/btp/single-basic/README.md
+++ b/examples/btp/single-basic/README.md
@@ -1,0 +1,25 @@
+# Example: one SAP system/client with shared Basic authentication
+
+One XSUAA-protected `/mcp` endpoint whose SAP requests all use the same technical user. Use these
+files at
+[step 4 of the deployment runbook](../../../docs_page/btp-cloud-foundry-deployment.md#4-create-the-landscape-extension);
+the runbook contains the copy command, deployment order and acceptance checks.
+
+| File | Replace with your landscape values |
+|---|---|
+| [profile.mtaext](profile.mtaext) | Destination name; keep the conservative policy for initial acceptance |
+| [basic.destination.json](basic.destination.json) | Name, virtual URL, SID/client and description; user and secret supplied securely by their owner |
+
+The profile explicitly disables Principal Propagation because the base MTA enables it. XSUAA still
+identifies and authorizes the MCP caller, but SAP audit records show only the destination's shared
+technical user. Use a dedicated least-privileged account, not `SAP_ALL` or a dialog administrator.
+
+The initial profile is ADT-only: it disables gCTS, FLP and UI5 Repository feature probes so Cloud
+Connector needs only `/sap/bc/adt` with all sub-paths. If one of those capabilities is later
+approved, add its exact resource path first and change its `SAP_FEATURE_*` setting in the reviewed
+extension; see the
+[Cloud Connector path reference](../../../docs_page/btp-destination-setup.md#cloud-connector-url-path-reference).
+
+The destination must exist before ARC-1 starts with this profile. Acceptance uses safe reads
+followed by [backend identity verification](../../../docs_page/principal-propagation-setup.md#verify-the-backend-identity)
+with Basis; for this topology the expected identity is the approved technical user.

--- a/examples/btp/single-basic/basic.destination.json
+++ b/examples/btp/single-basic/basic.destination.json
@@ -1,0 +1,12 @@
+{
+  "Name": "ARC1_QAS_001_BASIC",
+  "Type": "HTTP",
+  "URL": "http://qas-basic.example.invalid:8080",
+  "ProxyType": "OnPremise",
+  "Authentication": "BasicAuthentication",
+  "User": "<owner-supplied-technical-user>",
+  "Password": "<owner-supplied-managed-secret>",
+  "sap-sysid": "QAS",
+  "sap-client": "001",
+  "Description": "QAS client 001 - shared technical identity"
+}

--- a/examples/btp/single-basic/profile.mtaext
+++ b/examples/btp/single-basic/profile.mtaext
@@ -1,14 +1,15 @@
-# Fictional, conservative profile. Read README.md before copying to mta-overrides.mtaext.
+# Fictional, conservative ADT-only profile. Read README.md before copying to mta-overrides.mtaext.
 _schema-version: "3.1"
-ID: arc1-single-pp-example
+ID: arc1-single-basic-example
 extends: arc1-mcp
 modules:
   - name: arc1-mcp-server
     properties:
-      SAP_BTP_DESTINATION: "ARC1_QAS_001_STARTUP"
-      SAP_BTP_PP_DESTINATION: "ARC1_QAS_001_PP"
-      SAP_PP_ENABLED: "true"
-      SAP_PP_STRICT: "true"
+      SAP_BTP_DESTINATION: "ARC1_QAS_001_BASIC"
+      # The base MTA enables PP. A shared-identity single target must disable
+      # both flags explicitly rather than relying on an omitted property.
+      SAP_PP_ENABLED: "false"
+      SAP_PP_STRICT: "false"
       SAP_PP_ALLOW_SHARED_COOKIES: "false"
       ARC1_MULTI_TARGET_ENDPOINTS: "false"
       ARC1_MULTI_TARGET_ALLOW_BASIC_AUTH: "false"
@@ -25,5 +26,5 @@ modules:
       SAP_FEATURE_GCTS: "off"
       SAP_FEATURE_UI5REPO: "off"
       SAP_FEATURE_FLP: "off"
-      # These profiles do not opt users into analysis/test workloads in SAP.
+      # This profile does not opt users into analysis/test workloads in SAP.
       SAP_DENY_ACTIONS: "SAPDiagnose.atc,SAPDiagnose.unittest"

--- a/examples/btp/single-pp/README.md
+++ b/examples/btp/single-pp/README.md
@@ -18,5 +18,10 @@ prove the mappings; ask the Connector/Basis owner to confirm them.
 The startup user is not a PP fallback. Use a least-privileged startup account, not `SAP_ALL` or a
 dialog administrator. Both destinations must exist before ARC-1 starts with this profile.
 
+The initial profile disables gCTS, FLP and UI5 Repository feature probes so Cloud Connector needs
+only `/sap/bc/adt` with all sub-paths. Add an optional resource path and re-enable its feature only
+as one reviewed capability change; see the
+[Cloud Connector path reference](../../../docs_page/btp-destination-setup.md#cloud-connector-url-path-reference).
+
 Acceptance uses safe reads followed by [backend identity verification](../../../docs_page/principal-propagation-setup.md#verify-the-backend-identity).
 `SAPRead(SYSTEM).user` alone is not proof of the SAP login identity.

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "test:reliability-report": "node scripts/ci/collect-test-reliability.mjs",
     "test:runtime-report": "node scripts/ci/test-runtime-summary.mjs",
     "test:assert-execution": "node scripts/ci/assert-required-test-execution.mjs",
-    "btp:validate": "npx mbt validate && npx mbt validate -e mta-overrides.mtaext.example && npx mbt validate -e mta-overrides.mtaext.example -e mta-ui-approuter.mtaext && npx mbt validate -e examples/btp/single-pp/profile.mtaext && npx mbt validate -e examples/btp/multi-pp/profile.mtaext",
+    "btp:validate": "npx mbt validate && npx mbt validate -e mta-overrides.mtaext.example && npx mbt validate -e mta-overrides.mtaext.example -e mta-ui-approuter.mtaext && npx mbt validate -e examples/btp/single-basic/profile.mtaext && npx mbt validate -e examples/btp/single-pp/profile.mtaext && npx mbt validate -e examples/btp/multi-pp/profile.mtaext",
     "btp:build": "npx mbt build",
     "btp:build-ui-ext": "npx mbt build -e mta-ui-approuter.mtaext",
     "btp:deploy": "node -e \"const v=require('./package.json').version;require('child_process').execSync('cf deploy mta_archives/arc1-mcp_'+v+'.mtar',{stdio:'inherit'})\"",

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -505,6 +505,16 @@ describe('Feature Detection', () => {
       expect(urls).not.toContain('/sap/bc/adt/filestore/ui5-bsp');
     });
 
+    it('does not request non-ADT capability paths when the BTP acceptance profile disables them', async () => {
+      const client = mockProbeClient();
+      await probeFeatures(client, { ...defaultConfig, gcts: 'off', ui5repo: 'off', flp: 'off' });
+      const urls = ((client as any).get.mock.calls as Array<[string]>).map((call) => call[0]);
+
+      expect(urls).not.toContain('/sap/bc/cts_abapvcs/system');
+      expect(urls).not.toContain('/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV');
+      expect(urls).not.toContain('/sap/opu/odata/UI2/PAGE_BUILDER_CUST/');
+    });
+
     it('does not fail feature probing when discovery request fails', async () => {
       const client = mockProbeClient({ discoveryFails: true });
       const result = await probeFeatures(client, defaultConfig);

--- a/tests/unit/adt/features.test.ts
+++ b/tests/unit/adt/features.test.ts
@@ -507,12 +507,36 @@ describe('Feature Detection', () => {
 
     it('does not request non-ADT capability paths when the BTP acceptance profile disables them', async () => {
       const client = mockProbeClient();
-      await probeFeatures(client, { ...defaultConfig, gcts: 'off', ui5repo: 'off', flp: 'off' });
-      const urls = ((client as any).get.mock.calls as Array<[string]>).map((call) => call[0]);
+      const result = await probeFeatures(client, { ...defaultConfig, gcts: 'off', ui5repo: 'off', flp: 'off' });
+      const urls = vi.mocked(client.get).mock.calls.map(([url]) => url);
 
-      expect(urls).not.toContain('/sap/bc/cts_abapvcs/system');
-      expect(urls).not.toContain('/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV');
-      expect(urls).not.toContain('/sap/opu/odata/UI2/PAGE_BUILDER_CUST/');
+      expect(urls).toContain('/sap/bc/adt/discovery');
+      expect(urls.every((url) => url.startsWith('/sap/bc/adt/'))).toBe(true);
+      for (const id of ['gcts', 'ui5repo', 'flp'] as const) {
+        expect(result[id]).toMatchObject({ available: false, mode: 'off' });
+      }
+    });
+
+    it.each([401, 403, 404])('retains ADT evidence when optional OData probes return %i', async (status) => {
+      const client = mockProbeClient();
+      const get = vi.mocked(client.get);
+      const originalGet = get.getMockImplementation()!;
+      get.mockImplementation((url, headers, options) => {
+        if (url.startsWith('/sap/opu/odata/')) {
+          return Promise.reject(new AdtApiError('Optional service unavailable', status, url));
+        }
+        return originalGet(url, headers, options);
+      });
+
+      const result = await probeFeatures(client, defaultConfig);
+
+      expect(get).toHaveBeenCalledWith('/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV', undefined, { probe: true });
+      expect(get).toHaveBeenCalledWith('/sap/opu/odata/UI2/PAGE_BUILDER_CUST/', undefined, { probe: true });
+      expect(result.ui5repo.available).toBe(false);
+      expect(result.flp.available).toBe(false);
+      expect(result.rap.available).toBe(true);
+      expect(result.authProbe?.searchAccess).toBe(true);
+      expect(result.discoveryMap?.get('/sap/bc/adt/oo/classes')).toEqual(['application/vnd.sap.adt.oo.classes.v4+xml']);
     });
 
     it('does not fail feature probing when discovery request fails', async () => {

--- a/tests/unit/server/btp-docs-contract.test.ts
+++ b/tests/unit/server/btp-docs-contract.test.ts
@@ -39,6 +39,36 @@ function assertParity(markdown: string): void {
 }
 
 describe('BTP documentation contracts', () => {
+  it('routes one-target readers to both supported on-premise identity profiles', () => {
+    const overview = read('docs_page/btp-overview.md');
+    const deployment = read('docs_page/deployment.md');
+    const runbook = read('docs_page/btp-cloud-foundry-deployment.md');
+    const destinations = read('docs_page/btp-destination-setup.md');
+
+    for (const entrypoint of [overview, deployment]) {
+      expect(entrypoint).toContain('single-PP');
+      expect(entrypoint).toContain('single-Basic');
+    }
+    expect(runbook).toContain('cp -n examples/btp/single-basic/profile.mtaext mta-overrides.mtaext');
+    expect(destinations).toContain('SAP_PP_ENABLED: "false"');
+    expect(destinations).toContain('SAP_PP_STRICT: "false"');
+  });
+
+  it('documents the non-ADT auto-probe paths and the ADT-only opt-out', () => {
+    const destinations = read('docs_page/btp-destination-setup.md');
+    for (const value of ['SAP_FEATURE_GCTS=off', 'SAP_FEATURE_FLP=off', 'SAP_FEATURE_UI5REPO=off']) {
+      expect(destinations).toContain(value);
+    }
+    for (const path of [
+      '/sap/bc/cts_abapvcs',
+      '/sap/opu/odata/UI2/PAGE_BUILDER_CUST',
+      '/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV',
+    ]) {
+      expect(destinations).toContain(path);
+    }
+    expect(destinations).toContain('an ADT-only deployment needs only `/sap/bc/adt`');
+  });
+
   it('uses the observed CF route rather than deriving OAuth URLs from the space', () => {
     const xsuaa = read('docs_page/xsuaa-setup.md');
     expect(xsuaa).toContain('cf app <app-name>');

--- a/tests/unit/server/btp-docs-contract.test.ts
+++ b/tests/unit/server/btp-docs-contract.test.ts
@@ -46,8 +46,13 @@ describe('BTP documentation contracts', () => {
     const destinations = read('docs_page/btp-destination-setup.md');
 
     for (const entrypoint of [overview, deployment]) {
-      expect(entrypoint).toContain('single-PP');
-      expect(entrypoint).toContain('single-Basic');
+      const singleTargetRow = entrypoint.split('\n').find((line) => /^\|.*one on-prem/i.test(line));
+      expect(singleTargetRow).toContain(
+        '[single-PP](btp-cloud-foundry-deployment.md#single-target-read-only-pp-profile)',
+      );
+      expect(singleTargetRow).toContain(
+        '[single-Basic](btp-cloud-foundry-deployment.md#single-target-read-only-shared-basic-profile)',
+      );
     }
     expect(runbook).toContain('cp -n examples/btp/single-basic/profile.mtaext mta-overrides.mtaext');
     expect(destinations).toContain('SAP_PP_ENABLED: "false"');

--- a/tests/unit/server/btp-pp-profiles.test.ts
+++ b/tests/unit/server/btp-pp-profiles.test.ts
@@ -11,6 +11,7 @@ const base = parse(read('mta.yaml'));
 const app = base.modules.find((module: { name: string }) => module.name === 'arc1-mcp-server');
 const profile = (name: string) => parse(read(`examples/btp/${name}/profile.mtaext`));
 const destination = (name: string, file: string) => JSON.parse(read(`examples/btp/${name}/${file}.destination.json`));
+const PROFILE_NAMES = ['single-basic', 'single-pp', 'multi-pp'] as const;
 
 // Only the property maps of these constrained examples are overlaid here. MBT separately
 // validates the actual descriptors; this helper is not a general MTA merger.
@@ -67,7 +68,7 @@ function assertFixtureFields(raw: Record<string, unknown>) {
   expect(url.username).toBe('');
   expect(url.password).toBe('');
   if (raw.Authentication === 'BasicAuthentication') {
-    expect(raw.User).toBe('<owner-supplied-startup-user>');
+    expect(raw.User).toMatch(/^<owner-supplied-(startup|technical)-user>$/);
     expect(raw.Password).toBe('<owner-supplied-managed-secret>');
   } else {
     expect(raw.Authentication).toBe('PrincipalPropagation');
@@ -77,7 +78,7 @@ function assertFixtureFields(raw: Record<string, unknown>) {
   expect(Object.keys(raw).filter((key) => /secret|token|certificate/i.test(key))).toEqual([]);
 }
 
-describe('actual BTP PP setup examples', () => {
+describe('actual BTP setup examples', () => {
   const savedEnv = { ...process.env };
   beforeEach(() => {
     for (const key of Object.keys(process.env)) {
@@ -90,12 +91,10 @@ describe('actual BTP PP setup examples', () => {
     vi.restoreAllMocks();
   });
 
-  it.each(['single-pp', 'multi-pp'])('resolves %s with the conservative safety ceiling', (name) => {
+  it.each(PROFILE_NAMES)('resolves %s with the conservative safety ceiling', (name) => {
     const config = resolveProfile(name);
     expect(config).toMatchObject({
       transport: 'http-streamable',
-      ppEnabled: true,
-      ppStrict: true,
       ppAllowSharedCookies: false,
       multiTargetAllowBasicAuth: false,
       cacheMode: 'none',
@@ -106,6 +105,9 @@ describe('actual BTP PP setup examples', () => {
       allowFreeSQL: false,
       allowTransportWrites: false,
       allowGitWrites: false,
+      featureGcts: 'off',
+      featureUi5Repo: 'off',
+      featureFlp: 'off',
     });
     expect(config.denyActions).toEqual(['SAPDiagnose.atc', 'SAPDiagnose.unittest']);
     expect(process.env.ARC1_PLUGINS).toBe('');
@@ -114,11 +116,23 @@ describe('actual BTP PP setup examples', () => {
     expect(process.env.ARC1_MULTI_TARGET_AUTHORIZATION).toBeUndefined();
   });
 
+  it('configures one shared Basic destination without PP or multi-target mode', () => {
+    const config = resolveProfile('single-basic');
+    const raw = destination('single-basic', 'basic');
+    expect(config).toMatchObject({ ppEnabled: false, ppStrict: false, multiTargetEndpoints: false });
+    expect(process.env.SAP_BTP_DESTINATION).toBe(raw.Name);
+    expect(process.env.SAP_BTP_PP_DESTINATION).toBeUndefined();
+    assertFixtureFields(raw);
+    expect(raw.Authentication).toBe('BasicAuthentication');
+    expect(raw['sap-client']).toBe('001');
+    expect(Object.keys(raw).filter((key) => key.startsWith('arc1.'))).toEqual([]);
+  });
+
   it('pairs single startup and request destination names/client intent without multi markers', () => {
     const config = resolveProfile('single-pp');
     const startup = destination('single-pp', 'startup');
     const request = destination('single-pp', 'request');
-    expect(config.multiTargetEndpoints).toBe(false);
+    expect(config).toMatchObject({ ppEnabled: true, ppStrict: true, multiTargetEndpoints: false });
     expect(process.env.SAP_BTP_DESTINATION).toBe(startup.Name);
     expect(process.env.SAP_BTP_PP_DESTINATION).toBe(request.Name);
     expect(startup.Name).not.toBe(request.Name);
@@ -135,7 +149,7 @@ describe('actual BTP PP setup examples', () => {
     const config = resolveProfile('multi-pp');
     const raw = ['qas-001', 'qas-100'].map((file) => destination('multi-pp', file));
     raw.forEach(assertFixtureFields);
-    expect(config.multiTargetEndpoints).toBe(true);
+    expect(config).toMatchObject({ ppEnabled: true, ppStrict: true, multiTargetEndpoints: true });
     expect(process.env.SAP_BTP_DESTINATION).toBeUndefined();
     expect(process.env.SAP_BTP_PP_DESTINATION).toBeUndefined();
     const result = registry(raw, config);
@@ -158,16 +172,16 @@ describe('actual BTP PP setup examples', () => {
     expect(registry([raw], config, [raw.Name]).targets).toHaveLength(0);
   });
 
-  it('wires both packs into MBT validation and excludes examples/private files from packaging', () => {
+  it('wires every pack into MBT validation and excludes examples/private files from packaging', () => {
     const command = JSON.parse(read('package.json')).scripts['btp:validate'];
-    for (const name of ['single-pp', 'multi-pp']) {
+    for (const name of PROFILE_NAMES) {
       expect(command).toContain(`mbt validate -e examples/btp/${name}/profile.mtaext`);
     }
     expect(app['build-parameters'].ignore).toEqual(expect.arrayContaining(['examples/', '.arc1/']));
     expect(read('.gitignore').split('\n')).toContain('.arc1/');
   });
 
-  it.each(['single-pp', 'multi-pp'])('documents a non-overwriting copy command for %s', (name) => {
+  it.each(PROFILE_NAMES)('documents a non-overwriting copy command for %s', (name) => {
     const guide = read('docs_page/btp-cloud-foundry-deployment.md');
     const command = guide.split('\n').find((line) => line.startsWith(`cp -n examples/btp/${name}/`));
     expect(command).toBe(`cp -n examples/btp/${name}/profile.mtaext mta-overrides.mtaext`);
@@ -175,7 +189,7 @@ describe('actual BTP PP setup examples', () => {
   });
 
   it('keeps example readers on the canonical procedure and separates SAP identity evidence', () => {
-    for (const name of ['single-pp', 'multi-pp']) {
+    for (const name of PROFILE_NAMES) {
       const example = read(`examples/btp/${name}/README.md`);
       expect(example).toContain('btp-cloud-foundry-deployment.md#4-create-the-landscape-extension');
       expect(example).toContain('principal-propagation-setup.md#verify-the-backend-identity');


### PR DESCRIPTION
## Change

Add a complete read-only single-target Basic BTP profile and destination template. The base MTA enables PP, so the profile explicitly sets both `SAP_PP_ENABLED=false` and `SAP_PP_STRICT=false` while retaining XSUAA for MCP users. SAP uses one approved technical identity. The three tracked profiles disable unused gCTS/FLP/UI5 Repository probes so initial Cloud Connector exposure can remain ADT-only.

Entry pages lead to one canonical runbook. Document Basic prerequisites, the shared-identity tradeoff, destination ownership, credential-rotation restarts, optional feature paths and separate safe-read/backend-identity acceptance. Preserve #678 callback hardening and upgrade guidance. Startup errors now describe both discovery bootstrap paths; `SAPTargets` labels are explicitly multi-target-only.

[Review plan and evidence](docs/plans/2026-09-21-single-basic-profile-review.md).

## Compatibility and scope

Documentation, examples and regression coverage only; no production source change. Existing deployments must review their own extension rather than overwrite it. New profiles remain read-only, with data/SQL, plugins/UI and ATC/Unit workloads off. PP remains recommended for per-user SAP attribution. This does not broaden the separate experimental multi-target Basic exception.

## Validation

- 188 focused configuration/profile/feature/startup/documentation tests and **6,970 full unit tests pass**.
- Typecheck, lint, policy, file/schema budgets, all **six MTA validation combinations**, and strict MkDocs pass. Lint has two existing informational notices.
- Parsed profile reproduces the important before/after: inherited PP/strict true becomes false; XSUAA remains true; writes false and non-ADT probes off.
- Walked the Markdown entry point through profile selection, destinations, callback configuration, deployment and separate identity acceptance. Retained existing anchors and non-overwriting copy commands.
- Real-system testing: **N/A for this documentation-only change**. No new Cloud Connector/XSUAA customer deployment or backend identity certification is claimed. Those remain explicit operator acceptance steps.
- GitHub CI is not being waited on, as requested. Main merged normally; no force-push.

## Roadmap

- [x] Checked `docs_page/roadmap.md`: **No roadmap impact**; DOC-02's broader Basis handbook and independent owner acceptance remain outstanding.
